### PR TITLE
fix(render): 렌더 충실도 5건 — faux-bold/landscape/취소선 DIFFSPEC/글리프 폴백/셀 세로정렬

### DIFF
--- a/crates/hwp-convert/src/format.rs
+++ b/crates/hwp-convert/src/format.rs
@@ -175,10 +175,11 @@ fn apply_format(mut cs: CharShape, fmt: &CharFormat) -> CharShape {
         }
     }
     if let Some(s) = fmt.strike {
-        cs.attr &= !(0x7 << 18); // 취소선 비트 18~20
+        cs.attr &= !(0x7 << 18); // 취소선 비트 18~20 (바이트 왕복 보존)
         if s {
             cs.attr |= 1 << 18;
         }
+        cs.strike = s; // 의미 플래그 — has_strike/렌더/hwpx SOLID 쓰기 근거
     }
     if let Some(sz) = fmt.size_pt {
         cs.base_size = (sz * 100.0).round().max(100.0) as i32;

--- a/crates/hwp-model/src/header.rs
+++ b/crates/hwp-model/src/header.rs
@@ -82,8 +82,12 @@ pub struct CharShape {
     pub offsets: [i8; LANG_COUNT],
     /// 기준 크기 (HWPUNIT — 10pt = 1000)
     pub base_size: i32,
-    /// 속성 비트 (기울임/굵게/밑줄/취소선 등)
+    /// 속성 비트 (기울임/굵게/밑줄 등). 취소선 비트(18~20)는 DIFFSPEC라 신뢰하지 않음 — `strike` 참조.
     pub attr: u32,
+    /// 취소선 표시 여부 (의미 플래그). HWP5는 raw 비트가 불신뢰라 항상 false,
+    /// HWPX는 visible `<hp:strikeout>`(NONE/3D 제외)일 때만 true. 바이너리에 쓰지 않음.
+    #[serde(default)]
+    pub strike: bool,
     pub shadow_gap: (i8, i8),
     /// COLORREF (0x00BBGGRR)
     pub text_color: u32,
@@ -116,9 +120,15 @@ impl CharShape {
         self.underline_kind() == 1
     }
 
-    /// 취소선 (bits 18~20).
+    /// 취소선 여부 (명시적 `strike` 플래그 기반).
+    ///
+    /// HWP5 속성의 "취소선" 비트(18~20)는 **스펙 이견(DIFFSPEC) 영역**이라 신뢰할 수 없다 —
+    /// pyhwp(레퍼런스)는 취소선을 비트로 모델링하지 않고, bits 18~20을 취소선으로 읽으면 한글이
+    /// **평문으로 렌더하는** 실문서(보도자료 등)에 가짜 취소선이 그어진다(한글 PrvImage 대조 확인).
+    /// 따라서 HWP5 reader는 raw 비트로 strike를 켜지 않는다. HWPX reader만 명시적 `<hp:strikeout>`
+    /// 의 visible shape(NONE/3D 제외)일 때 `strike`를 켠다. `attr`는 보존(바이트 동일 왕복 무영향).
     pub fn has_strike(&self) -> bool {
-        (self.attr >> 18) & 0x7 != 0
+        self.strike
     }
 
     /// 글자 음영(배경 하이라이트)이 있는지. 0xFFFFFFFF=없음 관례.

--- a/crates/hwp-render/src/fonts.rs
+++ b/crates/hwp-render/src/fonts.rs
@@ -171,6 +171,39 @@ impl FontStore {
         result
     }
 
+    /// 주어진 문자에 (.notdef 아닌) 글리프가 있는 커버리지 폴백 글꼴을 찾는다
+    /// (함초롬 우선 → CJK 폴백). 주 글꼴이 특정 글자를 못 가질 때 그 글자만 이
+    /// 글꼴로 바꿔 두부(□) 글리프를 방지한다. 문자별 결과를 캐시한다.
+    pub fn font_covering(&mut self, c: char) -> Option<Arc<LoadedFont>> {
+        const COVERAGE_FALLBACKS: &[&str] = &[
+            "함초롬바탕",
+            "HCR Batang",
+            "함초롬돋움",
+            "HCR Dotum",
+            "Noto Serif CJK KR",
+            "Noto Sans CJK KR",
+            "NanumMyeongjo",
+            "NanumGothic",
+            "Apple SD Gothic Neo",
+            "AppleMyungjo",
+        ];
+        let key = format!("\u{1}cover:{}", c as u32);
+        if let Some(cached) = self.resolved.get(&key) {
+            return cached.clone();
+        }
+        let mut result = None;
+        for name in COVERAGE_FALLBACKS {
+            if let Some(font) = self.try_family(name)
+                && font_has_char(&font, c)
+            {
+                result = Some(font);
+                break;
+            }
+        }
+        self.resolved.insert(key, result.clone());
+        result
+    }
+
     fn try_family(&mut self, name: &str) -> Option<Arc<LoadedFont>> {
         let id = self.db.query(&Query {
             families: &[Family::Name(name)],
@@ -209,4 +242,12 @@ impl Default for FontStore {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// 글꼴이 해당 문자에 (.notdef 아닌) 글리프를 갖는지.
+fn font_has_char(font: &LoadedFont, c: char) -> bool {
+    rustybuzz::ttf_parser::Face::parse(&font.data, font.index)
+        .ok()
+        .and_then(|f| f.glyph_index(c))
+        .is_some_and(|g| g.0 != 0)
 }

--- a/crates/hwp-render/src/layout.rs
+++ b/crates/hwp-render/src/layout.rs
@@ -102,14 +102,19 @@ pub fn layout_document(
                 warnings.push("PAGE_DEF 없음 — A4 기본값 사용".to_string());
                 default_page()
             });
-        let (w, h) = (
-            page_def.width.to_pt() as f32,
-            page_def.height.to_pt() as f32,
-        );
+        // 가로(landscape, PAGE_DEF attr bit0): 용지를 90° 돌려 폭↔높이를 맞바꾼다.
+        // (이전엔 방향 무시 → 가로 문서가 세로로 렌더돼 우측 열이 잘렸다.)
+        let landscape = page_def.attr & 1 != 0;
+        let (paper_w_hu, paper_h_hu) = if landscape {
+            (page_def.height.0, page_def.width.0)
+        } else {
+            (page_def.width.0, page_def.height.0)
+        };
+        let (w, h) = (paper_w_hu as f32 / 100.0, paper_h_hu as f32 / 100.0);
         let body_left = page_def.margin_left.to_pt() as f32;
         let body_top = (page_def.margin_top.0 + page_def.margin_header.0) as f32 / 100.0;
         let body_width =
-            (page_def.width.0 - page_def.margin_left.0 - page_def.margin_right.0) as f32 / 100.0;
+            (paper_w_hu - page_def.margin_left.0 - page_def.margin_right.0) as f32 / 100.0;
         // 본문 영역 하한 (넘침 분할 기준)
         let body_bottom = h - (page_def.margin_bottom.0 + page_def.margin_footer.0) as f32 / 100.0;
 

--- a/crates/hwp-render/src/layout.rs
+++ b/crates/hwp-render/src/layout.rs
@@ -889,22 +889,27 @@ fn layout_table(
             .iter()
             .sum();
         let (ml, mr, mt, mb) = cell_margins(table, cell);
-        let mut scratch = PageList {
-            width_pt: page.width_pt,
-            height_pt: page.height_pt,
-            items: Vec::new(),
+        // 빈 셀은 스크래치 레이아웃(할당+셰이핑)을 생략 — 내용 높이 0(여백 mt+mb는 아래서 반영).
+        let content_h = if cell.paragraphs.is_empty() {
+            0.0
+        } else {
+            let mut scratch = PageList {
+                width_pt: page.width_pt,
+                height_pt: page.height_pt,
+                items: Vec::new(),
+            };
+            let mut scratch_warn = Vec::new();
+            layout_box_paragraphs(
+                doc,
+                store,
+                &mut scratch,
+                &cell.paragraphs,
+                0.0,
+                0.0,
+                (cw - ml - mr).max(4.0),
+                &mut scratch_warn,
+            )
         };
-        let mut scratch_warn = Vec::new();
-        let content_h = layout_box_paragraphs(
-            doc,
-            store,
-            &mut scratch,
-            &cell.paragraphs,
-            0.0,
-            0.0,
-            (cw - ml - mr).max(4.0),
-            &mut scratch_warn,
-        );
         content_h_by_cell.push(content_h);
         let needed = content_h + mt + mb;
         let span = (cell.row_span as usize).max(1);

--- a/crates/hwp-render/src/layout.rs
+++ b/crates/hwp-render/src/layout.rs
@@ -829,6 +829,23 @@ fn layout_para_objects(
 }
 
 /// 표 하나를 (x, y)에 배치하고 높이를 반환한다.
+/// 셀 여백 (왼/오른/위/아래) pt — 셀 지정 → 표 기본 → 한글 기본.
+fn cell_margins(table: &Table, cell: &hwp_model::Cell) -> (f32, f32, f32, f32) {
+    let m = if cell.margins.iter().any(|&v| v > 0) {
+        cell.margins
+    } else if table.inner_margins.iter().any(|&v| v > 0) {
+        table.inner_margins
+    } else {
+        DEFAULT_CELL_MARGINS
+    };
+    (
+        m[0] as f32 / 100.0,
+        m[1] as f32 / 100.0,
+        m[2] as f32 / 100.0,
+        m[3] as f32 / 100.0,
+    )
+}
+
 fn layout_table(
     doc: &Document,
     store: &mut FontStore,
@@ -856,11 +873,61 @@ fn layout_table(
     fill_unknown(&mut col_w, 60.0);
     fill_unknown(&mut row_h, 18.0);
 
+    // 측정 패스: 실제 내용 높이로 행 높이를 확장한다(저장된 cell.height는 한글의 줄바꿈
+    // 기준이라, 셰이핑/합성 줄바꿈이 더 많은 줄을 만들면 내용이 다음 행을 침범해 겹친다 —
+    // 실측 높이와 max로 행을 늘려 방지). 스크래치 페이지에 그려 높이만 잰다. 실측 내용
+    // 높이는 세로정렬에 재사용한다(재측정 회피).
+    let mut spanned: Vec<(usize, usize, f32)> = Vec::new(); // (시작행, 스팬, 필요높이)
+    let mut content_h_by_cell: Vec<f32> = Vec::with_capacity(table.cells.len());
+    for cell in &table.cells {
+        let (c, r) = (cell.col as usize, cell.row as usize);
+        if c >= cols || r >= rows {
+            content_h_by_cell.push(0.0);
+            continue;
+        }
+        let cw: f32 = col_w[c..(c + cell.col_span as usize).min(cols)]
+            .iter()
+            .sum();
+        let (ml, mr, mt, mb) = cell_margins(table, cell);
+        let mut scratch = PageList {
+            width_pt: page.width_pt,
+            height_pt: page.height_pt,
+            items: Vec::new(),
+        };
+        let mut scratch_warn = Vec::new();
+        let content_h = layout_box_paragraphs(
+            doc,
+            store,
+            &mut scratch,
+            &cell.paragraphs,
+            0.0,
+            0.0,
+            (cw - ml - mr).max(4.0),
+            &mut scratch_warn,
+        );
+        content_h_by_cell.push(content_h);
+        let needed = content_h + mt + mb;
+        let span = (cell.row_span as usize).max(1);
+        if span == 1 {
+            row_h[r] = row_h[r].max(needed);
+        } else {
+            spanned.push((r, span, needed));
+        }
+    }
+    // row_span>1 셀: 스팬 행 합이 부족하면 마지막 스팬 행에 부족분을 더한다.
+    for (r, span, needed) in spanned {
+        let end = (r + span).min(rows);
+        let cur: f32 = row_h[r..end].iter().sum();
+        if end > r && needed > cur {
+            row_h[end - 1] += needed - cur;
+        }
+    }
+
     // 누적 오프셋
     let col_x: Vec<f32> = prefix_sums(&col_w, x);
     let row_y: Vec<f32> = prefix_sums(&row_h, y);
 
-    for cell in &table.cells {
+    for (ci, cell) in table.cells.iter().enumerate() {
         let (c, r) = (cell.col as usize, cell.row as usize);
         if c >= cols || r >= rows {
             warnings.push(format!("셀 주소가 표 범위를 벗어남: ({r},{c})"));
@@ -891,26 +958,23 @@ fn layout_table(
             });
         }
 
-        // 2) 내용 — 셀 여백(셀 지정 → 표 기본 → 한글 기본) 적용
-        let margins = if cell.margins.iter().any(|&m| m > 0) {
-            cell.margins
-        } else if table.inner_margins.iter().any(|&m| m > 0) {
-            table.inner_margins
-        } else {
-            DEFAULT_CELL_MARGINS
+        // 2) 내용 — 셀 여백 + 세로정렬(list_attr bits5~6: 0=위, 1=가운데, 2=아래).
+        //    측정 패스의 실측 내용 높이로 남는 공간을 계산해 오프셋한다.
+        let (ml, mr, mt, mb) = cell_margins(table, cell);
+        let content_h = content_h_by_cell.get(ci).copied().unwrap_or(0.0);
+        let avail = (ch - mt - mb - content_h).max(0.0);
+        let voff = match (cell.list_attr >> 5) & 0x3 {
+            1 => avail * 0.5,
+            2 => avail,
+            _ => 0.0,
         };
-        let (ml, mr, mt) = (
-            margins[0] as f32 / 100.0,
-            margins[1] as f32 / 100.0,
-            margins[2] as f32 / 100.0,
-        );
         layout_box_paragraphs(
             doc,
             store,
             page,
             &cell.paragraphs,
             cx + ml,
-            cy + mt,
+            cy + mt + voff,
             (cw - ml - mr).max(4.0),
             warnings,
         );

--- a/crates/hwp-render/src/pdf.rs
+++ b/crates/hwp-render/src/pdf.rs
@@ -32,8 +32,8 @@ use crate::shape::ShapedRun;
 
 /// 합성 기울임 탄젠트 (png.rs/svg.rs와 동일, ≈12°).
 const ITALIC_SKEW: f32 = 0.2126;
-/// 합성 굵게 스트로크 굵기 (글자 크기 대비, png.rs와 동일).
-const BOLD_STROKE: f32 = 0.03;
+/// 합성 굵게 스트로크 굵기 (글자 크기 대비, png.rs와 동일). 한컴 굵게 대조 보정(4.5%).
+const BOLD_STROKE: f32 = 0.045;
 
 /// 문서 전체를 단일 멀티페이지 PDF 바이트로 렌더링한다.
 pub fn render_pdf(list: &DisplayList, warnings: &mut Vec<String>) -> Result<Vec<u8>, RenderError> {

--- a/crates/hwp-render/src/png.rs
+++ b/crates/hwp-render/src/png.rs
@@ -326,8 +326,9 @@ fn draw_glyph_run(
             } else {
                 pixmap.fill_path(&path, &paint, FillRule::Winding, t, None);
                 if run.bold {
+                    // 합성 굵게 4.5% (한컴 굵게 대조 보정 — pdf.rs BOLD_STROKE와 동일)
                     let stroke = Stroke {
-                        width: run.size_pt * 0.03 / glyph_scale,
+                        width: run.size_pt * 0.045 / glyph_scale,
                         ..Stroke::default()
                     };
                     pixmap.stroke_path(&path, &paint, &stroke, t, None);

--- a/crates/hwp-render/src/shape.rs
+++ b/crates/hwp-render/src/shape.rs
@@ -260,9 +260,12 @@ fn shape_piece(
                 .is_some_and(|g| g.0 != 0)
     };
 
-    // (글꼴, 텍스트, 시작 wchar) 세그먼트로 분할 — Text 글자는 각 1 wchar.
+    // (글꼴, 텍스트, 시작 wchar) 세그먼트로 분할. start_wchar는 UTF-16 코드유닛
+    // 오프셋이므로 문자마다 len_utf16()(BMP=1, 그 외=2)만큼 진행한다(비-BMP 글자에서
+    // start_wchar 어긋나 링크범위·lineseg 매핑이 깨지지 않게).
     let mut segments: Vec<(Arc<LoadedFont>, String, u32)> = Vec::new();
-    for (cur, c) in (start_wchar..).zip(text.chars()) {
+    let mut cur = start_wchar;
+    for c in text.chars() {
         let font = if primary_covers(c) {
             primary.clone()
         } else {
@@ -272,6 +275,7 @@ fn shape_piece(
             Some((f, t, _)) if Arc::ptr_eq(f, &font) => t.push(c),
             _ => segments.push((font, c.to_string(), cur)),
         }
+        cur += c.len_utf16() as u32;
     }
 
     segments
@@ -459,10 +463,13 @@ pub fn shape_plain(
     } else {
         1
     };
-    // 링크/마커는 단일 런만 사용 — 첫 세그먼트만 취한다(글자별 폴백은 본문 텍스트 전용).
-    shape_piece(store, doc, Some(&cs), lang, text, 0)
-        .into_iter()
-        .next()
+    // 합성 텍스트(수식/마커)는 단일 Run만 배치하므로 주 글꼴로 통짜 셰이핑한다.
+    // shape_piece의 글자별 폴백은 여러 Run으로 쪼개지는데, 여기서 첫 세그먼트만 취하면
+    // 나머지 글자가 사라진다(내용 누락). 미지원 글자는 tofu로 두되 누락은 막는다
+    // (글자별 폴백은 본문 shape_range 경로 전용).
+    let face_id = cs.face_ids.get(lang).copied().unwrap_or(0);
+    let font = store.resolve(doc, lang, face_id)?;
+    shape_with_font(&font, &cs, lang, text, 0, cs.is_bold())
 }
 
 /// 각주/미주 본문 마커(윗첨자 번호). 주변 글자모양을 따라 ~65% 크기로 줄이고
@@ -589,5 +596,19 @@ mod link_tests {
         let mut items2 = vec![run_at(9)];
         apply_link_style(&mut items2, &[]);
         assert!(matches!(&items2[0], InlineItem::Run(r) if !r.underline));
+    }
+
+    #[test]
+    fn shape_plain_전체_텍스트_보존() {
+        // 회귀 가드: shape_plain 이 (구버전처럼) 폴백 첫 세그먼트만 취해 나머지 글자를
+        // 버리지 않고 전체 텍스트를 셰이핑해야 한다. 폰트 부재 환경은 resolve→None 으로
+        // 스킵(폰트 있는 CI에서 검출).
+        let doc = hwp_convert::from_markdown("x"); // default_header(함초롬바탕) 폰트 포함
+        let mut store = FontStore::new();
+        let text = "abc 123 가나다";
+        if let Some(run) = shape_plain(&mut store, &doc, text, 10.0, 0) {
+            assert_eq!(run.text, text, "전체 텍스트 보존(세그먼트 누락 없음)");
+            assert!(!run.glyphs.is_empty(), "글리프 생성됨");
+        }
     }
 }

--- a/crates/hwp-render/src/shape.rs
+++ b/crates/hwp-render/src/shape.rs
@@ -206,9 +206,12 @@ pub fn shape_range_notes(
             continue;
         }
         let shape = doc.header.char_shapes.get(piece.shape_id as usize);
-        match shape_piece(store, doc, shape, piece.lang, &piece.text, piece.start) {
-            Some(run) => out.push(InlineItem::Run(run)),
-            None => warnings.push(format!("셰이핑 실패: {:?}", piece.text)),
+        let runs = shape_piece(store, doc, shape, piece.lang, &piece.text, piece.start);
+        if runs.is_empty() {
+            warnings.push(format!("셰이핑 실패: {:?}", piece.text));
+        }
+        for run in runs {
+            out.push(InlineItem::Run(run));
         }
     }
     for (_, item) in item_iter {
@@ -217,6 +220,9 @@ pub fn shape_range_notes(
     out
 }
 
+/// 한 조각을 셰이핑한다. 해석된 주 글꼴이 일부 글자를 갖지 않으면(.notdef) 그
+/// 글자만 커버리지 폴백 글꼴로 바꿔, 글꼴 경계마다 별도 [`ShapedRun`]으로 나눈다
+/// (예: macOS "휴먼명조"에 ❍(U+274D)가 없을 때 함초롬/Noto로 폴백 — 두부(□) 방지).
 fn shape_piece(
     store: &mut FontStore,
     doc: &Document,
@@ -224,12 +230,69 @@ fn shape_piece(
     lang: usize,
     text: &str,
     start_wchar: u32,
-) -> Option<ShapedRun> {
+) -> Vec<ShapedRun> {
     let default_shape = CharShape::default();
     let cs = shape.unwrap_or(&default_shape);
     let face_id = cs.face_ids.get(lang).copied().unwrap_or(0);
-    let font = store.resolve(doc, lang, face_id)?;
+    let Some(primary) = store.resolve(doc, lang, face_id) else {
+        return Vec::new();
+    };
 
+    // 요청 글꼴이 굵은(heavy) 계열인데 대체 글꼴엔 굵은 페이스가 없으면 faux-bold로
+    // 보강한다(예: HY견고딕/헤드라인M → 함초롬돋움 regular).
+    let face_name = doc
+        .header
+        .fonts
+        .get(lang)
+        .and_then(|f| f.get(face_id as usize))
+        .map(|f| f.name.as_str())
+        .unwrap_or("");
+    let bold = cs.is_bold() || is_heavy_name(face_name);
+
+    // 글자별 글꼴 배정: primary가 글리프를 가지면 primary, 아니면 커버리지 폴백.
+    let primary_face = rustybuzz::ttf_parser::Face::parse(&primary.data, primary.index).ok();
+    let primary_covers = |c: char| {
+        // 공백·제어는 항상 primary 사용(불필요한 폴백 분할 방지).
+        c.is_whitespace()
+            || primary_face
+                .as_ref()
+                .and_then(|f| f.glyph_index(c))
+                .is_some_and(|g| g.0 != 0)
+    };
+
+    // (글꼴, 텍스트, 시작 wchar) 세그먼트로 분할 — Text 글자는 각 1 wchar.
+    let mut segments: Vec<(Arc<LoadedFont>, String, u32)> = Vec::new();
+    for (cur, c) in (start_wchar..).zip(text.chars()) {
+        let font = if primary_covers(c) {
+            primary.clone()
+        } else {
+            store.font_covering(c).unwrap_or_else(|| primary.clone())
+        };
+        match segments.last_mut() {
+            Some((f, t, _)) if Arc::ptr_eq(f, &font) => t.push(c),
+            _ => segments.push((font, c.to_string(), cur)),
+        }
+    }
+
+    segments
+        .into_iter()
+        .filter_map(|(font, seg_text, seg_start)| {
+            shape_with_font(&font, cs, lang, &seg_text, seg_start, bold)
+        })
+        .collect()
+}
+
+/// 주어진 글꼴 하나로 텍스트를 셰이핑해 [`ShapedRun`]을 만든다(첨자·자간·장평·
+/// 음영/그림자/외곽선/양각/음각 효과 필드까지 채운다). `bold`는 호출부가 결정
+/// (요청이 굵음이거나, 굵은 페이스 없는 heavy 글꼴이라 faux-bold가 필요할 때 true).
+fn shape_with_font(
+    font: &Arc<LoadedFont>,
+    cs: &CharShape,
+    lang: usize,
+    text: &str,
+    start_wchar: u32,
+    bold: bool,
+) -> Option<ShapedRun> {
     let face = rustybuzz::Face::from_slice(&font.data, font.index)?;
     let upem = face.units_per_em() as f32;
 
@@ -278,11 +341,11 @@ fn shape_piece(
     }
 
     Some(ShapedRun {
-        font,
+        font: font.clone(),
         size_pt,
         x_scale,
         color: cs.text_color,
-        bold: cs.is_bold(),
+        bold,
         italic: cs.is_italic(),
         underline: cs.has_underline(),
         strike: cs.has_strike(),
@@ -301,6 +364,22 @@ fn shape_piece(
         text: text.to_string(),
         start_wchar,
     })
+}
+
+/// 글꼴 이름이 굵은(heavy/bold) 계열인지 — 대체 글꼴 faux-bold 판단용.
+fn is_heavy_name(name: &str) -> bool {
+    const HEAVY: &[&str] = &[
+        "견고딕",
+        "견명조",
+        "헤드라인",
+        "굵은",
+        "Heavy",
+        "Black",
+        "ExtraBold",
+        "Ultra",
+        "Bold",
+    ];
+    HEAVY.iter().any(|k| name.contains(k))
 }
 
 /// 하이퍼링크 색(COLORREF 0x00BBGGRR = 파랑).
@@ -380,7 +459,10 @@ pub fn shape_plain(
     } else {
         1
     };
+    // 링크/마커는 단일 런만 사용 — 첫 세그먼트만 취한다(글자별 폴백은 본문 텍스트 전용).
     shape_piece(store, doc, Some(&cs), lang, text, 0)
+        .into_iter()
+        .next()
 }
 
 /// 각주/미주 본문 마커(윗첨자 번호). 주변 글자모양을 따라 ~65% 크기로 줄이고
@@ -407,7 +489,10 @@ fn note_mark_run(
     cs.base_size = ((base_size as f32) * 0.65).max(500.0) as i32;
     cs.attr = 0; // 마커엔 굵게/기울임 등 합성 효과 불필요
     let text = number.to_string();
-    let mut run = shape_piece(store, doc, Some(&cs), 1, &text, pos)?;
+    // 마커는 단일 런(숫자) — 첫 세그먼트만 취한다.
+    let mut run = shape_piece(store, doc, Some(&cs), 1, &text, pos)
+        .into_iter()
+        .next()?;
     // 윗첨자: 위로 올림(y-up 좌표, 백엔드가 baseline-y에서 y_offset만큼 올림).
     let raise = (base_size as f32 / 100.0) * 0.34;
     for g in &mut run.glyphs {

--- a/crates/hwp-render/src/svg.rs
+++ b/crates/hwp-render/src/svg.rs
@@ -88,9 +88,10 @@ fn render_page(page: &PageList) -> String {
                         0.025 * upem
                     )
                 } else if run.bold {
+                    // 합성 굵게 4.5% (한컴 굵게 대조 보정 — pdf.rs BOLD_STROKE와 동일)
                     format!(
                         r#" fill="{color}" stroke="{color}" stroke-width="{:.1}""#,
-                        0.03 * upem
+                        0.045 * upem
                     )
                 } else {
                     format!(r#" fill="{color}""#)

--- a/crates/hwp5/src/doc_info.rs
+++ b/crates/hwp5/src/doc_info.rs
@@ -245,6 +245,8 @@ fn parse_char_shape(data: &[u8]) -> Result<CharShape> {
         offsets,
         base_size,
         attr,
+        // HWP5 raw 비트(18~20)는 DIFFSPEC라 취소선으로 신뢰하지 않음 (가짜 취소선 방지).
+        strike: false,
         shadow_gap,
         text_color,
         underline_color,

--- a/crates/hwpx/src/read/header.rs
+++ b/crates/hwpx/src/read/header.rs
@@ -223,7 +223,8 @@ pub fn parse_header(xml: &str) -> Result<(DocHeader, Vec<String>)> {
                             let shape = attr(e, "shape");
                             let visible = matches!(shape.as_deref(), Some(s) if s != "NONE" && !s.contains("3D"));
                             if visible {
-                                cs.attr |= 1 << 18;
+                                cs.attr |= 1 << 18; // 바이트 왕복 보존
+                                cs.strike = true; // 의미 플래그 (has_strike 근거)
                             }
                         }
                     }


### PR DESCRIPTION
렌더 충실도 수정 5건입니다. 각 항목은 실문서를 한글(Hancom) PrvImage 썸네일과 대조해 검증했습니다. PR #1(기능)과 **독립**이며, 최신 `main`(PR #2 머지 후) 위에 5개 focused 커밋으로 얹었습니다.

## 수정 항목

1. **faux-bold weight 3% → 4.5%** (`pdf.rs`/`png.rs`/`svg.rs`)
   합성 굵게(글꼴에 굵은 얼굴이 없을 때 윤곽선 스트로크로 근사)가 한컴 굵게 대비 너무 가늘었다. 세 백엔드의 스트로크 굵기를 글자 크기의 4.5%로 통일 보정(outline 0.025는 유지).

2. **landscape 용지** (`layout.rs` `layout_document`)
   `PAGE_DEF` attr bit0(가로, hwpx `landscape="WIDELY"`)를 무시하고 늘 세로로 배치 → 가로 문서가 세로 페이지로 렌더돼 우측 열이 잘렸다. 방향을 감지해 용지 폭/높이를 스왑하고 본문 폭을 재계산. 세로 문서는 동작 불변.

3. **HWP5 취소선 DIFFSPEC** (`hwp-model/header.rs` + readers + `hwp-convert/format.rs`)
   HWP5 CharShape 속성 비트 18~20("취소선")은 스펙 이견(DIFFSPEC) 영역이라 신뢰할 수 없다 — 이 비트가 켜졌지만 한글이 평문으로 렌더하는 실문서(보도자료 등)에 가짜 취소선이 그어졌다. raw 비트 대신 의미 플래그 `CharShape.strike`(serde default, 바이너리 미기록)를 도입: `has_strike()`가 이 플래그를 읽고, HWP5 reader는 켜지 않으며(가짜 취소선 제거), HWPX reader는 visible `<hp:strikeout>`(NONE/3D 제외)일 때만 켠다. `apply_format`(set-format)도 함께 설정해 편집↔렌더↔hwpx SOLID 쓰기 일관. attr는 보존돼 바이트 왕복 무영향.

4. **글자별 커버리지 폴백(두부 □ 방지)** (`fonts.rs`/`shape.rs`)
   주 글꼴이 특정 글자를 갖지 않으면 두부(□)로 렌더됐다(예: macOS "휴먼명조"의 일부 기호). `shape_piece`를 단일→`Vec`로 바꿔, primary가 커버 못 하는 글자만 커버리지 폴백 글꼴(함초롬→Noto/Nanum)로 바꾸고 글꼴 경계마다 별도 런으로 분할. 셰이핑 본체는 `shape_with_font`로 추출(첨자·자간·장평·음영/그림자/외곽선/양각/음각 필드 유지). 굵은(heavy) 이름 글꼴에 굵은 페이스가 없으면 faux-bold 보강. 본문은 모든 폴백 세그먼트 사용, 링크·각주 마커는 단일 런. 일반 텍스트는 단일 세그먼트 = 기존 출력 동일.

5. **표 셀 세로정렬 + 실측 행 높이** (`layout.rs` `layout_table`)
   셀 내용을 항상 상단 고정 → `list_attr` bits5~6(0=위/1=가운데/2=아래)로 세로 오프셋. 또한 저장된 `cell.height`는 한글 줄바꿈 기준이라 우리 셰이핑이 더 많은 줄을 만들면 내용이 다음 행을 침범했다 → 렌더 전 측정 패스로 실측 내용 높이를 재고 행 높이를 확장(row_span>1은 마지막 스팬 행에 가산). 실측 높이는 세로정렬 계산에 재사용.

## 검증
- `cargo build`/`fmt --all --check`/`clippy --all-targets -- -D warnings` 클린.
- `cargo test --workspace` **137 통과 / 0 실패** — 픽스처 있음·없음 모두. 기존 render/golden/pdf/취소선 테스트 그대로 통과(폴백은 단일 세그먼트로 회귀 없음).
- `git merge-tree main` 충돌 0.
- 실문서 렌더 육안 확인(표 셀 겹침 없음, 굵게 무게, 두부 없음).

> 픽스처 바이너리는 로컬 검증만(업스트림 정책). PR #1(기능)과 독립적으로 리뷰 가능합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
