### PR TITLE
ci: 버전 관리 기반 태그 트리거 릴리스 (테스트 통과 + 버전 일치 게이트)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
   pull_request:
+  # release.yml 이 태그 릴리스 전에 이 test 잡을 재사용(테스트 통과 게이트)한다.
+  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+# vX.Y.Z 태그를 푸시하면: (1) 테스트 통과 (2) 태그↔Cargo.toml 버전 일치 를 확인한
+# 뒤에만, 플랫폼별 `hwp` 바이너리를 빌드해 GitHub Release(아카이브 + sha256)로 게시한다.
+# 릴리스 절차: scripts/release.sh X.Y.Z  →  git push origin main && git push origin vX.Y.Z
+on:
+  push:
+    tags: ["v[0-9]+.[0-9]+.[0-9]+*"] # v1.2.3, v1.2.3-rc1 등
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # 테스트 통과 게이트 — ci.yml 의 fmt/clippy/test 잡을 그대로 재사용(단일 진실).
+  test:
+    uses: ./.github/workflows/ci.yml
+
+  # 버전 관리 게이트 — 태그가 Cargo.toml [workspace.package] version 과 일치해야 릴리스.
+  verify-version:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: 태그 ↔ Cargo.toml 버전 일치 확인
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          ver=$(awk '/^\[workspace\.package\]/{p=1;next} /^\[/{p=0} p&&/^version[[:space:]]*=/{sub(/^version[[:space:]]*=[[:space:]]*"/,"");sub(/".*/,"");print;exit}' Cargo.toml)
+          echo "tag=$tag  Cargo.toml=$ver"
+          if [ "$tag" != "$ver" ]; then
+            echo "::error::태그 v$tag 가 Cargo.toml [workspace.package] version=$ver 와 불일치. scripts/release.sh 로 버전 bump 후 태깅하세요."
+            exit 1
+          fi
+
+  # 릴리스 셸 생성(커밋/PR 기반 자동 노트) — 한 번만. 이미 있으면 건너뜀(재실행 안전).
+  create-release:
+    needs: [test, verify-version]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: GitHub Release 생성
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 \
+            || gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes --verify-tag
+
+  # 플랫폼별 `hwp` 바이너리 빌드 → 아카이브(tar.gz/zip) + sha256 을 릴리스에 업로드.
+  upload-assets:
+    needs: create-release
+    strategy:
+      fail-fast: false # 한 타깃 실패가 다른 타깃을 취소하지 않게
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      # 릴리스 바이너리는 stable 로 빌드(최신 최적화). MSRV 호환은 test 잡이 이미 보장.
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: hwp
+          target: ${{ matrix.target }}
+          archive: $bin-$tag-$target
+          checksum: sha256
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,9 @@ name: Release
 # 릴리스 절차: scripts/release.sh X.Y.Z  →  git push origin main && git push origin vX.Y.Z
 on:
   push:
-    tags: ["v[0-9]+.[0-9]+.[0-9]+*"] # v1.2.3, v1.2.3-rc1 등
+    # glob 패턴(정규식 아님) — 멀티자리/프리릴리스 모두 매칭(v10.2.3, v0.2.0-rc1).
+    # 정확한 버전 검증은 아래 verify-version 잡이 담당한다.
+    tags: ["v*.*.*"]
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -77,6 +77,31 @@ cargo install --path crates/hwp-cli   # `hwp` 바이너리 설치
 
 > 이후 예시에서 `<repo>`는 위에서 클론한 디렉터리의 절대 경로를 가리킨다.
 
+### 다운로드 (사전 빌드 바이너리)
+
+각 [릴리스](https://github.com/YeolHanMyeong/hwp-cli/releases)에 플랫폼별 `hwp` 아카이브와 `.sha256` 체크섬이 첨부된다:
+
+| 플랫폼 | 아카이브 |
+|---|---|
+| Linux x86_64 | `hwp-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz` |
+| macOS Apple Silicon | `hwp-vX.Y.Z-aarch64-apple-darwin.tar.gz` |
+| macOS Intel | `hwp-vX.Y.Z-x86_64-apple-darwin.tar.gz` |
+| Windows x86_64 | `hwp-vX.Y.Z-x86_64-pc-windows-msvc.zip` |
+
+압축을 풀어 `hwp`를 PATH에 두면 된다(체크섬 검증: `shasum -a 256 -c hwp-*.sha256`).
+렌더/PDF엔 CJK 폰트가 필요하고(위 폰트 지정 참고), 텍스트 추출·변환은 폰트 없이 동작한다.
+
+### 릴리스 (메인테이너)
+
+버전은 워크스페이스 `Cargo.toml`의 `[workspace.package] version`이 단일 기준(SSOT)이다.
+
+```sh
+scripts/release.sh 0.2.0                        # 버전 bump + 커밋 + 태그 (푸시는 수동)
+git push origin main && git push origin v0.2.0  # 태그 푸시가 릴리스를 트리거
+```
+
+`vX.Y.Z` 태그를 푸시하면 `release.yml`이 ① 테스트(fmt/clippy/test) 통과 ② 태그↔`Cargo.toml` 버전 일치를 확인한 **뒤에만** 4개 플랫폼 바이너리를 빌드해 GitHub Release로 게시한다. 태그가 커밋된 버전과 다르면 릴리스가 차단된다.
+
 ## 빠른 시작 (Quickstart)
 
 ```sh

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# scripts/release.sh X.Y.Z
+#
+# 워크스페이스 버전(Cargo.toml [workspace.package] version)을 bump 하고 커밋 + 태그를
+# 만든다. 푸시는 수동 — 태그 푸시가 release.yml 을 트리거해 실제 릴리스가 일어난다:
+#
+#     scripts/release.sh 0.2.0
+#     git push origin main && git push origin v0.2.0
+#
+# 자체 점검:  scripts/release.sh --self-test
+set -euo pipefail
+
+# 시맨틱 버전(프리릴리스는 하이픈으로 시작): 0.2.0, 1.10.3, 0.2.0-rc1, 0.2.0-rc.1
+semver_ok() { printf '%s' "$1" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; }
+# Cargo.toml [workspace.package] 섹션의 version 값을 뽑는다 (awk — GNU/BSD 이식성).
+extract_version() {
+  awk '/^\[workspace\.package\]/{p=1;next} /^\[/{p=0} p&&/^version[[:space:]]*=/{sub(/^version[[:space:]]*=[[:space:]]*"/,"");sub(/".*/,"");print;exit}' "$1"
+}
+
+# --- 자체 점검(git 부작용 없음) ---------------------------------------------
+if [ "${1:-}" = "--self-test" ]; then
+  for v in 0.2.0 1.10.3 0.2.0-rc1 10.0.0; do
+    semver_ok "$v" || { echo "self-test FAIL: '$v' 는 통과해야 함"; exit 1; }
+  done
+  for v in "" v1.2.3 1.2 1.2.3.4 1.2.x abc; do
+    semver_ok "$v" && { echo "self-test FAIL: '$v' 는 거부돼야 함"; exit 1; }
+  done
+  cur=$(extract_version "$(git rev-parse --show-toplevel)/Cargo.toml")
+  semver_ok "$cur" || { echo "self-test FAIL: Cargo.toml version '$cur' 파싱 불가"; exit 1; }
+  echo "self-test OK (semver 규칙 + Cargo.toml=$cur)"
+  exit 0
+fi
+
+# --- 릴리스 준비 -------------------------------------------------------------
+ver="${1:-}"
+[ -n "$ver" ] || { echo "usage: scripts/release.sh X.Y.Z" >&2; exit 2; }
+semver_ok "$ver" || { echo "오류: 시맨틱 버전 형식이 아닙니다: '$ver' (예: 0.2.0, 0.2.0-rc1)" >&2; exit 1; }
+
+cd "$(git rev-parse --show-toplevel)"
+
+[ -z "$(git status --porcelain)" ] || { echo "오류: 작업 트리가 깨끗하지 않습니다. 커밋/스태시 후 다시 실행하세요." >&2; exit 1; }
+if git rev-parse "v$ver" >/dev/null 2>&1; then
+  echo "오류: 태그 v$ver 가 이미 존재합니다." >&2; exit 1
+fi
+
+old=$(extract_version Cargo.toml)
+[ "$old" != "$ver" ] || { echo "오류: 이미 버전이 $ver 입니다." >&2; exit 1; }
+
+# [workspace.package] 섹션의 첫 version 라인만 교체.
+perl -0pi -e 's/(\[workspace\.package\][^\[]*?\nversion = ")[^"]*(")/${1}'"$ver"'${2}/s' Cargo.toml
+
+new=$(extract_version Cargo.toml)
+if [ "$new" != "$ver" ]; then
+  echo "오류: Cargo.toml 버전 교체 실패(현재: '$new'). 수동 확인 필요." >&2
+  git checkout -- Cargo.toml
+  exit 1
+fi
+
+cargo update --workspace >/dev/null # Cargo.lock 의 워크스페이스 크레이트 버전 동기화
+
+git add Cargo.toml Cargo.lock
+git commit -m "chore(release): v$ver"
+git tag -a "v$ver" -m "v$ver"
+
+cat <<EOF
+✅ v$ver 준비 완료 ($old → $ver, 커밋 + 태그 생성).
+   푸시하면 릴리스 CI(테스트 통과 + 버전 확인 후 빌드)가 트리거됩니다:
+     git push origin main && git push origin v$ver
+EOF

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -39,7 +39,7 @@ semver_ok "$ver" || { echo "오류: 시맨틱 버전 형식이 아닙니다: '$v
 cd "$(git rev-parse --show-toplevel)"
 
 [ -z "$(git status --porcelain)" ] || { echo "오류: 작업 트리가 깨끗하지 않습니다. 커밋/스태시 후 다시 실행하세요." >&2; exit 1; }
-if git rev-parse "v$ver" >/dev/null 2>&1; then
+if git rev-parse -q --verify "refs/tags/v$ver" >/dev/null; then
   echo "오류: 태그 v$ver 가 이미 존재합니다." >&2; exit 1
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,7 +56,10 @@ if [ "$new" != "$ver" ]; then
   exit 1
 fi
 
-cargo update --workspace >/dev/null # Cargo.lock 의 워크스페이스 크레이트 버전 동기화
+# Cargo.lock 의 워크스페이스 크레이트 버전만 재잠금. --workspace 는 워크스페이스
+# 패키지만 대상이고, --offline 로 레지스트리 조회를 막아 외부 의존성은 절대 bump 되지
+# 않게 한다(릴리스 커밋에 원치 않는 dependency 변경 혼입 방지).
+cargo update --workspace --offline >/dev/null
 
 git add Cargo.toml Cargo.lock
 git commit -m "chore(release): v$ver"


### PR DESCRIPTION
버전 관리 기반 릴리스 자동화를 추가합니다. `vX.Y.Z` 태그를 푸시하면 **테스트 통과 + 태그↔버전 일치**를 확인한 뒤에만 플랫폼별 `hwp` 바이너리를 빌드해 GitHub Release로 게시합니다. PR #1/#3과 독립이며 최신 `main` 위에 얹었습니다.

## 동작

`vX.Y.Z` 태그 push → `release.yml`:
1. **`test`** — `ci.yml`의 fmt/clippy/test 잡을 그대로 재사용(`workflow_call`). 테스트 통과 게이트.
2. **`verify-version`** — 태그(`vX.Y.Z`)가 `Cargo.toml [workspace.package] version`과 일치하는지 확인. 불일치면 릴리스 차단(버전 bump 없이 태깅한 사고 방지).
3. **`create-release`** — `needs: [test, verify-version]`. `gh release create --generate-notes`로 릴리스 셸 생성(재실행 안전).
4. **`upload-assets`** — 4개 타깃 매트릭스에서 `taiki-e/upload-rust-binary-action`으로 빌드·아카이브·sha256·업로드:
   - `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin`, `x86_64-apple-darwin`, `x86_64-pc-windows-msvc`

즉, 릴리스는 **테스트 통과 + 버전 일치**를 모두 충족할 때만 일어납니다.

## 버전 관리

버전 SSOT는 `Cargo.toml`의 `[workspace.package] version`입니다.

```sh
scripts/release.sh 0.2.0                        # semver/clean-tree/중복태그 가드 → bump + Cargo.lock 동기화 + 커밋 + 태그
git push origin main && git push origin v0.2.0  # 태그 push 가 릴리스 트리거
```

`release.sh`는 `--self-test`(semver 규칙 + Cargo.toml 파싱 검증)를 포함하고 GNU/BSD(awk) 이식성을 갖습니다.

## 포함 변경
- `.github/workflows/release.yml` (신규)
- `.github/workflows/ci.yml` — `workflow_call` 추가(테스트 잡 재사용, push/PR CI 동작 불변)
- `scripts/release.sh` (신규, 실행권한)
- `README.md` — 다운로드(4 플랫폼 아카이브 + sha256) + 릴리스 절차

## 검증
- 두 워크플로 YAML 구문·잡 그래프 확인(`create-release` needs `test`+`verify-version`).
- 버전 가드 추출기(awk, GNU/BSD)와 태그-비교 로직 로컬 확인(일치=통과, 불일치=차단).
- `release.sh --self-test` 통과, 버전 치환이 `[workspace.package]`만 바꾸고 외부 의존성 버전은 불변임을 확인.
- 실제 태그 릴리스는 메인테이너 첫 태그에서 e2e 됩니다(이 PR은 릴리스를 만들지 않음).

> `taiki-e/upload-rust-binary-action`은 Rust CLI 릴리스에 널리 쓰이는 액션으로 타깃 설치·빌드·아카이브·체크섬·업로드를 처리합니다. 코드사인/노터라이즈, crates.io/Homebrew 배포는 범위 밖.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
