### PR TITLE
  hwpx fill 정합성 3종 — lineseg 캐시 제거·미리보기 동기화·zip 속성 복원

### DIFF
--- a/crates/hwp-cli/src/commands/fill.rs
+++ b/crates/hwp-cli/src/commands/fill.rs
@@ -1,8 +1,10 @@
 //! `hwp fill` — 템플릿 채우기.
 //!
 //! 두 경로: (1) **자리표시자 치환**(기본) — `Contents/section*.xml`의 `{{name}}`만
-//! 외과 치환하고 나머지 패키지 엔트리(미리보기·compat·BinData)를 바이트 보존(hwpx
-//! 입력 전용). (2) **데이터 구동 표 채우기** — `--data`에 `tables` 지시가 있으면 IR로
+//! 외과 치환하고 나머지 패키지 엔트리(썸네일·compat·BinData)를 바이트 보존(hwpx
+//! 입력 전용). 치환 문단의 줄 배치 캐시 제거, 미리보기 텍스트(PrvText)·content.hpf
+//! 동기 치환, zip 엔트리 메타데이터 복원까지 수행한다([`hwpx::patch`] 참조).
+//! (2) **데이터 구동 표 채우기** — `--data`에 `tables` 지시가 있으면 IR로
 //! 읽어 표 행을 데이터 수만큼 늘리고(add_rows) 셀을 채운 뒤 다시 쓴다(.hwp/.hwpx 모두).
 
 use std::collections::BTreeMap;

--- a/crates/hwpx/src/patch.rs
+++ b/crates/hwpx/src/patch.rs
@@ -12,6 +12,10 @@
 //!   않은 문단은 바이트 그대로 두고, 치환이 전혀 없는 섹션은 raw 복사한다.
 //! - `Preview/PrvText.txt`(UTF-8/UTF-16LE 자동 감지)와 `Contents/content.hpf`에
 //!   남은 자리표시자도 함께 치환한다 (탐색기·한글 미리보기에 옛 텍스트 잔류 방지).
+//! - 다시 쓴 엔트리의 zip 중앙 디렉터리 메타데이터(생성 시스템·수정 시각·
+//!   external attr)를 원본 값으로 되돌린다. hwp2hwpx 등 Java 변환본은
+//!   FAT origin(생성 시스템 0)·external attr 0인데, 재작성 시 기본값이 섞이면
+//!   한글이 "손상/변조" 경고를 띄우는 사례가 있다.
 //!
 //! 한계: 자리표시자가 `<hp:t>` 런/문단 경계를 가로지르면(예: `<hp:t>{{기</hp:t>
 //! <hp:t>관명}}</hp:t>`) 문자열 치환이 매칭하지 못한다. 템플릿은 자리표시자를
@@ -89,6 +93,10 @@ pub fn fill_placeholders(
         }
     }
     zip.finish()?;
+
+    // 다시 쓴 엔트리의 zip 메타데이터를 원본과 동일하게 복원 (best-effort:
+    // ZIP64 등 파싱 불가 구조면 그대로 둔다 — 치환 결과 자체는 유효).
+    sync_entry_metadata(input, output)?;
     Ok(counts)
 }
 
@@ -270,4 +278,145 @@ fn xml_escape(s: &str) -> String {
         }
     }
     out
+}
+
+// ---------------------------------------------------------------------------
+// zip 엔트리 메타데이터 복원
+// ---------------------------------------------------------------------------
+
+/// zip 중앙 디렉터리 엔트리의 메타데이터 (진단·검증용).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ZipEntryMeta {
+    /// version made by — 상위 바이트가 생성 시스템(0=FAT/DOS, 3=Unix).
+    pub version_made_by: u16,
+    /// MS-DOS 수정 시각.
+    pub mod_time: u16,
+    /// MS-DOS 수정 날짜.
+    pub mod_date: u16,
+    /// external file attributes — Unix는 상위 16비트에 모드, FAT origin은 0.
+    pub external_attr: u32,
+}
+
+/// zip 파일의 엔트리 이름 → 중앙 디렉터리 메타데이터. ZIP64 등 파싱 불가
+/// 구조면 빈 맵을 반환한다.
+pub fn zip_entry_metadata(path: &Path) -> Result<BTreeMap<String, ZipEntryMeta>> {
+    let data = std::fs::read(path)?;
+    let entries = parse_central_directory(&data).unwrap_or_default();
+    Ok(entries.into_iter().map(|e| (e.name, e.meta)).collect())
+}
+
+struct CdEntry {
+    name: String,
+    /// 중앙 디렉터리 레코드 시작 오프셋.
+    cd_pos: usize,
+    /// 대응 로컬 헤더 오프셋.
+    local_offset: u32,
+    meta: ZipEntryMeta,
+}
+
+/// 출력 zip의 각 엔트리에 대해, 같은 이름이 입력에 있으면 생성 시스템
+/// (version made by)·수정 시각·external attr를 입력 값으로 되돌린다.
+/// 로컬 헤더의 수정 시각도 함께 맞춰 중앙 디렉터리와의 불일치를 막는다.
+///
+/// 근거: hwp2hwpx(Java) 변환본은 FAT origin(생성 시스템 0)·external attr 0으로
+/// 기록되는데, 재작성 엔트리에 Unix 퍼미션/현재 시각이 섞이면 한글 문서 보안
+/// 검사에서 "손상/변조" 경고가 뜨는 사례가 있다 (han-auto에서 실증).
+fn sync_entry_metadata(input: &Path, output: &Path) -> Result<()> {
+    let src = std::fs::read(input)?;
+    let Some(src_entries) = parse_central_directory(&src) else {
+        return Ok(());
+    };
+    let src_map: BTreeMap<&str, &CdEntry> =
+        src_entries.iter().map(|e| (e.name.as_str(), e)).collect();
+
+    let mut dst = std::fs::read(output)?;
+    let Some(dst_entries) = parse_central_directory(&dst) else {
+        return Ok(());
+    };
+
+    const LOCAL_SIG: [u8; 4] = [0x50, 0x4B, 0x03, 0x04];
+    let mut changed = false;
+    for e in &dst_entries {
+        let Some(s) = src_map.get(e.name.as_str()) else {
+            continue;
+        };
+        if e.meta == s.meta {
+            continue;
+        }
+        write_u16(&mut dst, e.cd_pos + 4, s.meta.version_made_by);
+        write_u16(&mut dst, e.cd_pos + 12, s.meta.mod_time);
+        write_u16(&mut dst, e.cd_pos + 14, s.meta.mod_date);
+        write_u32(&mut dst, e.cd_pos + 38, s.meta.external_attr);
+        let lo = e.local_offset as usize;
+        if dst.len() >= lo + 30 && dst[lo..lo + 4] == LOCAL_SIG {
+            write_u16(&mut dst, lo + 10, s.meta.mod_time);
+            write_u16(&mut dst, lo + 12, s.meta.mod_date);
+        }
+        changed = true;
+    }
+    if changed {
+        std::fs::write(output, &dst)?;
+    }
+    Ok(())
+}
+
+/// 중앙 디렉터리를 파싱한다. ZIP64이거나 구조가 어긋나면 `None`
+/// (호출부는 메타데이터 복원을 건너뛴다).
+fn parse_central_directory(data: &[u8]) -> Option<Vec<CdEntry>> {
+    const EOCD_SIG: [u8; 4] = [0x50, 0x4B, 0x05, 0x06];
+    const CD_SIG: [u8; 4] = [0x50, 0x4B, 0x01, 0x02];
+
+    // EOCD는 파일 끝 22바이트 + 최대 65535바이트 주석 안에 있다. 뒤에서부터 탐색.
+    let tail_start = data.len().saturating_sub(22 + 65_535);
+    let last = data.len().checked_sub(22)?;
+    let eocd = (tail_start..=last)
+        .rev()
+        .find(|&i| data[i..i + 4] == EOCD_SIG)?;
+
+    let total = read_u16(data, eocd + 10)? as usize;
+    let cd_offset = read_u32(data, eocd + 16)? as usize;
+    if total == 0xFFFF || cd_offset == 0xFFFF_FFFF_usize {
+        return None; // ZIP64 — hwpx에선 비현실적 크기, 복원 생략
+    }
+
+    let mut entries = Vec::with_capacity(total);
+    let mut pos = cd_offset;
+    for _ in 0..total {
+        if data.get(pos..pos + 4)? != CD_SIG {
+            return None;
+        }
+        let name_len = read_u16(data, pos + 28)? as usize;
+        let extra_len = read_u16(data, pos + 30)? as usize;
+        let comment_len = read_u16(data, pos + 32)? as usize;
+        let name_bytes = data.get(pos + 46..pos + 46 + name_len)?;
+        entries.push(CdEntry {
+            name: String::from_utf8_lossy(name_bytes).into_owned(),
+            cd_pos: pos,
+            local_offset: read_u32(data, pos + 42)?,
+            meta: ZipEntryMeta {
+                version_made_by: read_u16(data, pos + 4)?,
+                mod_time: read_u16(data, pos + 12)?,
+                mod_date: read_u16(data, pos + 14)?,
+                external_attr: read_u32(data, pos + 38)?,
+            },
+        });
+        pos += 46 + name_len + extra_len + comment_len;
+    }
+    Some(entries)
+}
+
+fn read_u16(data: &[u8], pos: usize) -> Option<u16> {
+    Some(u16::from_le_bytes(data.get(pos..pos + 2)?.try_into().ok()?))
+}
+
+fn read_u32(data: &[u8], pos: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(data.get(pos..pos + 4)?.try_into().ok()?))
+}
+
+fn write_u16(data: &mut [u8], pos: usize, v: u16) {
+    data[pos..pos + 2].copy_from_slice(&v.to_le_bytes());
+}
+
+fn write_u32(data: &mut [u8], pos: usize, v: u32) {
+    data[pos..pos + 4].copy_from_slice(&v.to_le_bytes());
 }

--- a/crates/hwpx/src/patch.rs
+++ b/crates/hwpx/src/patch.rs
@@ -5,10 +5,13 @@
 //! 이 모듈은 본문 `Contents/section*.xml`의 `{{name}}` 텍스트만 외과적으로 치환하고
 //! 나머지 엔트리는 ZIP raw 복사로 **바이트 보존**한다(mimetype STORED·순서 포함).
 //!
-//! 치환은 문단 단위로 수행하며, 치환된 문단의 `<hp:linesegarray>`(줄 배치 캐시)를
-//! 제거한다. 텍스트 길이가 바뀌었는데 줄 배치가 남아 있으면 macOS 한글에서
-//! 글자가 겹쳐 보이고 "변조" 보안 경고의 원인이 된다. 치환되지 않은 문단은
-//! 바이트 그대로 두고, 치환이 전혀 없는 섹션은 raw 복사한다.
+//! 치환에 수반되는 정합성 처리:
+//! - 치환은 문단 단위로 수행하며, 치환된 문단의 `<hp:linesegarray>`(줄 배치
+//!   캐시)를 제거한다. 텍스트 길이가 바뀌었는데 줄 배치가 남아 있으면 macOS
+//!   한글에서 글자가 겹쳐 보이고 "변조" 보안 경고의 원인이 된다. 치환되지
+//!   않은 문단은 바이트 그대로 두고, 치환이 전혀 없는 섹션은 raw 복사한다.
+//! - `Preview/PrvText.txt`(UTF-8/UTF-16LE 자동 감지)와 `Contents/content.hpf`에
+//!   남은 자리표시자도 함께 치환한다 (탐색기·한글 미리보기에 옛 텍스트 잔류 방지).
 //!
 //! 한계: 자리표시자가 `<hp:t>` 런/문단 경계를 가로지르면(예: `<hp:t>{{기</hp:t>
 //! <hp:t>관명}}</hp:t>`) 문자열 치환이 매칭하지 못한다. 템플릿은 자리표시자를
@@ -23,6 +26,7 @@ use crate::error::Result;
 
 /// `Contents/section*.xml`의 `{{name}}`을 값으로 치환하고, 그 외 엔트리는 원본 그대로
 /// 복사한다. 반환: 이름 → 본문 치환 횟수(요청한 모든 이름 포함, 미발견은 0).
+/// 미리보기·content.hpf 치환은 횟수에 포함하지 않는다.
 pub fn fill_placeholders(
     input: &Path,
     output: &Path,
@@ -57,6 +61,17 @@ pub fn fill_placeholders(
             let mut xml = String::new();
             archive.by_index(i)?.read_to_string(&mut xml)?;
             fill_section_xml(&xml, values, &mut counts).map(String::into_bytes)
+        } else if name == "Preview/PrvText.txt" {
+            let mut raw = Vec::new();
+            archive.by_index(i)?.read_to_end(&mut raw)?;
+            patch_preview_text(&raw, values)
+        } else if name == "Contents/content.hpf" {
+            let mut raw = Vec::new();
+            archive.by_index(i)?.read_to_end(&mut raw)?;
+            std::str::from_utf8(&raw)
+                .ok()
+                .and_then(|xml| replace_placeholders(xml, values, true))
+                .map(String::into_bytes)
         } else {
             None
         };
@@ -194,6 +209,54 @@ fn strip_linesegarray(para: &mut String) {
         };
         para.replace_range(a..end, "");
     }
+}
+
+/// 미리보기 텍스트의 자리표시자를 치환한다. 원본 인코딩(UTF-8 또는
+/// UTF-16LE, BOM 유무 포함)을 그대로 유지한다. 변경 없으면 `None`.
+fn patch_preview_text(raw: &[u8], values: &BTreeMap<String, String>) -> Option<Vec<u8>> {
+    const BOM: [u8; 2] = [0xFF, 0xFE];
+    // hwp2hwpx 등 Java 변환본은 UTF-16LE(BOM), 한글 직접 저장본은 UTF-8이
+    // 일반적이다. BOM 또는 선두 NUL 바이트(ASCII의 상위 바이트)로 판별.
+    let utf16 = raw.starts_with(&BOM) || raw.iter().take(64).any(|&b| b == 0);
+    if utf16 {
+        let has_bom = raw.starts_with(&BOM);
+        let body = if has_bom { &raw[2..] } else { raw };
+        let units: Vec<u16> = body
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+        let text = String::from_utf16_lossy(&units);
+        let replaced = replace_placeholders(&text, values, false)?;
+        let mut out = Vec::with_capacity(raw.len());
+        if has_bom {
+            out.extend_from_slice(&BOM);
+        }
+        for u in replaced.encode_utf16() {
+            out.extend_from_slice(&u.to_le_bytes());
+        }
+        Some(out)
+    } else {
+        let text = std::str::from_utf8(raw).ok()?;
+        replace_placeholders(text, values, false).map(String::into_bytes)
+    }
+}
+
+/// `{{name}}` → 값 치환. `escape`면 XML 이스케이프 적용. 변경 없으면 `None`.
+fn replace_placeholders(
+    text: &str,
+    values: &BTreeMap<String, String>,
+    escape: bool,
+) -> Option<String> {
+    let mut out: Option<String> = None;
+    for (k, v) in values {
+        let needle = format!("{{{{{k}}}}}");
+        let target = out.as_deref().unwrap_or(text);
+        if target.contains(needle.as_str()) {
+            let value = if escape { xml_escape(v) } else { v.clone() };
+            out = Some(target.replace(needle.as_str(), &value));
+        }
+    }
+    out
 }
 
 fn xml_escape(s: &str) -> String {

--- a/crates/hwpx/src/patch.rs
+++ b/crates/hwpx/src/patch.rs
@@ -5,6 +5,11 @@
 //! 이 모듈은 본문 `Contents/section*.xml`의 `{{name}}` 텍스트만 외과적으로 치환하고
 //! 나머지 엔트리는 ZIP raw 복사로 **바이트 보존**한다(mimetype STORED·순서 포함).
 //!
+//! 치환은 문단 단위로 수행하며, 치환된 문단의 `<hp:linesegarray>`(줄 배치 캐시)를
+//! 제거한다. 텍스트 길이가 바뀌었는데 줄 배치가 남아 있으면 macOS 한글에서
+//! 글자가 겹쳐 보이고 "변조" 보안 경고의 원인이 된다. 치환되지 않은 문단은
+//! 바이트 그대로 두고, 치환이 전혀 없는 섹션은 raw 복사한다.
+//!
 //! 한계: 자리표시자가 `<hp:t>` 런/문단 경계를 가로지르면(예: `<hp:t>{{기</hp:t>
 //! <hp:t>관명}}</hp:t>`) 문자열 치환이 매칭하지 못한다. 템플릿은 자리표시자를
 //! 단일 런으로 작성할 것(현행 내장 템플릿은 모두 단일 런).
@@ -17,7 +22,7 @@ use std::path::Path;
 use crate::error::Result;
 
 /// `Contents/section*.xml`의 `{{name}}`을 값으로 치환하고, 그 외 엔트리는 원본 그대로
-/// 복사한다. 반환: 이름 → 치환 횟수(요청한 모든 이름 포함, 미발견은 0).
+/// 복사한다. 반환: 이름 → 본문 치환 횟수(요청한 모든 이름 포함, 미발견은 0).
 pub fn fill_placeholders(
     input: &Path,
     output: &Path,
@@ -41,36 +46,154 @@ pub fn fill_placeholders(
     let mut zip = zip::ZipWriter::new(out);
 
     let mut counts: BTreeMap<String, usize> = values.keys().map(|k| (k.clone(), 0)).collect();
+    let deflated = zip::write::SimpleFileOptions::default()
+        .compression_method(zip::CompressionMethod::Deflated);
 
     for i in 0..archive.len() {
         let name = archive.by_index_raw(i)?.name().to_string();
         let is_section = name.starts_with("Contents/section") && name.ends_with(".xml");
 
-        if is_section {
+        let rewritten: Option<Vec<u8>> = if is_section {
             let mut xml = String::new();
             archive.by_index(i)?.read_to_string(&mut xml)?;
-            for (k, v) in values {
-                let needle = format!("{{{{{k}}}}}"); // {{k}}
-                let n = xml.matches(needle.as_str()).count();
-                if n > 0 {
-                    xml = xml.replace(needle.as_str(), &xml_escape(v));
-                    if let Some(c) = counts.get_mut(k) {
-                        *c += n;
-                    }
-                }
-            }
-            let opts = zip::write::SimpleFileOptions::default()
-                .compression_method(zip::CompressionMethod::Deflated);
-            zip.start_file(&name, opts)?;
-            zip.write_all(xml.as_bytes())?;
+            fill_section_xml(&xml, values, &mut counts).map(String::into_bytes)
         } else {
-            // 미리보기·compat·BinData·mimetype(STORED) 등 전부 바이트 보존.
-            let raw = archive.by_index_raw(i)?;
-            zip.raw_copy_file(raw)?;
+            None
+        };
+
+        match rewritten {
+            Some(bytes) => {
+                zip.start_file(&name, deflated)?;
+                zip.write_all(&bytes)?;
+            }
+            // 무변경 엔트리는 전부 바이트 보존 (미리보기·compat·BinData·mimetype STORED 포함).
+            None => {
+                let raw = archive.by_index_raw(i)?;
+                zip.raw_copy_file(raw)?;
+            }
         }
     }
     zip.finish()?;
     Ok(counts)
+}
+
+/// 섹션 XML에서 자리표시자를 문단 단위로 치환한다. 치환이 일어난 문단은
+/// `<hp:linesegarray>`를 제거하고(한글이 열 때 줄 배치 재계산), 나머지 문단은
+/// 바이트 그대로 둔다. 변경이 없으면 `None`.
+fn fill_section_xml(
+    xml: &str,
+    values: &BTreeMap<String, String>,
+    counts: &mut BTreeMap<String, usize>,
+) -> Option<String> {
+    let mut out = String::with_capacity(xml.len());
+    let mut cursor = 0usize;
+    let mut changed = false;
+
+    for (start, end) in paragraph_spans(xml) {
+        let para = &xml[start..end];
+        let mut replaced: Option<String> = None;
+        for (k, v) in values {
+            let needle = format!("{{{{{k}}}}}"); // {{k}}
+            let target = replaced.as_deref().unwrap_or(para);
+            let n = target.matches(needle.as_str()).count();
+            if n > 0 {
+                let next = target.replace(needle.as_str(), &xml_escape(v));
+                replaced = Some(next);
+                if let Some(c) = counts.get_mut(k) {
+                    *c += n;
+                }
+            }
+        }
+        if let Some(mut new_para) = replaced {
+            strip_linesegarray(&mut new_para);
+            out.push_str(&xml[cursor..start]);
+            out.push_str(&new_para);
+            cursor = end;
+            changed = true;
+        }
+    }
+    if !changed {
+        return None;
+    }
+    out.push_str(&xml[cursor..]);
+    Some(out)
+}
+
+/// 최상위 `<hp:p …>…</hp:p>` 구간(바이트 오프셋)을 찾는다. 표 셀 등 중첩 문단은
+/// 바깥 문단 구간에 포함된다(치환 시 바깥 문단째로 처리 — 줄 배치 제거는
+/// 넉넉해도 안전하다: 한글이 해당 문단만 재계산).
+///
+/// 주의: 속성값 안의 `>`는 고려하지 않는다(한글 계열 직렬화기는 속성에 `>`를
+/// 이스케이프해 출력하므로 실 파일에서는 발생하지 않음).
+fn paragraph_spans(xml: &str) -> Vec<(usize, usize)> {
+    const OPEN: &str = "<hp:p";
+    const CLOSE: &str = "</hp:p>";
+    let bytes = xml.as_bytes();
+    let mut spans = Vec::new();
+    let mut depth = 0usize;
+    let mut top_start = 0usize;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        if bytes[i] != b'<' {
+            i += 1;
+            continue;
+        }
+        let rest = &xml[i..];
+        if rest.starts_with(CLOSE) {
+            if depth > 0 {
+                depth -= 1;
+                if depth == 0 {
+                    spans.push((top_start, i + CLOSE.len()));
+                }
+            }
+            i += CLOSE.len();
+        } else if rest.starts_with(OPEN)
+            && matches!(
+                bytes.get(i + OPEN.len()),
+                Some(b' ' | b'>' | b'/' | b'\t' | b'\r' | b'\n')
+            )
+        {
+            let Some(gt) = rest.find('>') else { break };
+            let close = i + gt;
+            if bytes[close - 1] == b'/' {
+                // 자기닫힘 빈 문단 — 텍스트가 없으므로 구간으로만 기록.
+                if depth == 0 {
+                    spans.push((i, close + 1));
+                }
+            } else {
+                if depth == 0 {
+                    top_start = i;
+                }
+                depth += 1;
+            }
+            i = close + 1;
+        } else {
+            i += 1;
+        }
+    }
+    spans
+}
+
+/// 문단 문자열에서 `<hp:linesegarray …>…</hp:linesegarray>`(자기닫힘 포함)를
+/// 모두 제거한다.
+fn strip_linesegarray(para: &mut String) {
+    const OPEN: &str = "<hp:linesegarray";
+    const CLOSE: &str = "</hp:linesegarray>";
+    while let Some(a) = para.find(OPEN) {
+        let after = a + OPEN.len();
+        let Some(gt) = para[after..].find('>').map(|p| after + p) else {
+            break;
+        };
+        let end = if para.as_bytes()[gt - 1] == b'/' {
+            gt + 1
+        } else {
+            match para[gt..].find(CLOSE) {
+                Some(p) => gt + p + CLOSE.len(),
+                None => break,
+            }
+        };
+        para.replace_range(a..end, "");
+    }
 }
 
 fn xml_escape(s: &str) -> String {

--- a/crates/hwpx/tests/patch.rs
+++ b/crates/hwpx/tests/patch.rs
@@ -2,8 +2,8 @@
 //!
 //! 합성 HWPX(미리보기 썸네일 + `hp:switch` 호환 블록 + `{{name}}`)를 만든 뒤,
 //! 채우기 후에도 비대상 엔트리가 바이트 보존되고 본문 자리표시자만 치환되는지,
-//! 그리고 치환 부수 정합성(줄 배치 캐시 제거·미리보기/hpf 동기화)이
-//! 지켜지는지 검증.
+//! 그리고 치환 부수 정합성(줄 배치 캐시 제거·미리보기/hpf 동기화·zip 메타데이터
+//! 복원)이 지켜지는지 검증.
 
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
@@ -200,6 +200,59 @@ fn fill_hpf_동기화_및_이스케이프() {
         prv.contains("A&B<연구소> 운영 보고"),
         "미리보기는 평문: {prv}"
     );
+
+    let _ = std::fs::remove_file(&src);
+    let _ = std::fs::remove_file(&out);
+}
+
+/// 입력 zip의 특정 엔트리를 Java 변환본 스타일(FAT origin, external attr 0,
+/// 고정 시각)로 바이트 패치한다. 중앙 디렉터리 레코드: 시그니처 PK\x01\x02,
+/// version_made_by @+4, mod time/date @+12/+14, external attr @+38, 이름 @+46.
+fn set_fat_attrs(path: &std::path::Path, name: &str) {
+    let mut bytes = std::fs::read(path).unwrap();
+    let sig = [0x50, 0x4B, 0x01, 0x02];
+    let mut patched = false;
+    for i in 0..bytes.len().saturating_sub(46 + name.len()) {
+        if bytes[i..i + 4] == sig && &bytes[i + 46..i + 46 + name.len()] == name.as_bytes() {
+            bytes[i + 4] = 20; // version 2.0
+            bytes[i + 5] = 0; // 생성 시스템 FAT/DOS
+            bytes[i + 12..i + 14].copy_from_slice(&0u16.to_le_bytes()); // mod time
+            bytes[i + 14..i + 16].copy_from_slice(&0x21u16.to_le_bytes()); // 1980-01-01
+            bytes[i + 38..i + 42].copy_from_slice(&0u32.to_le_bytes()); // external attr
+            patched = true;
+        }
+    }
+    assert!(patched, "fixture 중앙 디렉터리에서 {name} 못 찾음");
+    std::fs::write(path, bytes).unwrap();
+}
+
+#[test]
+fn fill_zip_메타데이터_복원() {
+    let dir = std::env::temp_dir();
+    let src = dir.join("hwpx_patch_src_attrs.hwpx");
+    let out = dir.join("hwpx_patch_out_attrs.hwpx");
+    build_fixture(&src);
+    // 입력을 Java 변환본처럼: 다시 쓰이는 엔트리(section0)를 FAT origin으로.
+    set_fat_attrs(&src, "Contents/section0.xml");
+
+    fill_기관명(&src, &out, "제주한라대학교");
+
+    let src_meta = hwpx::patch::zip_entry_metadata(&src).unwrap();
+    let out_meta = hwpx::patch::zip_entry_metadata(&out).unwrap();
+    let name = "Contents/section0.xml";
+    assert_eq!(
+        out_meta.get(name),
+        src_meta.get(name),
+        "다시 쓴 엔트리의 zip 메타데이터는 원본과 동일해야"
+    );
+    let m = out_meta.get(name).unwrap();
+    assert_eq!(m.version_made_by >> 8, 0, "생성 시스템 FAT 유지");
+    assert_eq!(m.external_attr, 0, "external attr 0 유지");
+
+    // 출력이 여전히 유효한 zip인지 (중앙 디렉터리 패치 후 재열기).
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(&out).unwrap()).unwrap();
+    let section = String::from_utf8(read_entry(&mut zip, "Contents/section0.xml")).unwrap();
+    assert!(section.contains("제주한라대학교"));
 
     let _ = std::fs::remove_file(&src);
     let _ = std::fs::remove_file(&out);

--- a/crates/hwpx/tests/patch.rs
+++ b/crates/hwpx/tests/patch.rs
@@ -2,7 +2,8 @@
 //!
 //! 합성 HWPX(미리보기 썸네일 + `hp:switch` 호환 블록 + `{{name}}`)를 만든 뒤,
 //! 채우기 후에도 비대상 엔트리가 바이트 보존되고 본문 자리표시자만 치환되는지,
-//! 그리고 치환 문단의 줄 배치 캐시 제거가 지켜지는지 검증.
+//! 그리고 치환 부수 정합성(줄 배치 캐시 제거·미리보기/hpf 동기화)이
+//! 지켜지는지 검증.
 
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
@@ -29,6 +30,15 @@ fn utf16le_bom(text: &str) -> Vec<u8> {
         out.extend_from_slice(&u.to_le_bytes());
     }
     out
+}
+
+fn decode_utf16le_bom(raw: &[u8]) -> String {
+    assert_eq!(&raw[..2], &[0xFF, 0xFE], "UTF-16LE BOM 유지돼야");
+    let units: Vec<u16> = raw[2..]
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    String::from_utf16(&units).unwrap()
 }
 
 fn build_fixture(path: &std::path::Path) {
@@ -141,6 +151,54 @@ fn fill_치환_문단만_lineseg_제거() {
     assert!(
         p2.contains(r#"<hp:lineseg textpos="0" vertpos="100"/>"#),
         "무변경 문단의 lineseg 캐시는 보존돼야: {p2}"
+    );
+
+    let _ = std::fs::remove_file(&src);
+    let _ = std::fs::remove_file(&out);
+}
+
+#[test]
+fn fill_미리보기_utf16_동기화() {
+    let dir = std::env::temp_dir();
+    let src = dir.join("hwpx_patch_src_prv.hwpx");
+    let out = dir.join("hwpx_patch_out_prv.hwpx");
+    build_fixture(&src);
+
+    fill_기관명(&src, &out, "제주한라대학교");
+
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(&out).unwrap()).unwrap();
+    let prv = decode_utf16le_bom(&read_entry(&mut zip, "Preview/PrvText.txt"));
+    assert!(
+        prv.contains("제주한라대학교 운영 보고"),
+        "미리보기 텍스트 동기화: {prv}"
+    );
+    assert!(!prv.contains("{{기관명}}"), "미리보기 자리표시자 잔류 금지");
+
+    let _ = std::fs::remove_file(&src);
+    let _ = std::fs::remove_file(&out);
+}
+
+#[test]
+fn fill_hpf_동기화_및_이스케이프() {
+    let dir = std::env::temp_dir();
+    let src = dir.join("hwpx_patch_src_hpf.hwpx");
+    let out = dir.join("hwpx_patch_out_hpf.hwpx");
+    build_fixture(&src);
+
+    // XML 특수문자 값 — hpf/section에는 이스케이프돼 들어가야 한다.
+    fill_기관명(&src, &out, "A&B<연구소>");
+
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(&out).unwrap()).unwrap();
+    let hpf = String::from_utf8(read_entry(&mut zip, "Contents/content.hpf")).unwrap();
+    assert!(
+        hpf.contains("A&amp;B&lt;연구소&gt; 운영 보고"),
+        "hpf 메타데이터 동기화(+이스케이프): {hpf}"
+    );
+    // 미리보기는 평문이므로 이스케이프 없이 원문 그대로.
+    let prv = decode_utf16le_bom(&read_entry(&mut zip, "Preview/PrvText.txt"));
+    assert!(
+        prv.contains("A&B<연구소> 운영 보고"),
+        "미리보기는 평문: {prv}"
     );
 
     let _ = std::fs::remove_file(&src);

--- a/crates/hwpx/tests/patch.rs
+++ b/crates/hwpx/tests/patch.rs
@@ -1,7 +1,8 @@
 //! 충실도 보존 fill (patch::fill_placeholders) 통합 테스트.
 //!
 //! 합성 HWPX(미리보기 썸네일 + `hp:switch` 호환 블록 + `{{name}}`)를 만든 뒤,
-//! 채우기 후에도 비대상 엔트리가 바이트 보존되고 본문 자리표시자만 치환되는지 검증.
+//! 채우기 후에도 비대상 엔트리가 바이트 보존되고 본문 자리표시자만 치환되는지,
+//! 그리고 치환 문단의 줄 배치 캐시 제거가 지켜지는지 검증.
 
 use std::collections::BTreeMap;
 use std::io::{Read, Write};
@@ -10,6 +11,25 @@ use zip::CompressionMethod;
 use zip::write::SimpleFileOptions;
 
 const PRV_IMAGE: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 1, 2, 3, 4];
+
+const SECTION0: &str = concat!(
+    "<hs:sec>",
+    // 치환 대상 문단 — 줄 배치 캐시 보유 (치환 후 제거돼야 함)
+    "<hp:p id=\"1\"><hp:run><hp:t>{{기관명}} 운영 보고</hp:t></hp:run>",
+    "<hp:linesegarray><hp:lineseg textpos=\"0\" vertpos=\"0\"/></hp:linesegarray></hp:p>",
+    // 무변경 문단 — 줄 배치 캐시가 그대로 남아야 함
+    "<hp:p id=\"2\"><hp:run><hp:t>고정 문구</hp:t></hp:run>",
+    "<hp:linesegarray><hp:lineseg textpos=\"0\" vertpos=\"100\"/></hp:linesegarray></hp:p>",
+    "</hs:sec>"
+);
+
+fn utf16le_bom(text: &str) -> Vec<u8> {
+    let mut out = vec![0xFF, 0xFE];
+    for u in text.encode_utf16() {
+        out.extend_from_slice(&u.to_le_bytes());
+    }
+    out
+}
 
 fn build_fixture(path: &std::path::Path) {
     let file = std::fs::File::create(path).unwrap();
@@ -23,6 +43,17 @@ fn build_fixture(path: &std::path::Path) {
     zip.start_file("Preview/PrvImage.png", deflated).unwrap();
     zip.write_all(PRV_IMAGE).unwrap();
 
+    // hwp2hwpx(Java) 변환본 스타일: UTF-16LE + BOM 미리보기 텍스트.
+    zip.start_file("Preview/PrvText.txt", deflated).unwrap();
+    zip.write_all(&utf16le_bom("{{기관명}} 운영 보고\n고정 문구"))
+        .unwrap();
+
+    zip.start_file("Contents/content.hpf", deflated).unwrap();
+    zip.write_all(
+        "<opf:package><opf:title>{{기관명}} 운영 보고</opf:title></opf:package>".as_bytes(),
+    )
+    .unwrap();
+
     // 2016 호환 블록(hp:switch) — IR 경유 writer가 떨어뜨리는 부분.
     zip.start_file("Contents/header.xml", deflated).unwrap();
     zip.write_all(
@@ -32,11 +63,7 @@ fn build_fixture(path: &std::path::Path) {
 
     // 단일 런 자리표시자.
     zip.start_file("Contents/section0.xml", deflated).unwrap();
-    zip.write_all(
-        "<hs:sec><hp:p><hp:run><hp:t>{{기관명}} 운영 보고</hp:t></hp:run></hp:p></hs:sec>"
-            .as_bytes(),
-    )
-    .unwrap();
+    zip.write_all(SECTION0.as_bytes()).unwrap();
 
     zip.finish().unwrap();
 }
@@ -47,6 +74,16 @@ fn read_entry(zip: &mut zip::ZipArchive<std::fs::File>, name: &str) -> Vec<u8> {
     buf
 }
 
+fn fill_기관명(
+    src: &std::path::Path,
+    out: &std::path::Path,
+    value: &str,
+) -> BTreeMap<String, usize> {
+    let mut values = BTreeMap::new();
+    values.insert("기관명".to_string(), value.to_string());
+    hwpx::patch::fill_placeholders(src, out, &values).unwrap()
+}
+
 #[test]
 fn fill_preserves_preview_and_compat() {
     let dir = std::env::temp_dir();
@@ -54,10 +91,8 @@ fn fill_preserves_preview_and_compat() {
     let out = dir.join("hwpx_patch_out.hwpx");
     build_fixture(&src);
 
-    let mut values = BTreeMap::new();
-    values.insert("기관명".to_string(), "제주한라대학교".to_string());
-    let counts = hwpx::patch::fill_placeholders(&src, &out, &values).unwrap();
-    assert_eq!(counts.get("기관명"), Some(&1), "{{기관명}} 1회 치환");
+    let counts = fill_기관명(&src, &out, "제주한라대학교");
+    assert_eq!(counts.get("기관명"), Some(&1), "{{기관명}} 본문 1회 치환");
 
     let mut zip = zip::ZipArchive::new(std::fs::File::open(&out).unwrap()).unwrap();
 
@@ -82,6 +117,37 @@ fn fill_preserves_preview_and_compat() {
 }
 
 #[test]
+fn fill_치환_문단만_lineseg_제거() {
+    let dir = std::env::temp_dir();
+    let src = dir.join("hwpx_patch_src_lineseg.hwpx");
+    let out = dir.join("hwpx_patch_out_lineseg.hwpx");
+    build_fixture(&src);
+
+    fill_기관명(&src, &out, "제주한라대학교");
+
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(&out).unwrap()).unwrap();
+    let section = String::from_utf8(read_entry(&mut zip, "Contents/section0.xml")).unwrap();
+
+    // 치환된 문단(id=1)의 줄 배치 캐시는 제거 — 남아 있으면 macOS 한글에서
+    // 글자 겹침·변조 경고의 원인.
+    let p1 =
+        &section[section.find("<hp:p id=\"1\"").unwrap()..section.find("<hp:p id=\"2\"").unwrap()];
+    assert!(
+        !p1.contains("linesegarray"),
+        "치환 문단의 lineseg 캐시 제거돼야: {p1}"
+    );
+    // 무변경 문단(id=2)은 줄 배치 캐시까지 그대로.
+    let p2 = &section[section.find("<hp:p id=\"2\"").unwrap()..];
+    assert!(
+        p2.contains(r#"<hp:lineseg textpos="0" vertpos="100"/>"#),
+        "무변경 문단의 lineseg 캐시는 보존돼야: {p2}"
+    );
+
+    let _ = std::fs::remove_file(&src);
+    let _ = std::fs::remove_file(&out);
+}
+
+#[test]
 fn fill_reports_unfilled_as_zero() {
     let dir = std::env::temp_dir();
     let src = dir.join("hwpx_patch_src2.hwpx");
@@ -92,6 +158,14 @@ fn fill_reports_unfilled_as_zero() {
     values.insert("없는키".to_string(), "x".to_string());
     let counts = hwpx::patch::fill_placeholders(&src, &out, &values).unwrap();
     assert_eq!(counts.get("없는키"), Some(&0), "미발견 키는 0");
+
+    // 아무것도 안 바뀌면 섹션도 raw copy — 바이트 보존.
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(&out).unwrap()).unwrap();
+    assert_eq!(
+        read_entry(&mut zip, "Contents/section0.xml"),
+        SECTION0.as_bytes(),
+        "무변경 섹션은 바이트 보존"
+    );
 
     let _ = std::fs::remove_file(&src);
     let _ = std::fs::remove_file(&out);


### PR DESCRIPTION
1. 문단 단위 치환 + 치환 문단 lineseg 캐시 제거
- 자리표시자 치환을 섹션 전역 문자열 치환에서 **최상위 문단 단위**로 좁힘
- 치환된 문단의 `<hp:linesegarray>`(줄 배치 캐시)를 제거 — 텍스트가 바뀌었는데
  줄 배치가 남아 있으면 macOS 한글에서 글자 겹침·"변조" 보안 경고의 원인
- 무변경 문단은 캐시까지 바이트 그대로, 무변경 섹션은 raw copy로 격상

2. PrvText·content.hpf 자리표시자 동기 치환
- 본문 치환 후 `Preview/PrvText.txt`와 `Contents/content.hpf`에 남은
  자리표시자도 함께 치환 — 안 하면 탐색기·한글 미리보기에 옛 텍스트 잔류
- 미리보기는 원본 인코딩(UTF-8 / UTF-16LE+BOM, hwp2hwpx Java 변환본 대응)을
  감지해 그대로 유지, hpf는 XML 이스케이프 적용

3. 다시 쓴 엔트리의 zip 메타데이터 원본 복원
- fill 완료 후 출력 zip의 중앙 디렉터리를 직접 파싱해, 다시 쓴 엔트리의
  생성 시스템·수정 시각·external attr를 입력 값으로 바이트 패치
- Java 변환본(FAT origin, external attr 0) 재작성 시 Unix 퍼미션/현재 시각이
  섞여 한글이 "손상/변조" 경고를 띄우는 사례 대응
- ZIP64 등 파싱 불가 구조면 건너뛰는 best-effort, 진단용 `zip_entry_metadata()` 공개


검증

- 통합 테스트 4개 추가 (`crates/hwpx/tests/patch.rs`, 총 7개 통과):
  치환 문단만 lineseg 제거 / UTF-16LE 미리보기 동기화 / hpf 이스케이프 치환 / FAT 속성 복원
- clippy 0 경고, 워크스페이스 전체 테스트 통과
  (기존부터 실패하던 `hwp-render` `cff_otf_pdf_임베드_구조`는 본 변경과 무관)
- 실파일 검증: 한글 저장본 `브라더 공공기관 보고서 양식.hwpx`로
  자리표시자 3개 fill → 치환 문단의 lineseg 8개만 정확히 제거(103→95),
  무변경 엔트리 12개 바이트 동일, zip 속성 14개 엔트리 전부 원본 일치,
  `validate` 유효 + PNG 렌더 정상 확인