### PR TITLE
feat(hwpx): 각주/미주·수식 쓰기 — 변환·편집 시 내용 소실 해소

### DIFF
--- a/crates/hwpx/src/read/section.rs
+++ b/crates/hwpx/src/read/section.rs
@@ -1183,6 +1183,39 @@ fn read_element_text(reader: &mut XmlReader<'_>, end: &[u8]) -> Result<String> {
                 })?;
                 out.push_str(&s);
             }
+            Event::CData(t) => {
+                let s = t.xml10_content().map_err(|e| HwpxError::Xml {
+                    entry: "section".to_string(),
+                    message: e.to_string(),
+                })?;
+                out.push_str(&s);
+            }
+            Event::GeneralRef(r) => {
+                if let Some(ch) = r.resolve_char_ref().map_err(|e| HwpxError::Xml {
+                    entry: "section".to_string(),
+                    message: e.to_string(),
+                })? {
+                    out.push(ch);
+                } else {
+                    let name = r.decode().map_err(|e| HwpxError::Xml {
+                        entry: "section".to_string(),
+                        message: e.to_string(),
+                    })?;
+                    match name.as_ref() {
+                        "amp" => out.push('&'),
+                        "lt" => out.push('<'),
+                        "gt" => out.push('>'),
+                        "quot" => out.push('"'),
+                        "apos" => out.push('\''),
+                        _ => {
+                            // 외부 엔티티는 DTD 없이 해석할 수 없으므로 원형을 보존한다.
+                            out.push('&');
+                            out.push_str(&name);
+                            out.push(';');
+                        }
+                    }
+                }
+            }
             Event::End(e) if e.local_name().as_ref() == end => break,
             Event::Eof => break,
             _ => {}

--- a/crates/hwpx/src/write/section.rs
+++ b/crates/hwpx/src/write/section.rs
@@ -8,8 +8,8 @@ use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
 use hwp_model::{
-    BinRef, Cell, Control, Document, GenericControl, HwpChar, PageDef, Paragraph, Picture, Section,
-    ShapeKind, Table,
+    BinRef, Cell, Control, Document, Equation, GenericControl, HwpChar, PageDef, Paragraph,
+    Picture, Section, ShapeKind, Table,
 };
 
 use crate::write::templates::esc;
@@ -239,6 +239,20 @@ fn write_paragraph(
                         open_run!(cur_shape);
                         flush_text(out, &mut text_buf);
                         write_header_footer(out, doc, g, ids, bins, preserve_linesegs, warnings);
+                    }
+                    Control::Generic(g) if g.ctrl_id == *b"fn  " || g.ctrl_id == *b"en  " => {
+                        open_run!(cur_shape);
+                        flush_text(out, &mut text_buf);
+                        write_footnote_endnote(out, doc, g, ids, bins, preserve_linesegs, warnings);
+                    }
+                    Control::Generic(g) if g.equation.is_some() => {
+                        // 리더 parse_equation의 역 — 수식은 hp:ctrl이 아닌 run 수준 개체.
+                        open_run!(cur_shape);
+                        flush_text(out, &mut text_buf);
+                        let Some(eq) = &g.equation else {
+                            unreachable!("equation.is_some() 가드");
+                        };
+                        write_equation(out, eq, ids);
                     }
                     Control::Table(table) => {
                         open_run!(cur_shape);
@@ -535,6 +549,57 @@ fn write_header_footer(
         out.push_str("</hp:subList>");
     }
     let _ = write!(out, "</hp:{el}></hp:ctrl>");
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_footnote_endnote(
+    out: &mut String,
+    doc: &Document,
+    g: &GenericControl,
+    ids: &mut IdSeq,
+    bins: &mut BinCollector,
+    preserve_linesegs: bool,
+    warnings: &mut Vec<String>,
+) {
+    let el = if g.ctrl_id == *b"fn  " {
+        "footNote"
+    } else {
+        "endNote"
+    };
+    let _ = write!(out, r##"<hp:ctrl><hp:{el} id="{}">"##, ids.next());
+    for list in &g.paragraph_lists {
+        out.push_str(
+            r##"<hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0">"##,
+        );
+        for para in &list.paragraphs {
+            write_paragraph(
+                out,
+                doc,
+                para,
+                ids,
+                bins,
+                false,
+                preserve_linesegs,
+                warnings,
+            );
+        }
+        out.push_str("</hp:subList>");
+    }
+    let _ = write!(out, "</hp:{el}></hp:ctrl>");
+}
+
+fn write_equation(out: &mut String, eq: &Equation, ids: &mut IdSeq) {
+    let _ = write!(
+        out,
+        r##"<hp:equation id="{}" version="Equation Version 60" baseLine="85" textColor="#000000" baseUnit="1000" lineMode="0" font="HYhwpEQ"><hp:sz width="{}" height="{}" protect="0"/><hp:pos treatAsChar="{}" affectLSpacing="0" flowWithText="1" allowOverlap="0" holdAnchorAndSO="0" vertRelTo="PARA" horzRelTo="PARA" vertAlign="TOP" horzAlign="LEFT" vertOffset="{}" horzOffset="{}"/><hp:outMargin left="56" right="56" top="56" bottom="56"/><hp:script>{}</hp:script></hp:equation>"##,
+        ids.next(),
+        eq.width,
+        eq.height,
+        u8::from(eq.inline),
+        eq.y,
+        eq.x,
+        esc(&eq.script),
+    );
 }
 
 /// hwp5 gso 공통 개체 헤더(20B+): attr(u32)@0, 세로 오프셋@4, 가로 오프셋@8, 폭@12, 높이@16,

--- a/crates/hwpx/tests/write.rs
+++ b/crates/hwpx/tests/write.rs
@@ -251,6 +251,158 @@ fn attach_gso(para: &mut hwp_model::Paragraph, g: hwp_model::GenericControl) {
     para.header.ctrl_mask = 0;
 }
 
+/// 문단 끝에 각주/미주 컨트롤(ExtCtrl 코드 17 + Generic)을 부착한다.
+fn attach_note(para: &mut hwp_model::Paragraph, g: hwp_model::GenericControl) {
+    use hwp_model::HwpChar;
+    let idx = para.controls.len() as u32;
+    para.chars.push(HwpChar::ExtCtrl {
+        code: 17,
+        ctrl_id: g.ctrl_id,
+        payload: hwp_convert::field::rev_payload(&g.ctrl_id),
+        ctrl_index: Some(idx),
+    });
+    para.controls.push(hwp_model::Control::Generic(g));
+    para.header.ctrl_mask = 0;
+}
+
+fn text_para(text: &str) -> hwp_model::Paragraph {
+    hwp_model::Paragraph {
+        chars: text.chars().map(hwp_model::HwpChar::Text).collect(),
+        char_shape_runs: vec![(0, hwp_model::CharShapeId(0))],
+        ..Default::default()
+    }
+}
+
+/// 각주/미주가 hwpx `<hp:footNote>/<hp:endNote>`로 방출되고 subList 텍스트를 보존한다.
+#[test]
+fn 각주_미주_hwpx_왕복() {
+    use hwp_model::{Control, GenericControl, ParagraphList};
+
+    let mut doc = hwp_convert::from_markdown("본문\n\n둘째");
+    let foot = GenericControl {
+        ctrl_id: *b"fn  ",
+        data: Vec::new(),
+        paragraph_lists: vec![ParagraphList {
+            header_data: Vec::new(),
+            paragraphs: vec![text_para("각주 내용입니다")],
+        }],
+        extras: Vec::new(),
+        raw_children: Vec::new(),
+        gso_shapes: Vec::new(),
+        equation: None,
+        column_def: None,
+    };
+    let end = GenericControl {
+        ctrl_id: *b"en  ",
+        data: Vec::new(),
+        paragraph_lists: vec![ParagraphList {
+            header_data: Vec::new(),
+            paragraphs: vec![text_para("미주 내용입니다")],
+        }],
+        extras: Vec::new(),
+        raw_children: Vec::new(),
+        gso_shapes: Vec::new(),
+        equation: None,
+        column_def: None,
+    };
+    let para = &mut doc.sections[0].paragraphs[1];
+    attach_note(para, foot);
+    attach_note(para, end);
+
+    let out = tmp("notes.hwpx");
+    let warnings = hwpx::write_document(&doc, &out).unwrap();
+    assert!(!warnings.iter().any(|w| w.contains("DROP")), "{warnings:?}");
+
+    let reread = hwpx::read_document(&out).unwrap();
+    assert!(
+        !reread.warnings.iter().any(|w| w.contains("DROP")),
+        "{:?}",
+        reread.warnings
+    );
+    let doc = reread.document;
+    for (ctrl_id, text) in [(*b"fn  ", "각주 내용입니다"), (*b"en  ", "미주 내용입니다")]
+    {
+        let note = doc.sections[0]
+            .paragraphs
+            .iter()
+            .flat_map(|p| &p.controls)
+            .find_map(|c| match c {
+                Control::Generic(g) if g.ctrl_id == ctrl_id => Some(g),
+                _ => None,
+            })
+            .unwrap_or_else(|| panic!("{} 재읽기 실패", String::from_utf8_lossy(&ctrl_id)));
+        let got = note.paragraph_lists[0].paragraphs[0].plain_text();
+        assert_eq!(got, text);
+    }
+}
+
+/// 수식이 run 수준 `<hp:equation>`으로 방출되고 스크립트/크기/인라인 배치를 보존한다.
+#[test]
+fn 수식_hwpx_왕복() {
+    use hwp_model::{Control, Equation, GenericControl};
+
+    let mut doc = hwp_convert::from_markdown("본문\n\n둘째");
+    let equations = [
+        Equation {
+            script: "a over b = c_1 ^2".to_string(),
+            width: 4000,
+            height: 1200,
+            inline: true,
+            x: 0,
+            y: 0,
+        },
+        Equation {
+            script: "x < y & y > z".to_string(),
+            width: 0,
+            height: 0,
+            inline: true,
+            x: 0,
+            y: 0,
+        },
+    ];
+    for eq in equations.iter().cloned() {
+        attach_gso(
+            &mut doc.sections[0].paragraphs[1],
+            GenericControl {
+                ctrl_id: *b"eqed",
+                data: Vec::new(),
+                paragraph_lists: Vec::new(),
+                extras: Vec::new(),
+                raw_children: Vec::new(),
+                gso_shapes: Vec::new(),
+                equation: Some(eq),
+                column_def: None,
+            },
+        );
+    }
+
+    let out = tmp("equation.hwpx");
+    let warnings = hwpx::write_document(&doc, &out).unwrap();
+    assert!(!warnings.iter().any(|w| w.contains("DROP")), "{warnings:?}");
+
+    let reread = hwpx::read_document(&out).unwrap();
+    assert!(
+        !reread.warnings.iter().any(|w| w.contains("DROP")),
+        "{:?}",
+        reread.warnings
+    );
+    let got: Vec<_> = reread.document.sections[0]
+        .paragraphs
+        .iter()
+        .flat_map(|p| &p.controls)
+        .filter_map(|c| match c {
+            Control::Generic(g) => g.equation.as_ref(),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(got.len(), 2);
+    assert_eq!(got[0].script, equations[0].script.trim());
+    assert_eq!((got[0].width, got[0].height), (4000, 1200));
+    assert!(got[0].inline);
+    assert_eq!(got[1].script, equations[1].script.trim());
+    assert_eq!((got[1].width, got[1].height), (0, 0));
+}
+
 /// hwp5-출신 글상자(gso + 문단)가 hwpx `<hp:rect>+<hp:drawText>` 왕복을 통과한다 —
 /// 이전엔 통째로 드롭돼 안의 텍스트가 소실됐다.
 #[test]

--- a/docs/구현현황-분석.md
+++ b/docs/구현현황-분석.md
@@ -1,0 +1,133 @@
+# hwp-cli 메인 기능 구현 현황 분석
+
+> 작성일: 2026-07-06 · 기준 커밋: `fb88bb4` (수식 정식 조판 mini-TeX 머지)
+> 코드 전수 조사(크레이트 6개, 약 29,000줄 Rust) + 설계 문서(`docs/design/`) 대조 결과.
+>
+> **갱신 2026-07-06**: Tier 2 #1(hwpx 각주/미주·수식 writer arm) 완료 반영 (㊶, 커밋 `d96d504`).
+
+---
+
+## TL;DR
+
+**프로젝트가 표방하는 목표(읽기·변환·렌더·쓰기·AI편집, 한컴 무의존) 기준으로 핵심 파이프라인은 사실상 완성 단계다.** 테스트 213개, 소스 내 TODO/unimplemented 0건, hwp5 바이트 동일 왕복이 CI 게이트로 봉인돼 있고, 진단 코퍼스 51케이스 × 10검사 전부 통과 상태. 남은 갭은 3개 층위로 나뉜다:
+
+1. **포맷 간 의미 변환 갭** (구현 가치 높음) — ~~각주/미주·수식이 hwp→hwpx 변환 시 드롭~~ → **㊶에서 해소**(hwpx writer arm 추가, 실기 미검증). 잔여: hwp5 출신 수식의 EQEDIT 스크립트 미추출, hwpx→hwp 도형 안전 저하(텍스트만 보존)
+2. **렌더 충실도 갭** (선별 구현) — 어울림/자리차지(text wrap), 수식 행렬·극한, 탭 종류, 세로쓰기, WMF/EMF
+3. **전면 미구현** (대부분 안 해도 되는 영역) — 차트, OLE, 양식객체, 바탕쪽, 변경추적, 암호화/DRM 복호화
+
+---
+
+## 1. 영역별 구현 매트릭스
+
+| 기능 영역 | hwp5 읽기 | hwpx 읽기 | hwp5 쓰기 | hwpx 쓰기 | 렌더 | 판정 |
+|---|---|---|---|---|---|---|
+| 텍스트·문단·서식 | ✅ | ✅ | ✅ | ✅ | ✅ | **완성** |
+| 표 (병합·대각선·편집) | ✅ | ✅ | ✅ | ✅ | ✅ | **완성** |
+| 이미지 (PNG/JPG/BMP/GIF) | ✅ | ✅ | ✅ 합성 | ✅ | ✅ | **완성** |
+| 필드·누름틀·하이퍼링크·책갈피 | ✅ | ✅ | ✅ 생성까지 | ✅ | ✅ | **완성** (실기 검증) |
+| 머리말/꼬리말 | ✅ (Generic) | ✅ | ✅ | ✅ | ✅ | 완성에 준함 |
+| 구역·다단 (colPr/COLDEF) | ✅ | ✅ | ✅ | ✅ | ✅ | 완성 (colSz/colLine 미수집) |
+| 각주/미주 | raw 보존 | ✅ | raw 왕복만 | ✅ (㊶, 실기 미검증) | ✅ 페이지 하단 | **부분** |
+| 수식 | raw 보존 | ✅ | raw 왕복만 | ✅ hwpx 출신만 (㊶) | ✅ mini-TeX | **부분** |
+| 도형·글상자 | raw+렌더 파싱 | ✅ ShapeGeom | ⚠️ 안전 저하 | ✅ | ✅ 회전행렬까지 | **부분** |
+| 개체 배치 (어울림 등) | 파싱만 | 파싱만 | — | — | ❌ 절대좌표만 | **미완** |
+| 차트·OLE·양식객체 | raw 보존 | ❌ | raw 왕복만 | ❌ | ❌ 생략 경고 | 미구현 |
+| 암호화·배포용(DRM) | 감지·거부 | — | — | — | — | 정책적 미구현 |
+
+---
+
+## 2. 크레이트별 상세 현황
+
+### 2.1 hwp5 — HWP 5.0 바이너리 (`crates/hwp5/`)
+
+**읽기.**
+- 레코드 태그 전체 상수화(`record/tag.rs`), "알려진 prefix 구조체 + tail 보존" 규칙으로 전방 호환 무손실 파싱.
+- DocInfo 의미 파싱: DOCUMENT_PROPERTIES, ID_MAPPINGS, BIN_DATA, FACE_NAME, BORDER_FILL, CHAR_SHAPE, PARA_SHAPE, STYLE, NUMBERING(렌더용 7수준 템플릿), BULLET. **TAB_DEF는 raw 보존만.**
+- BodyText 의미 파싱: PARA_HEADER/TEXT/CHAR_SHAPE/LINE_SEG + 무결성 교차검증(nchars↔WCHAR 수, ExtCtrl↔CTRL_HEADER).
+- 컨트롤 의미 파싱은 4종: **표(tbl)·구역정의(secd, PAGE_DEF)·그림(gso, 조건부)·단정의(cold)**. 나머지(머리말/꼬리말·각주/미주·필드·책갈피·글상자·수식·OLE)는 `GenericControl`로 ctrl_id+페이로드+`raw_children` 서브트리 **무손실 보존**.
+
+**쓰기.** 두 경로 병행:
+- (A) 원본 보존 재작성 — hwp 출신·무수정 문서는 압축 해제 스트림 기준 **바이트 동일** (`tests/identity.rs`, `tests/roundtrip.rs` 게이트).
+- (B) 합성(synthesis) — md/hwpx 출신·편집 문서. 그림 레코드 합성(SHAPE_COMPONENT_PICTURE + BIN_DATA), secd 필수 자식 보충, COMPATIBLE_DOCUMENT 서브트리, 문단 불변식(0x0d, bit31=마지막 문단, instance_id 유니크, PARA_LINE_SEG 합성), CFB V3 강제, EncryptVersion=4, 보조 스트림(DocOptions/Scripts/PrvText/PrvImage) 표본 동형 생성.
+- **한계**: hwpx 출신 구조화 도형/글상자는 안전 저하(텍스트만 본문 hoist, 래퍼 생략, `write.rs:455-463` "kind별 정합 역합성은 후속 과제").
+
+**압축/암호화.** zlib(raw deflate) 완전 지원. 암호화·배포용(DRM) 문서는 플래그 판별 후 명확한 에러로 **읽기 거부**(복호화 미구현 — 의도된 정책).
+
+### 2.2 hwpx — OWPML/KS X 6101 (`crates/hwpx/`)
+
+**읽기.** 본문: `hp:p/run/t/tab/lineBreak/secPr/ctrl/tbl/equation/linesegarray/pic` + 도형 6종(`rect/ellipse/line/polygon/curve/arc`→ShapeGeom). ctrl: fieldBegin/End(중첩 LIFO), bookmark, colPr, header/footer, footNote/endNote, autoNum, pageNum, pageHiding, newNum. header.xml: fontface, charPr(효과 전체), paraPr, numbering, bullet, borderFill, style.
+- 미수집: colPr의 colSz/colLine(단별 폭·구분선), tabPr 세부, beginNum 읽기.
+
+**쓰기.** 템플릿 파일이 아닌 **IR→XML 합성**(패키지 부속만 표본 상수). 도형은 hwpx 출신 ShapeGeom과 hwp5 출신 gso 양쪽 방출, 글상자는 rect+drawText로 텍스트·필드·책갈피 보존. run당 도형 12개 분할(한글 ~21개 렌더 한계 회피).
+- ~~핵심 갭: 각주/미주(`fn`/`en`)·수식(`eqed`)은 writer match arm이 없어 DROP~~ → **㊶에서 해소**: `write_footnote_endnote`(`<hp:ctrl><hp:footNote|endNote>`+subList)·`write_equation`(run 수준 `<hp:equation>`+`hp:script`) 추가, 왕복 테스트 2종(`각주_미주_hwpx_왕복`, `수식_hwpx_왕복` — XML 특수문자 케이스 포함). 부수 개선: `read_element_text`가 `hp:script`의 CDATA·엔티티 참조를 해석. **잔여**: hwp5 출신 수식(`equation: None`)은 여전히 안전 DROP, 한글 실기 수용 미검증.
+- 왕복은 "의미 동등"이 목표. 바이트 보존은 `patch.rs`(ZIP raw 복사 + `{{name}}` 외과 치환) 경로 전용.
+
+**미구현(읽기·쓰기 모두)**: 차트, OLE, 양식객체(comboBox 등), 비디오, 스크립트, 바탕쪽(마스터페이지), 개체 그룹(`hp:container`는 텍스트만 수집).
+
+### 2.3 hwp-render — PNG/SVG/PDF (`crates/hwp-render/`, 약 7,500줄)
+
+- **PDF가 가장 완성도 높음**: 폰트 서브셋(subsetter) → Identity-H CID 합성(glyf=CIDFontType2/FontFile2, CFF=CIDFontType0/FontFile3), ToUnicode CMap(검색·복사 가능), JPEG 무손실 DCTDecode 통과, 알파 SMask.
+- **레이아웃**: 저장된 PARA_LINE_SEG 우선 + 자체 그리디 줄바꿈 폴백, 양쪽정렬(공백 우선 분배), 다단(단 넘김/페이지 넘김 구분), 표(열 폭 확정 → 행 높이 실측 → 병합·대각선), 연결 글상자, 머리말/꼬리말, 각주/미주(페이지 하단 + 구분선 + 윗첨자 번호).
+- **텍스트**: rustybuzz 셰이핑, 7언어 슬롯, 글자별 커버리지 폴백, 자간/장평, 밑줄·취소선·음영·그림자·양각·음각·외곽선·첨자, faux-bold/italic.
+- **도형**: 선/사각형(둥근 모서리)/타원/호/다각형/곡선, 단색·그러데이션(선형/방사형)·이미지 채움, 점선 5종, 화살촉, hwp5 경로는 어파인 행렬로 회전·플립까지, 그룹 재귀(깊이 16).
+- **수식 mini-TeX**: 분수(over/atop), 근호, 상하 첨자, 그리스 문자·연산자 매핑, 함수어 로만체. **미지원: 행렬, 큰 연산자 상하한 스택, LEFT/RIGHT 구분자.**
+- **미구현**: 어울림/자리차지 text wrap(floating 개체를 본문이 피해 흐르지 않음), 세로쓰기, WMF/EMF(자홍 placeholder), 차트/OLE(생략 경고), 미주가 문서 끝이 아닌 페이지 하단, 탭은 왼쪽 정렬만.
+
+### 2.4 hwp-model / hwp-convert / hwp-cli
+
+- **IR**(hwp-model): Document→Section→Paragraph→HwpChar 4종(Text/CharCtrl/InlineCtrl/ExtCtrl) + Control 4종(SectionDef/Table/Picture/Generic). CharShape/ParaShape/Style/FaceName/BorderFill 완전 모델. 렌더 전용 보조: ColumnDef, ShapeGeom, Equation, bullet_chars/numbering_levels. 미해석은 `OpaqueRecord`로 무손실 운반.
+- **변환**(hwp-convert): 읽기 hwp5/hwpx/json → 쓰기 **hwp/hwpx/md/json/html/pdf/odt**. markdown→IR: 헤딩·굵게/기울임·GFM 표·목록·인용문·코드블록·링크(→%hlk 하이퍼링크). IR→markdown: 이미지는 빈 플레이스홀더, 하이퍼링크 문법 미생성. `--strict`는 DROP 경고 시 비정상 종료. `--embed-bin`으로 이미지 포함 자급식 JSON.
+- **CLI** 14개 서브커맨드: info, cat, convert, render, new, diff, edit, fields, bookmarks, slots, fill, validate, mcp, dump.
+- **edit 프리미티브 15종**: replace, set-cell, set-field, set-meta, create-field, create-bookmark, create-hyperlink, insert-image, set-format, set-align, insert-para(-before), delete-para, add-row, delete-row, verify.
+- **MCP 도구 12개**: hwp_info/read/list_fields/list_bookmarks/render/edit/convert/new/diff/slots/fill/validate. (README의 "8개 도구"는 구버전 기술 — 갱신 필요.)
+
+---
+
+## 3. "어디까지 구현해야 하는가" — 목표 기준 티어
+
+목표가 "한컴 무의존 서버/CI에서 실무 문서를 다루는 것"이므로, HWP 5.0/OWPML 전체 스펙이 아니라 **실무 문서 출현 빈도 × 파이프라인 완결성** 기준으로 판단한다.
+
+### Tier 1 — 필수 (완료됨)
+
+텍스트·서식·표·이미지·필드·머리꼬리말·다단·렌더·왕복. 게이트(바이트 동일 왕복 + 한글 실기 규칙 카탈로그)까지 있어 **추가 구현이 아니라 유지 대상**.
+
+### Tier 2 — 해야 할 것 (우선순위순)
+
+| # | 항목 | 비용 | 근거 |
+|---|---|---|---|
+| 1 | ~~**hwpx writer에 각주/미주·수식 방출 arm 추가**~~ ✅ **완료** (커밋 `d96d504`, ㊶) | 낮음 | 자체 왕복 검증 통과. **잔여**: ① 한글 실기 수용 검증 ② hwp5 출신 수식은 EQEDIT 스크립트 미추출이라 여전히 DROP — hwp5 파서에서 `GenericControl.equation` 채우는 후속 작업 필요(렌더도 함께 개선됨) |
+| 2 | **개체 배치 충실도** (어울림/자리차지, vertRelTo/textWrap/z-order) | 중간 | 렌더러가 floating 개체를 절대좌표에 그리기만 함. 미해결 이슈(annual 5·6쪽 글상자 드롭+페이지 오버플로)의 유력 원인으로 설계 문서(00-overview, 08-external-research)가 지목. 렌더 픽셀 정확도의 다음 관문 |
+| 3 | **hwpx→hwp 도형 정합 역합성** | 높음 | 현재는 안전 저하(텍스트 hoist, 래퍼 생략). kind별 정품 템플릿 기반 역합성은 정답지 실기 반복 필요(`hwp5/src/write.rs:455-463` 명시). 완성 시 "도형 포함 양방향 변환" 완결 |
+| 4 | **미주를 문서 끝에 배치** | 낮음 | 현재 각주처럼 페이지 하단 렌더. 렌더 수정만으로 해결 |
+| 5 | 잔여 정밀도 묶음 | 낮음~중간 | 탭 종류(오른쪽/가운데/소수점), NUMBERING 시작번호(현재 1 고정), 다단 colSz/colLine, IR→md 하이퍼링크 문법·이미지 추출, 수식 행렬·큰연산자 상하한 |
+
+### Tier 3 — 안 해도 되는 것 (목표 대비 투자수익 낮음)
+
+- **차트·OLE·양식객체·비디오**: 실무 출현 빈도 낮고 렌더에 별도 엔진 필요. 현재의 "raw 보존(동일 포맷 왕복 무손실) + 렌더 생략 경고"가 합리적 종착점. 확장하더라도 렌더에서 placeholder 박스 표시 정도.
+- **암호화/배포용(DRM) 복호화**: 법적·정책적 별개 문제. 현재의 명확한 감지·거부가 올바른 설계.
+- **세로쓰기, 바탕쪽(마스터페이지), 변경추적 의미 모델, WMF/EMF**: 특수 문서 전용. WMF/EMF는 벡터 변환 의존성이 커서 현재의 placeholder + 경고가 실용적.
+
+---
+
+## 4. 품질 상태 — 구현 "깊이"의 근거
+
+- **게이트 3중**:
+  1. L0 identity — 레코드 재직렬화가 압축 해제 기준 바이트 동일 (`hwp5/tests/identity.rs`)
+  2. roundtrip — hwp→IR→hwp 바이트 동일, 표·이미지·도형·책갈피 포함 (`hwp5/tests/roundtrip.rs`)
+  3. golden 렌더 — 한글 출력 PNG 대조, bad-pixel 0.6% 상한 (`hwp-render/tests/golden.rs`, `HWP_GOLDEN=1`)
+- **CI**: MSRV 1.93 고정, fmt/clippy(-D warnings)/test 전부 강제. fixture 부재 시 자동 스킵 설계.
+- **한글 실기 호환 규칙 30여 개** (`docs/design/07-hangul-compat-rules.md`): CFB V3 강제, EncryptVersion=4, bit31=리스트 마지막 문단 표식, 빈 문단 PARA_TEXT 생략, COMPATIBLE_DOCUMENT 필수, 표 블록 패딩 566 등 — 공개 스펙에 없는 암묵 불변식을 정품 바이트 대조·실기로만 확정한 것이 이 프로젝트의 실질 해자.
+- **진단 코퍼스** (`tools/diagnostic_corpus.py`): 기능 격리 51케이스 × 10검사 전부 통과 (2026-07 기준).
+- **문서화된 미해결**: annual 5·6쪽 글상자 드롭+페이지 오버플로(개체 속성 충실도 유력), 양쪽정렬(U2)·자간(U4) 정밀도 — 모두 Tier 2의 #2(배치 충실도)와 같은 축.
+
+---
+
+## 5. 결론
+
+"메인 기능"은 전부 구현됐다. 다음 마일스톤으로 가치 있는 것은 세 가지다:
+
+1. ~~**hwpx 각주/수식 writer arm**~~ ✅ **완료** (㊶) — 잔여: 한글 실기 검증 + hwp5 EQEDIT 스크립트 추출(추출되면 hwp 출신 수식의 변환·렌더가 동시에 열림)
+2. **개체 배치 충실도** — 렌더 정확도의 다음 병목이자 알려진 미해결 이슈의 원인 축
+3. **도형 역합성** — 양방향 변환의 마지막 조각
+
+차트/OLE/DRM은 현재의 "보존+거부" 설계가 종착점으로 타당하다.


### PR DESCRIPTION

hwpx writer에 방출 arm이 없어 각주/미주/수식이 쓰기 시 통째로 DROP됐습니다. 각주 든 hwpx는 편집만 해도 각주가 사라지는 데이터 손실입니다.

fn/en 컨트롤은 hp:footNote/hp:endNote + subList로 방출합니다(write_header_footer 거울 구조). 수식은 equation이 채워진 경우에만 run 수준 hp:equation으로 방출하고, hwp5 출신(스크립트 미추출)은 기존 안전 DROP을 유지합니다. 리더도 하나 보강했습니다. hp:script의 엔티티(&lt;, &amp;)를 해석해 특수문자 수식이 읽기에서도 유실되던 결함을 수정했습니다.

기존 방출 경로는 무변경입니다. 왕복 테스트 2종 추가, fmt·clippy·test 통과.

참고: 한글 실기 미검증(자체 왕복만 통과). hwp5 수식의 EQEDIT 스크립트 추출은 후속 PR 예정.