### PR TITLE
fix: Windows CI 테스트 실패 진단·해결 + 포크 문서 일반화

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ HWP_FONT_DIR=$PWD/fonts python3 tools/diagnostic_corpus.py   # 진단 코퍼스 
 
 - 기능추가·수정·문서 등 **모든 작업은 별도 브랜치**에서 한다: `feat/<주제>`·`fix/<주제>`·`docs/<주제>`.
   main 직접 push 금지.
-- 포크 구도 주의: 브랜치는 origin(entelecheia 포크)에 push하고, **PR은 upstream
-  (YeolHanMyeong/hwp-cli) main을 대상으로** 연다. 포크 자체 main으로 PR하지 않는다.
+- 포크 구도 주의: 브랜치는 자신의 포크(origin)에 push하고, **PR은 원 저장소(upstream)의
+  main을 대상으로** 연다. 포크 자체 main으로 PR하지 않는다.
 - PR로 제출하고, **CI green(ubuntu+macOS 필수)을 확인한 뒤 squash 머지**한다(머지 커밋 제목의
   `(#N)` 관례 유지). Windows 잡은 참고용(비차단 — 잡은 빨갛게 보여도 워크플로는 통과).
 - PR 전 로컬 게이트는 `scripts/check.sh` — CI와 동일 3커맨드(fmt → clippy --all-targets

--- a/crates/hwp-cli/tests/cli.rs
+++ b/crates/hwp-cli/tests/cli.rs
@@ -103,6 +103,16 @@ fn tmp(name: &str) -> PathBuf {
     dir.join(name)
 }
 
+/// 실패 진단용: 파일의 cat 출력(본문+stderr)을 덤프한다 (Windows CI 전용 결함 추적).
+fn dump_file(path: &PathBuf) -> String {
+    let out = hwp().arg("cat").arg(path).output().unwrap();
+    format!(
+        "stdout={:?} stderr={:?}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    )
+}
+
 #[test]
 fn cat_with_header_footer_hidden_flags() {
     // 합성 문서로 cat 텍스트 추출 옵션 플래그가 파싱되고 본문을 출력하는지(스모크).
@@ -387,8 +397,9 @@ fn edit_add_row_then_fill() {
         .unwrap();
     assert!(
         r1.status.success(),
-        "edit --add-row: {}",
-        String::from_utf8_lossy(&r1.stderr)
+        "edit --add-row: {} | form.hwp: {}",
+        String::from_utf8_lossy(&r1.stderr),
+        dump_file(&form)
     );
     // pass 2: 추가된 행 셀 채움
     let out = tmp("hwp_cli_addrow_out.hwp");
@@ -457,8 +468,9 @@ fn fill_data_tables_grows() {
         .unwrap();
     assert!(
         r.status.success(),
-        "fill --data tables: {}",
-        String::from_utf8_lossy(&r.stderr)
+        "fill --data tables: {} | form.hwp: {}",
+        String::from_utf8_lossy(&r.stderr),
+        dump_file(&form)
     );
     let j = String::from_utf8_lossy(&r.stdout);
     assert!(j.contains("\"rows_added\""), "rows_added 키: {j}");
@@ -863,7 +875,8 @@ fn edit_seal_floating_image_roundtrip() {
     assert!(ct5.status.success(), "hwp5 재읽기 성공");
     assert!(
         String::from_utf8_lossy(&ct5.stdout).contains("(인)"),
-        "hwp5 왕복 후 앵커 유지"
+        "hwp5 왕복 후 앵커 유지 | out.hwp: {}",
+        dump_file(&out_hwp)
     );
 
     for f in [&md, &src, &png, &out_hwpx, &out_hwp] {

--- a/crates/hwp-cli/tests/cli.rs
+++ b/crates/hwp-cli/tests/cli.rs
@@ -103,13 +103,19 @@ fn tmp(name: &str) -> PathBuf {
     dir.join(name)
 }
 
-/// 실패 진단용: 파일의 cat 출력(본문+stderr)을 덤프한다 (Windows CI 전용 결함 추적).
+/// 실패 진단용: 파일의 cat 출력(본문+stderr)과 info(스트림 크기)를 덤프한다
+/// (Windows CI 전용 결함 추적 — write 측 산출물이 비었는지, read 측이 잃는지 구분).
 fn dump_file(path: &PathBuf) -> String {
-    let out = hwp().arg("cat").arg(path).output().unwrap();
+    let cat = hwp().arg("cat").arg(path).output().unwrap();
+    let info = hwp().args(["info", "--json"]).arg(path).output().unwrap();
     format!(
-        "stdout={:?} stderr={:?}",
-        String::from_utf8_lossy(&out.stdout),
-        String::from_utf8_lossy(&out.stderr)
+        "cat_stdout={:?} cat_stderr={:?} info={}",
+        String::from_utf8_lossy(&cat.stdout),
+        String::from_utf8_lossy(&cat.stderr),
+        String::from_utf8_lossy(&info.stdout)
+            .chars()
+            .take(400)
+            .collect::<String>()
     )
 }
 

--- a/crates/hwp5/src/container.rs
+++ b/crates/hwp5/src/container.rs
@@ -50,7 +50,10 @@ impl Hwp5Container {
             .walk()
             .filter(|e| e.is_stream())
             .map(|e| StreamInfo {
-                path: e.path().to_string_lossy().into_owned(),
+                // cfb의 Entry::path()는 Path::join으로 만드므로 Windows에서는 구분자가
+                // `\`로 렌더된다 — 스트림 경로 필터(`/BodyText/Section`)와 open_stream이
+                // `/`를 전제하므로 항상 `/`로 정규화한다(CFB 항목명 자체엔 구분자가 못 옴).
+                path: e.path().to_string_lossy().replace('\\', "/"),
                 size: e.len(),
             })
             .collect();

--- a/crates/hwp5/tests/synth.rs
+++ b/crates/hwp5/tests/synth.rs
@@ -779,3 +779,26 @@ fn 스타일_사다리_hwp5_정의_왕복() {
     assert!(text.contains("항목"), "{text}");
     assert!(!text.contains("❍"), "리터럴 마커는 더 쓰지 않는다: {text}");
 }
+
+/// 스트림 경로 구분자 회귀: cfb 열거가 플랫폼 구분자(Windows `\`)를 섞어도
+/// list_streams/body_sections는 항상 `/` 정규 경로를 돌려줘야 한다 — 아니면
+/// Windows에서 `/BodyText/Section` 필터가 전부 빗나가 본문이 빈 문서로 읽힌다
+/// (CI windows-latest의 "표 #0 없음"/빈 cat 3건의 근본 원인).
+#[test]
+fn 스트림_경로_구분자_정규화() {
+    let doc = hwp_convert::from_markdown("본문\n");
+    let out = tmp("path_sep.hwp");
+    hwp5::write_document(&doc, &out, &hwp5::WriteOptions::default()).unwrap();
+    let mut c = hwp5::Hwp5Container::open(&out).unwrap();
+    let streams = c.list_streams();
+    assert!(!streams.is_empty());
+    for s in &streams {
+        assert!(s.path.starts_with('/'), "절대 경로: {}", s.path);
+        assert!(!s.path.contains('\\'), "백슬래시 금지: {}", s.path);
+    }
+    let sections = c.body_sections();
+    assert_eq!(sections, vec!["/BodyText/Section0".to_string()]);
+    // 열거 경로로 바로 읽기가 돼야 한다.
+    let body = c.read_record_stream(&sections[0]).unwrap();
+    assert!(!body.is_empty(), "본문 스트림 읽기");
+}


### PR DESCRIPTION
## 목적
- Windows 레그(참고용)에서만 실패하는 3개 테스트의 원인 진단·해결:
  - edit_add_row_then_fill, fill_data_tables_grows: `표 #0를 찾을 수 없습니다`
  - edit_seal_floating_image_roundtrip: hwp5 왕복 후 앵커 소실
- CLAUDE.md 포크 구도 문구를 구체 계정명 없이 일반화

## 진행 방식
1단계(이 커밋): 실패 지점에 중간 산출물 cat 덤프 계측 → Windows CI 로그로 가설 이분
2단계: 근본 원인 수정 커밋 추가 예정

체크리스트: scripts/check.sh 통과(로컬 macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018AiF9yuE7MwRk4uYZBonw9