### PR TITLE
기능: 감사 1순위 배치 — 필드 33종·머리말 적용쪽·부유 그림 배치·스토리지 보존 (GF-4·GE-α9·GE-9·GE-β7/β8)

### DIFF
--- a/crates/hwp-convert/src/field.rs
+++ b/crates/hwp-convert/src/field.rs
@@ -33,10 +33,17 @@ pub struct FieldInfo {
     pub value: String,
 }
 
-/// 필드 종류 컨트롤 ID인지(누름틀·계산식·하이퍼링크 등).
+/// 필드 종류 컨트롤 ID인지(누름틀·계산식·하이퍼링크 등). 스펙 표 128의 34종 중
+/// **메모(`%%me`)를 제외한 33종**을 인식한다. 인식하지 못하면 hwpx write가 필드를
+/// **통째 드롭**(catch-all)하므로, 종류 라벨을 몰라도 최소한 fieldBegin/End·내용
+/// 텍스트는 보존하도록 목록에 담는다(OWPML type은 [`owpml_field_type`]의 UNKNOWN
+/// 폴백 — GF-1과 동일 손실 등급). `%%me`는 메모 리스트(GB-7)와 짝을 이뤄야 하는데
+/// 그 본문은 아직 미방출이라, 근거 없이 dangling 메모 필드를 내보내면 한글에서
+/// 문서가 깨질 수 있어 **의도적으로 보류**한다(정답지 필요).
 pub fn is_field_ctrl_id(ctrl_id: &[u8; 4]) -> bool {
     matches!(
         ctrl_id,
+        // 기존 12종(표 128).
         b"%clk"
             | b"%fmu"
             | b"%hlk"
@@ -49,6 +56,29 @@ pub fn is_field_ctrl_id(ctrl_id: &[u8; 4]) -> bool {
             | b"%smr"
             | b"%usr"
             | b"%unk"
+            // 변경추적 필드 19종(FIELD_REVISION_*, 표 128).
+            | b"%sig"
+            | b"%spl"
+            | b"%%mr"
+            | b"%%*d"
+            | b"%%*a"
+            | b"%%*C"
+            | b"%%*S"
+            | b"%%*T"
+            | b"%%*P"
+            | b"%%*L"
+            | b"%%*c"
+            | b"%%*h"
+            | b"%%*A"
+            | b"%%*i"
+            | b"%%*t"
+            | b"%%*r"
+            | b"%%*l"
+            | b"%%*n"
+            | b"%%*e"
+            // 개인정보 보안·차례(표 128). 메모(%%me)는 GB-7 연동 우려로 보류.
+            | b"%cpr"
+            | b"%toc"
     )
 }
 
@@ -66,6 +96,10 @@ pub fn owpml_field_type(ctrl_id: &[u8; 4]) -> &'static str {
         b"%pat" => "PATH",
         b"%smr" => "SUMMARY",
         b"%usr" => "USER_INFO",
+        // 차례 — 정답지 코퍼스 실측(과업지시서 hwpx `type="TABLEOFCONTENTS"`).
+        b"%toc" => "TABLEOFCONTENTS",
+        // 변경추적 19종·개인정보(%cpr)는 OWPML type 이름 근거가 없어 UNKNOWN 폴백
+        // (fieldBegin/End·내용은 보존, 종류 라벨만 상실 — GF-1 등급).
         _ => "UNKNOWN",
     }
 }
@@ -84,6 +118,7 @@ pub fn field_ctrl_id_from_owpml(t: &str) -> [u8; 4] {
         "PATH" | "FILE_PATH" => *b"%pat",
         "SUMMARY" => *b"%smr",
         "USER_INFO" => *b"%usr",
+        "TABLEOFCONTENTS" => *b"%toc",
         _ => *b"%unk",
     }
 }
@@ -101,8 +136,10 @@ fn kind_of(ctrl_id: &[u8; 4]) -> &'static str {
         b"%pat" => "파일경로",
         b"%smr" => "문서요약",
         b"%usr" => "사용자정보",
+        b"%cpr" => "개인정보보호",
+        b"%toc" => "차례",
         b"%unk" => "알수없음",
-        _ => "필드",
+        _ => "필드", // 변경추적(FIELD_REVISION_*) 등은 일반 라벨
     }
 }
 

--- a/crates/hwp-convert/src/from_markdown.rs
+++ b/crates/hwp-convert/src/from_markdown.rs
@@ -363,6 +363,8 @@ pub fn from_markdown_with(md: &str, opts: &MarkdownImportOptions) -> Document {
         bin_streams: b.bin_streams,
         hwpx_settings_xml: None,
         hwpx_version_xml: None,
+        hwp5_xml_template: Vec::new(),
+        hwp5_doc_history: Vec::new(),
     }
 }
 

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -27,6 +27,17 @@ pub struct Document {
     /// 통과시키기 위한 슬롯. hwp5 출신 문서는 `None`(쓰기 시 기본 상수).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hwpx_version_xml: Option<String>,
+    /// hwp5 `/XMLTemplate` 스토리지의 스트림 원문(스트림 CFB 경로 + 압축 미해제
+    /// 바이트). XML 스키마 바인딩 문서(전자정부 서식 등, §3.2.10)의 부속 파트를 IR
+    /// 경유 되쓰기에서 그대로 통과시키는 슬롯. 내용은 해석하지 않는다. hwpx 출신·해당
+    /// 스토리지가 없는 hwp5 문서는 빈 벡터.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hwp5_xml_template: Vec<(String, Vec<u8>)>,
+    /// hwp5 `/DocHistory` 스토리지의 스트림 원문(스트림 CFB 경로 + 압축 미해제
+    /// 바이트). 문서 이력(§3.2.11·§4.4)을 되쓰기에서 그대로 통과시키는 슬롯. 내용은
+    /// 해석하지 않는다(§4.4 파서는 범위 밖). hwpx 출신·이력이 없는 문서는 빈 벡터.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hwp5_doc_history: Vec<(String, Vec<u8>)>,
 }
 
 /// 문서 수준 메타데이터 (요약 정보 / OPF 메타).

--- a/crates/hwp5/src/body_text.rs
+++ b/crates/hwp5/src/body_text.rs
@@ -307,13 +307,16 @@ fn find_picture_record(children: &[RecordNode]) -> Option<&RecordNode> {
 /// + 꼭지점 4점(32) + 자르기(16) + 안쪽 여백(8) + 밝기(1)+명암(1)+효과(1)
 /// + **BinItem ID(2)** — 오프셋 71.
 fn parse_picture_gso(common: &[u8], children: &[RecordNode]) -> Result<hwp_model::Picture> {
-    // 개체 공통 속성: 속성(4) 세로(4) 가로(4) 폭(4) 높이(4)
+    // 개체 공통 속성(표 69): 속성(4) 세로offset(4) 가로offset(4) 폭(4) 높이(4) z-order(4)
     let mut r = ByteReader::new(common);
     let attr = r.read_u32()?;
-    let _v_offset = r.read_u32()?;
-    let _h_offset = r.read_u32()?;
+    let vert_offset = r.read_i32()?;
+    let horz_offset = r.read_i32()?;
     let width = HwpUnit(r.read_i32()?);
     let height = HwpUnit(r.read_i32()?);
+    // z-order는 폭/높이 뒤(@20) — GsoPlacement(표 69)와 동일 레이아웃. 손상·짧은
+    // 데이터면 0 폴백.
+    let z_order = r.read_i32().unwrap_or(0).max(0) as u32;
 
     let pic_node = find_picture_record(children)
         .ok_or_else(|| crate::error::Hwp5Error::MalformedRecord("그림 레코드 없음".into()))?;
@@ -326,10 +329,13 @@ fn parse_picture_gso(common: &[u8], children: &[RecordNode]) -> Result<hwp_model
         width,
         height,
         treat_as_char: attr & 1 != 0,
-        // hwp5 원본은 배치를 common_data로 보존하므로 합성용 필드는 0.
-        z_order: 0,
-        vert_offset: 0,
-        horz_offset: 0,
+        // 부유(글 앞) 그림 배치 승계(GE-9): 세로/가로 오프셋·z-order를 실값으로
+        // 올린다. GE-8이 TABLE에 쓴 GsoPlacement와 동일 표 69 레이아웃. hwpx write가
+        // floating `<hp:pos>`/zOrder에 그대로 방출한다. common_data raw는 그대로
+        // 두므로 hwp5→hwp5 identity 재직렬화는 무손실.
+        z_order,
+        vert_offset,
+        horz_offset,
         bin_ref: hwp_model::BinRef::Id(hwp_model::BinDataId(bin_id)),
         extras: children.iter().map(to_opaque).collect(),
     })
@@ -679,4 +685,41 @@ fn subtree_has_paragraphs(node: &RecordNode) -> bool {
     node.children.iter().any(|c| {
         c.tag == tag::PARA_HEADER || c.tag == tag::LIST_HEADER || subtree_has_paragraphs(c)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// GE-9: 부유 그림의 세로/가로 오프셋·z-order를 개체 공통 속성(표 69)에서
+    /// 실값으로 승계한다(이전엔 전부 0 하드코딩 → 좌상단 뭉침).
+    #[test]
+    fn 부유_그림_배치_승계() {
+        let mut common = Vec::new();
+        common.extend_from_slice(&0u32.to_le_bytes()); // attr: 글자처럼=0(부유)
+        common.extend_from_slice(&5000i32.to_le_bytes()); // 세로 offset
+        common.extend_from_slice(&3000i32.to_le_bytes()); // 가로 offset
+        common.extend_from_slice(&10000i32.to_le_bytes()); // 폭
+        common.extend_from_slice(&8000i32.to_le_bytes()); // 높이
+        common.extend_from_slice(&7i32.to_le_bytes()); // z-order
+        common.extend_from_slice(&[0u8; 8]); // 바깥 여백 4×u16
+
+        // 그림 레코드: 71B 스킵 후 bin_id(u16).
+        let mut pic_data = vec![0u8; 71];
+        pic_data.extend_from_slice(&3u16.to_le_bytes());
+        let pic_node = RecordNode {
+            tag: tag::SHAPE_COMPONENT_PICTURE,
+            data: pic_data,
+            children: Vec::new(),
+        };
+
+        let p = parse_picture_gso(&common, &[pic_node]).unwrap();
+        assert!(!p.treat_as_char, "부유(글자처럼=false)");
+        assert_eq!(p.vert_offset, 5000, "세로 offset 승계");
+        assert_eq!(p.horz_offset, 3000, "가로 offset 승계");
+        assert_eq!(p.z_order, 7, "z-order 승계");
+        assert_eq!(p.width.0, 10000);
+        assert_eq!(p.height.0, 8000);
+        assert_eq!(p.bin_ref, hwp_model::BinRef::Id(hwp_model::BinDataId(3)));
+    }
 }

--- a/crates/hwp5/src/read.rs
+++ b/crates/hwp5/src/read.rs
@@ -67,6 +67,21 @@ pub fn read_document(path: &Path) -> Result<ReadResult> {
         .map(|raw| crate::summary::parse_summary(&raw))
         .unwrap_or_default();
 
+    // XMLTemplate·DocHistory 스토리지: 내용 해석 없이 원문 바이트 그대로 포착
+    // (§3.2.10·§3.2.11·§4.4). IR 경유 되쓰기에서 writer가 재방출한다. 스토리지별
+    // 압축 규칙이 스펙에 미기재라 **해제하지 않고** 바이트 그대로가 무손실이다.
+    let mut hwp5_xml_template = Vec::new();
+    let mut hwp5_doc_history = Vec::new();
+    for info in container.list_streams() {
+        if info.path.starts_with("/XMLTemplate/") {
+            let raw = container.read_stream_raw(&info.path)?;
+            hwp5_xml_template.push((info.path.clone(), raw));
+        } else if info.path.starts_with("/DocHistory/") {
+            let raw = container.read_stream_raw(&info.path)?;
+            hwp5_doc_history.push((info.path.clone(), raw));
+        }
+    }
+
     let document = Document {
         meta: DocMeta {
             source_format: "hwp5".to_string(),
@@ -79,6 +94,8 @@ pub fn read_document(path: &Path) -> Result<ReadResult> {
         // hwp5 출신 문서는 hwpx 부속 파트가 없다 → None(쓰기 시 기본 상수).
         hwpx_settings_xml: None,
         hwpx_version_xml: None,
+        hwp5_xml_template,
+        hwp5_doc_history,
     };
     Ok(ReadResult { document, warnings })
 }

--- a/crates/hwp5/src/write.rs
+++ b/crates/hwp5/src/write.rs
@@ -226,6 +226,21 @@ pub fn write_document(doc: &Document, path: &Path, opts: &WriteOptions) -> Resul
     if let Some(img) = &opts.prv_image {
         cfb.create_new_stream("/PrvImage")?.write_all(img)?;
     }
+    // XMLTemplate·DocHistory 스토리지 원문 재방출(§3.2.10·§3.2.11 — 내용 미해석
+    // pass-through). read가 압축 미해제로 포착했으므로 그대로 쓴다(compress 금지 —
+    // 바이트 동일 보존). 스트림의 상위 스토리지는 mkdir -p로 확보한다.
+    for (path, bytes) in doc
+        .hwp5_xml_template
+        .iter()
+        .chain(doc.hwp5_doc_history.iter())
+    {
+        if let Some((parent, _)) = path.rsplit_once('/')
+            && !parent.is_empty()
+        {
+            cfb.create_storage_all(parent)?;
+        }
+        cfb.create_new_stream(path.as_str())?.write_all(bytes)?;
+    }
     cfb.flush()?;
     Ok(warnings)
 }

--- a/crates/hwp5/tests/synth.rs
+++ b/crates/hwp5/tests/synth.rs
@@ -802,3 +802,69 @@ fn 스트림_경로_구분자_정규화() {
     let body = c.read_record_stream(&sections[0]).unwrap();
     assert!(!body.is_empty(), "본문 스트림 읽기");
 }
+
+/// GE-β7/β8: XMLTemplate·DocHistory 스토리지가 read→write 되쓰기에서 원문 바이트
+/// 그대로 통과한다(내용 미해석 pass-through). 합성 .hwp에 두 스토리지를 주입한 뒤
+/// read_document→write_document 후 스트림 존재·바이트 동일을 확인한다.
+#[test]
+fn xmltemplate_dochistory_스토리지_왕복() {
+    use std::io::{Read as _, Write as _};
+
+    // 1. 기본 문서를 저장하고 CFB에 두 스토리지를 주입한다(한글 저장본 모사).
+    let doc = hwp_convert::from_markdown("본문");
+    let a = tmp("storage_a.hwp");
+    hwp5::write_document(&doc, &a, &hwp5::WriteOptions::default()).unwrap();
+
+    let tmpl_bytes: Vec<u8> = (0u8..=255).collect(); // 압축 안 된 임의 바이트
+    let hist_bytes: Vec<u8> = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x00, 0x01, 0x02];
+    {
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&a)
+            .unwrap();
+        let mut cfb = cfb::CompoundFile::open(file).unwrap();
+        cfb.create_storage("/XMLTemplate").unwrap();
+        cfb.create_new_stream("/XMLTemplate/Schema")
+            .unwrap()
+            .write_all(&tmpl_bytes)
+            .unwrap();
+        cfb.create_storage("/DocHistory").unwrap();
+        cfb.create_new_stream("/DocHistory/VersionLog0")
+            .unwrap()
+            .write_all(&hist_bytes)
+            .unwrap();
+        cfb.flush().unwrap();
+    }
+
+    // 2. read_document이 두 스토리지를 원문 그대로 IR에 올린다.
+    let reread = hwp5::read_document(&a).unwrap().document;
+    assert_eq!(
+        reread.hwp5_xml_template,
+        vec![("/XMLTemplate/Schema".to_string(), tmpl_bytes.clone())],
+        "XMLTemplate 포착"
+    );
+    assert_eq!(
+        reread.hwp5_doc_history,
+        vec![("/DocHistory/VersionLog0".to_string(), hist_bytes.clone())],
+        "DocHistory 포착"
+    );
+
+    // 3. write_document이 두 스토리지를 바이트 동일하게 재방출한다.
+    let b = tmp("storage_b.hwp");
+    hwp5::write_document(&reread, &b, &hwp5::WriteOptions::default()).unwrap();
+    let file = std::fs::File::open(&b).unwrap();
+    let mut cfb = cfb::CompoundFile::open(file).unwrap();
+    let mut got_tmpl = Vec::new();
+    cfb.open_stream("/XMLTemplate/Schema")
+        .unwrap()
+        .read_to_end(&mut got_tmpl)
+        .unwrap();
+    assert_eq!(got_tmpl, tmpl_bytes, "XMLTemplate 바이트 동일");
+    let mut got_hist = Vec::new();
+    cfb.open_stream("/DocHistory/VersionLog0")
+        .unwrap()
+        .read_to_end(&mut got_hist)
+        .unwrap();
+    assert_eq!(got_hist, hist_bytes, "DocHistory 바이트 동일");
+}

--- a/crates/hwpx/src/read/mod.rs
+++ b/crates/hwpx/src/read/mod.rs
@@ -87,6 +87,9 @@ pub fn read_document(path: &Path) -> Result<ReadResult> {
             bin_streams,
             hwpx_settings_xml,
             hwpx_version_xml,
+            // hwpx 출신은 hwp5 전용 스토리지가 없다(GE-β7/β8 경로 무관).
+            hwp5_xml_template: Vec::new(),
+            hwp5_doc_history: Vec::new(),
         },
         warnings,
     })

--- a/crates/hwpx/src/write/section.rs
+++ b/crates/hwpx/src/write/section.rs
@@ -859,6 +859,23 @@ fn write_col_ctrl(out: &mut String, col: Option<&hwp_model::ColumnDef>) {
     );
 }
 
+/// 머리말/꼬리말 적용쪽(applyPageType) 역매핑. `g.data` 선두 UINT32의 bits0-1이
+/// 적용될 페이지 종류다(0=양쪽·1=짝수·2=홀수). hwp5-origin은 CTRL_HEADER 속성(표
+/// 141), hwpx-origin은 read 측 `head_foot_data`가 만든 8B 페이로드(apply@0)로, 두
+/// 경로 모두 선두 u32에 적용쪽이 실린다 — read의 정매핑을 그대로 뒤집는다.
+fn header_footer_apply_page(data: &[u8]) -> &'static str {
+    let apply = if data.len() >= 4 {
+        u32::from_le_bytes([data[0], data[1], data[2], data[3]]) & 0x3
+    } else {
+        0
+    };
+    match apply {
+        1 => "EVEN",
+        2 => "ODD",
+        _ => "BOTH",
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn write_header_footer(
     out: &mut String,
@@ -874,9 +891,10 @@ fn write_header_footer(
     } else {
         "footer"
     };
+    let apply = header_footer_apply_page(&g.data);
     let _ = write!(
         out,
-        r##"<hp:ctrl><hp:{el} id="{}" applyPageType="BOTH">"##,
+        r##"<hp:ctrl><hp:{el} id="{}" applyPageType="{apply}">"##,
         ids.next()
     );
     for list in &g.paragraph_lists {

--- a/crates/hwpx/tests/write.rs
+++ b/crates/hwpx/tests/write.rs
@@ -220,6 +220,75 @@ fn markdown_각주_취소선_목록_hwpx_완전왕복() {
     assert!(md_out.contains("- 안쪽 가"), "중첩 불릿: {md_out}");
 }
 
+/// 머리말/꼬리말 적용쪽(applyPageType)이 hwpx write→read 왕복에서 보존된다(GE-α9).
+/// 이전엔 writer가 `applyPageType="BOTH"` 상수라 짝수/홀수 구분 머리말이 항상
+/// "양쪽"으로 뭉개졌다. `g.data` 선두 u32(적용쪽)를 read의 역매핑으로 방출한다.
+#[test]
+fn 머리말_적용쪽_hwpx_왕복() {
+    use hwp_model::{Control, GenericControl, HwpChar, Paragraph, ParagraphList};
+
+    for (apply, want, tag) in [(1u32, "EVEN", 1u8), (2u32, "ODD", 2u8)] {
+        let mut doc = hwp_convert::from_markdown("본문");
+        // head_foot_data 레이아웃: apply(u32)@0 + id(u32)@4.
+        let mut data = Vec::with_capacity(8);
+        data.extend_from_slice(&apply.to_le_bytes());
+        data.extend_from_slice(&0u32.to_le_bytes());
+        let g = GenericControl {
+            ctrl_id: *b"head",
+            data,
+            paragraph_lists: vec![ParagraphList {
+                header_data: Vec::new(),
+                paragraphs: vec![Paragraph::default()],
+            }],
+            extras: Vec::new(),
+            raw_children: Vec::new(),
+            gso_shapes: Vec::new(),
+            equation: None,
+            column_def: None,
+        };
+        // 머리말 컨트롤을 문단에 ExtCtrl(코드 16)로 부착.
+        let para = &mut doc.sections[0].paragraphs[0];
+        let idx = para.controls.len() as u32;
+        para.chars.push(HwpChar::ExtCtrl {
+            code: 16,
+            ctrl_id: *b"head",
+            payload: hwp_convert::field::rev_payload(b"head"),
+            ctrl_index: Some(idx),
+        });
+        para.controls.push(Control::Generic(g));
+
+        let out = tmp(&format!("hf_{apply}.hwpx"));
+        let warnings = hwpx::write_document(&doc, &out).unwrap();
+        assert!(warnings.is_empty(), "{warnings:?}");
+
+        // 방출 XML에 상수 BOTH가 아니라 실제 적용쪽이 들어간다.
+        let bytes = std::fs::read(&out).unwrap();
+        let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+        let mut raw = Vec::new();
+        zip.by_name("Contents/section0.xml")
+            .unwrap()
+            .read_to_end(&mut raw)
+            .unwrap();
+        let xml = String::from_utf8(raw).unwrap();
+        assert!(
+            xml.contains(&format!(r#"applyPageType="{want}""#)),
+            "applyPageType={want} 방출: {xml}"
+        );
+
+        // 되읽은 head 컨트롤의 g.data 선두 u32가 적용쪽을 보존.
+        let reread = hwpx::read_document(&out).unwrap().document;
+        let apply_byte = reread.sections[0]
+            .paragraphs
+            .iter()
+            .flat_map(|p| &p.controls)
+            .find_map(|c| match c {
+                Control::Generic(g) if g.ctrl_id == *b"head" => Some(g.data.first().copied()),
+                _ => None,
+            });
+        assert_eq!(apply_byte, Some(Some(tag)), "적용쪽 왕복 (apply={apply})");
+    }
+}
+
 /// 본문 탭이 hwpx에서 `<hp:t>` **안**의 중첩 `<hp:tab width leader type/>`(정품 mixed
 /// content)로 방출되고 raw 0x09가 절대 없어야 한다. t 밖 형제 bare 탭은 한글이 폭 0으로
 /// 무시하고(D3 밀착), raw 0x09를 t 안에 그대로 두면 한글이 파일을 열지 못한다(D3 먹통).

--- a/crates/hwpx/tests/write.rs
+++ b/crates/hwpx/tests/write.rs
@@ -464,6 +464,115 @@ fn 필드_생성_hwpx_왕복() {
     assert_eq!(fields[0].value, "홍길동");
 }
 
+/// GF-4: 표 128의 확장 필드(변경추적·차례·개인정보)가 hwpx write에서 DROP되지
+/// 않고 fieldBegin/End·내용 텍스트로 방출된다. OWPML type은 근거 없어 UNKNOWN 폴백
+/// (라벨은 잃어도 필드·내용 보존 — GF-1 등급). 재읽기 시 %unk로 되살아나 왕복 성립.
+#[test]
+fn 확장필드_hwp5출신_hwpx_방출() {
+    use hwp_model::{Control, GenericControl, HwpChar};
+
+    // 대표 3종: 변경추적(삭제, %%*d)·차례(%toc)·개인정보(%cpr). 각 필드를 한
+    // 문단에 FIELD_START(코드3)+내용+FIELD_END(코드4)로 배치.
+    let fields: [(&[u8; 4], &str); 3] = [
+        (b"%%*d", "삭제된 문장"),
+        (b"%toc", "제1장 서론"),
+        (b"%cpr", "홍**"),
+    ];
+    let mut doc = hwp_convert::from_markdown("본문");
+    let para = &mut doc.sections[0].paragraphs[0];
+    para.chars.clear();
+    para.controls.clear();
+    for (i, (id, text)) in fields.iter().enumerate() {
+        para.chars.push(HwpChar::ExtCtrl {
+            code: 3, // FIELD_START
+            ctrl_id: **id,
+            payload: hwp_convert::field::rev_payload(id),
+            ctrl_index: Some(i as u32),
+        });
+        para.chars.extend(text.chars().map(HwpChar::Text));
+        para.chars.push(HwpChar::InlineCtrl {
+            code: 4, // FIELD_END
+            payload: hwp_convert::field::field_end_payload(id),
+        });
+        para.controls.push(Control::Generic(GenericControl {
+            ctrl_id: **id,
+            data: vec![0u8; 11], // 속성4 기타1 len2=0 id4
+            paragraph_lists: Vec::new(),
+            extras: Vec::new(),
+            raw_children: Vec::new(),
+            gso_shapes: Vec::new(),
+            equation: None,
+            column_def: None,
+        }));
+    }
+    para.header.ctrl_mask = 0;
+
+    let out = tmp("ext_fields.hwpx");
+    let warnings = hwpx::write_document(&doc, &out).unwrap();
+    // 확장 필드는 DROP 경고 없이 방출돼야 한다.
+    assert!(
+        !warnings.iter().any(|w| w.contains("DROP")),
+        "DROP 경고: {warnings:?}"
+    );
+
+    let bytes = std::fs::read(&out).unwrap();
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+    let mut raw = Vec::new();
+    zip.by_name("Contents/section0.xml")
+        .unwrap()
+        .read_to_end(&mut raw)
+        .unwrap();
+    let xml = String::from_utf8(raw).unwrap();
+    assert_eq!(
+        xml.matches("<hp:fieldBegin").count(),
+        3,
+        "fieldBegin 3개: {xml}"
+    );
+    assert_eq!(
+        xml.matches("<hp:fieldEnd").count(),
+        3,
+        "fieldEnd 3개: {xml}"
+    );
+    for (_, text) in &fields {
+        assert!(xml.contains(text), "내용 텍스트 보존({text}): {xml}");
+    }
+    // 차례(%toc)는 코퍼스 실측 OWPML type으로, 변경추적·개인정보는 UNKNOWN 폴백으로.
+    assert!(
+        xml.contains(r#"type="TABLEOFCONTENTS""#),
+        "%toc→TABLEOFCONTENTS: {xml}"
+    );
+    assert_eq!(
+        xml.matches(r#"type="UNKNOWN""#).count(),
+        2,
+        "%%*d·%cpr→UNKNOWN 2개: {xml}"
+    );
+
+    // 재읽기: 필드가 되살아나고 내용 텍스트가 보존된다(왕복 성립). %toc는 종류까지
+    // 왕복(%toc), 변경추적·개인정보는 %unk로 하향(내용은 보존).
+    let reread = hwpx::read_document(&out).unwrap().document;
+    let got = hwp_convert::list_fields(&reread);
+    assert_eq!(got.len(), 3, "필드 3개 왕복: {got:?}");
+    let by_value: std::collections::HashMap<&str, &str> = got
+        .iter()
+        .map(|f| (f.value.as_str(), f.ctrl_id.as_str()))
+        .collect();
+    assert_eq!(
+        by_value.get("제1장 서론"),
+        Some(&"%toc"),
+        "%toc 종류 왕복: {got:?}"
+    );
+    assert_eq!(
+        by_value.get("삭제된 문장"),
+        Some(&"%unk"),
+        "변경추적→%unk: {got:?}"
+    );
+    assert_eq!(
+        by_value.get("홍**"),
+        Some(&"%unk"),
+        "개인정보→%unk: {got:?}"
+    );
+}
+
 /// 책갈피(bokm) hwpx 왕복: create_bookmark → write → `<hp:bookmark name>` → read → list_bookmarks.
 #[test]
 fn 책갈피_생성_hwpx_왕복() {

--- a/crates/hwpx/tests/write.rs
+++ b/crates/hwpx/tests/write.rs
@@ -175,6 +175,71 @@ fn md_이미지_코드_hwpx_왕복() {
     );
 }
 
+/// GE-9: 부유(글 앞) 그림의 세로/가로 오프셋·z-order가 hwpx `<hp:pos>`/zOrder에
+/// 방출된다. hwp5 read가 실값을 승계하면(parse_picture_gso) writer가 그대로 쓴다 —
+/// 이전엔 0 하드코딩이라 떠 있는 그림이 좌상단(offset 0)에 뭉쳤다.
+#[test]
+fn 부유_그림_배치_hwpx_방출() {
+    use std::io::Write as _;
+    let dir = std::env::temp_dir().join("hwpx-ge9-float");
+    std::fs::create_dir_all(&dir).unwrap();
+    let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+    png.extend([0, 0, 0, 13]);
+    png.extend(b"IHDR");
+    png.extend(16u32.to_be_bytes());
+    png.extend(16u32.to_be_bytes());
+    png.extend([0u8; 8]);
+    let fig = dir.join("g.png");
+    std::fs::File::create(&fig)
+        .unwrap()
+        .write_all(&png)
+        .unwrap();
+
+    let mut doc = hwp_convert::from_markdown_with(
+        "이미지.\n\n![alt](g.png)\n",
+        &hwp_convert::MarkdownImportOptions {
+            base_dir: Some(&dir),
+        },
+    );
+    // 그림을 부유(글 앞) + 오프셋·z-order로 바꾼다(hwp5 read가 승계했을 값을 모사).
+    for para in &mut doc.sections[0].paragraphs {
+        for c in &mut para.controls {
+            if let hwp_model::Control::Picture(p) = c {
+                p.treat_as_char = false;
+                p.vert_offset = 5000;
+                p.horz_offset = 3000;
+                p.z_order = 7;
+            }
+        }
+    }
+    let out = tmp("ge9_float.hwpx");
+    let warnings = hwpx::write_document(&doc, &out).unwrap();
+    assert!(!warnings.iter().any(|w| w.contains("DROP")), "{warnings:?}");
+
+    let bytes = std::fs::read(&out).unwrap();
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+    let mut raw = Vec::new();
+    zip.by_name("Contents/section0.xml")
+        .unwrap()
+        .read_to_end(&mut raw)
+        .unwrap();
+    let xml = String::from_utf8(raw).unwrap();
+    // 부유 <hp:pic zOrder="7"> + <hp:pos ... vertOffset="5000" horzOffset="3000">.
+    assert!(xml.contains(r#"zOrder="7""#), "z-order 방출: {xml}");
+    assert!(
+        xml.contains(r#"vertOffset="5000""#),
+        "세로 오프셋 방출: {xml}"
+    );
+    assert!(
+        xml.contains(r#"horzOffset="3000""#),
+        "가로 오프셋 방출: {xml}"
+    );
+    assert!(
+        xml.contains(r#"treatAsChar="0""#),
+        "부유(treatAsChar=0) 방출: {xml}"
+    );
+}
+
 /// GI-1/GI-2 왕복 (b): md(각주·취소선·순서목록·중첩) → hwpx 저장 → 재읽기 → md.
 #[test]
 fn markdown_각주_취소선_목록_hwpx_완전왕복() {


### PR DESCRIPTION
## 배경

2026-07-19 스펙 전수 감사(#15)에서 확정한 콘텐츠 소실급 갭의 1차 수정 배치. 5건 중 4건 구현, 1건 보류.

## 구현 (커밋 4개)

- **GE-α9** — 머리말/꼬리말 `applyPageType` 실값 방출 (BOTH 상수 → 표 141 bit0-1 역매핑, 0=BOTH·1=EVEN·2=ODD)
- **GE-9** — 부유 그림 배치 승계: `parse_picture_gso`의 오프셋·z-order 0 하드코딩 제거, 표 69 실값을 IR로 승계 (GE-8의 GsoPlacement 선례). `common_data` raw 무변경 — identity 게이트 유지
- **GF-4** — 필드 인식 33/34종으로 확장: 변경추적 19종(표 128 ctrl_id 전수 대조 완료)·`%cpr`·`%toc` 추가 → 통째 DROP 해소. `%toc`는 정답지 실측(`type="TABLEOFCONTENTS"`)으로 양방향 매핑, 나머지는 UNKNOWN 폴백(내용 보존, GF-1 등급으로 하향). **`%%me`(메모)는 GB-7 연동 위험으로 의도적 보류**
- **GE-β7/β8** — XMLTemplate·DocHistory 스토리지 raw pass-through (GE-β5 선례, 압축 미해제 바이트 보존 — 되쓰기 침묵 소실 해소)

## 보류

- **GF-5 (숨은설명 hwpx 방출)** — OWPML 요소명을 코퍼스 hwpx 11개 전수 검색으로도 실측 못 함(유일 후보 shapeComment는 그림 설명문으로 무관 판정). 추측 방출 금지 원칙에 따라 보류. **필요 정답지: 한글에서 '숨은 설명' 넣은 문서의 hwpx 저장본**

## 검증

- 표 128 ctrl_id 19종·표 141 비트 의미 — 스펙 원문 재대조 완료 (리뷰어 독립 확인)
- `scripts/check.sh` 전체 통과 (구현자·리뷰어 각 1회), 신규 테스트 5종
- 실측: annual_report.hwp→hwpx 변환에서 부유 개체 `hp:pos`가 실제 오프셋으로 방출됨 확인 (기존: 전부 0)

## ⚠ 머지 전 실기 검증 필요 (불변식 3)

hwpx 방출 변경(GE-α9·GF-4·GE-9)은 한글 실기 확인이 필요합니다:
1. 홀·짝 구분 머리말 문서 hwp→hwpx 변환본이 한글에서 열리고 적용쪽 유지되는지
2. 변경추적 필드·차례 필드 포함 문서 변환본이 열리는지
3. 부유 그림 문서 변환본에서 그림 위치가 원본과 일치하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)