### PR TITLE
문서: 저장소 이전 반영 — 옛 주소 참조·포크 PR 구도 정리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,8 @@ HWP_FONT_DIR=$PWD/fonts python3 tools/diagnostic_corpus.py   # 진단 코퍼스 
 
 - 기능추가·수정·문서 등 **모든 작업은 별도 브랜치**에서 한다: `feat/<주제>`·`fix/<주제>`·`docs/<주제>`.
   main 직접 push 금지.
-- 포크 구도 주의: 브랜치는 자신의 포크(origin)에 push하고, **PR은 원 저장소(upstream)의
-  main을 대상으로** 연다. 포크 자체 main으로 PR하지 않는다.
+- 정본 저장소는 `STAIxBWLB/hwp-cli`(= origin)다. 브랜치를 origin에 push하고 **origin의
+  main을 대상으로 PR**을 연다. (과거의 포크→upstream 구도는 폐지됨.)
 - PR로 제출하고, **CI green(ubuntu+macOS 필수)을 확인한 뒤 squash 머지**한다(머지 커밋 제목의
   `(#N)` 관례 유지). Windows 잡은 참고용(비차단 — 잡은 빨갛게 보여도 워크플로는 통과).
 - PR 전 로컬 게이트는 `scripts/check.sh` — CI와 동일 3커맨드(fmt → clippy --all-targets

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A clean-room Rust toolkit to read, convert, render, write and AI-edit HWP 5.0 / HWPX documents with **no Hancom or COM dependency** — runs on Linux / macOS / CI.
 
-[![CI](https://github.com/YeolHanMyeong/hwp-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/YeolHanMyeong/hwp-cli/actions/workflows/ci.yml)
+[![CI](https://github.com/STAIxBWLB/hwp-cli/actions/workflows/ci.yml/badge.svg)](https://github.com/STAIxBWLB/hwp-cli/actions/workflows/ci.yml)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#라이선스)
 [![Rust](https://img.shields.io/badge/rust-edition%202024-orange.svg)](Cargo.toml)
 
@@ -70,7 +70,7 @@
 ### 빌드 / 설치
 
 ```sh
-git clone git@github.com:YeolHanMyeong/hwp-cli.git && cd hwp-cli
+git clone git@github.com:STAIxBWLB/hwp-cli.git && cd hwp-cli
 cargo build --release
 cargo install --path crates/hwp-cli   # `hwp` 바이너리 설치
 ```
@@ -79,7 +79,7 @@ cargo install --path crates/hwp-cli   # `hwp` 바이너리 설치
 
 ### 다운로드 (사전 빌드 바이너리)
 
-각 [릴리스](https://github.com/YeolHanMyeong/hwp-cli/releases)에 플랫폼별 `hwp` 아카이브와 `.sha256` 체크섬이 첨부된다:
+각 [릴리스](https://github.com/STAIxBWLB/hwp-cli/releases)에 플랫폼별 `hwp` 아카이브와 `.sha256` 체크섬이 첨부된다:
 
 | 플랫폼 | 아카이브 |
 |---|---|


### PR DESCRIPTION
## 배경

저장소가 `YeolHanMyeong/hwp-cli`(포크)에서 조직 소유 독립 리포 `STAIxBWLB/hwp-cli`로 이전됨에 따라, 커밋된 문서에 남은 옛 주소 참조와 더 이상 맞지 않는 포크 기반 PR 구도 설명을 정리한다.

## 변경 내용

- **README.md**: CI 배지 URL(5행)·clone 주소(73행)·릴리스 링크(82행)를 `STAIxBWLB/hwp-cli` 기준으로 교체
- **CLAUDE.md**: "포크(origin)에 push → upstream main 대상 PR" 구도 설명을 폐지하고, 정본 저장소 = origin(`STAIxBWLB/hwp-cli`) main 대상 PR로 정정

## 검증

- `scripts/check.sh` 통과 (fmt / clippy -D warnings / test — 문서만 변경이므로 코드 영향 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)