### PR TITLE
기능: convert에 --font-dir 플래그 추가 — PDF 변환 외부 폰트 CLI 제어

### DIFF
--- a/crates/hwp-cli/src/cli.rs
+++ b/crates/hwp-cli/src/cli.rs
@@ -76,6 +76,9 @@ pub enum Cmd {
         /// (md) 숨은 설명 텍스트도 포함 (기본: 제외)
         #[arg(long = "with-hidden")]
         with_hidden: bool,
+        /// (pdf) 추가 폰트 디렉터리 (반복 가능, 기본: HWP_FONT_DIR 또는 fonts/)
+        #[arg(long)]
+        font_dir: Vec<PathBuf>,
     },
 
     /// 페이지 렌더링

--- a/crates/hwp-cli/src/commands/convert.rs
+++ b/crates/hwp-cli/src/commands/convert.rs
@@ -3,7 +3,7 @@
 //! M2 범위: hwp/hwpx → markdown/JSON. hwpx 쓰기(M4)와 hwp 쓰기(M6)는
 //! 이후 마일스톤.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::commands::cat::load_document;
 use hwp_cli::cli::ConvertFormat;
@@ -19,6 +19,7 @@ pub struct MdOpts<'a> {
     pub with_hidden: bool,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     input: &Path,
     output: &Path,
@@ -27,6 +28,7 @@ pub fn run(
     preserve_layout: bool,
     embed_bin: bool,
     md_opts: &MdOpts,
+    font_dirs: Vec<PathBuf>,
 ) -> anyhow::Result<()> {
     // PDF는 문서 포맷 변환이 아니라 렌더 출력 — render 경로에 위임한다
     // (사용자의 "변환" 프레이밍 대응: `hwp convert in.hwp -o out.pdf`).
@@ -42,7 +44,7 @@ pub fn run(
             "all",
             96.0,
             Some(hwp_cli::cli::RenderFormat::Pdf),
-            Vec::new(),
+            font_dirs,
         );
     }
 
@@ -101,7 +103,7 @@ pub fn run(
         }
         ConvertFormat::Pdf => {
             let doc = load_document(input)?;
-            let result = hwp_render::render_document_pdf(&doc, &pdf_render_opts(), None)?;
+            let result = hwp_render::render_document_pdf(&doc, &pdf_render_opts(font_dirs), None)?;
             print_warnings(&result.report);
             std::fs::write(output, &result.data)?;
         }
@@ -209,7 +211,7 @@ pub fn write_by_ext(
             Vec::new()
         }
         Some("pdf") => {
-            let result = hwp_render::render_document_pdf(doc, &pdf_render_opts(), None)?;
+            let result = hwp_render::render_document_pdf(doc, &pdf_render_opts(Vec::new()), None)?;
             std::fs::write(output, &result.data)?;
             result.report
         }
@@ -231,11 +233,12 @@ pub fn resolve_font_dirs(given: Vec<std::path::PathBuf>) -> Vec<std::path::PathB
     )]
 }
 
-/// PDF 렌더 옵션 — 폰트는 `HWP_FONT_DIR`(없으면 `fonts/`)에서 해석.
-fn pdf_render_opts() -> hwp_render::RenderOptions {
+/// PDF 렌더 옵션 — 폰트는 `given`(`--font-dir`)이 비었으면 `HWP_FONT_DIR`
+/// (없으면 `fonts/`)에서 해석.
+fn pdf_render_opts(given: Vec<PathBuf>) -> hwp_render::RenderOptions {
     hwp_render::RenderOptions {
         dpi: 96.0,
-        font_dirs: resolve_font_dirs(Vec::new()),
+        font_dirs: resolve_font_dirs(given),
     }
 }
 

--- a/crates/hwp-cli/src/main.rs
+++ b/crates/hwp-cli/src/main.rs
@@ -46,6 +46,7 @@ fn main() -> anyhow::Result<()> {
             media_dir,
             with_header_footer,
             with_hidden,
+            font_dir,
         } => commands::convert::run(
             &input,
             &output,
@@ -58,6 +59,7 @@ fn main() -> anyhow::Result<()> {
                 with_header_footer,
                 with_hidden,
             },
+            font_dir,
         ),
         Cmd::Render {
             input,

--- a/docs/manual/cli-reference.md
+++ b/docs/manual/cli-reference.md
@@ -64,6 +64,7 @@
 | `--media-dir` | `<MEDIA_DIR>` |  | (md) 이미지 추출 디렉터리 — 기본 "<출력스템>.media". 상대경로는 출력 파일 기준으로 해석하고 링크는 입력한 경로 그대로 쓴다 (예: figs) |
 | `--with-header-footer` |  |  | (md) 머리말/꼬리말 텍스트도 포함 (기본: 제외) |
 | `--with-hidden` |  |  | (md) 숨은 설명 텍스트도 포함 (기본: 제외) |
+| `--font-dir` | `<FONT_DIR>` |  | (pdf) 추가 폰트 디렉터리 (반복 가능, 기본: HWP_FONT_DIR 또는 fonts/) |
 
 ## `hwp render`
 


### PR DESCRIPTION
## 요약

render/diff/mcp에는 있던 `--font-dir`가 `convert`(PDF 출력)에는 없어 `HWP_FONT_DIR` 환경변수로만 외부 폰트를 지정할 수 있던 비대칭을 해소한다.

- **`convert`에 `--font-dir <FONT_DIR>` 추가** — 반복 지정 가능. help 표기는 md 전용 옵션들의 `(md)` 관례에 맞춘 `(pdf)` 접두.
- **두 PDF 경로 모두 관통** — ① 확장자 `.pdf` 추론 시 render 위임 경로(기존 `Vec::new()` 하드코딩 제거), ② 명시적 `--to pdf` match 팔(`pdf_render_opts(font_dirs)`).
- **하위 호환** — 미지정 시 기존과 동일하게 `HWP_FONT_DIR` → `fonts/` 폴백(`resolve_font_dirs`).
- **범위 밖** — `write_by_ext`(edit/new/MCP 저장 공용)의 PDF 경로는 기존 환경변수 기본값 유지. 호출처 4곳 관통은 별도 작업.
- `docs/manual/cli-reference.md`는 드리프트 게이트 bless(`HWP_UPDATE_DOCS=1 cargo test -p hwp-cli --test cli_reference`)로 재생성.
- clippy `too_many_arguments`(8/7)는 동급 명령 핸들러(edit·diff) 관례대로 `#[allow]` 처리.

## 검증

- `scripts/check.sh` 통과 (fmt / clippy `-D warnings` / test 전체).
- **격리 실기 테스트** — `fonts/` 없는 CWD + `HWP_FONT_DIR` 미설정에서 플래그 유무 대조:
  - 플래그 없음: `함초롬바탕 → AppleMyungjo` 시스템 폰트 대체, PDF 136,561B
  - `--font-dir <외부 디렉터리>`: `글꼴 일치: 함초롬바탕/돋움`, PDF 123,990B (임베드 폰트 상이)
  - 확장자 추론·`--to pdf` 두 경로 모두 동일하게 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)