### PR TITLE
기능: Homebrew 설치 지원 — 저장소 자체 tap + 릴리스 시 formula 자동 갱신

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,3 +75,30 @@ jobs:
           archive: $bin-$tag-$target
           checksum: sha256
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Homebrew formula(저장소 자체가 tap) 의 version/sha256 을 방금 올라온 자산 기준으로
+  # 갱신해 main 에 커밋한다. 자산이 다 올라온 뒤라야 체크섬을 받을 수 있어 마지막 잡이다.
+  # 실패해도 릴리스 자체는 유효하며, 로컬에서 scripts/update_formula.sh X.Y.Z 로 복구한다.
+  update-formula:
+    needs: upload-assets
+    runs-on: ubuntu-latest
+    steps:
+      # 태그가 아니라 main 을 체크아웃한다 — 커밋 대상이 main 이기 때문.
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - name: formula 갱신 + 커밋
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ver="${GITHUB_REF_NAME#v}"
+          scripts/update_formula.sh "$ver"
+          if git diff --quiet Formula/hwp.rb; then
+            echo "formula 변경 없음 — 커밋 생략"
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/hwp.rb
+          git commit -m "정리(brew): formula v$ver"
+          git push origin HEAD:main

--- a/Formula/hwp.rb
+++ b/Formula/hwp.rb
@@ -7,7 +7,8 @@
 # version/sha256 은 태그 푸시 때 release.yml 의 update-formula 잡이 자동 갱신한다
 # (손으로 고치지 말 것 — 다음 릴리스에서 덮어써진다).
 class Hwp < Formula
-  desc "HWP 5.0/HWPX 문서 읽기·변환·렌더·편집 단일 바이너리"
+  # brew style: desc 는 formula 이름(hwp)으로 시작하면 안 된다.
+  desc "한글 문서(HWP 5.0·HWPX) 읽기·변환·렌더·편집 단일 바이너리"
   homepage "https://github.com/STAIxBWLB/hwp-cli"
   version "0.2.0"
   license any_of: ["MIT", "Apache-2.0"]

--- a/Formula/hwp.rb
+++ b/Formula/hwp.rb
@@ -1,0 +1,55 @@
+# Homebrew formula — 저장소 자체가 tap 이다(별도 homebrew-* 저장소 없음).
+#
+#   brew tap staixbwlb/hwp https://github.com/STAIxBWLB/hwp-cli
+#   brew install hwp
+#
+# 릴리스 아카이브(사전 빌드 바이너리)를 받아 설치하므로 Rust 툴체인이 필요 없다.
+# version/sha256 은 태그 푸시 때 release.yml 의 update-formula 잡이 자동 갱신한다
+# (손으로 고치지 말 것 — 다음 릴리스에서 덮어써진다).
+class Hwp < Formula
+  desc "HWP 5.0/HWPX 문서 읽기·변환·렌더·편집 단일 바이너리"
+  homepage "https://github.com/STAIxBWLB/hwp-cli"
+  version "0.2.0"
+  license any_of: ["MIT", "Apache-2.0"]
+
+  on_macos do
+    on_arm do
+      url "https://github.com/STAIxBWLB/hwp-cli/releases/download/v#{version}/hwp-v#{version}-aarch64-apple-darwin.tar.gz"
+      sha256 "3e657d637586f74ab46fbfb5e7c305bf7a98865abf47e57f71a9bf32fa3ab8cb"
+    end
+    on_intel do
+      url "https://github.com/STAIxBWLB/hwp-cli/releases/download/v#{version}/hwp-v#{version}-x86_64-apple-darwin.tar.gz"
+      sha256 "0fde75d68d892922ae0172387e9ee3f200d25b463d9f395ca0a2c580e703312f"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/STAIxBWLB/hwp-cli/releases/download/v#{version}/hwp-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "75a5bd4e5df99d764b4dc269d284f6b418544d517f9347225a6d537ef00172fb"
+    end
+  end
+
+  def install
+    bin.install "hwp"
+  end
+
+  def caveats
+    <<~EOS
+      렌더링(render/convert -o *.pdf|png)에는 CJK 폰트가 필요하다:
+        brew install --cask font-noto-sans-cjk-kr
+      또는 함초롬 폰트 디렉터리를 지정한다:
+        hwp render doc.hwp -o out.png --font-dir <폰트디렉터리>
+        HWP_FONT_DIR=<폰트디렉터리> hwp convert doc.hwp -o out.pdf
+      텍스트 추출·포맷 변환(cat/convert -o *.md|hwpx|json)은 폰트 없이 동작한다.
+    EOS
+  end
+
+  test do
+    # 버전 출력 + 실제 문서 생성/재읽기까지 확인한다(바이너리만 놓고 통과하지 않게).
+    assert_match version.to_s, shell_output("#{bin}/hwp --version")
+    (testpath/"t.md").write("# 제목\n\n본문입니다.\n")
+    system bin/"hwp", "new", "--from", testpath/"t.md", "-o", testpath/"t.hwpx"
+    assert_match "본문입니다", shell_output("#{bin}/hwp cat #{testpath}/t.hwpx")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -67,7 +67,20 @@
 | `render` / `diff` / `mcp` | `--font-dir <dir>` 플래그(반복 지정 가능) |
 | `convert` / 테스트 | 환경변수 `HWP_FONT_DIR`(미설정 시 프로젝트 `fonts/` 자동 사용) |
 
-### 빌드 / 설치
+### 설치 (Homebrew — macOS / Linux)
+
+저장소 자체가 tap이다(별도 `homebrew-*` 저장소 없음). 릴리스 바이너리를 받으므로 Rust 툴체인이 필요 없다.
+
+```sh
+brew tap staixbwlb/hwp https://github.com/STAIxBWLB/hwp-cli
+brew install hwp
+hwp --version
+```
+
+업그레이드는 `brew update && brew upgrade hwp`. 지원 플랫폼은 macOS(Apple Silicon·Intel)와 Linux x86_64이며,
+Windows는 아래 [사전 빌드 바이너리](#다운로드-사전-빌드-바이너리)를 쓴다.
+
+### 빌드 / 설치 (소스)
 
 ```sh
 git clone git@github.com:STAIxBWLB/hwp-cli.git && cd hwp-cli
@@ -101,6 +114,8 @@ git push origin main && git push origin v0.2.0  # 태그 푸시가 릴리스를 
 ```
 
 `vX.Y.Z` 태그를 푸시하면 `release.yml`이 ① 테스트(fmt/clippy/test) 통과 ② 태그↔`Cargo.toml` 버전 일치를 확인한 **뒤에만** 4개 플랫폼 바이너리를 빌드해 GitHub Release로 게시한다. 태그가 커밋된 버전과 다르면 릴리스가 차단된다.
+
+자산 업로드가 끝나면 `update-formula` 잡이 `Formula/hwp.rb`의 version·sha256을 릴리스 체크섬으로 갱신해 main에 커밋한다(brew tap 자동 추종). 잡이 실패했거나 수동 복구가 필요하면 `scripts/update_formula.sh X.Y.Z`를 로컬에서 돌리면 된다 — formula를 손으로 고치지 말 것.
 
 ## 빠른 시작 (Quickstart)
 

--- a/scripts/update_formula.sh
+++ b/scripts/update_formula.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# scripts/update_formula.sh X.Y.Z
+#
+# 릴리스 vX.Y.Z 의 자산 체크섬으로 Formula/hwp.rb 의 version·sha256 을 갱신한다.
+# release.yml 의 update-formula 잡이 태그 푸시 때 호출하며, 로컬에서도 쓸 수 있다
+# (릴리스 자산이 이미 올라와 있어야 한다 — gh CLI 인증 필요).
+#
+# sha256 은 "직전 url 라인의 타깃 트리플"에 매칭해 바꾼다. formula 의 순서가 바뀌어도
+# 안전하고, 하나라도 못 바꾸면 실패한다(조용한 오래된 체크섬 방지).
+#
+# 자체 점검:  scripts/update_formula.sh --self-test
+set -euo pipefail
+
+REPO_SLUG="STAIxBWLB/hwp-cli"
+# formula 가 다루는 타깃(윈도우는 brew 대상 아님).
+TARGETS="aarch64-apple-darwin x86_64-apple-darwin x86_64-unknown-linux-gnu"
+
+semver_ok() { printf '%s' "$1" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; }
+
+# 체크섬 파일 1줄("<sha>  <파일명>")에서 sha 만 뽑는다.
+sha_only() { awk '{print $1; exit}'; }
+
+# formula 본문(stdin) 의 version 과 각 타깃 sha256 을 치환해 stdout 으로 낸다.
+# 인자: <version> <triple=sha ...>
+patch_formula() {
+  local ver="$1"; shift
+  awk -v ver="$ver" -v pairs="$*" '
+    BEGIN {
+      n = split(pairs, kv, " ")
+      for (i = 1; i <= n; i++) { split(kv[i], p, "="); sha[p[1]] = p[2] }
+    }
+    # version "0.2.0"
+    /^[[:space:]]*version "/ && !seen_ver { sub(/"[^"]*"/, "\"" ver "\""); seen_ver = 1; print; next }
+    # url ... hwp-v#{version}-<triple>.tar.gz  → 다음 sha256 라인이 이 타깃의 것
+    /^[[:space:]]*url "/ {
+      cur = ""
+      for (t in sha) if (index($0, "-" t ".tar.gz") > 0) cur = t
+      print; next
+    }
+    /^[[:space:]]*sha256 "/ && cur != "" {
+      sub(/"[^"]*"/, "\"" sha[cur] "\""); done[cur] = 1; cur = ""; print; next
+    }
+    { print }
+    END {
+      for (t in sha) if (!(t in done)) { print "치환 실패: " t > "/dev/stderr"; exit 1 }
+      if (!seen_ver) { print "치환 실패: version" > "/dev/stderr"; exit 1 }
+    }
+  '
+}
+
+# --- 자체 점검(네트워크·git 부작용 없음) -------------------------------------
+if [ "${1:-}" = "--self-test" ]; then
+  out=$(printf '%s\n' \
+    '  version "0.0.1"' \
+    '      url "https://x/hwp-v#{version}-aarch64-apple-darwin.tar.gz"' \
+    '      sha256 "old1"' \
+    '      url "https://x/hwp-v#{version}-x86_64-unknown-linux-gnu.tar.gz"' \
+    '      sha256 "old2"' \
+    | patch_formula 9.9.9 aarch64-apple-darwin=new1 x86_64-unknown-linux-gnu=new2)
+  printf '%s' "$out" | grep -q 'version "9.9.9"' || { echo "self-test FAIL: version"; exit 1; }
+  printf '%s' "$out" | grep -q 'sha256 "new1"'   || { echo "self-test FAIL: sha1"; exit 1; }
+  printf '%s' "$out" | grep -q 'sha256 "new2"'   || { echo "self-test FAIL: sha2"; exit 1; }
+  # 대상 타깃이 formula 에 없으면 실패해야 한다(조용한 통과 금지).
+  if printf '  version "0.0.1"\n' | patch_formula 1.2.3 missing-triple=x >/dev/null 2>&1; then
+    echo "self-test FAIL: 누락 타깃이 통과함"; exit 1
+  fi
+  echo "self-test OK (version/sha 치환 + 누락 검출)"
+  exit 0
+fi
+
+# --- 실행 --------------------------------------------------------------------
+ver="${1:-}"
+[ -n "$ver" ] || { echo "usage: scripts/update_formula.sh X.Y.Z" >&2; exit 2; }
+semver_ok "$ver" || { echo "오류: 시맨틱 버전이 아닙니다: '$ver'" >&2; exit 1; }
+
+cd "$(git rev-parse --show-toplevel)"
+formula="Formula/hwp.rb"
+[ -f "$formula" ] || { echo "오류: $formula 없음" >&2; exit 1; }
+
+pairs=""
+for t in $TARGETS; do
+  asset="hwp-v$ver-$t.sha256"
+  sha="$(gh release download "v$ver" -R "$REPO_SLUG" -p "$asset" -O - 2>/dev/null | sha_only)" || true
+  [ -n "$sha" ] || { echo "오류: 체크섬 자산을 받지 못함: $asset" >&2; exit 1; }
+  pairs="$pairs $t=$sha"
+done
+
+tmp="$(mktemp)"
+# shellcheck disable=SC2086 # pairs 는 공백 구분 인자 목록으로 전달해야 한다.
+patch_formula "$ver" $pairs < "$formula" > "$tmp"
+mv "$tmp" "$formula"
+echo "✅ $formula → v$ver 갱신 완료"


### PR DESCRIPTION
`brew`로 `hwp`를 설치할 수 있게 한다. 별도 `homebrew-*` 저장소 없이 **이 저장소를 tap으로** 쓴다.

```sh
brew tap staixbwlb/hwp https://github.com/STAIxBWLB/hwp-cli
brew install hwp
```

## 변경

- **`Formula/hwp.rb`** — 릴리스 사전 빌드 아카이브를 받아 설치하므로 Rust 툴체인이 필요 없다. macOS(arm64·x86_64) + Linux x86_64. `test` 블록은 `--version`만 보지 않고 md→hwpx 생성 후 `cat`으로 본문을 되읽어 실제 동작을 확인한다. `caveats`로 렌더용 CJK 폰트 안내.
- **`scripts/update_formula.sh`** — 릴리스 자산의 `.sha256`으로 formula의 version·sha256을 치환. sha는 **직전 `url` 라인의 타깃 트리플에 매칭**해 바꾸고, 하나라도 치환 못 하면 실패한다(오래된 체크섬이 조용히 남는 것 방지). `--self-test` 포함.
- **`release.yml`의 `update-formula` 잡** — 자산 업로드 완료 후 위 스크립트로 formula를 갱신해 main에 커밋. 태그를 밀 때마다 brew가 최신 버전을 따라간다. 잡이 실패해도 릴리스 자체는 유효하고 로컬 재실행으로 복구된다.
- **README** — brew 설치 절차 + 릴리스 절차의 formula 자동 갱신 명시.

## 검증

- `scripts/update_formula.sh --self-test` 통과(치환 + 누락 타깃 검출).
- **실제 v0.2.0 릴리스 체크섬으로 실행 → formula 무변경**: 커밋된 sha256이 실제 릴리스 자산과 일치함을 확인.
- `ruby -c Formula/hwp.rb`, release.yml YAML 파싱 통과.
- 로컬 `brew install --formula ./Formula/hwp.rb` 설치·동작 확인(아래 코멘트에 결과).