### PR TITLE
feat(convert): gaejosik bullet ladder, symbol paragraph indent, wider heading number guard

### DIFF
--- a/crates/hwp-convert/src/from_markdown.rs
+++ b/crates/hwp-convert/src/from_markdown.rs
@@ -450,11 +450,13 @@ struct Builder {
     in_blockquote: u32,        // 인용문 중첩 깊이(>0이면 인용 문단)
     in_codeblock: bool,        // 코드블록 구간(회색 배경 문단)
     heading: Option<u16>,      // 1..=6
-    // H1~H3 절 번호 사다리(1. / 1-1. / 1-1-1.) — 보고서 표준. 제목이 숫자로
-    // 시작하면 접두를 생략한다(이중 번호 방지).
+    // H1~H3 절 번호 사다리(1. / 1-1. / 1-1-1.) — 보고서 표준. 제목이 이미 번호로
+    // 시작하면(1. / Ⅰ. / 가.) 접두를 생략한다(이중 번호 방지).
     h_counters: [u32; 3],
     pending_heading_num: Option<String>,
     section_para_shape: Option<u16>, // H2/H3 들여쓰기(left 2000) 문단모양 인덱스
+    // 개조식 기호(□·○)로 시작하는 본문 문단의 내어쓰기 문단모양(기호별 1회 할당).
+    symbol_para_shapes: HashMap<char, u16>,
     // 표 수집 상태
     table: Option<TableBuilder>,
     // 목록 상태 — 수준별 프레임 스택(중첩), 항목 문단에 머리 문단모양을 부여.
@@ -583,7 +585,8 @@ impl Builder {
         }
         // 목록 항목이 열려 있으면 머리(NUMBER/BULLET) 문단모양을 우선한다.
         // 그 외: 코드블록→4(회색 배경), 인용→3(들여쓰기+막대), 제목→1,
-        // 표 셀→0(간격 없음), 본문→2.
+        // 표 셀→0(간격 없음), 개조식 기호 본문(□·○)→내어쓰기 모양, 본문→2.
+        let symbol = leading_symbol(&self.chars);
         let para_shape = if let Some(id) = self.active_list_para_shape() {
             id
         } else if self.in_codeblock {
@@ -599,6 +602,8 @@ impl Builder {
             }
         } else if self.table.is_some() {
             0
+        } else if let Some(sym) = symbol {
+            self.symbol_para_shape(sym)
         } else {
             2
         };
@@ -642,10 +647,12 @@ impl Builder {
                 self.numbering_levels.push(levels);
                 self.push_list_para_shape(2, level, def_id)
             }
-            // 글머리표 목록: 불릿 문자 + BULLET 머리.
+            // 글머리표 목록: 불릿 문자 + BULLET 머리. 글머리 문자는 개조식 사다리
+            // (□ → ○ → - → ·)의 아래 두 칸을 쓴다 — 이 도구의 대상이 한국 공문서라
+            // 1수준 `-`, 2수준 이하 `·`가 기본이다(`•`는 더 쓰지 않는다).
             None => {
                 let def_id = self.bullet_chars.len() as u16;
-                self.bullet_chars.push('•');
+                self.bullet_chars.push(if level >= 2 { '·' } else { '-' });
                 self.push_list_para_shape(3, level, def_id)
             }
         };
@@ -678,6 +685,30 @@ impl Builder {
             numbering_id: def_id,
             ..ParaShape::default()
         });
+        idx
+    }
+
+    /// 개조식 기호 문단(`□ `·`○ `)용 내어쓰기 문단모양을 만들어(기호별 1회) 인덱스를 준다.
+    /// push_list_para_shape와 같은 여백 사다리를 쓰되 머리(BULLET) 비트는 세우지 않는다 —
+    /// 기호가 이미 본문 텍스트에 있으므로 한글이 마커를 겹쳐 그리면 안 된다.
+    fn symbol_para_shape(&mut self, sym: char) -> u16 {
+        if let Some(&id) = self.symbol_para_shapes.get(&sym) {
+            return id;
+        }
+        let step = 2000i32;
+        // □=1단, ○=2단. 내어쓰기(-step)로 접힌 줄이 기호 뒤 본문에 맞춰 정렬된다.
+        let depth = if sym == '□' { 1 } else { 2 };
+        let idx = BASE_PARA_SHAPES + self.extra_para_shapes.len() as u16;
+        self.extra_para_shapes.push(ParaShape {
+            attr1: 0x180 | (1 << 2), // 정상 본문 + 왼쪽 정렬(머리 종류/수준 없음)
+            margin_left: depth * step,
+            indent: -step,
+            line_spacing_old: 160,
+            line_spacing: 160,
+            border_fill_id: 2,
+            ..ParaShape::default()
+        });
+        self.symbol_para_shapes.insert(sym, idx);
         idx
     }
 
@@ -867,10 +898,10 @@ impl Builder {
             Event::Start(Tag::Strikethrough) => self.strike = true,
             Event::End(TagEnd::Strikethrough) => self.strike = false,
             Event::Text(t) => {
-                // 절 번호 접두: 제목 첫 텍스트 앞에 삽입(숫자 시작 제목은 생략).
+                // 절 번호 접두: 제목 첫 텍스트 앞에 삽입(이미 번호가 있는 제목은 생략).
                 if self.heading.is_some()
                     && let Some(num) = self.pending_heading_num.take()
-                    && !t.starts_with(|c: char| c.is_ascii_digit())
+                    && !starts_with_literal_number(&t)
                 {
                     self.push_text(&num);
                 }
@@ -987,6 +1018,28 @@ impl Builder {
             _ => {}
         }
     }
+}
+
+/// 문단이 개조식 기호 `□ `/`○ `로 시작하면 그 기호를 준다. markdown은 줄 앞 공백을
+/// 지워 사다리가 평평해지므로, 이 문단만 여백으로 단을 복원한다(정확히 이 두 접두만).
+fn leading_symbol(chars: &[HwpChar]) -> Option<char> {
+    match (chars.first(), chars.get(1)) {
+        (Some(HwpChar::Text(sym @ ('□' | '○'))), Some(HwpChar::Text(' '))) => Some(*sym),
+        _ => None,
+    }
+}
+
+/// 제목이 이미 번호를 달고 있는지 — 자동 절번호 접두를 생략할 조건(이중 번호 방지).
+/// 아라비아 숫자(`1.`), 전각 로마 숫자(`Ⅰ.`·`ⅰ.`), 한글 항목 기호(`가.`·`나)`).
+/// 번호 없는 낱말 제목(`사업 개요`)은 걸리지 않아 자동 번호를 그대로 받는다.
+fn starts_with_literal_number(t: &str) -> bool {
+    let mut chars = t.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    first.is_ascii_digit()
+        || ('\u{2160}'..='\u{217F}').contains(&first)
+        || (('\u{AC00}'..='\u{D7A3}').contains(&first) && matches!(chars.next(), Some('.' | ')')))
 }
 
 fn heading_level(level: HeadingLevel) -> u16 {
@@ -1455,5 +1508,102 @@ mod tests {
         let text = doc.plain_text();
         assert!(text.contains("1. 서론"), "{text}");
         assert!(!text.contains("1. 1. 서론"), "이중 번호 금지: {text}");
+    }
+
+    /// 개조식 리터럴 번호(전각 로마 숫자·한글 항목 기호)도 자동 절번호를 막는다.
+    /// 단 번호 없는 낱말 제목은 그대로 자동 번호를 받는다(가드 과확장 방지).
+    #[test]
+    fn 헤딩_리터럴_번호_이중번호_방지() {
+        let doc = from_markdown("# Ⅰ. 사업 개요\n## 가. 배경\n## 나) 세부\n");
+        let text = doc.plain_text();
+        assert!(text.contains("Ⅰ. 사업 개요"), "{text}");
+        assert!(!text.contains("1. Ⅰ."), "전각 로마 숫자 이중 번호: {text}");
+        assert!(!text.contains("1-1. 가."), "한글 `가.` 이중 번호: {text}");
+        assert!(!text.contains("1-2. 나)"), "한글 `나)` 이중 번호: {text}");
+
+        let plain = from_markdown("## 사업 개요\n").plain_text();
+        assert!(
+            plain.contains("1-1. 사업 개요"),
+            "낱말 제목은 자동 번호: {plain}"
+        );
+    }
+
+    /// 글머리 문자 사다리: 1수준 `-`, 2수준 이하 `·`(개조식 표준, `•` 폐기).
+    #[test]
+    fn 글머리_사다리_수준별_문자() {
+        let doc = from_markdown("- 상위\n  - 하위\n");
+        assert_eq!(doc.header.bullet_chars, vec!['-', '·']);
+    }
+
+    /// `□ `/`○ ` 본문 문단은 내어쓰기 문단모양(여백 사다리)을 받고, 머리(BULLET)
+    /// 비트는 세우지 않는다(기호가 이미 텍스트에 있음). 그 외 문단은 그대로 본문(2).
+    #[test]
+    fn 개조식_기호_문단_내어쓰기() {
+        let doc = from_markdown("□ 현황\n\n○ 세부\n\n□ 계획\n\n일반 문단\n");
+        let ps_of = |needle: &str| {
+            doc.sections[0]
+                .paragraphs
+                .iter()
+                .find(|p| {
+                    p.chars
+                        .iter()
+                        .filter_map(|c| match c {
+                            HwpChar::Text(ch) => Some(*ch),
+                            _ => None,
+                        })
+                        .collect::<String>()
+                        .contains(needle)
+                })
+                .unwrap_or_else(|| panic!("{needle} 문단 없음"))
+                .para_shape
+                .0
+        };
+        let square = ps_of("□ 현황");
+        let circle = ps_of("○ 세부");
+        assert_eq!(ps_of("□ 계획"), square, "같은 기호는 문단모양 재사용");
+        assert_eq!(ps_of("일반 문단"), 2, "기호 없는 본문은 기본 본문 모양");
+
+        let shape = |id: u16| &doc.header.para_shapes[id as usize];
+        assert_eq!(
+            (shape(square).margin_left, shape(square).indent),
+            (2000, -2000)
+        );
+        assert_eq!(
+            (shape(circle).margin_left, shape(circle).indent),
+            (4000, -2000)
+        );
+        assert_eq!(shape(square).head_type(), 0, "머리(BULLET) 비트 없음");
+        assert_eq!(shape(circle).head_type(), 0, "머리(BULLET) 비트 없음");
+    }
+
+    /// 표 셀·제목·목록 항목은 기호 문단모양의 영향을 받지 않는다.
+    #[test]
+    fn 개조식_기호_예외_경로() {
+        use hwp_model::Control;
+        let doc = from_markdown("# □ 제목\n\n- □ 항목\n\n| □ 머리 |\n|----|\n| □ 셀 |\n");
+        let heading = &doc.sections[0].paragraphs[0];
+        assert_eq!(heading.para_shape.0, 1, "제목은 제목 문단모양");
+        let table = doc.sections[0]
+            .paragraphs
+            .iter()
+            .flat_map(|p| &p.controls)
+            .find_map(|c| match c {
+                Control::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("표 없음");
+        for cell in &table.cells {
+            assert_eq!(cell.paragraphs[0].para_shape.0, 0, "표 셀은 셀 문단모양");
+        }
+        let item = doc.sections[0]
+            .paragraphs
+            .iter()
+            .find(|p| p.para_shape.0 >= BASE_PARA_SHAPES)
+            .expect("목록 항목 없음");
+        assert_eq!(
+            doc.header.para_shapes[item.para_shape.0 as usize].head_type(),
+            3,
+            "목록 항목은 BULLET 머리 유지"
+        );
     }
 }

--- a/crates/hwp5/tests/synth.rs
+++ b/crates/hwp5/tests/synth.rs
@@ -155,11 +155,15 @@ fn 왕복_각주_목록_hwp5_규격() {
     );
 
     // 4) BULLET 레코드가 정품 필드 패턴과 일치(사업계획서 전수 대조): 25B, [8..12]=글자모양
-    //    id 없음(0xFFFFFFFF), [12..14]=글머리표 문자(우리 '•'=0x2022). 오프셋이 어긋나면
-    //    한글이 마커를 미표시한다(1차 H2 실기 결함).
+    //    id 없음(0xFFFFFFFF), [12..14]=글머리표 문자(IR bullet_chars 순서대로 — 개조식
+    //    사다리라 수준별로 다르다). 오프셋이 어긋나면 한글이 마커를 미표시한다(1차 H2 실기 결함).
     let bullets = all_records(&di, 0x18);
-    assert!(!bullets.is_empty(), "BULLET 레코드 존재");
-    for b in &bullets {
+    assert_eq!(
+        bullets.len(),
+        doc.header.bullet_chars.len(),
+        "BULLET 레코드 수 == IR 글머리 정의 수"
+    );
+    for (b, want) in bullets.iter().zip(&doc.header.bullet_chars) {
         assert_eq!(b.len(), 25, "BULLET 레코드 25B(정품 실측)");
         assert_eq!(
             &b[8..12],
@@ -168,8 +172,8 @@ fn 왕복_각주_목록_hwp5_규격() {
         );
         assert_eq!(
             u16::from_le_bytes([b[12], b[13]]),
-            0x2022,
-            "글머리표 문자 '•'가 오프셋 12에 있어야"
+            *want as u16,
+            "글머리표 문자 '{want}'가 오프셋 12에 있어야"
         );
     }
 


### PR DESCRIPTION
## 배경 — 개조식 표준 통합

워크스페이스의 한국어 공식문서 표기를 하나로 정했다: 본문 기호 사다리는 `□`(U+25A1) → `○`(U+25CB) → `-` → `·`(U+00B7), 제목 번호는 markdown 원문에 리터럴로 쓴다(`## Ⅰ. 사업 개요`, `#### 가. 배경`; `Ⅰ`은 전각 U+2160). markdown 임포터가 이 표준을 따르도록 맞춘다.

변경은 전부 `crates/hwp-convert/src/from_markdown.rs`(+ 테스트)에 있다. 모델·writer 계층은 이미 임의 글머리 문자를 나르므로(`bullet_chars: Vec<char>` → hwpx `<hh:bullet char=…>`, hwp5 `make_bullet_data`) writer 변경은 없다.

## 1) 수준별 글머리 문자 사다리

`start_list`가 박아 쓰던 `'•'`를 목록 중첩 수준에 따라 고른다 — 1수준 `-`, 2수준 이하 `·`.

```md
- 교육과정 개편
  - 기초 트랙 신설
```

| | before | after |
|---|---|---|
| `bullet_chars` | `['•', '•']` | `['-', '·']` |
| hwpx `<hh:bullets>` | `char="•"` ×2 | `char="-"`, `char="·"` |

**기본 동작이 바뀐다** — 이 도구의 대상이 한국 공문서라 사다리를 기본값으로 둔다. md 재수출은 GFM 규약대로 `-`를 쓰므로(`markdown.rs`의 `ty == 3` 분기) 왕복 산출물에는 영향이 없다.

## 2) `□`/`○` 본문 문단 내어쓰기

`□ 현황` 같은 줄은 지금까지 본문 문단(para_shape 2, 여백 0)으로 흘러 기호는 남되 사다리가 평평해졌다(markdown이 줄 앞 공백을 지운다). 이제 문단 선두가 정확히 `"□ "`/`"○ "`이면 내어쓰기 문단모양을 준다.

| 접두 | margin_left | indent | 첫 줄 위치 |
|---|---|---|---|
| `□ ` | 2000 | -2000 | 0 |
| `○ ` | 4000 | -2000 | 2000 |

`push_list_para_shape`의 여백 사다리를 그대로 쓰되 **머리(BULLET) 비트는 세우지 않는다** — 기호가 이미 본문 텍스트에 있어 한글이 마커를 겹쳐 그리면 안 된다. 문단모양은 기호별로 1회만 할당해 재사용한다. 제목·목록 항목·표 셀은 그 분기가 앞서므로 영향받지 않는다.

생성된 hwpx(`hwp new --from`)에서 확인:

```xml
<hh:paraPr id="6" …><hh:heading type="NONE" …/>   <!-- □ -->
  <hh:margin><hc:intent value="-1000"…/><hc:left value="1000"…/>…
<hh:paraPr id="7" …><hh:heading type="NONE" …/>   <!-- ○ -->
  <hh:margin><hc:intent value="-1000"…/><hc:left value="2000"…/>…
<hh:paraPr id="8" …><hh:heading type="BULLET" idRef="1" level="1"/>  <!-- 목록은 그대로 -->
```

## 3) 제목 이중 번호 가드 확대

자동 절번호(`1. `·`1-1. `) 생략 조건이 ASCII 숫자 시작뿐이라, 리터럴 개조식 번호에 번호가 겹쳐 붙었다. 이제 세 경우를 생략한다.

- ASCII 숫자 (기존)
- 전각 로마 숫자 U+2160..=U+217F (`Ⅰ`, `Ⅱ`, `ⅰ`…)
- 한글 음절 U+AC00..=U+D7A3 + 둘째 글자가 `.` 또는 `)` (`가.`, `나)`)

낱말 제목(`사업 개요`)은 걸리지 않아 자동 번호를 그대로 받는다.

## 스모크 체크

입력:

```md
# Ⅰ. 사업 개요
## 가. 배경
□ 제주 지역 AI 인재 수요 급증
○ 산업계 채용 규모 연 30% 증가
□ 대응 방향
- 교육과정 개편
  - 기초 트랙 신설
## 나) 추진 체계
### 사업 개요
```

`hwp new --from …` → `hwp cat`(hwpx·hwp5 양쪽 동일):

```
Ⅰ. 사업 개요          ← 자동 번호 없음
가. 배경               ← 자동 번호 없음
□ 제주 지역 AI 인재 수요 급증
○ 산업계 채용 규모 연 30% 증가
□ 대응 방향
교육과정 개편
기초 트랙 신설
나) 추진 체계          ← 자동 번호 없음
1-2-1. 사업 개요       ← 낱말 제목은 자동 번호 유지
```

## 테스트

`crates/hwp-convert/src/from_markdown.rs`에 4개 추가(리터럴 번호 가드, 글머리 사다리, `□`/`○` 여백·재사용·머리비트 없음, 제목·목록·표 셀 예외 경로). `crates/hwp5/tests/synth.rs`의 BULLET 레코드 테스트는 `'•'` 리터럴 바이트 대신 IR `bullet_chars` 순서와 대조하도록 바꿨다 — 오프셋 12 검증이라는 원래 의도는 유지하면서 사다리를 견딘다.

`scripts/check.sh` (= CI 3종 게이트 fmt/clippy/test) 로컬 통과.

머지·릴리스는 메인테이너 판단에 맡긴다(이 PR은 머지하지 않음).

🤖 Generated with [Claude Code](https://claude.com/claude-code)