### PR TITLE
fix: gaejosik □/○ 문단 간격 + 목록 마커(-/·) 가시성

### DIFF
--- a/crates/hwp-convert/src/from_markdown.rs
+++ b/crates/hwp-convert/src/from_markdown.rs
@@ -703,6 +703,10 @@ impl Builder {
             attr1: 0x180 | (1 << 2), // 정상 본문 + 왼쪽 정렬(머리 종류/수준 없음)
             margin_left: depth * step,
             indent: -step,
+            // □ 블록 경계가 눈에 보이게 문단 간격을 준다 — □ 위 600은 제목(1)의
+            // spacing_top, 공통 아래 300은 제목의 spacing_bottom 관례와 맞춘 값.
+            spacing_top: if depth == 1 { 600 } else { 0 },
+            spacing_bottom: 300,
             line_spacing_old: 160,
             line_spacing: 160,
             border_fill_id: 2,
@@ -1574,6 +1578,15 @@ mod tests {
         );
         assert_eq!(shape(square).head_type(), 0, "머리(BULLET) 비트 없음");
         assert_eq!(shape(circle).head_type(), 0, "머리(BULLET) 비트 없음");
+        // 문단 간격: □ 블록 경계가 보이도록 위 600, 공통 아래 300 (○는 위 0).
+        assert_eq!(
+            (shape(square).spacing_top, shape(square).spacing_bottom),
+            (600, 300)
+        );
+        assert_eq!(
+            (shape(circle).spacing_top, shape(circle).spacing_bottom),
+            (0, 300)
+        );
     }
 
     /// 표 셀·제목·목록 항목은 기호 문단모양의 영향을 받지 않는다.

--- a/crates/hwp-render/src/layout.rs
+++ b/crates/hwp-render/src/layout.rs
@@ -462,6 +462,10 @@ pub fn layout_document(
                             left + (avail - natural) * if align == 3 { 0.5 } else { 1.0 },
                             0.0,
                         )
+                    } else if marker.is_some() && geom.first_indent < 0.0 {
+                        // 목록 문단의 내어쓰기 구간은 마커 자리다(한글 실기와 동일).
+                        // 첫 줄 텍스트를 left로 되돌리지 않으면 마커가 글자 밑에 깔린다.
+                        (left, 0.0)
                     } else {
                         (left, first_x - left)
                     };
@@ -1418,6 +1422,9 @@ fn layout_box_para_iter<'a>(
                         left + (avail - natural) * if align == 3 { 0.5 } else { 1.0 },
                         0.0,
                     )
+                } else if marker.is_some() && geom.first_indent < 0.0 {
+                    // 내어쓰기 구간은 마커 자리 — 본문 폴백 경로와 같은 규칙.
+                    (left, 0.0)
                 } else {
                     (left, first_x - left)
                 };

--- a/crates/hwp-render/tests/render.rs
+++ b/crates/hwp-render/tests/render.rs
@@ -698,3 +698,49 @@ fn 쪽_테두리_렌더() {
         );
     }
 }
+
+/// 목록(불릿) 문단: 마커는 내어쓰기 구간에, 첫 줄 텍스트는 좌여백(left)에 온다.
+/// 과거엔 첫 줄 텍스트가 left+indent(마커 자리)까지 당겨져 마커가 글자 밑에 깔렸다.
+/// 글리프 유무는 폰트 가용성에 좌우되므로(CLAUDE.md CI 규칙) 글리프가 없으면 스킵.
+#[test]
+fn 목록_마커_내어쓰기_배치() {
+    use hwp_render::display::Item;
+    let doc = hwp_convert::from_markdown("- 항목입니다\n");
+    let mut store = hwp_render::FontStore::new();
+    let mut warns = Vec::new();
+    let list = hwp_render::layout::layout_document(&doc, &mut store, &mut warns);
+    let glyphs: Vec<(f32, &str)> = list.pages[0]
+        .items
+        .iter()
+        .filter_map(|it| match it {
+            Item::Glyphs { x, run, .. } => Some((*x, run.text.as_str())),
+            _ => None,
+        })
+        .collect();
+    if glyphs.is_empty() {
+        eprintln!("스킵: 사용 가능한 폰트 없음 — 글리프 미생성");
+        return;
+    }
+    let marker_x = glyphs
+        .iter()
+        .find(|(_, t)| t.contains('-'))
+        .map(|(x, _)| *x)
+        .expect("불릿 마커(-) 글리프가 있어야");
+    let text_x = glyphs
+        .iter()
+        .find(|(_, t)| t.contains('항'))
+        .map(|(x, _)| *x)
+        .expect("본문 첫 글자 글리프가 있어야");
+    // 문단모양: margin_left=2000(10pt), indent=-2000. 본문 좌변 = 페이지 여백
+    // 8504HU(from_markdown 기본) = 85.04pt, left = 그 + 10pt.
+    let body_left = 85.04_f32;
+    let left = body_left + 10.0;
+    assert!(
+        (text_x - left).abs() < 0.5,
+        "첫 줄 텍스트는 left({left})에 와야: {text_x}"
+    );
+    assert!(
+        marker_x < text_x && marker_x >= body_left - 0.5,
+        "마커는 내어쓰기 구간([{body_left}, {text_x}))에 와야: {marker_x}"
+    );
+}


### PR DESCRIPTION
## 요약

v0.4.0 개조식 사다리(cc747f0) 검증에서 발견된 렌더/생성 결함 2건 수정.

- **□/○ 문단 간격**: symbol_para_shape가 spacing_top/bottom을 넣지 않아 기호 문단이 본문보다 촘촘하게 붙어 □ 블록 경계가 보이지 않았음. □ 위 600, 공통 아래 300(제목 문단모양 관례와 일치).
- **목록 마커 가시성**: 내어쓰기(indent<0) 목록 문단에서 첫 줄 텍스트가 left+indent(마커 자리)까지 당겨져 render_list_marker가 그린 -/· 마커가 글자 밑에 깔림. 마커 있는 문단은 첫 줄을 left에 유지해 마커가 내어쓰기 구간을 차지하게 수정(한글 실기와 동일). 본문·표 셀 폴백 경로 모두 적용.

## 검증

- `scripts/check.sh` 통과 (fmt/clippy/test)
- 로컬 렌더(HCR 폰트): □→○→-→· 사다리 4단 전부 마커·들여쓰기 정상 표시 확인
- 신규 테스트: 기호 문단 간격 단언 4건, 목록 마커 배치 구조 테스트(폰트 없으면 스킵 — CI 안전)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZwXDZBV7WAkYGAW6DbYAy