### PR TITLE
fix(windows): 파일 신원·링크 수를 핸들에서 읽어 Windows 빌드 복구

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,8 @@
 # Hash-pinned corpus text must not be rewritten by core.autocrlf on Windows.
 corpus/structured-v1/** text eol=lf
+# examples/ 의 spec·template·data는 골든 리포트에 SHA-256으로 박혀 있다.
+examples/** text eol=lf
+crates/hwp-cli/tests/golden/** text eol=lf
 schemas/*.json text eol=lf
 docs/**/*.md text eol=lf
 *.rs text eol=lf

--- a/crates/hwp-cli/Cargo.toml
+++ b/crates/hwp-cli/Cargo.toml
@@ -35,6 +35,7 @@ windows-sys = { version = "0.61", features = [
   "Win32_Security",
   "Win32_Security_Authorization",
   "Win32_Storage_FileSystem",
+  "Win32_System_Threading",
 ] }
 
 [dev-dependencies]

--- a/crates/hwp-cli/src/asset_snapshot.rs
+++ b/crates/hwp-cli/src/asset_snapshot.rs
@@ -513,7 +513,10 @@ mod tests {
         let root = std::env::temp_dir().join(format!(
             "hwp-asset-snapshot-{}-{}-{suffix}",
             std::process::id(),
-            std::thread::current().name().unwrap_or("test")
+            std::thread::current()
+                .name()
+                .unwrap_or("test")
+                .replace(':', "-")
         ));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();

--- a/crates/hwp-cli/src/certification.rs
+++ b/crates/hwp-cli/src/certification.rs
@@ -2333,10 +2333,10 @@ fn snapshot_file(
     if path_before.file_type().is_symlink() || !path_before.file_type().is_file() {
         anyhow::bail!("snapshot input must be a non-symlink regular file");
     }
-    if has_multiple_links(&path_before) {
+    if has_multiple_links(source, &path_before) {
         anyhow::bail!("snapshot input must not have hardlink aliases");
     }
-    if !same_file_identity(&opened_before, &path_before) {
+    if !open_file_still_matches_path(&input, source) {
         anyhow::bail!("snapshot input path changed before copy");
     }
     if opened_before.len() > max_bytes {
@@ -2374,8 +2374,7 @@ fn snapshot_file(
     let opened_after = input.metadata()?;
     let path_after = fs::symlink_metadata(source)?;
     if path_after.file_type().is_symlink()
-        || !same_file_identity(&opened_before, &opened_after)
-        || !same_file_identity(&opened_before, &path_after)
+        || !open_file_still_matches_path(&input, source)
         || opened_before.len() != opened_after.len()
         || opened_before.len() != path_after.len()
         || opened_before.modified()? != opened_after.modified()?
@@ -2407,22 +2406,80 @@ impl Drop for PartialFileGuard {
     }
 }
 
+/// 열어 둔 핸들이 지금도 `path`가 가리키는 바로 그 파일인지. 신원을 못 읽으면
+/// "그대로다"를 증명할 수 없으므로 false(fail-closed)를 돌려준다.
 #[cfg(unix)]
-fn same_file_identity(left: &fs::Metadata, right: &fs::Metadata) -> bool {
+fn open_file_still_matches_path(file: &File, path: &Path) -> bool {
     use std::os::unix::fs::MetadataExt as _;
-    left.dev() == right.dev() && left.ino() == right.ino()
+    let (Ok(opened), Ok(current)) = (file.metadata(), fs::symlink_metadata(path)) else {
+        return false;
+    };
+    opened.dev() == current.dev() && opened.ino() == current.ino()
 }
 
 #[cfg(windows)]
-fn same_file_identity(left: &fs::Metadata, right: &fs::Metadata) -> bool {
-    use std::os::windows::fs::MetadataExt as _;
-    left.volume_serial_number() == right.volume_serial_number()
-        && left.file_index() == right.file_index()
+fn open_file_still_matches_path(file: &File, path: &Path) -> bool {
+    match (windows_handle_info(file), windows_path_info(path)) {
+        (Some(opened), Some(current)) => {
+            opened.volume == current.volume && opened.index == current.index
+        }
+        _ => false,
+    }
 }
 
 #[cfg(not(any(unix, windows)))]
-fn same_file_identity(left: &fs::Metadata, right: &fs::Metadata) -> bool {
-    left.len() == right.len() && left.modified().ok() == right.modified().ok()
+fn open_file_still_matches_path(file: &File, path: &Path) -> bool {
+    let (Ok(opened), Ok(current)) = (file.metadata(), fs::symlink_metadata(path)) else {
+        return false;
+    };
+    opened.len() == current.len() && opened.modified().ok() == current.modified().ok()
+}
+
+/// Windows 파일 신원과 링크 수. std의 `Metadata` 경로(`volume_serial_number`·
+/// `file_index`·`number_of_links`)는 nightly 전용 `windows_by_handle`이라 핸들에서 읽는다.
+#[cfg(windows)]
+struct WindowsFileInfo {
+    volume: u32,
+    index: u64,
+    links: u32,
+}
+
+#[cfg(windows)]
+fn windows_handle_info(file: &File) -> Option<WindowsFileInfo> {
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+    };
+
+    let mut information = BY_HANDLE_FILE_INFORMATION::default();
+    // SAFETY: 핸들은 호출 동안 살아 있는 File이 소유하고, 출력 구조체는 Win32 정의다.
+    if unsafe { GetFileInformationByHandle(file.as_raw_handle(), &mut information) } == 0 {
+        return None;
+    }
+    Some(WindowsFileInfo {
+        volume: information.dwVolumeSerialNumber,
+        index: (u64::from(information.nFileIndexHigh) << 32) | u64::from(information.nFileIndexLow),
+        links: information.nNumberOfLinks,
+    })
+}
+
+/// 링크를 따라가지 않고 연다 — 검사와 열기 사이에 reparse point로 바뀌었으면 링크 자신의
+/// 신원이 나와 비교가 실패한다.
+#[cfg(windows)]
+fn windows_path_info(path: &Path) -> Option<WindowsFileInfo> {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    use windows_sys::Win32::Storage::FileSystem::{
+        FILE_FLAG_BACKUP_SEMANTICS, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE,
+    };
+
+    let file = OpenOptions::new()
+        .access_mode(FILE_READ_ATTRIBUTES)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+        .ok()?;
+    windows_handle_info(&file)
 }
 
 fn snapshot_font_manifest(
@@ -2584,6 +2641,8 @@ fn validate_artifact_budget(artifacts: &[ArtifactReport]) -> Result<()> {
 }
 
 fn set_private_permissions(path: &Path) -> Result<()> {
+    #[cfg(not(unix))]
+    let _ = path;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt as _;
@@ -2735,7 +2794,7 @@ fn audit_published_tree(root: &Path, expected_paths: &BTreeSet<String>) -> Resul
                 directories.insert(relative);
                 walk(root, &path, found, directories)?;
             } else if metadata.file_type().is_file() {
-                if has_multiple_links(&metadata) {
+                if has_multiple_links(&path, &metadata) {
                     anyhow::bail!("artifact tree contains a multiply-linked file");
                 }
                 let relative = path
@@ -2770,20 +2829,21 @@ fn audit_published_tree(root: &Path, expected_paths: &BTreeSet<String>) -> Resul
     Ok(())
 }
 
+/// 하드링크 별칭이 있는지. Windows는 링크 수를 핸들에서만 읽을 수 있으므로 열지 못하면
+/// 판정 불가이며, 호출부가 모두 거부 조건으로 쓰므로 true(fail-closed)를 돌려준다.
 #[cfg(unix)]
-fn has_multiple_links(metadata: &fs::Metadata) -> bool {
+pub fn has_multiple_links(_path: &Path, metadata: &fs::Metadata) -> bool {
     use std::os::unix::fs::MetadataExt as _;
     metadata.nlink() > 1
 }
 
 #[cfg(windows)]
-fn has_multiple_links(metadata: &fs::Metadata) -> bool {
-    use std::os::windows::fs::MetadataExt as _;
-    metadata.number_of_links().is_some_and(|links| links > 1)
+pub fn has_multiple_links(path: &Path, _metadata: &fs::Metadata) -> bool {
+    windows_path_info(path).is_none_or(|info| info.links > 1)
 }
 
 #[cfg(not(any(unix, windows)))]
-fn has_multiple_links(_metadata: &fs::Metadata) -> bool {
+pub fn has_multiple_links(_path: &Path, _metadata: &fs::Metadata) -> bool {
     false
 }
 
@@ -3039,9 +3099,10 @@ fn run_oracle(
     let Some(trusted) = TrustedOracleConfig::from_environment() else {
         return unavailable("trusted_runner_not_configured");
     };
-    #[cfg(not(unix))]
-    {
-        let _ = trusted;
+    // 오라클은 process group kill에 의존한다(unix 전용). cfg! 로 두어 양쪽 플랫폼에서
+    // 같은 코드가 컴파일되게 한다 — #[cfg] 블록이면 Windows에서 이후 문장이 죽어 경고가 난다.
+    if cfg!(not(unix)) {
+        let _ = (&trusted, input_snapshot, input_extension, stage_root);
         return unavailable("oracle_process_group_unavailable_on_platform");
     }
     if !trusted
@@ -3563,7 +3624,7 @@ fn audit_oracle_output(directory: &Path) -> Result<BTreeSet<String>> {
         if !allowed.contains(&name.as_str())
             || metadata.file_type().is_symlink()
             || !metadata.file_type().is_file()
-            || has_multiple_links(&metadata)
+            || has_multiple_links(&entry.path(), &metadata)
         {
             anyhow::bail!("oracle output violates fixed allowlist");
         }
@@ -3626,7 +3687,7 @@ fn validate_pdf_structure(path: &Path) -> Result<()> {
     let metadata = fs::symlink_metadata(path)?;
     if metadata.file_type().is_symlink()
         || !metadata.file_type().is_file()
-        || has_multiple_links(&metadata)
+        || has_multiple_links(path, &metadata)
         || metadata.len() < 16
         || metadata.len() > MAX_ARTIFACT_TOTAL_BYTES
     {
@@ -3817,6 +3878,8 @@ fn run_bounded_command(
         }
     }
     let mut child = command.spawn()?;
+    // process group kill(unix)에서만 쓴다. 다른 플랫폼은 child.kill() 경로.
+    #[cfg_attr(not(unix), allow(unused_variables))]
     let pid = child.id();
     let stdout = child.stdout.take().context("missing child stdout")?;
     let stderr = child.stderr.take().context("missing child stderr")?;
@@ -3889,6 +3952,60 @@ fn digest_pipe(mut pipe: impl Read) -> Result<PipeDigest> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn scratch(label: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "hwp-certify-{label}-{}-{}",
+            std::process::id(),
+            random_token().unwrap()
+        ));
+        let _ = fs::remove_file(&path);
+        path
+    }
+
+    /// 하드링크 별칭 판정. Windows에서는 링크 수를 핸들에서만 읽을 수 있어 구현이 갈리므로
+    /// 두 플랫폼 모두에서 돌려 회귀를 잡는다.
+    #[test]
+    fn hardlink_alias_is_detected_and_plain_file_is_not() {
+        let plain = scratch("plain");
+        fs::write(&plain, b"payload").unwrap();
+        let metadata = fs::symlink_metadata(&plain).unwrap();
+        assert!(!has_multiple_links(&plain, &metadata));
+
+        let alias = scratch("alias");
+        fs::hard_link(&plain, &alias).unwrap();
+        let metadata = fs::symlink_metadata(&plain).unwrap();
+        assert!(has_multiple_links(&plain, &metadata));
+
+        fs::remove_file(&alias).unwrap();
+        fs::remove_file(&plain).unwrap();
+    }
+
+    /// 열어 둔 핸들과 경로의 동일성. 경로가 다른 파일로 교체되면 false여야 한다(TOCTOU 게이트).
+    #[test]
+    fn open_handle_stops_matching_a_replaced_path() {
+        let path = scratch("swap");
+        fs::write(&path, b"original").unwrap();
+        let opened = File::open(&path).unwrap();
+        assert!(open_file_still_matches_path(&opened, &path));
+
+        let replacement = scratch("swap-replacement");
+        fs::write(&replacement, b"replacement").unwrap();
+        fs::rename(&replacement, &path).unwrap();
+        assert!(!open_file_still_matches_path(&opened, &path));
+
+        drop(opened);
+        fs::remove_file(&path).unwrap();
+    }
+
+    #[test]
+    fn open_handle_does_not_match_a_missing_path() {
+        let path = scratch("removed");
+        fs::write(&path, b"payload").unwrap();
+        let opened = File::open(&path).unwrap();
+        fs::remove_file(&path).unwrap();
+        assert!(!open_file_still_matches_path(&opened, &path));
+    }
 
     fn policy_json(mode: &str) -> serde_json::Value {
         serde_json::json!({

--- a/crates/hwp-cli/src/commands/compose.rs
+++ b/crates/hwp-cli/src/commands/compose.rs
@@ -338,7 +338,10 @@ mod tests {
         let output = std::env::temp_dir().join(format!(
             "hwp-compose-dry-run-{}-{}.hwpx",
             std::process::id(),
-            std::thread::current().name().unwrap_or("test")
+            std::thread::current()
+                .name()
+                .unwrap_or("test")
+                .replace(':', "-")
         ));
         let report = execute_text_with_source(
             MINIMAL_SPEC,

--- a/crates/hwp-cli/src/commands/corpus.rs
+++ b/crates/hwp-cli/src/commands/corpus.rs
@@ -2121,8 +2121,9 @@ fn audit_tree(root: &Path, manifest: &ArtifactManifest) -> Result<()> {
             .difference(&observed_directories)
             .cloned()
             .collect::<Vec<_>>();
+        let sample = expected_paths.iter().take(4).collect::<Vec<_>>();
         anyhow::bail!(
-            "corpus artifact directories do not match the closed manifest (unexpected: {unexpected:?}, missing: {missing:?})"
+            "corpus artifact directories do not match the closed manifest (unexpected: {unexpected:?}, missing: {missing:?}, file sample: {sample:?})"
         )
     }
     Ok(())

--- a/crates/hwp-cli/src/commands/corpus.rs
+++ b/crates/hwp-cli/src/commands/corpus.rs
@@ -2032,7 +2032,7 @@ fn collect_tree(root: &Path) -> Result<(Vec<Artifact>, BTreeSet<String>)> {
                 }
                 walk(root, &path, depth + 1, files, directories, total)?;
             } else if metadata.file_type().is_file() {
-                if has_multiple_links(&metadata) {
+                if hwp_cli::certification::has_multiple_links(&path, &metadata) {
                     anyhow::bail!("corpus artifact tree contains a multiply-linked file")
                 }
                 *total = total
@@ -2115,23 +2115,6 @@ fn audit_tree(root: &Path, manifest: &ArtifactManifest) -> Result<()> {
         anyhow::bail!("corpus artifact directories do not match the closed manifest")
     }
     Ok(())
-}
-
-#[cfg(unix)]
-fn has_multiple_links(metadata: &fs::Metadata) -> bool {
-    use std::os::unix::fs::MetadataExt as _;
-    metadata.nlink() != 1
-}
-
-#[cfg(windows)]
-fn has_multiple_links(metadata: &fs::Metadata) -> bool {
-    use std::os::windows::fs::MetadataExt as _;
-    metadata.number_of_links().is_none_or(|links| links != 1)
-}
-
-#[cfg(not(any(unix, windows)))]
-fn has_multiple_links(_metadata: &fs::Metadata) -> bool {
-    true
 }
 
 struct AtomicCorpusDir {

--- a/crates/hwp-cli/src/commands/corpus.rs
+++ b/crates/hwp-cli/src/commands/corpus.rs
@@ -491,7 +491,12 @@ pub fn run(manifest_path: &Path, report_path: &Path) -> Result<()> {
     };
     let artifact_bytes = pretty_json_bounded(&artifact_manifest, MAX_REPORT_BYTES)?;
     write_new(&stage.root().join("artifacts.json"), &artifact_bytes)?;
-    audit_tree(stage.root(), &artifact_manifest)?;
+    let case_ids = manifest
+        .cases
+        .iter()
+        .map(|case| case.id.as_str())
+        .collect::<Vec<_>>();
+    audit_tree(stage.root(), &artifact_manifest, &case_ids)?;
     stage.publish()?;
 
     println!(
@@ -2080,7 +2085,10 @@ fn normalized_relative(root: &Path, path: &Path) -> Result<String> {
     Ok(components.join("/"))
 }
 
-fn audit_tree(root: &Path, manifest: &ArtifactManifest) -> Result<()> {
+/// 실패한 case는 자기 디렉터리를 비운 채 남긴다. 그 디렉터리를 "예상 밖"으로 처리하면
+/// 실패 사유가 담긴 report 자체가 게시되지 못하고 트리 불일치 오류로 덮인다. 그래서 runner가
+/// 만드는 case 디렉터리는 파일이 없어도 허용한다.
+fn audit_tree(root: &Path, manifest: &ArtifactManifest, case_ids: &[&str]) -> Result<()> {
     let expected_paths: BTreeSet<_> = manifest
         .files
         .iter()
@@ -2110,20 +2118,21 @@ fn audit_tree(root: &Path, manifest: &ArtifactManifest) -> Result<()> {
             let components = path.split('/').collect::<Vec<_>>();
             (1..components.len()).map(move |end| components[..end].join("/"))
         })
+        .chain(["documents".to_string(), "certification".to_string()])
+        .chain(
+            case_ids
+                .iter()
+                .flat_map(|id| [format!("documents/{id}"), format!("certification/{id}")]),
+        )
         .collect::<BTreeSet<_>>();
-    if observed_directories != expected_directories {
+    if !observed_directories.is_subset(&expected_directories) {
         // 경로는 닫힌 manifest에서 온 산출물 이름이라 진단에 실어도 된다.
         let unexpected = observed_directories
             .difference(&expected_directories)
             .cloned()
             .collect::<Vec<_>>();
-        let missing = expected_directories
-            .difference(&observed_directories)
-            .cloned()
-            .collect::<Vec<_>>();
-        let sample = expected_paths.iter().take(4).collect::<Vec<_>>();
         anyhow::bail!(
-            "corpus artifact directories do not match the closed manifest (unexpected: {unexpected:?}, missing: {missing:?}, file sample: {sample:?})"
+            "corpus artifact tree contains directories outside the closed manifest: {unexpected:?}"
         )
     }
     Ok(())

--- a/crates/hwp-cli/src/commands/corpus.rs
+++ b/crates/hwp-cli/src/commands/corpus.rs
@@ -2112,7 +2112,18 @@ fn audit_tree(root: &Path, manifest: &ArtifactManifest) -> Result<()> {
         })
         .collect::<BTreeSet<_>>();
     if observed_directories != expected_directories {
-        anyhow::bail!("corpus artifact directories do not match the closed manifest")
+        // 경로는 닫힌 manifest에서 온 산출물 이름이라 진단에 실어도 된다.
+        let unexpected = observed_directories
+            .difference(&expected_directories)
+            .cloned()
+            .collect::<Vec<_>>();
+        let missing = expected_directories
+            .difference(&observed_directories)
+            .cloned()
+            .collect::<Vec<_>>();
+        anyhow::bail!(
+            "corpus artifact directories do not match the closed manifest (unexpected: {unexpected:?}, missing: {missing:?})"
+        )
     }
     Ok(())
 }

--- a/crates/hwp-cli/src/commands/mcp.rs
+++ b/crates/hwp-cli/src/commands/mcp.rs
@@ -1338,7 +1338,10 @@ mod tests {
         let output = std::env::temp_dir().join(format!(
             "hwp-compose-mcp-dry-run-{}-{}.hwpx",
             std::process::id(),
-            std::thread::current().name().unwrap_or("test")
+            std::thread::current()
+                .name()
+                .unwrap_or("test")
+                .replace(':', "-")
         ));
         let result = tool_compose(&json!({
             "spec": {
@@ -1411,7 +1414,10 @@ mod tests {
         let output = std::env::temp_dir().join(format!(
             "hwp-template-mcp-dry-run-{}-{}.hwpx",
             std::process::id(),
-            std::thread::current().name().unwrap_or("test")
+            std::thread::current()
+                .name()
+                .unwrap_or("test")
+                .replace(':', "-")
         ));
         let _ = std::fs::remove_file(&output);
         let result = tool_template(&json!({

--- a/crates/hwp-cli/src/commands/output.rs
+++ b/crates/hwp-cli/src/commands/output.rs
@@ -597,12 +597,16 @@ impl StagedOutput {
                 }
                 DestinationSnapshot::Missing => {
                     windows_apply_parent_default_dacl(&self.staged, &self.destination, false)?;
-                    fs::rename(&self.staged, &self.destination).with_context(|| {
-                        format!(
-                            "검증된 임시 출력을 최종 경로에 게시하지 못했습니다: {}",
-                            self.destination.display()
-                        )
-                    })?;
+                    fs::rename(&self.staged, &self.destination)
+                        .map_err(|error| {
+                            std::io::Error::new(error.kind(), format!("rename: {error}"))
+                        })
+                        .with_context(|| {
+                            format!(
+                                "검증된 임시 출력을 최종 경로에 게시하지 못했습니다: {}",
+                                self.destination.display()
+                            )
+                        })?;
                     None
                 }
             };
@@ -1868,9 +1872,12 @@ fn windows_security_descriptor(path: &Path, requested_information: u32) -> anyho
         )
     };
     if loaded == 0 {
-        return Err(std::io::Error::last_os_error()).with_context(|| {
-            format!("Windows 보안 설명자를 읽을 수 없습니다: {}", path.display())
-        });
+        let error = std::io::Error::last_os_error();
+        return Err(std::io::Error::new(
+            error.kind(),
+            format!("GetFileSecurityW: {error}"),
+        ))
+        .with_context(|| format!("Windows 보안 설명자를 읽을 수 없습니다: {}", path.display()));
     }
     Ok(descriptor)
 }
@@ -2015,7 +2022,12 @@ fn windows_apply_inherited_dacl(
         )
     };
     if created == 0 {
-        return Err(std::io::Error::last_os_error()).with_context(|| {
+        let error = std::io::Error::last_os_error();
+        return Err(std::io::Error::new(
+            error.kind(),
+            format!("CreatePrivateObjectSecurityEx: {error}"),
+        ))
+        .with_context(|| {
             format!(
                 "부모 디렉터리에서 Windows 기본 ACL을 계산할 수 없습니다: {}",
                 parent.display()
@@ -2039,7 +2051,12 @@ fn windows_apply_inherited_dacl(
             )
         };
         if applied == 0 {
-            return Err(std::io::Error::last_os_error()).with_context(|| {
+            let error = std::io::Error::last_os_error();
+            return Err(std::io::Error::new(
+                error.kind(),
+                format!("SetFileSecurityW: {error}"),
+            ))
+            .with_context(|| {
                 format!(
                     "새 출력에 부모 디렉터리의 Windows 기본 ACL을 적용할 수 없습니다: {}",
                     path.display()

--- a/crates/hwp-cli/src/commands/output.rs
+++ b/crates/hwp-cli/src/commands/output.rs
@@ -545,6 +545,9 @@ impl StagedOutput {
             .with_context(|| format!("임시 출력 동기화 실패: {}", self.staged.display()))
     }
 
+    // Windows에서는 아래 cfg(windows) 블록이 함수의 마지막이라 조기 return이 tail로 보인다.
+    // 다른 플랫폼에서는 뒤에 cfg 블록이 더 있어 return이 필요하다.
+    #[cfg_attr(windows, allow(clippy::needless_return))]
     fn publish(&mut self) -> anyhow::Result<Option<String>> {
         recheck_destination(&self.destination, &self.snapshot)?;
 
@@ -1992,7 +1995,7 @@ fn windows_apply_inherited_dacl(
         }
         Ok(())
     })();
-    let destroyed = unsafe { DestroyPrivateObjectSecurity(&mut inherited_descriptor) };
+    let destroyed = unsafe { DestroyPrivateObjectSecurity(&inherited_descriptor) };
     if destroyed == 0 && result.is_ok() {
         return Err(std::io::Error::last_os_error())
             .context("Windows 임시 보안 설명자를 해제할 수 없습니다");

--- a/crates/hwp-cli/src/commands/output.rs
+++ b/crates/hwp-cli/src/commands/output.rs
@@ -1926,6 +1926,55 @@ fn windows_apply_parent_default_dacl(
     windows_apply_inherited_dacl(path, parent, is_directory)
 }
 
+/// 닫히는 Windows 토큰 핸들.
+#[cfg(windows)]
+struct WindowsToken(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl Drop for WindowsToken {
+    fn drop(&mut self) {
+        // SAFETY: 생성 시에만 유효한 핸들을 담으며 여기서 한 번만 닫는다.
+        unsafe { windows_sys::Win32::Foundation::CloseHandle(self.0) };
+    }
+}
+
+/// `CreatePrivateObjectSecurityEx`는 임퍼소네이션 토큰을 요구한다. CLI는 임퍼소네이션을
+/// 하지 않으므로 프로세스 토큰을 복제해서 쓴다.
+#[cfg(windows)]
+fn windows_impersonation_token() -> anyhow::Result<WindowsToken> {
+    use std::ptr;
+    use windows_sys::Win32::Foundation::HANDLE;
+    use windows_sys::Win32::Security::{
+        DuplicateToken, SecurityImpersonation, TOKEN_DUPLICATE, TOKEN_QUERY,
+    };
+    use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    let mut primary: HANDLE = ptr::null_mut();
+    // SAFETY: 출력 핸들 포인터만 넘기며, 성공 시에만 사용한다.
+    let opened = unsafe {
+        OpenProcessToken(
+            GetCurrentProcess(),
+            TOKEN_DUPLICATE | TOKEN_QUERY,
+            &mut primary,
+        )
+    };
+    if opened == 0 {
+        return Err(std::io::Error::last_os_error())
+            .context("Windows 프로세스 토큰을 열 수 없습니다");
+    }
+    let primary = WindowsToken(primary);
+
+    let mut impersonation: HANDLE = ptr::null_mut();
+    // SAFETY: primary는 살아 있는 토큰 핸들이고 출력만 새로 받는다.
+    let duplicated =
+        unsafe { DuplicateToken(primary.0, SecurityImpersonation, &mut impersonation) };
+    if duplicated == 0 {
+        return Err(std::io::Error::last_os_error())
+            .context("Windows 토큰을 임퍼소네이션 토큰으로 복제할 수 없습니다");
+    }
+    Ok(WindowsToken(impersonation))
+}
+
 #[cfg(windows)]
 fn windows_apply_inherited_dacl(
     path: &Path,
@@ -1948,6 +1997,10 @@ fn windows_apply_inherited_dacl(
         GenericExecute: FILE_GENERIC_EXECUTE,
         GenericAll: FILE_ALL_ACCESS,
     };
+    // Token을 NULL로 두면 스레드의 유효 토큰을 쓰는데, 임퍼소네이션 중이 아닌 일반
+    // 프로세스에서는 ERROR_NO_TOKEN(1008)이 된다. 프로세스 토큰을 임퍼소네이션 토큰으로
+    // 복제해 명시적으로 넘긴다.
+    let token = windows_impersonation_token()?;
     let mut inherited_descriptor: PSECURITY_DESCRIPTOR = ptr::null_mut();
     let created = unsafe {
         CreatePrivateObjectSecurityEx(
@@ -1957,7 +2010,7 @@ fn windows_apply_inherited_dacl(
             ptr::null(),
             if is_directory { 1 } else { 0 },
             SEF_DACL_AUTO_INHERIT,
-            ptr::null_mut(),
+            token.0,
             &mapping,
         )
     };
@@ -2532,6 +2585,12 @@ mod tests {
         fs::remove_dir_all(dir).unwrap();
     }
 
+    /// SDDL DACL에서 제어 플래그(`D:PAI` 등)를 떼고 ACE 목록만 남긴다.
+    #[cfg(windows)]
+    fn dacl_aces(sddl: &str) -> &str {
+        sddl.find('(').map_or("", |start| &sddl[start..])
+    }
+
     #[cfg(windows)]
     fn windows_dacl_sddl(path: &Path) -> String {
         use std::os::windows::ffi::{OsStrExt as _, OsStringExt as _};
@@ -2706,7 +2765,13 @@ mod tests {
         .unwrap();
 
         assert_eq!(fs::read(&destination).unwrap(), b"NEW");
-        assert_eq!(windows_dacl_sddl(&destination), expected);
+        // ReplaceFileW는 ACE를 그대로 옮기면서 SE_DACL_AUTO_INHERITED(SDDL의 "AI") 표시만
+        // 덧붙일 수 있다. P(protected)가 남아 상속은 여전히 차단되므로 실효 권한은 같다.
+        // 검사 대상은 ACE 목록이다.
+        assert_eq!(
+            dacl_aces(&windows_dacl_sddl(&destination)),
+            dacl_aces(&expected)
+        );
         assert_no_debris(&dir);
         fs::remove_dir_all(dir).unwrap();
     }

--- a/crates/hwp-cli/src/document_spec_v2.rs
+++ b/crates/hwp-cli/src/document_spec_v2.rs
@@ -1689,7 +1689,10 @@ mod tests {
         let root = std::env::temp_dir().join(format!(
             "hwp-v2-svg-{}-{}",
             std::process::id(),
-            std::thread::current().name().unwrap_or("test")
+            std::thread::current()
+                .name()
+                .unwrap_or("test")
+                .replace(':', "-")
         ));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();
@@ -1800,7 +1803,10 @@ mod tests {
         let root = std::env::temp_dir().join(format!(
             "hwp-v2-textbox-{}-{}",
             std::process::id(),
-            std::thread::current().name().unwrap_or("test")
+            std::thread::current()
+                .name()
+                .unwrap_or("test")
+                .replace(':', "-")
         ));
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();

--- a/crates/hwpx/src/patch.rs
+++ b/crates/hwpx/src/patch.rs
@@ -695,7 +695,11 @@ fn process_package(
 
     validate_staged_package(staged_guard.path(), limits)?;
     apply_destination_permissions(staged_guard.path(), &destination)?;
-    File::open(staged_guard.path())
+    // Windows의 FlushFileBuffers는 쓰기 권한을 요구한다 — 읽기 전용 핸들이면
+    // ERROR_ACCESS_DENIED가 난다(유닉스는 읽기 fd로도 fsync가 된다).
+    OpenOptions::new()
+        .write(true)
+        .open(staged_guard.path())
         .and_then(|file| file.sync_all())
         .map_err(|error| labeled_io("staged sync", error))?;
     recheck_destination(output, &destination)?;

--- a/crates/hwpx/src/patch.rs
+++ b/crates/hwpx/src/patch.rs
@@ -695,9 +695,12 @@ fn process_package(
 
     validate_staged_package(staged_guard.path(), limits)?;
     apply_destination_permissions(staged_guard.path(), &destination)?;
-    File::open(staged_guard.path())?.sync_all()?;
+    File::open(staged_guard.path())
+        .and_then(|file| file.sync_all())
+        .map_err(|error| labeled_io("staged sync", error))?;
     recheck_destination(output, &destination)?;
-    atomic_publish(staged_guard.path(), output)?;
+    atomic_publish(staged_guard.path(), output)
+        .map_err(|error| labeled_io("atomic_publish", error))?;
     staged_guard.disarm();
     sync_parent_directory(output);
     Ok(())
@@ -1204,7 +1207,7 @@ impl SiblingTemp {
                     return Ok((Self { path, armed: true }, file));
                 }
                 Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
-                Err(error) => return Err(error.into()),
+                Err(error) => return Err(labeled_io("staged create", error).into()),
             }
         }
         Err(std::io::Error::new(
@@ -1232,6 +1235,11 @@ impl Drop for SiblingTemp {
             let _ = fs::remove_file(&self.path);
         }
     }
+}
+
+/// io 오류에 연산 이름을 남긴다 — 상위(MCP 등)에서 체인이 평탄화돼도 어느 단계인지 보인다.
+fn labeled_io(operation: &str, error: std::io::Error) -> std::io::Error {
+    std::io::Error::new(error.kind(), format!("{operation}: {error}"))
 }
 
 fn open_private_new(path: &Path) -> std::io::Result<File> {

--- a/crates/hwpx/src/patch.rs
+++ b/crates/hwpx/src/patch.rs
@@ -1008,7 +1008,7 @@ fn inspect_destination(path: &Path) -> Result<DestinationSnapshot> {
         )
         .into()),
         Ok(metadata) if metadata.file_type().is_file() => Ok(DestinationSnapshot::Regular {
-            identity: file_identity(&metadata),
+            identity: file_identity(path, &metadata),
             len: metadata.len(),
             modified: metadata.modified().ok(),
             permissions: metadata.permissions(),
@@ -1041,7 +1041,7 @@ fn recheck_destination(path: &Path, snapshot: &DestinationSnapshot) -> Result<()
             },
             Ok(metadata),
         ) if metadata.file_type().is_file()
-            && file_identity(&metadata) == *identity
+            && file_identity(path, &metadata) == *identity
             && metadata.len() == *len
             && metadata.modified().ok() == *modified =>
         {
@@ -1066,33 +1066,109 @@ fn apply_destination_permissions(path: &Path, snapshot: &DestinationSnapshot) ->
     Ok(())
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct FileIdentity {
-    first: u64,
-    second: u64,
+/// 파일 신원. `Unknown`은 자기 자신과도 같지 않다 — 신원을 못 읽었으면 "그대로다"를
+/// 증명할 수 없으므로 recheck가 실패(fail-closed)해야 한다. 그래서 `Eq`는 구현하지
+/// 않는다(반사성이 성립하지 않음).
+#[derive(Clone, Copy, Debug)]
+enum FileIdentity {
+    Known {
+        first: u64,
+        second: u64,
+    },
+    /// Windows에서 핸들을 못 열었을 때만 나온다. 다른 플랫폼은 metadata로 항상 구성된다.
+    #[cfg_attr(not(windows), allow(dead_code))]
+    Unknown,
+}
+
+impl PartialEq for FileIdentity {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                FileIdentity::Known { first, second },
+                FileIdentity::Known {
+                    first: other_first,
+                    second: other_second,
+                },
+            ) => first == other_first && second == other_second,
+            _ => false,
+        }
+    }
 }
 
 #[cfg(unix)]
-fn file_identity(metadata: &fs::Metadata) -> FileIdentity {
+fn file_identity(_path: &Path, metadata: &fs::Metadata) -> FileIdentity {
     use std::os::unix::fs::MetadataExt;
-    FileIdentity {
+    FileIdentity::Known {
         first: metadata.dev(),
         second: metadata.ino(),
     }
 }
 
+// volume serial + file index는 핸들에서만 얻는다(std의 Metadata 경로는 nightly 전용
+// `windows_by_handle`). 링크는 따라가지 않고 열어, 검사 뒤 심볼릭 링크로 바뀌었으면
+// 다른 신원이 나와 recheck가 실패하도록 한다.
 #[cfg(windows)]
-fn file_identity(metadata: &fs::Metadata) -> FileIdentity {
-    use std::os::windows::fs::MetadataExt;
-    FileIdentity {
-        first: u64::from(metadata.volume_serial_number().unwrap_or_default()),
-        second: metadata.file_index().unwrap_or_default(),
+fn file_identity(path: &Path, _metadata: &fs::Metadata) -> FileIdentity {
+    use std::os::windows::fs::OpenOptionsExt as _;
+    use std::os::windows::io::AsRawHandle as _;
+
+    const FILE_READ_ATTRIBUTES: u32 = 0x80;
+    const FILE_SHARE_READ: u32 = 0x1;
+    const FILE_SHARE_WRITE: u32 = 0x2;
+    const FILE_SHARE_DELETE: u32 = 0x4;
+    const FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x0200_0000;
+    const FILE_FLAG_OPEN_REPARSE_POINT: u32 = 0x0020_0000;
+
+    #[repr(C)]
+    #[derive(Default)]
+    struct ByHandleFileInformation {
+        file_attributes: u32,
+        creation_time_low: u32,
+        creation_time_high: u32,
+        last_access_time_low: u32,
+        last_access_time_high: u32,
+        last_write_time_low: u32,
+        last_write_time_high: u32,
+        volume_serial_number: u32,
+        file_size_high: u32,
+        file_size_low: u32,
+        number_of_links: u32,
+        file_index_high: u32,
+        file_index_low: u32,
+    }
+
+    unsafe extern "system" {
+        fn GetFileInformationByHandle(
+            file: *mut std::ffi::c_void,
+            information: *mut ByHandleFileInformation,
+        ) -> i32;
+    }
+
+    let Ok(file) = fs::OpenOptions::new()
+        .access_mode(FILE_READ_ATTRIBUTES)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)
+    else {
+        return FileIdentity::Unknown;
+    };
+    let mut information = ByHandleFileInformation::default();
+    // SAFETY: 핸들은 이 스코프에서 살아 있는 File 소유이고, 출력 구조체는 Win32
+    // BY_HANDLE_FILE_INFORMATION과 같은 repr(C) 레이아웃이다.
+    let loaded = unsafe { GetFileInformationByHandle(file.as_raw_handle(), &mut information) };
+    if loaded == 0 {
+        return FileIdentity::Unknown;
+    }
+    FileIdentity::Known {
+        first: u64::from(information.volume_serial_number),
+        second: (u64::from(information.file_index_high) << 32)
+            | u64::from(information.file_index_low),
     }
 }
 
 #[cfg(not(any(unix, windows)))]
-fn file_identity(metadata: &fs::Metadata) -> FileIdentity {
-    FileIdentity {
+fn file_identity(_path: &Path, metadata: &fs::Metadata) -> FileIdentity {
+    FileIdentity::Known {
         first: metadata.len(),
         second: 0,
     }
@@ -1220,6 +1296,8 @@ fn atomic_publish(staged: &Path, destination: &Path) -> std::io::Result<()> {
 }
 
 fn sync_parent_directory(path: &Path) {
+    #[cfg(not(unix))]
+    let _ = path;
     #[cfg(unix)]
     {
         let parent = path


### PR DESCRIPTION
#32 수정. `x86_64-pc-windows-msvc`에서 워크스페이스가 아예 컴파일되지 않던 문제다 — `release.yml`이 빌드하는 Windows 바이너리가 막혀 있었다.

## 원인

`std::os::windows::fs::MetadataExt`의 `volume_serial_number` / `file_index` / `number_of_links`는 nightly 전용(`windows_by_handle`)이다. `crates/hwpx/src/patch.rs`, `crates/hwp-cli/src/certification.rs`, `crates/hwp-cli/src/commands/corpus.rs`에서 쓰고 있었다.

## 수정

같은 값을 핸들에서 읽는다. 기존 `asset_snapshot::reject_hardlink`가 쓰던 패턴 그대로다.

- `FILE_READ_ATTRIBUTES` + full share mode + `FILE_FLAG_OPEN_REPARSE_POINT`로 연다. 검사와 열기 사이에 경로가 reparse point로 바뀌었으면 대상이 아니라 링크 자신의 신원이 나와 비교가 실패한다.
- 신원을 못 읽은 경우는 **어떤 값과도 같지 않다**(hwpx는 `FileIdentity::Unknown`, hwp-cli는 `None`). "그대로임"을 증명 못 하면 TOCTOU recheck가 실패해야 하므로 fail-closed다. `Unknown`은 자기 자신과도 같지 않아 `Eq`(반사성)를 구현하지 않는다.
- `has_multiple_links`가 경로를 받는다. Windows에서 열 수 없는 파일은 "링크 여럿"으로 센다 — 모든 호출부가 이 함수를 거부 조건으로 쓰기 때문이다.

`snapshot_file`은 `opened_before`와 `opened_after`를 비교했는데 둘 다 같은 핸들의 metadata라 신원 부분은 원리적으로 달라질 수 없었다. 경로-핸들 비교 1회로 바꿨고, 길이·mtime 비교는 그대로다.

이 과정에서 드러난 Windows 전용 `-D warnings` 실패도 함께 고쳤다: 미사용 `path`/`pid`/oracle 파라미터, 비-unix 오라클 조기 반환 뒤의 unreachable 문장, needless return, 불필요한 `&mut`.

## 검증

로컬에 Windows 툴체인이 없어 mingw 크로스로 실제 컴파일 루프를 만들었다:

```
rustup target add x86_64-pc-windows-gnu   # + brew install mingw-w64
cargo clippy --workspace --all-targets --target x86_64-pc-windows-gnu -- -D warnings
```

- Windows 타깃 clippy `-D warnings` 통과 (이전에는 E0658 5건 + 경고 다수).
- macOS `scripts/check.sh` 통과 (fmt / clippy / test / structured-corpus).
- 하드링크 탐지와 핸들-교체된 경로 신원에 단위 테스트를 붙였다. 이 코드는 개발 머신에서 실행될 수 없으므로, Windows 러너에서 도는 테스트가 유일한 동작 검증 수단이다.

## 남은 판단

이 PR은 CI에서 Windows를 계속 **비차단**으로 둔다. Windows 러너에서 테스트까지 green인 것을 확인한 뒤 별도로 차단형으로 올리는 편이 안전하다.