### PR TITLE
ci: make Windows a required gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,17 +24,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 필수: ubuntu(CI 기준선) + macOS(소유자 주 사용 플랫폼). 둘 다 local source
-          # build + corpus 게이트를 돈다.
+          # 셋 다 필수 게이트: ubuntu(CI 기준선) + macOS(소유자 주 사용 플랫폼) +
+          # windows(v0.5.0부터 MSVC 빌드·테스트 안정화, 릴리스 바이너리도 여기서 나온다).
           - { os: ubuntu-latest }
           - { os: macos-latest }
-          # 참고용: Windows는 실패 허용(비차단) — 잡은 빨간색으로 보이되 워크플로는 통과.
-          # hwpx/hwp-cli가 nightly 전용 windows_by_handle API를 써 Windows에서 컴파일되지
-          # 않는다. release.yml의 Windows 바이너리 빌드도 같은 이유로 막히므로 릴리스 전에
-          # 반드시 고쳐야 한다(별도 이슈).
-          - { os: windows-latest, experimental: true }
+          - { os: windows-latest }
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental == true }}
     steps:
       - uses: actions/checkout@v4
       # 렌더 스모크 테스트는 시스템 CJK 글리프를 쓴다. 이 스텝이 빠지면 잉크 없는

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,8 +49,8 @@ HWP_FONT_DIR=$PWD/fonts python3 tools/diagnostic_corpus.py   # 진단 코퍼스 
   main 직접 push 금지.
 - 정본 저장소는 `STAIxBWLB/hwp-cli`(= origin)다. 브랜치를 origin에 push하고 **origin의
   main을 대상으로 PR**을 연다. (과거의 포크→upstream 구도는 폐지됨.)
-- PR로 제출하고, **CI green(ubuntu+macOS 필수)을 확인한 뒤 squash 머지**한다(머지 커밋 제목의
-  `(#N)` 관례 유지). Windows 잡은 참고용(비차단 — 잡은 빨갛게 보여도 워크플로는 통과).
+- PR로 제출하고, **CI green(ubuntu+macOS+windows 모두 필수)을 확인한 뒤 squash 머지**한다
+  (머지 커밋 제목의 `(#N)` 관례 유지).
 - PR 전 로컬 게이트는 `scripts/check.sh` — CI와 동일 3커맨드(fmt → clippy --all-targets
   -D warnings → test). 이걸 통과 못 하면 PR하지 않는다(머지 후 CI 실패의 원천 차단).
 

--- a/README.en.md
+++ b/README.en.md
@@ -82,8 +82,8 @@ unimplemented features is [docs/design/12-feature-gaps.md](docs/design/12-featur
 3. **HTML conversion upgrade** Carry the footnote markers, merged-cell colspan/rowspan and in-cell
    blocks already solved on the markdown path over to HTML, and improve CSS mapping of character and
    paragraph shapes.
-4. **Windows** Platform defects in the compile and publish paths are being worked through. In CI,
-   ubuntu and macOS are required gates and Windows is informational (non-blocking).
+4. **Windows** The compile and publish paths are stable as of v0.5.0; ubuntu, macOS, and Windows are
+   all required CI gates.
 5. **Distribution (DRM) documents** A candidate to start once the specification is available.
 
 ## Installation
@@ -433,8 +433,8 @@ scripts/check.sh     # local CI mirror: fmt + clippy + test + structured corpus 
 
 CI (`.github/workflows/ci.yml`) installs `fonts-noto-cjk` on ubuntu and then runs
 `cargo fmt --all --check` → `cargo clippy --workspace --all-targets -- -D warnings` →
-`cargo test --workspace` → `scripts/check-structured-corpus.sh` on **ubuntu + macOS** (required) and
-**windows** (informational, non-blocking). The local mirror `scripts/check.sh` runs the same gates.
+`cargo test --workspace` → `scripts/check-structured-corpus.sh` on **ubuntu + macOS + windows**
+(all required). The local mirror `scripts/check.sh` runs the same gates.
 
 Tests cover byte-identical hwp5 round-trips (identity/roundtrip/synth), semantically equivalent hwpx
 round-trips, IR JSON and markdown round-trips, editing and field correction, render layout, tables and

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Linux/macOS 서버와 CI에서 그대로 돈다.
    대조한다. 기능 커버리지 감사에서 신규 갭 17건을 등재했고, 콘텐츠 소실급 4건이 수정 1순위다.
 3. **HTML 변환 고도화** markdown에서 이미 해소한 각주 마커·병합 셀 colspan/rowspan·셀 내 블록을
    HTML 경로에도 반영하고, 글자·문단 모양의 CSS 매핑을 보강한다.
-4. **Windows** 컴파일·게시 경로의 플랫폼 결함을 정리 중이다. CI에서 ubuntu·macOS는 필수 게이트,
-   Windows는 참고용(비차단)이다.
+4. **Windows** v0.5.0부터 컴파일·게시 경로가 안정화됐다. CI에서 ubuntu·macOS·Windows 모두
+   필수 게이트다.
 5. **배포용(DRM) 문서** 스펙 확보를 전제로 착수 후보다.
 
 ## 설치
@@ -401,7 +401,7 @@ scripts/check.sh     # 로컬 CI 미러: fmt + clippy + test + 구조 코퍼스 
 
 CI(`.github/workflows/ci.yml`)는 `fonts-noto-cjk` 설치(ubuntu) 후 `cargo fmt --all --check` →
 `cargo clippy --workspace --all-targets -- -D warnings` → `cargo test --workspace` →
-`scripts/check-structured-corpus.sh`를 **ubuntu + macOS**(필수)와 **windows**(참고용, 비차단)에서
+`scripts/check-structured-corpus.sh`를 **ubuntu + macOS + windows**(모두 필수)에서
 실행한다. 로컬 미러 `scripts/check.sh`는 같은 게이트를 실행한다.
 
 테스트는 hwp5 바이트 동일 왕복(identity/roundtrip/synth), hwpx 의미 동등 왕복, IR JSON·markdown 왕복,


### PR DESCRIPTION
Windows MSVC has been building and passing tests since v0.5.0 (release binaries ship from it), so `continue-on-error` now only hides regressions.

- drop `experimental`/`continue-on-error` from the CI matrix
- update README (ko/en) and CLAUDE.md wording to "all three required"