### PR TITLE
feat: MCP sandbox + protocol negotiation + CLI-surface parity + first-class agent skill (#50, #51, #53)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,38 @@ jobs:
           checksum: sha256
           token: ${{ secrets.GITHUB_TOKEN }}
 
+  # claude.ai 스킬 번들: SKILL.md + bootstrap.sh + Linux x86_64 바이너리를 한 zip으로.
+  # 다운로드 스크립트 대신 바이너리를 싣는 이유: claude.ai 샌드박스 네트워크는 레지스트리로
+  # 제한되어 런타임에 바이너리를 받을 수 없기 때문(번들링이 다운로드를 이긴다).
+  skill-bundle:
+    needs: upload-assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: hwp-skill-claude-web.zip 조립 + 업로드
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          work=$(mktemp -d)
+          # 방금 upload-assets 가 올린 리눅스 아카이브(이름 규칙: $bin-$tag-$target.tar.gz).
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern "hwp-$GITHUB_REF_NAME-x86_64-unknown-linux-gnu.tar.gz" \
+            --dir "$work" --clobber
+          tar -xzf "$work/hwp-$GITHUB_REF_NAME-x86_64-unknown-linux-gnu.tar.gz" -C "$work"
+          bundle="$work/bundle"
+          mkdir -p "$bundle/bin"
+          cp skills/hwp/SKILL.md "$bundle/SKILL.md"
+          cp skills/hwp/claude-web/bootstrap.sh "$bundle/bootstrap.sh"
+          cp "$work/hwp" "$bundle/bin/hwp"
+          chmod +x "$bundle/bin/hwp" "$bundle/bootstrap.sh"
+          (cd "$bundle" && zip -r "$work/hwp-skill-claude-web.zip" SKILL.md bootstrap.sh bin/hwp)
+          (cd "$work" && sha256sum hwp-skill-claude-web.zip > hwp-skill-claude-web.zip.sha256)
+          gh release upload "$GITHUB_REF_NAME" \
+            "$work/hwp-skill-claude-web.zip" \
+            "$work/hwp-skill-claude-web.zip.sha256" \
+            --clobber
+
   # Homebrew formula(저장소 자체가 tap) 의 version/sha256 을 방금 올라온 자산 기준으로
   # 갱신해 main 에 커밋한다. 자산이 다 올라온 뒤라야 체크섬을 받을 수 있어 마지막 잡이다.
   # 실패해도 릴리스 자체는 유효하며, 로컬에서 scripts/update_formula.sh X.Y.Z 로 복구한다.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,9 +81,9 @@ jobs:
           checksum: sha256
           token: ${{ secrets.GITHUB_TOKEN }}
 
-  # claude.ai 스킬 번들: SKILL.md + bootstrap.sh + Linux x86_64 바이너리를 한 zip으로.
-  # 다운로드 스크립트 대신 바이너리를 싣는 이유: claude.ai 샌드박스 네트워크는 레지스트리로
-  # 제한되어 런타임에 바이너리를 받을 수 없기 때문(번들링이 다운로드를 이긴다).
+  # claude.ai skill bundle: SKILL.md + bootstrap.sh + the Linux x86_64 binary in one zip.
+  # Why the binary ships instead of a download script: the claude.ai sandbox network is
+  # restricted to registries, so the binary cannot be fetched at runtime (bundling beats downloading).
   skill-bundle:
     needs: upload-assets
     runs-on: ubuntu-latest
@@ -95,7 +95,7 @@ jobs:
         run: |
           set -euo pipefail
           work=$(mktemp -d)
-          # 방금 upload-assets 가 올린 리눅스 아카이브(이름 규칙: $bin-$tag-$target.tar.gz).
+          # The Linux archive just published by upload-assets (naming: $bin-$tag-$target.tar.gz).
           gh release download "$GITHUB_REF_NAME" \
             --pattern "hwp-$GITHUB_REF_NAME-x86_64-unknown-linux-gnu.tar.gz" \
             --dir "$work" --clobber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,47 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+**Added**
+
+- MCP server: `--root <dir>` (repeatable) sandboxes every path-typed tool argument — reads,
+  writes, nested `insert_image`/`seal`/`parts` paths, compose/template `base_dir`, per-call
+  `font_dir`, and the certify report directory. Roots are canonicalized at startup (a missing or
+  unreadable root fails fast); write guards reject `..` components and close the
+  symlink-overwrite escape. With no `--root` the server is unrestricted as before and prints a
+  one-line stderr warning at startup. (#50)
+- MCP protocol negotiation: `initialize` echoes the client's `protocolVersion` when it is one of
+  `2025-06-18` / `2025-03-26` / `2024-11-05`, and otherwise replies with the latest supported
+  version. (#50)
+- Compose/template asset hardening: the MCP `--root` sandbox now also binds spec-internal asset
+  references. DocumentSpec v1/v2 image and visual assets fail with
+  `asset_snapshot_outside_roots`, and TemplateSpec `reference_hwpx` packages fail with
+  `reference_outside_roots`, unless the resolved file sits under at least one root — so a spec
+  cannot reach files outside the sandbox even when `base_dir` itself is attacker-influenced.
+  CLI and corpus callers pass no roots and behave exactly as before. (#53)
+- MCP `hwp_edit` typed-operation parity: the seven edits that existed only as CLI string flags
+  are now structured JSON arguments — `add_table` (`[{anchor, rows: [[...]]}]`), `set_para`
+  (`[{pattern, line_spacing_pct | line_spacing_pt, indent_mm, left_mm, right_mm, top_mm,
+  bottom_mm}]`), `set_page` (a single object: `width_mm`/`height_mm`/`margin_*_mm`/
+  `orientation`), `delete_image` (`[{anchor}]`), `delete_table` (`[{index | anchor}]`, exactly
+  one of the two), and `delete_field`/`delete_bookmark` (`[{name}]`). They run through the same
+  strict, atomic, re-read-verified edit path as the CLI with identical applied/unapplied
+  semantics. (#50)
+- Edit `--verify` (and therefore MCP `hwp_edit`) now accepts `add_table` and image deletion:
+  the semantic canonicalizer gained the exact HWPX writer projections for freshly synthesized
+  tables (page-break/repeat-header attr and the inline default placement) and for bin streams
+  no control references anymore (the HWPX writer only embeds referenced streams), instead of
+  failing the re-read comparison. (#50)
+- MCP read/convert/render parity + new `hwp_grep` (16 tools total) (#50): `hwp_read` gains
+  `html`/`csv` formats, `with_header_footer`/`with_hidden`, and `with_segments` (markdown-only;
+  segments are filtered to the paginated window but keep absolute offsets). `hwp_convert` gains
+  explicit `to`, `font_dir`, `media_dir` and header/footer/hidden options — and PDF conversion
+  now actually receives the configured font directories instead of an empty list. `hwp_render`
+  gains `format` (png/svg/pdf), a `pages` range spec (mutually exclusive with the legacy `page`),
+  and `output_path` to write PNG/SVG/PDF files and return metadata instead of base64 (the escape
+  hatch from the 16 MiB response cap; single-page base64 PNG stays the default). The new
+  `hwp_grep` tool searches paragraph text and returns `{matches, count, truncated}` — zero
+  matches is a normal result.
+
 **Fixed**
 
 - Markdown export: footnotes referenced inside an HTML-fallback table emitted their definition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,9 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
   `asset_snapshot_outside_roots`, and TemplateSpec `reference_hwpx` packages fail with
   `reference_outside_roots`, unless the resolved file sits under at least one root — so a spec
   cannot reach files outside the sandbox even when `base_dir` itself is attacker-influenced.
-  CLI and corpus callers pass no roots and behave exactly as before. (#53)
+  The binding is verified against the opened file handle rather than the request pathname,
+  closing the rename-swap race between the path check and the open. CLI and corpus callers
+  pass no roots and behave exactly as before. (#53)
 - MCP `hwp_edit` typed-operation parity: the seven edits that existed only as CLI string flags
   are now structured JSON arguments — `add_table` (`[{anchor, rows: [[...]]}]`), `set_para`
   (`[{pattern, line_spacing_pct | line_spacing_pt, indent_mm, left_mm, right_mm, top_mm,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
   hatch from the 16 MiB response cap; single-page base64 PNG stays the default). The new
   `hwp_grep` tool searches paragraph text and returns `{matches, count, truncated}` — zero
   matches is a normal result.
+- First-class agent skill (#51): the canonical `skills/hwp/SKILL.md` (command quick reference,
+  MCP server usage, safety rules) is committed and embedded in the binary;
+  `hwp skill export [-o DIR]` materializes it, and `--install claude-code|codex` writes it to
+  `~/.claude/skills/hwp/` or `~/.codex/skills/hwp/`. The file is English-only by design — it
+  is consumed by agents, and one canonical language avoids bilingual double-maintenance.
+- Release packaging + AI integration docs (#51): every tag now also publishes
+  `hwp-skill-claude-web.zip` (+ `.sha256`) — SKILL.md, a bootstrap script and the bundled
+  Linux x86_64 binary, because the claude.ai sandbox network is registry-restricted and cannot
+  download the binary at runtime — and `docs/manual/ai-integrations.md` (English canonical,
+  Korean pair) documents per-client setup: Claude Code/Desktop, Codex CLI/cloud, Kiro/Kimi,
+  claude.ai skill upload, and Amazon Quick Suite (convert to docx/pdf and upload; remote HTTP
+  MCP tracked in #52).
 
 **Fixed**
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -339,6 +339,9 @@ hwp new --from report.json -o regen.hwpx # JSON IR → 신규 문서
 `2025-06-18`·`2025-03-26`·`2024-11-05` 중 하나면 그대로 돌려주고, 아니면 최신 지원 버전으로
 응답한다. stdout은 프로토콜 전용이고 로그는 stderr로 나간다.
 
+클라이언트별 설정(Claude Code/Desktop, Codex CLI/cloud, Kiro, Kimi, claude.ai 스킬 업로드,
+Amazon Quick Suite)과 번들 에이전트 스킬(`hwp skill export`):
+[docs/manual/ai-integrations.ko.md](docs/manual/ai-integrations.ko.md).
 
 ### 노출 도구 (16종)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -30,7 +30,7 @@ Linux/macOS 서버와 CI에서 그대로 돈다.
   리포트를 게시하고, `corpus`는 고정 코퍼스로 2회 생성 결과의 바이트·의미·렌더 해시 일치를 강제한다.
 - **AI 편집** IR을 JSON으로 내보내 고치고 되쓰는 read → edit → rewrite 왕복. 텍스트 치환, 표 셀 설정,
   누름틀/필드 채우기를 이미지·서식·미해석 레코드를 보존한 채 적용한다.
-- **MCP 서버** 의존성 없는(serde_json만) stdio MCP 서버로 15개 도구를 노출한다.
+- **MCP 서버** 의존성 없는(serde_json만) stdio MCP 서버로 16개 도구를 노출한다.
 
 ## 구현 상태
 
@@ -42,7 +42,7 @@ Linux/macOS 서버와 CI에서 그대로 돈다.
 | 구조 편집 (문단·표 행/열·셀 병합/분할·필드·이미지·도장) | 구현 완료 (병합 표 포함) |
 | DocumentSpec v1/v2, TemplateSpec v1 합성 | 구현 완료 |
 | 인증(certify) · 구조 코퍼스 게이트(corpus) | 구현 완료 |
-| MCP 서버 (15 도구) | 구현 완료 |
+| MCP 서버 (16 도구) | 구현 완료 |
 | HTML 변환 | 동작하나 markdown 대비 충실도 낮음 (로드맵) |
 | 수식 | 상자+스크립트 근사 렌더 |
 | 차트 · OLE | 미지원 |
@@ -335,18 +335,22 @@ hwp new --from report.json -o regen.hwpx # JSON IR → 신규 문서
 ## MCP 서버 (AI 에이전트 연동)
 
 `hwp mcp`는 tokio나 SDK 없이 `serde_json`만으로 동기 JSON-RPC 2.0(stdio, 줄 단위)을 구현한 MCP
-서버다(프로토콜 버전 `2024-11-05`). stdout은 프로토콜 전용이고 로그는 stderr로 나간다.
+서버다. 프로토콜 버전은 `initialize`에서 협상한다: 클라이언트의 `protocolVersion`이
+`2025-06-18`·`2025-03-26`·`2024-11-05` 중 하나면 그대로 돌려주고, 아니면 최신 지원 버전으로
+응답한다. stdout은 프로토콜 전용이고 로그는 stderr로 나간다.
 
-### 노출 도구 (15종)
+
+### 노출 도구 (16종)
 
 | 도구 | 필수 인자 | 기능 |
 |---|---|---|
 | `hwp_info` | `path` | 포맷/버전/속성/스트림 진단 |
-| `hwp_read` | `path` | 본문 추출. `json`이면 전체 IR. UTF-8 byte 페이지네이션(기본 256 KiB, 최대 1 MiB) |
+| `hwp_read` | `path` | 본문 추출(`plain`/`markdown`/`json`/`html`/`csv`, 머리말·꼬리말/숨은 설명/세그먼트 옵션). UTF-8 byte 페이지네이션(기본 256 KiB, 최대 1 MiB) |
+| `hwp_grep` | `path`, `pattern` | 문단 텍스트 검색. `{matches, count, truncated}` 반환 — 0건이어도 정상 결과 |
 | `hwp_list_fields` | `path` | 필드/누름틀 목록 |
 | `hwp_list_bookmarks` | `path` | 책갈피(bokm) 목록 |
 | `hwp_slots` | `path` | `{{name}}` 자리표시자 목록 |
-| `hwp_render` | `path` | 지정 페이지만 PNG로 렌더(dpi 36..=600, 응답 최대 16 MiB) |
+| `hwp_render` | `path` | 페이지를 PNG로 렌더(base64, 응답 최대 16 MiB)하거나 `output_path`로 PNG/SVG/PDF 파일 작성(dpi 36..=600) |
 | `hwp_edit` | `input`, `output` | typed JSON 작업으로 strict atomic 편집 |
 | `hwp_convert` | `input`, `output` | 포맷 변환(MCP의 `strict` 기본값은 true) |
 | `hwp_new` | `output` | markdown/JSON IR과 metadata에서 새 문서 생성 |
@@ -364,11 +368,17 @@ hwp new --from report.json -o regen.hwpx # JSON IR → 신규 문서
   "mcpServers": {
     "hwp": {
       "command": "hwp",
-      "args": ["mcp", "--font-dir", "<repo>/fonts"]
+      "args": ["mcp", "--font-dir", "<repo>/fonts", "--root", "<repo>"]
     }
   }
 }
 ```
+
+`--root`(반복 가능)는 도구가 다루는 모든 파일 경로 — 입력·출력, 중첩 이미지/부분 경로, spec
+`base_dir`, 호출당 `font_dir` — 를 지정 디렉터리 아래로 제한한다. 이 루트는 compose/template spec
+내부 참조에도 적용되어, spec이 참조하는 이미지·비주얼 에셋과 `reference_hwpx` 패키지도 허용 루트
+아래여야 한다. `--root` 없이 실행하면 종전처럼
+제한 없이 동작하며, 기동 시 stderr에 한 줄 경고를 출력한다.
 
 ### read → edit → rewrite 왕복
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,10 @@ with no tokio and no SDK. The protocol version is negotiated at `initialize`: a 
 `protocolVersion` of `2025-06-18`, `2025-03-26` or `2024-11-05` is echoed back, anything else gets
 the latest supported version. stdout carries the protocol; logs go to stderr.
 
+Per-client setup (Claude Code/Desktop, Codex CLI/cloud, Kiro, Kimi, claude.ai skill upload,
+Amazon Quick Suite) and the bundled agent skill (`hwp skill export`):
+[docs/manual/ai-integrations.md](docs/manual/ai-integrations.md).
+
 ### Exposed tools (16)
 
 | Tool | Required arguments | Purpose |

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ and in CI.
   twice and requires the document bytes, semantics and render hashes to match.
 - **AI editing** A read → edit → rewrite loop over the JSON IR. Text replacement, table cell values
   and field filling are applied while images, formatting and unparsed records are preserved.
-- **MCP server** A dependency-free (serde_json only) stdio MCP server exposing 15 tools.
+- **MCP server** A dependency-free (serde_json only) stdio MCP server exposing 16 tools.
 
 ## Implementation status
 
@@ -46,7 +46,7 @@ and in CI.
 | Structural editing (paragraphs, table rows/columns, cell merge/split, fields, images, seals) | Implemented, including merged tables |
 | DocumentSpec v1/v2 and TemplateSpec v1 composition | Implemented |
 | Certification (`certify`) and structured corpus gate (`corpus`) | Implemented |
-| MCP server (15 tools) | Implemented |
+| MCP server (16 tools) | Implemented |
 | HTML conversion | Works, but lower fidelity than markdown (roadmap) |
 | Equations | Approximated as a box plus the script |
 | Charts, OLE | Not supported |
@@ -364,18 +364,21 @@ Office on open), the preview image and settings.xml.
 ## MCP server (AI agent integration)
 
 `hwp mcp` implements synchronous JSON-RPC 2.0 over stdio (line-delimited) using only `serde_json`,
-with no tokio and no SDK (protocol version `2024-11-05`). stdout carries the protocol; logs go to stderr.
+with no tokio and no SDK. The protocol version is negotiated at `initialize`: a client
+`protocolVersion` of `2025-06-18`, `2025-03-26` or `2024-11-05` is echoed back, anything else gets
+the latest supported version. stdout carries the protocol; logs go to stderr.
 
-### Exposed tools (15)
+### Exposed tools (16)
 
 | Tool | Required arguments | Purpose |
 |---|---|---|
 | `hwp_info` | `path` | Format, version, properties and stream diagnostics |
-| `hwp_read` | `path` | Extract body text; `json` returns the full IR. UTF-8 byte pagination (256 KiB default, 1 MiB max) |
+| `hwp_read` | `path` | Extract body text (`plain`/`markdown`/`json`/`html`/`csv`; header/footer, hidden and segment options). UTF-8 byte pagination (256 KiB default, 1 MiB max) |
+| `hwp_grep` | `path`, `pattern` | Paragraph text search; returns `{matches, count, truncated}` — zero matches is a normal result |
 | `hwp_list_fields` | `path` | List fields |
 | `hwp_list_bookmarks` | `path` | List bookmarks (bokm) |
 | `hwp_slots` | `path` | List `{{name}}` placeholders |
-| `hwp_render` | `path` | Render one page to PNG (dpi 36..=600, response up to 16 MiB) |
+| `hwp_render` | `path` | Render pages to PNG (base64, response up to 16 MiB) or write PNG/SVG/PDF files via `output_path` (dpi 36..=600) |
 | `hwp_edit` | `input`, `output` | Strict atomic editing through typed JSON operations |
 | `hwp_convert` | `input`, `output` | Format conversion (`strict` defaults to true over MCP) |
 | `hwp_new` | `output` | Create a document from markdown or JSON IR plus metadata |
@@ -393,11 +396,18 @@ with no tokio and no SDK (protocol version `2024-11-05`). stdout carries the pro
   "mcpServers": {
     "hwp": {
       "command": "hwp",
-      "args": ["mcp", "--font-dir", "<repo>/fonts"]
+      "args": ["mcp", "--font-dir", "<repo>/fonts", "--root", "<repo>"]
     }
   }
 }
 ```
+
+`--root` (repeatable) sandboxes every file path the tools touch — inputs, outputs, nested
+image/part paths, spec `base_dir`s and per-call `font_dir`s — under the given directories. The
+roots also bind compose/template spec internals: image/visual assets and `reference_hwpx` packages
+referenced by a spec must resolve under an allowed root. Without
+any `--root` the server keeps the old unrestricted behavior and prints a one-line warning to stderr
+at startup.
 
 ### The read → edit → rewrite loop
 

--- a/crates/hwp-cli/src/asset_snapshot.rs
+++ b/crates/hwp-cli/src/asset_snapshot.rs
@@ -94,34 +94,42 @@ pub fn read_contained(
     relative_path: &Path,
     max_bytes: u64,
 ) -> Result<AssetSnapshot, AssetSnapshotError> {
-    read_contained_impl(base_dir, relative_path, max_bytes, || {}, || {})
+    read_contained_impl(base_dir, relative_path, max_bytes, &[], || {}, || {})
 }
 
-/// Defense-in-depth binding to the MCP sandbox roots. A no-op when `roots` is
-/// empty (CLI/corpus callers); otherwise the canonical resolved asset must sit
-/// under at least one root. Roots are expected to be canonical already.
-pub fn check_under_roots(resolved: &Path, roots: &[PathBuf]) -> Result<(), AssetSnapshotError> {
-    if roots.is_empty() {
-        return Ok(());
-    }
-    let canonical =
-        std::fs::canonicalize(resolved).map_err(|_| error(AssetSnapshotErrorCode::Missing))?;
-    if roots.iter().any(|root| canonical.starts_with(root)) {
-        Ok(())
-    } else {
-        Err(error(AssetSnapshotErrorCode::OutsideRoots))
-    }
+/// Same as [`read_contained`], plus a defense-in-depth binding to the MCP
+/// sandbox roots: the path of the opened asset is resolved from the file
+/// handle itself and must sit under at least one root. A no-op when `roots` is
+/// empty (CLI/corpus callers). Roots are expected to be canonical already.
+pub fn read_contained_with_roots(
+    base_dir: &Path,
+    relative_path: &Path,
+    max_bytes: u64,
+    roots: &[PathBuf],
+) -> Result<AssetSnapshot, AssetSnapshotError> {
+    read_contained_impl(base_dir, relative_path, max_bytes, roots, || {}, || {})
 }
 
 fn read_contained_impl(
     base_dir: &Path,
     relative_path: &Path,
     max_bytes: u64,
+    roots: &[PathBuf],
     after_parent_open: impl FnOnce(),
     after_open: impl FnOnce(),
 ) -> Result<AssetSnapshot, AssetSnapshotError> {
     validate_relative_path(relative_path)?;
     let file = secure_open_contained(base_dir, relative_path, after_parent_open)?;
+    // Judge the roots against the opened handle, not the request pathname:
+    // resolving the path from the descriptor keeps the check bound to the file
+    // that was actually opened even when a parent directory was renamed and
+    // replaced with a symlink between the walk and this point.
+    #[cfg(any(unix, windows))]
+    check_opened_under_roots(&file, roots)?;
+    // The fallback open path is pathname-based already, so its roots check
+    // stays a pathname canonicalize check as well.
+    #[cfg(not(any(unix, windows)))]
+    check_resolved_under_roots(&base_dir.join(relative_path), roots)?;
     let opened = file
         .metadata()
         .map_err(|_| error(AssetSnapshotErrorCode::ReadFailed))?;
@@ -374,6 +382,14 @@ fn validate_opened_containment(
     file: &std::fs::File,
     canonical_base: &Path,
 ) -> Result<(), AssetSnapshotError> {
+    if !windows_path_is_within(&opened_handle_path(file)?, canonical_base) {
+        return Err(error(AssetSnapshotErrorCode::ContainmentViolation));
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn opened_handle_path(file: &std::fs::File) -> Result<PathBuf, AssetSnapshotError> {
     use std::ffi::OsString;
     use std::os::windows::ffi::OsStringExt as _;
     use std::os::windows::io::AsRawHandle as _;
@@ -391,11 +407,9 @@ fn validate_opened_containment(
     if length == 0 || length as usize >= buffer.len() {
         return Err(error(AssetSnapshotErrorCode::ReadFailed));
     }
-    let opened = std::path::PathBuf::from(OsString::from_wide(&buffer[..length as usize]));
-    if !windows_path_is_within(&opened, canonical_base) {
-        return Err(error(AssetSnapshotErrorCode::ContainmentViolation));
-    }
-    Ok(())
+    Ok(PathBuf::from(OsString::from_wide(
+        &buffer[..length as usize],
+    )))
 }
 
 #[cfg(windows)]
@@ -415,6 +429,85 @@ fn windows_path_is_within(candidate: &Path, base: &Path) -> bool {
         || candidate
             .strip_prefix(&base)
             .is_some_and(|suffix| suffix.starts_with(['\\', '/']))
+}
+
+/// Defense-in-depth binding to the MCP sandbox roots. A no-op when `roots` is
+/// empty (CLI/corpus callers); otherwise the path of the opened file — resolved
+/// from the handle itself, never from the request pathname — must sit under at
+/// least one root. Roots are expected to be canonical already.
+#[cfg(any(unix, windows))]
+fn check_opened_under_roots(
+    file: &std::fs::File,
+    roots: &[PathBuf],
+) -> Result<(), AssetSnapshotError> {
+    if roots.is_empty() {
+        return Ok(());
+    }
+    // Canonicalize the handle path as well so residual symlink components in
+    // it cannot decide the comparison; fail closed when it no longer resolves.
+    let canonical = std::fs::canonicalize(opened_handle_path(file)?)
+        .map_err(|_| error(AssetSnapshotErrorCode::Missing))?;
+    #[cfg(unix)]
+    let contained = roots.iter().any(|root| canonical.starts_with(root));
+    #[cfg(windows)]
+    let contained = roots
+        .iter()
+        .any(|root| windows_path_is_within(&canonical, root));
+    if contained {
+        Ok(())
+    } else {
+        Err(error(AssetSnapshotErrorCode::OutsideRoots))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn opened_handle_path(file: &std::fs::File) -> Result<PathBuf, AssetSnapshotError> {
+    use std::os::fd::AsRawFd as _;
+    std::fs::read_link(format!("/proc/self/fd/{}", file.as_raw_fd()))
+        .map_err(|_| error(AssetSnapshotErrorCode::ReadFailed))
+}
+
+#[cfg(target_os = "macos")]
+fn opened_handle_path(file: &std::fs::File) -> Result<PathBuf, AssetSnapshotError> {
+    use std::os::fd::AsRawFd as _;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let mut buffer = vec![0 as libc::c_char; libc::MAXPATHLEN as usize];
+    // Safety: the caller holds `file` open, so the descriptor is valid, and the
+    // buffer is MAXPATHLEN writable bytes as F_GETPATH requires; on success the
+    // kernel writes a NUL-terminated path into it.
+    let result = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETPATH, buffer.as_mut_ptr()) };
+    if result == -1 {
+        return Err(error(AssetSnapshotErrorCode::ReadFailed));
+    }
+    let path = unsafe { std::ffi::CStr::from_ptr(buffer.as_ptr()) };
+    Ok(PathBuf::from(std::ffi::OsStr::from_bytes(path.to_bytes())))
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+fn opened_handle_path(_file: &std::fs::File) -> Result<PathBuf, AssetSnapshotError> {
+    // No portable handle-to-path mechanism on this target: fail closed (this
+    // is only reached with a non-empty roots list).
+    Err(error(AssetSnapshotErrorCode::ReadFailed))
+}
+
+/// Pathname-based fallback for targets without a handle-to-path mechanism —
+/// the open path there is pathname-based already, so the roots check is too.
+#[cfg(not(any(unix, windows)))]
+fn check_resolved_under_roots(
+    resolved: &Path,
+    roots: &[PathBuf],
+) -> Result<(), AssetSnapshotError> {
+    if roots.is_empty() {
+        return Ok(());
+    }
+    let canonical =
+        std::fs::canonicalize(resolved).map_err(|_| error(AssetSnapshotErrorCode::Missing))?;
+    if roots.iter().any(|root| canonical.starts_with(root)) {
+        Ok(())
+    } else {
+        Err(error(AssetSnapshotErrorCode::OutsideRoots))
+    }
 }
 
 fn error(code: AssetSnapshotErrorCode) -> AssetSnapshotError {
@@ -445,23 +538,74 @@ mod tests {
     }
 
     #[test]
-    fn roots_check_binds_resolved_assets_to_sandbox_roots() {
+    fn empty_roots_keep_reading_any_contained_asset() {
+        let root = test_root("roots-empty");
+        std::fs::write(root.join("asset.bin"), b"inside").unwrap();
+
+        let snapshot = read_contained_with_roots(&root, Path::new("asset.bin"), 64, &[]).unwrap();
+        assert_eq!(snapshot.data, b"inside");
+
+        cleanup_root(&root);
+    }
+
+    #[test]
+    fn roots_check_binds_opened_assets_to_sandbox_roots() {
         let parent = test_root("roots-parent");
         let sandbox = parent.join("sandbox");
         std::fs::create_dir(&sandbox).unwrap();
-        let inside = sandbox.join("asset.bin");
-        let outside = parent.join("outside.bin");
-        std::fs::write(&inside, b"inside").unwrap();
-        std::fs::write(&outside, b"outside").unwrap();
-
-        check_under_roots(&outside, &[]).unwrap();
+        std::fs::write(sandbox.join("asset.bin"), b"inside").unwrap();
+        std::fs::write(parent.join("outside.bin"), b"outside").unwrap();
         let roots = vec![std::fs::canonicalize(&sandbox).unwrap()];
-        check_under_roots(&inside, &roots).unwrap();
-        let failure = check_under_roots(&outside, &roots).unwrap_err();
+
+        let snapshot =
+            read_contained_with_roots(&parent, Path::new("sandbox/asset.bin"), 64, &roots).unwrap();
+        assert_eq!(snapshot.data, b"inside");
+
+        let failure =
+            read_contained_with_roots(&parent, Path::new("outside.bin"), 64, &roots).unwrap_err();
         assert_eq!(failure.code, AssetSnapshotErrorCode::OutsideRoots);
         assert!(!failure.to_string().contains(&parent.display().to_string()));
 
         cleanup_root(&parent);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn roots_check_is_anchored_to_the_opened_handle() {
+        use std::os::unix::fs::symlink;
+
+        let root = test_root("roots-swap");
+        let inside = root.join("assets");
+        let outside = test_root("roots-outside-canary");
+        std::fs::create_dir(&inside).unwrap();
+        std::fs::write(inside.join("image.bin"), b"contained-bytes").unwrap();
+        std::fs::write(outside.join("image.bin"), b"outside-canary").unwrap();
+        let roots = vec![std::fs::canonicalize(&root).unwrap()];
+
+        let snapshot = read_contained_impl(
+            &root,
+            Path::new("assets/image.bin"),
+            64,
+            &roots,
+            || {
+                std::fs::rename(&inside, root.join("opened-assets")).unwrap();
+                symlink(&outside, &inside).unwrap();
+            },
+            || {},
+        )
+        .unwrap();
+
+        // The opened file is the original inside asset, so the handle-anchored
+        // check passes and the read returns the original bytes — while a
+        // pathname-based check at the same instant would resolve
+        // `assets/image.bin` through the swapped symlink to the outside canary.
+        assert_eq!(snapshot.data, b"contained-bytes");
+        assert_eq!(
+            std::fs::read(inside.join("image.bin")).unwrap(),
+            b"outside-canary"
+        );
+        cleanup_root(&root);
+        cleanup_root(&outside);
     }
 
     #[cfg(unix)]
@@ -478,6 +622,7 @@ mod tests {
             &root,
             Path::new("asset.bin"),
             64,
+            &[],
             || {},
             || {
                 std::fs::rename(&asset, root.join("opened.bin")).unwrap();
@@ -507,6 +652,7 @@ mod tests {
             &root,
             Path::new("assets/image.bin"),
             64,
+            &[],
             || {
                 std::fs::rename(&inside, root.join("opened-assets")).unwrap();
                 symlink(&outside, &inside).unwrap();

--- a/crates/hwp-cli/src/asset_snapshot.rs
+++ b/crates/hwp-cli/src/asset_snapshot.rs
@@ -7,7 +7,7 @@
 
 use std::fmt;
 use std::io::Read as _;
-use std::path::{Component, Path};
+use std::path::{Component, Path, PathBuf};
 
 use sha2::{Digest as _, Sha256};
 
@@ -26,6 +26,7 @@ pub enum AssetSnapshotErrorCode {
     HardlinkForbidden,
     NotRegular,
     ContainmentViolation,
+    OutsideRoots,
     ChangedDuringOpen,
     LimitExceeded,
     ReadFailed,
@@ -41,6 +42,7 @@ impl AssetSnapshotErrorCode {
             Self::HardlinkForbidden => "hardlink_forbidden",
             Self::NotRegular => "not_regular",
             Self::ContainmentViolation => "containment_violation",
+            Self::OutsideRoots => "outside_roots",
             Self::ChangedDuringOpen => "changed_during_open",
             Self::LimitExceeded => "limit_exceeded",
             Self::ReadFailed => "read_failed",
@@ -65,6 +67,7 @@ impl fmt::Display for AssetSnapshotError {
             AssetSnapshotErrorCode::HardlinkForbidden => "multiply-linked assets are forbidden",
             AssetSnapshotErrorCode::NotRegular => "asset is not a regular file",
             AssetSnapshotErrorCode::ContainmentViolation => "asset is outside the spec directory",
+            AssetSnapshotErrorCode::OutsideRoots => "asset is outside the sandbox roots",
             AssetSnapshotErrorCode::ChangedDuringOpen => "asset changed while it was opened",
             AssetSnapshotErrorCode::LimitExceeded => "asset exceeds the byte limit",
             AssetSnapshotErrorCode::ReadFailed => "asset snapshot could not be read",
@@ -92,6 +95,22 @@ pub fn read_contained(
     max_bytes: u64,
 ) -> Result<AssetSnapshot, AssetSnapshotError> {
     read_contained_impl(base_dir, relative_path, max_bytes, || {}, || {})
+}
+
+/// Defense-in-depth binding to the MCP sandbox roots. A no-op when `roots` is
+/// empty (CLI/corpus callers); otherwise the canonical resolved asset must sit
+/// under at least one root. Roots are expected to be canonical already.
+pub fn check_under_roots(resolved: &Path, roots: &[PathBuf]) -> Result<(), AssetSnapshotError> {
+    if roots.is_empty() {
+        return Ok(());
+    }
+    let canonical =
+        std::fs::canonicalize(resolved).map_err(|_| error(AssetSnapshotErrorCode::Missing))?;
+    if roots.iter().any(|root| canonical.starts_with(root)) {
+        Ok(())
+    } else {
+        Err(error(AssetSnapshotErrorCode::OutsideRoots))
+    }
 }
 
 fn read_contained_impl(
@@ -423,6 +442,26 @@ mod tests {
         assert_eq!(failure.code, AssetSnapshotErrorCode::LimitExceeded);
 
         cleanup_root(&root);
+    }
+
+    #[test]
+    fn roots_check_binds_resolved_assets_to_sandbox_roots() {
+        let parent = test_root("roots-parent");
+        let sandbox = parent.join("sandbox");
+        std::fs::create_dir(&sandbox).unwrap();
+        let inside = sandbox.join("asset.bin");
+        let outside = parent.join("outside.bin");
+        std::fs::write(&inside, b"inside").unwrap();
+        std::fs::write(&outside, b"outside").unwrap();
+
+        check_under_roots(&outside, &[]).unwrap();
+        let roots = vec![std::fs::canonicalize(&sandbox).unwrap()];
+        check_under_roots(&inside, &roots).unwrap();
+        let failure = check_under_roots(&outside, &roots).unwrap_err();
+        assert_eq!(failure.code, AssetSnapshotErrorCode::OutsideRoots);
+        assert!(!failure.to_string().contains(&parent.display().to_string()));
+
+        cleanup_root(&parent);
     }
 
     #[cfg(unix)]

--- a/crates/hwp-cli/src/cli.rs
+++ b/crates/hwp-cli/src/cli.rs
@@ -330,6 +330,9 @@ pub enum Cmd {
         /// Default font directory for the render and diff tools (repeatable)
         #[arg(long)]
         font_dir: Vec<PathBuf>,
+        /// Restrict all file access to this directory (repeatable). Default: unrestricted
+        #[arg(long)]
+        root: Vec<PathBuf>,
     },
 
     /// Self-update: fetch the latest `hwp` from GitHub releases and replace the running binary

--- a/crates/hwp-cli/src/cli.rs
+++ b/crates/hwp-cli/src/cli.rs
@@ -351,6 +351,12 @@ pub enum Cmd {
         json: bool,
     },
 
+    /// Manage the bundled agent skill (SKILL.md for AI coding assistants)
+    Skill {
+        #[command(subcommand)]
+        cmd: SkillCmd,
+    },
+
     /// [developer] Dump record and package structure
     Dump {
         /// Target HWP/HWPX file
@@ -464,6 +470,29 @@ pub struct EditArgs {
     pub allow_partial: bool,
 }
 
+/// `hwp skill` 서브커맨드.
+#[derive(Subcommand)]
+pub enum SkillCmd {
+    /// Write the embedded SKILL.md into a directory (default ./hwp; the file lands at <DIR>/SKILL.md)
+    Export {
+        /// Output directory (mutually exclusive with --install)
+        #[arg(short, long, conflicts_with = "install")]
+        output: Option<PathBuf>,
+        /// Install into a known agent skills directory instead
+        #[arg(long, value_enum)]
+        install: Option<InstallTarget>,
+    },
+}
+
+/// `--install` 대상 — 에이전트별 스킬 디렉터리.
+#[derive(Clone, Copy, ValueEnum)]
+pub enum InstallTarget {
+    /// ~/.claude/skills/hwp/
+    ClaudeCode,
+    /// ~/.codex/skills/hwp/
+    Codex,
+}
+
 #[derive(Clone, Copy, ValueEnum)]
 pub enum TextFormat {
     Plain,
@@ -510,6 +539,16 @@ pub enum RenderFormat {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn skill_export_output_and_install_are_mutually_exclusive() {
+        assert!(
+            Cli::try_parse_from(["hwp", "skill", "export", "-o", "out", "--install", "codex"])
+                .is_err(),
+            "-o와 --install은 동시에 받지 않는다"
+        );
+        assert!(Cli::try_parse_from(["hwp", "skill", "export"]).is_ok());
+    }
 
     #[test]
     fn render_and_diff_reject_non_finite_or_out_of_range_dpi() {

--- a/crates/hwp-cli/src/cli.rs
+++ b/crates/hwp-cli/src/cli.rs
@@ -470,7 +470,7 @@ pub struct EditArgs {
     pub allow_partial: bool,
 }
 
-/// `hwp skill` 서브커맨드.
+/// `hwp skill` subcommand.
 #[derive(Subcommand)]
 pub enum SkillCmd {
     /// Write the embedded SKILL.md into a directory (default ./hwp; the file lands at <DIR>/SKILL.md)
@@ -484,7 +484,7 @@ pub enum SkillCmd {
     },
 }
 
-/// `--install` 대상 — 에이전트별 스킬 디렉터리.
+/// `--install` target — per-agent skill directory.
 #[derive(Clone, Copy, ValueEnum)]
 pub enum InstallTarget {
     /// ~/.claude/skills/hwp/

--- a/crates/hwp-cli/src/commands/compose.rs
+++ b/crates/hwp-cli/src/commands/compose.rs
@@ -110,7 +110,7 @@ pub fn execute_text_with_source(
 
 /// `execute_text_with_source`의 hermetic font variant. `font_files`가 있으면 HWP
 /// writer와 preview는 시스템 글꼴을 전혀 로드하지 않는다.
-/// `roots`가 비어 있지 않으면 spec 에셋을 해당 루트 아래로 제한한다(MCP 샌드박스).
+/// When `roots` is non-empty, spec assets are restricted below those roots (MCP sandbox).
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn execute_text_with_source_and_fonts(
     input: &str,

--- a/crates/hwp-cli/src/commands/compose.rs
+++ b/crates/hwp-cli/src/commands/compose.rs
@@ -65,6 +65,7 @@ pub fn run(
         dry_run,
         allow_visual_fallback,
         Some(spec_path),
+        &[],
     )?;
 
     if print_report || dry_run {
@@ -83,6 +84,7 @@ pub fn run(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn execute_text_with_source(
     input: &str,
     format: SpecInputFormat,
@@ -91,6 +93,7 @@ pub fn execute_text_with_source(
     dry_run: bool,
     allow_visual_fallback: bool,
     source_path: Option<&Path>,
+    roots: &[std::path::PathBuf],
 ) -> anyhow::Result<ComposeReportOutput> {
     execute_text_with_source_and_fonts(
         input,
@@ -101,11 +104,13 @@ pub fn execute_text_with_source(
         allow_visual_fallback,
         source_path,
         None,
+        roots,
     )
 }
 
 /// `execute_text_with_source`의 hermetic font variant. `font_files`가 있으면 HWP
 /// writer와 preview는 시스템 글꼴을 전혀 로드하지 않는다.
+/// `roots`가 비어 있지 않으면 spec 에셋을 해당 루트 아래로 제한한다(MCP 샌드박스).
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn execute_text_with_source_and_fonts(
     input: &str,
@@ -116,6 +121,7 @@ pub(crate) fn execute_text_with_source_and_fonts(
     allow_visual_fallback: bool,
     source_path: Option<&Path>,
     font_files: Option<&[std::path::PathBuf]>,
+    roots: &[std::path::PathBuf],
 ) -> anyhow::Result<ComposeReportOutput> {
     if spec_version(input, format).as_deref() == Some("2.0") {
         if allow_visual_fallback {
@@ -128,8 +134,16 @@ pub(crate) fn execute_text_with_source_and_fonts(
             }));
         }
         let spec = document_spec_v2::parse_spec_v2(input, format).map_err(compose_error)?;
-        execute_spec_v2_with_source(&spec, base_dir, output, dry_run, source_path, font_files)
-            .map(ComposeReportOutput::V2)
+        execute_spec_v2_with_source(
+            &spec,
+            base_dir,
+            output,
+            dry_run,
+            source_path,
+            font_files,
+            roots,
+        )
+        .map(ComposeReportOutput::V2)
     } else {
         let spec = document_spec::parse_spec(input, format).map_err(compose_error)?;
         execute_spec_with_source_and_fonts(
@@ -140,6 +154,7 @@ pub(crate) fn execute_text_with_source_and_fonts(
             allow_visual_fallback,
             source_path,
             font_files,
+            roots,
         )
         .map(ComposeReportOutput::V1)
     }
@@ -160,9 +175,10 @@ fn execute_spec_v2_with_source(
     dry_run: bool,
     source_path: Option<&Path>,
     font_files: Option<&[std::path::PathBuf]>,
+    roots: &[std::path::PathBuf],
 ) -> anyhow::Result<ComposeReportV2> {
     let write_hwp = output_kind(output)?;
-    let compiled = document_spec_v2::compile_spec_v2(spec, base_dir, output, dry_run)
+    let compiled = document_spec_v2::compile_spec_v2(spec, base_dir, output, dry_run, roots)
         .map_err(compose_error)?;
     let mut report = compiled.report;
     if dry_run {
@@ -208,11 +224,18 @@ pub(crate) fn execute_spec_with_source_and_fonts(
     allow_visual_fallback: bool,
     source_path: Option<&Path>,
     font_files: Option<&[std::path::PathBuf]>,
+    roots: &[std::path::PathBuf],
 ) -> anyhow::Result<ComposeReport> {
     let write_hwp = output_kind(output)?;
-    let compiled =
-        document_spec::compile_spec(spec, base_dir, output, dry_run, allow_visual_fallback)
-            .map_err(compose_error)?;
+    let compiled = document_spec::compile_spec(
+        spec,
+        base_dir,
+        output,
+        dry_run,
+        allow_visual_fallback,
+        roots,
+    )
+    .map_err(compose_error)?;
     let mut report = compiled.report;
     if dry_run {
         return Ok(report);
@@ -328,6 +351,7 @@ mod tests {
             true,
             false,
             None,
+            &[],
         )
         .expect_err("invalid output extension");
         assert!(error.to_string().contains(".txt"));
@@ -351,6 +375,7 @@ mod tests {
             true,
             false,
             None,
+            &[],
         )
         .expect("dry-run");
         assert!(report.dry_run());

--- a/crates/hwp-cli/src/commands/corpus.rs
+++ b/crates/hwp-cli/src/commands/corpus.rs
@@ -965,6 +965,7 @@ fn generate_native_source(
                 false,
                 None,
                 Some(font_files),
+                &[],
             )?;
         }
         PreparedGenerator::TemplateSpecData {
@@ -983,6 +984,7 @@ fn generate_native_source(
                 false,
                 &[],
                 Some(font_files),
+                &[],
             )?;
         }
     }
@@ -2380,6 +2382,7 @@ mod tests {
             Path::new("projection-test.hwpx"),
             true,
             false,
+            &[],
         )
         .unwrap()
         .document

--- a/crates/hwp-cli/src/commands/edit.rs
+++ b/crates/hwp-cli/src/commands/edit.rs
@@ -135,10 +135,40 @@ pub(crate) enum TypedEditOperation {
         row: u16,
         col: u16,
     },
+    AddTable {
+        anchor: String,
+        rows: Vec<Vec<String>>,
+    },
+    SetPara {
+        pattern: String,
+        /// HWPUNIT/pt×100 단위까지 변환된 문단모양(CLI `parse_para_props`와 같은 단위).
+        props: hwp_convert::ParaProps,
+    },
+    SetPage {
+        /// HWPUNIT 단위까지 변환된 페이지 설정(CLI `apply_page_prop`과 같은 단위).
+        props: hwp_convert::PageProps,
+    },
+    DeleteImage {
+        anchor: String,
+    },
+    DeleteTable {
+        /// 0-기반 표 인덱스. anchor와 상호 배타적(정확히 하나만 Some) — MCP 경계에서 강제.
+        index: Option<usize>,
+        /// 앵커 텍스트가 든 문단의 표. index와 상호 배타적.
+        anchor: Option<String>,
+    },
+    DeleteField {
+        name: String,
+    },
+    DeleteBookmark {
+        name: String,
+    },
 }
 
 impl TypedEditOperation {
     fn is_structural(&self) -> bool {
+        // 레거시 EditOperation::is_structural와 같은 분류를 유지한다(같은 작업은
+        // CLI/MCP 어느 경로든 같은 쓰기 경로를 타야 한다).
         matches!(
             self,
             Self::InsertImage { .. }
@@ -151,6 +181,11 @@ impl TypedEditOperation {
                 | Self::DeleteCol { .. }
                 | Self::MergeCells { .. }
                 | Self::SplitCell { .. }
+                | Self::AddTable { .. }
+                | Self::DeleteImage { .. }
+                | Self::DeleteTable { .. }
+                | Self::DeleteField { .. }
+                | Self::DeleteBookmark { .. }
         )
     }
 }
@@ -1268,6 +1303,83 @@ fn apply_typed_operation(
             eprintln!("셀 분할: 표{table} ({row},{col})");
             *edits += 1;
         }
+        TypedEditOperation::AddTable { anchor, rows } => {
+            hwp_convert::add_table(doc, anchor, rows).map_err(|error| anyhow::anyhow!(error))?;
+            eprintln!(
+                "표 삽입: {anchor:?} 뒤 ({}x{})",
+                rows.len(),
+                rows.first().map_or(0, Vec::len)
+            );
+            *edits += 1;
+        }
+        TypedEditOperation::SetPara { pattern, props } => {
+            let before = doc.clone();
+            let count = hwp_convert::set_para_props(doc, pattern, props);
+            if count == 0 {
+                unapplied.push(format!("set_para pattern={pattern:?}"));
+            } else {
+                eprintln!("문단 모양: {pattern:?} ({count}건)");
+                record_effect(
+                    &before,
+                    doc,
+                    format!("set_para pattern={pattern:?}"),
+                    edits,
+                    unapplied,
+                );
+            }
+        }
+        TypedEditOperation::SetPage { props } => {
+            let before = doc.clone();
+            let count = hwp_convert::set_page_def(doc, props);
+            if count == 0 {
+                unapplied.push("set_page".to_string());
+            } else {
+                eprintln!("페이지 설정: {count}구역");
+                record_effect(&before, doc, "set_page".to_string(), edits, unapplied);
+            }
+        }
+        TypedEditOperation::DeleteImage { anchor } => {
+            let count = hwp_convert::delete_object(doc, hwp_convert::ObjectKind::Image, anchor);
+            if count == 0 {
+                unapplied.push(format!("delete_image anchor={anchor:?}"));
+            } else {
+                eprintln!("그림 삭제: {anchor:?} ({count}건)");
+                *edits += count;
+            }
+        }
+        TypedEditOperation::DeleteTable { index, anchor } => {
+            // index/anchor 상호 배타는 MCP 경계에서 강제한다 — 여기서는 방어적으로 확인만.
+            let (kind, selector) = match (index, anchor) {
+                (Some(nth), None) => (hwp_convert::ObjectKind::TableNth(*nth), ""),
+                (None, Some(anchor)) => (hwp_convert::ObjectKind::Table, anchor.as_str()),
+                _ => anyhow::bail!("delete_table은 index와 anchor 중 하나만 지정해야 합니다"),
+            };
+            let count = hwp_convert::delete_object(doc, kind, selector);
+            if count == 0 {
+                unapplied.push(format!("delete_table index={index:?} anchor={anchor:?}"));
+            } else {
+                eprintln!("표 삭제: index={index:?} anchor={anchor:?} ({count}건)");
+                *edits += count;
+            }
+        }
+        TypedEditOperation::DeleteField { name } => {
+            let count = hwp_convert::delete_object(doc, hwp_convert::ObjectKind::Field, name);
+            if count == 0 {
+                unapplied.push(format!("delete_field name={name:?}"));
+            } else {
+                eprintln!("필드 삭제: {name:?} ({count}건)");
+                *edits += count;
+            }
+        }
+        TypedEditOperation::DeleteBookmark { name } => {
+            let count = hwp_convert::delete_object(doc, hwp_convert::ObjectKind::Bookmark, name);
+            if count == 0 {
+                unapplied.push(format!("delete_bookmark name={name:?}"));
+            } else {
+                eprintln!("책갈피 삭제: {name:?} ({count}건)");
+                *edits += count;
+            }
+        }
     }
     Ok(())
 }
@@ -1390,6 +1502,11 @@ pub(crate) fn parse_align(name: &str) -> anyhow::Result<u8> {
     })
 }
 
+/// mm → HWPUNIT (1mm = 7200/25.4). MCP처럼 수치가 이미 파싱된 호출자도 같은 변환을 쓴다.
+pub(crate) fn mm_to_hwpunit(mm: f32) -> i32 {
+    (mm * 7200.0 / 25.4).round() as i32
+}
+
 /// mm string → HWPUNIT (1mm = 7200/25.4).
 fn parse_mm(value: &str) -> anyhow::Result<i32> {
     let mm: f32 = value
@@ -1397,7 +1514,7 @@ fn parse_mm(value: &str) -> anyhow::Result<i32> {
         .trim_end_matches("mm")
         .parse()
         .with_context(|| format!("mm 값이 숫자가 아닙니다: {value:?}"))?;
-    Ok((mm * 7200.0 / 25.4).round() as i32)
+    Ok(mm_to_hwpunit(mm))
 }
 
 /// Parses `--set-para`'s "key:value" into ParaProps.
@@ -1508,6 +1625,37 @@ fn canonical_document(
         out
     }
 
+    /// 문서의 모든 Picture가 resolve_bin으로 참조하는 스트림의 semantic id를 모은다
+    /// (본문·표 셀·글상자 재귀).
+    fn collect_referenced_bin_ids(
+        paragraphs: &[hwp_model::Paragraph],
+        doc: &hwp_model::Document,
+        out: &mut Vec<String>,
+    ) {
+        for paragraph in paragraphs {
+            for control in &paragraph.controls {
+                match control {
+                    hwp_model::Control::Picture(picture) => {
+                        if let Some(bytes) = doc.resolve_bin(&picture.bin_ref) {
+                            out.push(binary_semantic_id(bytes));
+                        }
+                    }
+                    hwp_model::Control::Table(table) => {
+                        for cell in &table.cells {
+                            collect_referenced_bin_ids(&cell.paragraphs, doc, out);
+                        }
+                    }
+                    hwp_model::Control::Generic(generic) => {
+                        for list in &generic.paragraph_lists {
+                            collect_referenced_bin_ids(&list.paragraphs, doc, out);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
     fn is_default_column_def(column: &hwp_model::ColumnDef) -> bool {
         column.count == 1
             && column.kind == 0
@@ -1576,6 +1724,39 @@ fn canonical_document(
         for control in &mut paragraph.controls {
             match control {
                 hwp_model::Control::Table(table) => {
+                    if matches!(target, Some(SemanticTarget::Hwpx))
+                        && table.common_data.is_empty()
+                        && table.placement.is_none()
+                    {
+                        // HWPX writer는 합성 표(common_data·placement 비어 있음)를 셀 단위
+                        // 나눔+제목줄 반복(attr=6)과 인라인 기본 배치로 방출하고 reader가
+                        // 그대로 돌려준다. write_table의 fallback과 같은 값으로 투영하되
+                        // 폭/높이는 writer와 같은 그리드 추정(단일 span 셀 최댓값 합산)을 쓴다.
+                        table.attr = 6;
+                        let cols = table.cols.max(1) as usize;
+                        let rows = table.rows.max(1) as usize;
+                        let mut col_w = vec![0_i64; cols];
+                        let mut row_h = vec![0_i64; rows];
+                        for cell in &table.cells {
+                            let (col, row) = (cell.col as usize, cell.row as usize);
+                            if cell.col_span == 1 && col < cols {
+                                col_w[col] = col_w[col].max(i64::from(cell.width.0));
+                            }
+                            if cell.row_span == 1 && row < rows {
+                                row_h[row] = row_h[row].max(i64::from(cell.height.0));
+                            }
+                        }
+                        table.placement = Some(hwp_model::GsoPlacement {
+                            treat_as_char: true,
+                            flow_with_text: true,
+                            vert_rel_to: 2, // PARA
+                            horz_rel_to: 3, // PARA
+                            width: col_w.iter().sum::<i64>() as i32,
+                            height: row_h.iter().sum::<i64>() as i32,
+                            out_margins: [283; 4],
+                            ..Default::default()
+                        });
+                    }
                     for cell in &mut table.cells {
                         for paragraph in &mut cell.paragraphs {
                             canonicalize_paragraph(paragraph, target, source_doc);
@@ -1794,16 +1975,26 @@ fn canonical_document(
         for start in &mut canonical.header.properties.start_numbers {
             *start = (*start).max(1);
         }
+        // HWPX writer는 Picture가 참조하는 스트림만 패키지에 동봉한다(BinCollector).
+        // 미참조 스트림(삭제된 개체의 잔여 등)은 디스크에 존재하지 않으므로 양쪽에 같은
+        // 규칙으로 제외한다 — 참조된 스트림의 writer 손실은 그대로 검출된다.
+        let mut referenced_bins = Vec::new();
+        for section in &canonical.sections {
+            collect_referenced_bin_ids(&section.paragraphs, &canonical, &mut referenced_bins);
+        }
         for stream in &mut canonical.bin_streams {
             stream.name = binary_semantic_id(&stream.data);
         }
+        canonical
+            .bin_streams
+            .retain(|stream| referenced_bins.contains(&stream.name));
         canonical.bin_streams.sort_by(|left, right| {
             left.name
                 .cmp(&right.name)
                 .then_with(|| left.data.cmp(&right.data))
         });
         // HWPX writer는 같은 bytes를 한 package item으로 재사용한다. 이름/등장
-        // 순서는 의미가 아니지만 고유한 미참조 bytes는 남겨 writer 손실로 검출한다.
+        // 순서는 의미가 아니므로 정렬·중복 제거 후 bytes를 비교한다.
         canonical
             .bin_streams
             .dedup_by(|left, right| left.data == right.data);
@@ -2337,6 +2528,25 @@ mod tests {
                 data: vec![1, 2, 3],
             },
         ];
+        // canonicalizer는 HWPX writer(BinCollector)처럼 컨트롤이 참조하는 스트림만
+        // 남긴다 — 중복 제거를 검증하려면 두 스트림을 Picture가 참조해야 한다.
+        // writer가 같은 bytes를 한 항목으로 재사용하므로 둘 다 같은 항목을 가리킨다.
+        for _ in 0..2 {
+            duplicated.sections[0].paragraphs[0]
+                .controls
+                .push(hwp_model::Control::Picture(hwp_model::Picture {
+                    common_data: Vec::new(),
+                    width: hwp_model::HwpUnit(100),
+                    height: hwp_model::HwpUnit(100),
+                    treat_as_char: true,
+                    z_order: 0,
+                    vert_offset: 0,
+                    horz_offset: 0,
+                    description: None,
+                    bin_ref: hwp_model::BinRef::ItemRef("first.png".to_string()),
+                    extras: Vec::new(),
+                }));
+        }
         let mut single = duplicated.clone();
         single.bin_streams.pop();
 
@@ -2344,6 +2554,20 @@ mod tests {
         let single = semantic_signature_for(&single, Some(SemanticTarget::Hwpx));
         assert_eq!(duplicated, single);
         assert_eq!(duplicated.counts.bin_streams, 1);
+    }
+
+    #[test]
+    fn hwpx_canonical_semantics_drop_unreferenced_binary_content() {
+        // HWPX writer는 미참조 스트림을 동봉하지 않으므로(삭제된 개체의 잔여 등)
+        // canonicalizer도 같은 규칙으로 제외한다 — 제외하지 않으면 재읽기 검증이
+        // 디스크에 존재할 수 없는 스트림을 기대해 항상 실패한다.
+        let mut doc = hwp_convert::from_markdown("본문");
+        doc.bin_streams.push(hwp_model::BinStream {
+            name: "orphan.png".to_string(),
+            data: vec![1, 2, 3],
+        });
+        let signature = semantic_signature_for(&doc, Some(SemanticTarget::Hwpx));
+        assert_eq!(signature.counts.bin_streams, 0);
     }
 
     #[test]
@@ -2392,6 +2616,7 @@ mod tests {
             std::path::Path::new("out.hwpx"),
             false,
             false,
+            &[],
         )
         .unwrap();
         let output = std::env::temp_dir().join(format!(
@@ -2489,6 +2714,7 @@ mod tests {
             std::path::Path::new("out.hwp"),
             false,
             false,
+            &[],
         )
         .unwrap()
         .document;
@@ -2565,6 +2791,7 @@ mod tests {
             std::path::Path::new("out.hwp"),
             false,
             false,
+            &[],
         )
         .unwrap()
         .document;

--- a/crates/hwp-cli/src/commands/edit.rs
+++ b/crates/hwp-cli/src/commands/edit.rs
@@ -141,20 +141,20 @@ pub(crate) enum TypedEditOperation {
     },
     SetPara {
         pattern: String,
-        /// HWPUNIT/pt×100 단위까지 변환된 문단모양(CLI `parse_para_props`와 같은 단위).
+        /// Paragraph shape converted up to HWPUNIT/pt×100 units (same units as the CLI `parse_para_props`).
         props: hwp_convert::ParaProps,
     },
     SetPage {
-        /// HWPUNIT 단위까지 변환된 페이지 설정(CLI `apply_page_prop`과 같은 단위).
+        /// Page setup converted up to HWPUNIT units (same units as the CLI `apply_page_prop`).
         props: hwp_convert::PageProps,
     },
     DeleteImage {
         anchor: String,
     },
     DeleteTable {
-        /// 0-기반 표 인덱스. anchor와 상호 배타적(정확히 하나만 Some) — MCP 경계에서 강제.
+        /// 0-based table index. Mutually exclusive with anchor (exactly one is Some) — enforced at the MCP boundary.
         index: Option<usize>,
-        /// 앵커 텍스트가 든 문단의 표. index와 상호 배타적.
+        /// The table of the paragraph containing the anchor text. Mutually exclusive with index.
         anchor: Option<String>,
     },
     DeleteField {
@@ -167,8 +167,8 @@ pub(crate) enum TypedEditOperation {
 
 impl TypedEditOperation {
     fn is_structural(&self) -> bool {
-        // 레거시 EditOperation::is_structural와 같은 분류를 유지한다(같은 작업은
-        // CLI/MCP 어느 경로든 같은 쓰기 경로를 타야 한다).
+        // Keeps the same classification as the legacy EditOperation::is_structural (the same
+        // operation must take the same write path whether it comes via CLI or MCP).
         matches!(
             self,
             Self::InsertImage { .. }
@@ -1348,7 +1348,7 @@ fn apply_typed_operation(
             }
         }
         TypedEditOperation::DeleteTable { index, anchor } => {
-            // index/anchor 상호 배타는 MCP 경계에서 강제한다 — 여기서는 방어적으로 확인만.
+            // index/anchor mutual exclusion is enforced at the MCP boundary — here we only check defensively.
             let (kind, selector) = match (index, anchor) {
                 (Some(nth), None) => (hwp_convert::ObjectKind::TableNth(*nth), ""),
                 (None, Some(anchor)) => (hwp_convert::ObjectKind::Table, anchor.as_str()),
@@ -1502,7 +1502,7 @@ pub(crate) fn parse_align(name: &str) -> anyhow::Result<u8> {
     })
 }
 
-/// mm → HWPUNIT (1mm = 7200/25.4). MCP처럼 수치가 이미 파싱된 호출자도 같은 변환을 쓴다.
+/// mm → HWPUNIT (1mm = 7200/25.4). Callers with already-parsed numbers, like the MCP, use the same conversion.
 pub(crate) fn mm_to_hwpunit(mm: f32) -> i32 {
     (mm * 7200.0 / 25.4).round() as i32
 }
@@ -1625,8 +1625,8 @@ fn canonical_document(
         out
     }
 
-    /// 문서의 모든 Picture가 resolve_bin으로 참조하는 스트림의 semantic id를 모은다
-    /// (본문·표 셀·글상자 재귀).
+    /// Collects the semantic ids of every stream referenced via resolve_bin by any Picture
+    /// in the document (body, table cells, and text boxes, recursively).
     fn collect_referenced_bin_ids(
         paragraphs: &[hwp_model::Paragraph],
         doc: &hwp_model::Document,
@@ -1728,10 +1728,11 @@ fn canonical_document(
                         && table.common_data.is_empty()
                         && table.placement.is_none()
                     {
-                        // HWPX writer는 합성 표(common_data·placement 비어 있음)를 셀 단위
-                        // 나눔+제목줄 반복(attr=6)과 인라인 기본 배치로 방출하고 reader가
-                        // 그대로 돌려준다. write_table의 fallback과 같은 값으로 투영하되
-                        // 폭/높이는 writer와 같은 그리드 추정(단일 span 셀 최댓값 합산)을 쓴다.
+                        // The HWPX writer emits a synthetic table (empty common_data/placement)
+                        // split per cell with header-row repeat (attr=6) and the inline default
+                        // placement, and the reader returns it verbatim. Project the same values
+                        // as write_table's fallback, with width/height from the writer's grid
+                        // estimation (sum of max single-span cells).
                         table.attr = 6;
                         let cols = table.cols.max(1) as usize;
                         let rows = table.rows.max(1) as usize;
@@ -1975,9 +1976,10 @@ fn canonical_document(
         for start in &mut canonical.header.properties.start_numbers {
             *start = (*start).max(1);
         }
-        // HWPX writer는 Picture가 참조하는 스트림만 패키지에 동봉한다(BinCollector).
-        // 미참조 스트림(삭제된 개체의 잔여 등)은 디스크에 존재하지 않으므로 양쪽에 같은
-        // 규칙으로 제외한다 — 참조된 스트림의 writer 손실은 그대로 검출된다.
+        // The HWPX writer bundles only streams referenced by a Picture (BinCollector).
+        // Unreferenced streams (leftovers of deleted objects, etc.) do not exist on disk,
+        // so both sides exclude them by the same rule — writer loss of referenced streams
+        // is still detected.
         let mut referenced_bins = Vec::new();
         for section in &canonical.sections {
             collect_referenced_bin_ids(&section.paragraphs, &canonical, &mut referenced_bins);
@@ -1994,7 +1996,7 @@ fn canonical_document(
                 .then_with(|| left.data.cmp(&right.data))
         });
         // HWPX writer는 같은 bytes를 한 package item으로 재사용한다. 이름/등장
-        // 순서는 의미가 아니므로 정렬·중복 제거 후 bytes를 비교한다.
+        // Name/appearance order is not meaningful, so bytes are compared after sorting and deduplication.
         canonical
             .bin_streams
             .dedup_by(|left, right| left.data == right.data);
@@ -2528,9 +2530,10 @@ mod tests {
                 data: vec![1, 2, 3],
             },
         ];
-        // canonicalizer는 HWPX writer(BinCollector)처럼 컨트롤이 참조하는 스트림만
-        // 남긴다 — 중복 제거를 검증하려면 두 스트림을 Picture가 참조해야 한다.
-        // writer가 같은 bytes를 한 항목으로 재사용하므로 둘 다 같은 항목을 가리킨다.
+        // The canonicalizer keeps only streams referenced by a control, like the HWPX
+        // writer (BinCollector) — to exercise deduplication, both streams must be referenced
+        // by a Picture. The writer reuses one entry for identical bytes, so both point at
+        // the same entry.
         for _ in 0..2 {
             duplicated.sections[0].paragraphs[0]
                 .controls
@@ -2558,9 +2561,9 @@ mod tests {
 
     #[test]
     fn hwpx_canonical_semantics_drop_unreferenced_binary_content() {
-        // HWPX writer는 미참조 스트림을 동봉하지 않으므로(삭제된 개체의 잔여 등)
-        // canonicalizer도 같은 규칙으로 제외한다 — 제외하지 않으면 재읽기 검증이
-        // 디스크에 존재할 수 없는 스트림을 기대해 항상 실패한다.
+        // The HWPX writer does not bundle unreferenced streams (leftovers of deleted
+        // objects, etc.), so the canonicalizer excludes them by the same rule — otherwise
+        // the reread verification would expect streams that cannot exist on disk and always fail.
         let mut doc = hwp_convert::from_markdown("본문");
         doc.bin_streams.push(hwp_model::BinStream {
             name: "orphan.png".to_string(),

--- a/crates/hwp-cli/src/commands/grep.rs
+++ b/crates/hwp-cli/src/commands/grep.rs
@@ -6,7 +6,7 @@
 
 use std::path::Path;
 
-use hwp_model::{Control, HwpChar, Paragraph};
+use hwp_model::{Control, Document, HwpChar, Paragraph};
 
 use crate::commands::cat::load_document;
 
@@ -15,33 +15,39 @@ pub fn run(pattern: &str, file: &Path, ignore_case: bool) -> anyhow::Result<()> 
         anyhow::bail!("검색 패턴이 비어 있습니다");
     }
     let doc = load_document(file)?;
+    let matches = search(&doc, pattern, ignore_case)?;
+    if matches.is_empty() {
+        // grep(1) convention: no match is exit code 1 (no error message is printed).
+        std::process::exit(1);
+    }
+    let mut out = matches.join("\n");
+    out.push('\n');
+    print!("{out}");
+    Ok(())
+}
+
+/// 패턴이 든 문단 텍스트를 등장 순서로 모은다 (본문·표 셀·글상자 재귀).
+///
+/// `run`의 순수 코어 — CLI는 exit 코드 계약을, MCP는 그대로 결과를 반환한다.
+pub fn search(doc: &Document, pattern: &str, ignore_case: bool) -> anyhow::Result<Vec<String>> {
+    if pattern.is_empty() {
+        anyhow::bail!("검색 패턴이 비어 있습니다");
+    }
     let needle = if ignore_case {
         pattern.to_lowercase()
     } else {
         pattern.to_string()
     };
-    let mut found = 0usize;
-    let mut out = String::new();
+    let mut matches = Vec::new();
     for section in &doc.sections {
         for para in &section.paragraphs {
-            search_para(para, &needle, ignore_case, &mut out, &mut found);
+            search_para(para, &needle, ignore_case, &mut matches);
         }
     }
-    print!("{out}");
-    if found == 0 {
-        // grep(1) convention: no match is exit code 1 (no error message is printed).
-        std::process::exit(1);
-    }
-    Ok(())
+    Ok(matches)
 }
 
-fn search_para(
-    para: &Paragraph,
-    needle: &str,
-    ignore_case: bool,
-    out: &mut String,
-    found: &mut usize,
-) {
+fn search_para(para: &Paragraph, needle: &str, ignore_case: bool, matches: &mut Vec<String>) {
     let text = para_text(para);
     let haystack = if ignore_case {
         text.to_lowercase()
@@ -49,23 +55,21 @@ fn search_para(
         text.clone()
     };
     if !text.is_empty() && haystack.contains(needle) {
-        out.push_str(&text);
-        out.push('\n');
-        *found += 1;
+        matches.push(text);
     }
     for control in &para.controls {
         match control {
             Control::Table(t) => {
                 for cell in &t.cells {
                     for p in &cell.paragraphs {
-                        search_para(p, needle, ignore_case, out, found);
+                        search_para(p, needle, ignore_case, matches);
                     }
                 }
             }
             Control::Generic(g) => {
                 for list in &g.paragraph_lists {
                     for p in &list.paragraphs {
-                        search_para(p, needle, ignore_case, out, found);
+                        search_para(p, needle, ignore_case, matches);
                     }
                 }
             }

--- a/crates/hwp-cli/src/commands/grep.rs
+++ b/crates/hwp-cli/src/commands/grep.rs
@@ -26,9 +26,10 @@ pub fn run(pattern: &str, file: &Path, ignore_case: bool) -> anyhow::Result<()> 
     Ok(())
 }
 
-/// 패턴이 든 문단 텍스트를 등장 순서로 모은다 (본문·표 셀·글상자 재귀).
+/// Collects paragraph texts containing the pattern in order of appearance
+/// (body, table cells, and text boxes, recursively).
 ///
-/// `run`의 순수 코어 — CLI는 exit 코드 계약을, MCP는 그대로 결과를 반환한다.
+/// Pure core of `run` — the CLI wraps it with the exit-code contract, the MCP returns the result as-is.
 pub fn search(doc: &Document, pattern: &str, ignore_case: bool) -> anyhow::Result<Vec<String>> {
     if pattern.is_empty() {
         anyhow::bail!("검색 패턴이 비어 있습니다");

--- a/crates/hwp-cli/src/commands/mcp.rs
+++ b/crates/hwp-cli/src/commands/mcp.rs
@@ -13,19 +13,38 @@ use serde_json::{Value, json};
 
 use crate::commands::cat::load_document;
 
-const PROTOCOL_VERSION: &str = "2024-11-05";
+/// 지원하는 MCP 프로토콜 버전(최신 순). initialize 협상에서 쓴다.
+const SUPPORTED_PROTOCOL_VERSIONS: [&str; 3] = ["2025-06-18", "2025-03-26", "2024-11-05"];
 const MAX_REQUEST_LINE_BYTES: usize = 1024 * 1024;
 const DEFAULT_READ_BYTES: usize = 256 * 1024;
 const MAX_READ_BYTES: usize = 1024 * 1024;
 
-/// 서버 컨텍스트 (렌더/diff 기본 폰트 디렉터리).
+/// 서버 컨텍스트 (렌더/diff 기본 폰트 디렉터리, `--root` 파일 접근 샌드박스).
 pub struct Ctx {
     pub font_dirs: Vec<PathBuf>,
+    /// canonicalize된 허용 루트. 비어 있으면 파일 접근 무제한(기존 동작).
+    pub roots: Vec<PathBuf>,
 }
 
 /// stdio JSON-RPC 루프. EOF까지 한 줄씩 처리한다.
-pub fn run(font_dirs: Vec<PathBuf>) -> anyhow::Result<()> {
-    let ctx = Ctx { font_dirs };
+pub fn run(font_dirs: Vec<PathBuf>, roots: Vec<PathBuf>) -> anyhow::Result<()> {
+    let mut canonical_roots = Vec::with_capacity(roots.len());
+    for root in &roots {
+        let canonical = std::fs::canonicalize(root).map_err(|error| {
+            anyhow::anyhow!(
+                "--root 경로를 확인할 수 없습니다: {} ({error})",
+                root.display()
+            )
+        })?;
+        canonical_roots.push(canonical);
+    }
+    if canonical_roots.is_empty() {
+        eprintln!("경고: --root 미지정 — MCP 서버의 파일 접근이 제한되지 않습니다");
+    }
+    let ctx = Ctx {
+        font_dirs,
+        roots: canonical_roots,
+    };
     let stdin = std::io::stdin();
     let mut reader = stdin.lock();
     let stdout = std::io::stdout();
@@ -82,14 +101,25 @@ pub fn handle_request(line: &str, ctx: &Ctx) -> Option<String> {
     let is_notification = id.is_none();
 
     match method {
-        "initialize" => Some(result_response(
-            id_or_null(id),
-            json!({
-                "protocolVersion": PROTOCOL_VERSION,
-                "capabilities": {"tools": {}},
-                "serverInfo": {"name": "hwp-cli", "version": env!("CARGO_PKG_VERSION")},
-            }),
-        )),
+        "initialize" => {
+            // 프로토콜 협상: 클라이언트 요청 버전을 지원하면 그대로, 아니면 최신 버전으로 응답.
+            let requested = req
+                .get("params")
+                .and_then(|params| params.get("protocolVersion"))
+                .and_then(Value::as_str);
+            let protocol_version = match requested {
+                Some(version) if SUPPORTED_PROTOCOL_VERSIONS.contains(&version) => version,
+                _ => SUPPORTED_PROTOCOL_VERSIONS[0],
+            };
+            Some(result_response(
+                id_or_null(id),
+                json!({
+                    "protocolVersion": protocol_version,
+                    "capabilities": {"tools": {}},
+                    "serverInfo": {"name": "hwp-cli", "version": env!("CARGO_PKG_VERSION")},
+                }),
+            ))
+        }
         "notifications/initialized" | "notifications/cancelled" => None,
         "ping" => Some(result_response(id_or_null(id), json!({}))),
         "tools/list" => Some(result_response(
@@ -136,21 +166,22 @@ fn error_response(id: Value, code: i64, message: &str) -> String {
 /// 도구를 실행해 `tools/call` result를 만든다. 실행 오류는 isError=true content로.
 fn call_tool(name: &str, args: &Value, ctx: &Ctx) -> Value {
     let result: Result<Vec<Value>, String> = match name {
-        "hwp_info" => tool_info(args),
-        "hwp_read" => tool_read(args),
-        "hwp_list_fields" => tool_list_fields(args),
-        "hwp_list_bookmarks" => tool_list_bookmarks(args),
+        "hwp_info" => tool_info(args, ctx),
+        "hwp_read" => tool_read(args, ctx),
+        "hwp_grep" => tool_grep(args, ctx),
+        "hwp_list_fields" => tool_list_fields(args, ctx),
+        "hwp_list_bookmarks" => tool_list_bookmarks(args, ctx),
         "hwp_render" => tool_render(args, ctx),
-        "hwp_edit" => tool_edit(args),
-        "hwp_convert" => tool_convert(args),
-        "hwp_new" => tool_new(args),
-        "hwp_compose" => tool_compose(args),
-        "hwp_template" => tool_template(args),
+        "hwp_edit" => tool_edit(args, ctx),
+        "hwp_convert" => tool_convert(args, ctx),
+        "hwp_new" => tool_new(args, ctx),
+        "hwp_compose" => tool_compose(args, ctx),
+        "hwp_template" => tool_template(args, ctx),
         "hwp_diff" => tool_diff(args, ctx),
-        "hwp_slots" => tool_slots(args),
-        "hwp_fill" => tool_fill(args),
-        "hwp_validate" => tool_validate(args),
-        "hwp_certify" => tool_certify(args),
+        "hwp_slots" => tool_slots(args, ctx),
+        "hwp_fill" => tool_fill(args, ctx),
+        "hwp_validate" => tool_validate(args, ctx),
+        "hwp_certify" => tool_certify(args, ctx),
         other => Err(format!("알 수 없는 도구: {other}")),
     };
     match result {
@@ -254,6 +285,12 @@ fn optional_item_u16(item: &Value, operation: &str, key: &str) -> Result<Option<
         .transpose()
 }
 
+fn optional_item_usize(item: &Value, operation: &str, key: &str) -> Result<Option<usize>, String> {
+    item.get(key)
+        .map(|_| required_item_usize(item, operation, key))
+        .transpose()
+}
+
 fn optional_item_str<'a>(
     item: &'a Value,
     operation: &str,
@@ -293,33 +330,131 @@ fn optional_item_f32(item: &Value, operation: &str, key: &str) -> Result<Option<
         .transpose()
 }
 
+// ---- 경로 샌드박스 (`--root`) ----
+
+/// canonical 경로가 허용 root 중 하나 아래인지 확인한다.
+fn under_any_root(ctx: &Ctx, canonical: &Path, raw: &str) -> Result<PathBuf, String> {
+    if ctx.roots.iter().any(|root| canonical.starts_with(root)) {
+        Ok(canonical.to_path_buf())
+    } else {
+        Err(format!(
+            "허용된 --root 밖 경로라 거부합니다: {raw} ({}으로 확인됨)",
+            canonical.display()
+        ))
+    }
+}
+
+/// 읽기 경로 검증: 실존해야 하며(canonicalize), canonical 결과가 root 아래여야 한다.
+/// roots가 비어 있으면 검사 없이 통과(기존 동작).
+fn checked_read_path(ctx: &Ctx, raw: &str) -> Result<PathBuf, String> {
+    if ctx.roots.is_empty() {
+        return Ok(PathBuf::from(raw));
+    }
+    let canonical = std::fs::canonicalize(raw)
+        .map_err(|error| format!("경로를 확인할 수 없습니다: {raw} ({error})"))?;
+    under_any_root(ctx, &canonical, raw)
+}
+
+/// 쓰기 경로 검증: `..` 구성요소와 파일 이름 누락을 거부하고, 기존 파일이면
+/// canonicalize(심볼링크 덮어쓰기 우회 차단), 새 파일이면 부모를 canonicalize해 붙인 뒤
+/// root 검사를 한다. roots가 비어 있으면 검사 없이 통과(기존 동작).
+fn checked_write_path(ctx: &Ctx, raw: &str) -> Result<PathBuf, String> {
+    if ctx.roots.is_empty() {
+        return Ok(PathBuf::from(raw));
+    }
+    let path = Path::new(raw);
+    if path
+        .components()
+        .any(|component| matches!(component, std::path::Component::ParentDir))
+    {
+        return Err(format!("'..'를 포함한 출력 경로는 거부합니다: {raw}"));
+    }
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| format!("출력 경로에 파일 이름이 없습니다: {raw}"))?;
+    let resolved = if path.exists() {
+        std::fs::canonicalize(path)
+            .map_err(|error| format!("출력 경로를 확인할 수 없습니다: {raw} ({error})"))?
+    } else {
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        let canonical_parent = std::fs::canonicalize(parent).map_err(|error| {
+            format!(
+                "출력 경로의 부모 디렉터리를 확인할 수 없습니다: {} ({error})",
+                parent.display()
+            )
+        })?;
+        canonical_parent.join(file_name)
+    };
+    under_any_root(ctx, &resolved, raw)
+}
+
 fn font_dirs_for(args: &Value, ctx: &Ctx) -> Result<Vec<PathBuf>, String> {
     let mut dirs = ctx.font_dirs.clone();
     if let Some(d) = arg_str_opt(args, "font_dir")? {
-        dirs.push(PathBuf::from(d));
+        // 호출당 font_dir는 샌드박스 검사 대상(기동 시 --font-dir는 신뢰).
+        dirs.push(checked_read_path(ctx, d)?);
     }
     Ok(dirs)
 }
 
 // ---- 도구 핸들러 ----
 
-fn tool_info(args: &Value) -> Result<Vec<Value>, String> {
-    let path = arg_str(args, "path")?;
-    let v = crate::commands::info::info_json(Path::new(path)).map_err(|e| e.to_string())?;
+fn tool_info(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
+    let path = checked_read_path(ctx, arg_str(args, "path")?)?;
+    let v = crate::commands::info::info_json(&path).map_err(|e| e.to_string())?;
     Ok(vec![text_content(
         &serde_json::to_string_pretty(&v).unwrap_or_default(),
     )])
 }
 
-fn tool_read(args: &Value) -> Result<Vec<Value>, String> {
-    let path = arg_str(args, "path")?;
+fn tool_read(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
+    let path = checked_read_path(ctx, arg_str(args, "path")?)?;
     let format = arg_str_opt(args, "format")?.unwrap_or("plain");
-    let doc = load_document(Path::new(path)).map_err(|e| e.to_string())?;
-    let text = match format {
-        "plain" => doc.plain_text(),
-        "markdown" | "md" => hwp_convert::to_markdown(&doc),
-        "json" => hwp_convert::to_json(&doc, true, false).map_err(|e| e.to_string())?,
-        other => return Err(format!("알 수 없는 format: {other} (plain|markdown|json)")),
+    let with_header_footer = arg_bool(args, "with_header_footer", false)?;
+    let with_hidden = arg_bool(args, "with_hidden", false)?;
+    let with_segments = arg_bool(args, "with_segments", false)?;
+    // cat과 같은 계약: with_segments는 markdown 전용이고, with_* 플래그는
+    // plain/markdown에만 적용된다 (html/json/csv는 옵션 미대상 — 받아도 무시).
+    if with_segments && !matches!(format, "markdown" | "md") {
+        return Err(format!(
+            "with_segments는 format=markdown 전용입니다 (요청: {format})"
+        ));
+    }
+    let doc = load_document(&path).map_err(|e| e.to_string())?;
+    let text_options = || hwp_model::TextOptions {
+        include_header_footer: with_header_footer,
+        include_hidden: with_hidden,
+    };
+    let md_options = || hwp_convert::MarkdownOptions {
+        text: text_options(),
+        ..Default::default()
+    };
+    // with_segments면 markdown과 함께 문자 범위 세그먼트 맵을 받아 둔다.
+    let (text, segments) = match format {
+        "plain" => (doc.plain_text_with(&text_options()), None),
+        "markdown" | "md" if with_segments => {
+            let (markdown, segments) = hwp_convert::to_markdown_with_segments(&doc, &md_options())
+                .map_err(|e| e.to_string())?;
+            (markdown, Some(segments))
+        }
+        "markdown" | "md" => (
+            hwp_convert::to_markdown_with(&doc, &md_options()).map_err(|e| e.to_string())?,
+            None,
+        ),
+        "json" => (
+            hwp_convert::to_json(&doc, true, false).map_err(|e| e.to_string())?,
+            None,
+        ),
+        "html" => (hwp_convert::to_html(&doc), None),
+        "csv" => (hwp_convert::to_csv(&doc), None),
+        other => {
+            return Err(format!(
+                "알 수 없는 format: {other} (plain|markdown|json|html|csv)"
+            ));
+        }
     };
     let offset = usize::try_from(arg_u64(args, "offset", 0)?)
         .map_err(|_| "offset이 플랫폼 범위를 넘습니다".to_string())?;
@@ -346,15 +481,43 @@ fn tool_read(args: &Value) -> Result<Vec<Value>, String> {
         "truncated": truncated,
         "next_offset": truncated.then_some(end),
     });
+    let content = match segments {
+        // cat의 한 줄 JSON 봉투와 같은 모양이다. markdown은 반환 창 구간만 담고,
+        // 세그먼트는 창과 교차하는 것만 남기되 오프셋은 전체 markdown 기준
+        // 절대값(유니코드 문자 단위)을 유지한다.
+        Some(segments) => {
+            let char_start = text[..offset].chars().count();
+            let char_end = text[..end].chars().count();
+            let segments: Vec<Value> = segments
+                .iter()
+                .filter(|s| s.start < char_end && s.end > char_start)
+                .map(|s| {
+                    json!({
+                        "kind": "para",
+                        "section": s.section,
+                        "para": s.para,
+                        "start": s.start,
+                        "end": s.end,
+                    })
+                })
+                .collect();
+            let envelope = json!({
+                "markdown": &text[offset..end],
+                "segments": segments,
+            });
+            serde_json::to_string(&envelope).map_err(|e| e.to_string())?
+        }
+        None => text[offset..end].to_string(),
+    };
     Ok(vec![
-        text_content(&text[offset..end]),
+        text_content(&content),
         text_content(&serde_json::to_string(&metadata).unwrap_or_default()),
     ])
 }
 
-fn tool_list_fields(args: &Value) -> Result<Vec<Value>, String> {
-    let path = arg_str(args, "path")?;
-    let doc = load_document(Path::new(path)).map_err(|e| e.to_string())?;
+fn tool_list_fields(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
+    let path = checked_read_path(ctx, arg_str(args, "path")?)?;
+    let doc = load_document(&path).map_err(|e| e.to_string())?;
     let fields: Vec<Value> = hwp_convert::list_fields(&doc)
         .iter()
         .map(|f| {
@@ -369,9 +532,9 @@ fn tool_list_fields(args: &Value) -> Result<Vec<Value>, String> {
     )])
 }
 
-fn tool_list_bookmarks(args: &Value) -> Result<Vec<Value>, String> {
-    let path = arg_str(args, "path")?;
-    let doc = load_document(Path::new(path)).map_err(|e| e.to_string())?;
+fn tool_list_bookmarks(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
+    let path = checked_read_path(ctx, arg_str(args, "path")?)?;
+    let doc = load_document(&path).map_err(|e| e.to_string())?;
     let bookmarks: Vec<Value> = hwp_convert::list_bookmarks(&doc)
         .iter()
         .map(|b| json!({ "name": b.name }))
@@ -381,9 +544,9 @@ fn tool_list_bookmarks(args: &Value) -> Result<Vec<Value>, String> {
     )])
 }
 
-fn tool_slots(args: &Value) -> Result<Vec<Value>, String> {
-    let path = arg_str(args, "path")?;
-    let doc = load_document(Path::new(path)).map_err(|e| e.to_string())?;
+fn tool_slots(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
+    let path = checked_read_path(ctx, arg_str(args, "path")?)?;
+    let doc = load_document(&path).map_err(|e| e.to_string())?;
     let items: Vec<Value> = hwp_convert::scan_placeholders(&doc)
         .iter()
         .map(|p| json!({ "name": p.name, "occurrences": p.occurrences }))
@@ -393,9 +556,9 @@ fn tool_slots(args: &Value) -> Result<Vec<Value>, String> {
     )])
 }
 
-fn tool_fill(args: &Value) -> Result<Vec<Value>, String> {
-    let input = arg_str(args, "input")?;
-    let output = arg_str(args, "output")?;
+fn tool_fill(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
+    let input = checked_read_path(ctx, arg_str(args, "input")?)?;
+    let output = checked_write_path(ctx, arg_str(args, "output")?)?;
     let values_obj = args
         .get("values")
         .and_then(Value::as_object)
@@ -422,11 +585,12 @@ fn tool_fill(args: &Value) -> Result<Vec<Value>, String> {
             let path = v
                 .as_str()
                 .ok_or("parts 값은 부분 파일 경로 문자열이어야 합니다")?;
-            set.push(format!("{k}=@{path}"));
+            let path = checked_read_path(ctx, path)?;
+            set.push(format!("{k}=@{}", path.display()));
         }
         crate::commands::fill::execute(
-            Path::new(input),
-            Path::new(output),
+            &input,
+            &output,
             &set,
             None,
             arg_bool(args, "allow_partial", false)?,
@@ -434,8 +598,8 @@ fn tool_fill(args: &Value) -> Result<Vec<Value>, String> {
         .map_err(|error| format!("{error:#}"))?
     } else {
         crate::commands::fill::execute_values(
-            Path::new(input),
-            Path::new(output),
+            &input,
+            &output,
             &values,
             arg_bool(args, "allow_partial", false)?,
         )
@@ -447,15 +611,15 @@ fn tool_fill(args: &Value) -> Result<Vec<Value>, String> {
     )])
 }
 
-fn tool_validate(args: &Value) -> Result<Vec<Value>, String> {
-    let path = arg_str(args, "path")?;
-    let v = crate::commands::validate::validate_json(Path::new(path));
+fn tool_validate(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
+    let path = checked_read_path(ctx, arg_str(args, "path")?)?;
+    let v = crate::commands::validate::validate_json(&path);
     Ok(vec![text_content(
         &serde_json::to_string_pretty(&v).unwrap_or_default(),
     )])
 }
 
-fn tool_certify(args: &Value) -> Result<Vec<Value>, String> {
+fn tool_certify(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
     let object = args
         .as_object()
         .ok_or_else(|| "arguments는 객체여야 합니다".to_string())?;
@@ -465,10 +629,10 @@ fn tool_certify(args: &Value) -> Result<Vec<Value>, String> {
     {
         return Err(format!("알 수 없는 hwp_certify 인자: {unknown}"));
     }
-    let input = Path::new(arg_str(args, "input")?);
-    let policy = Path::new(arg_str(args, "policy")?);
-    let report = Path::new(arg_str(args, "report")?);
-    let outcome = hwp_cli::certification::execute(input, policy, report)
+    let input = checked_read_path(ctx, arg_str(args, "input")?)?;
+    let policy = checked_read_path(ctx, arg_str(args, "policy")?)?;
+    let report = checked_write_path(ctx, arg_str(args, "report")?)?;
+    let outcome = hwp_cli::certification::execute(&input, &policy, &report)
         .map_err(|error| format!("{error:#}"))?;
     let summary = serde_json::to_string_pretty(&json!({
         "overall": outcome.overall,
@@ -482,49 +646,195 @@ fn tool_certify(args: &Value) -> Result<Vec<Value>, String> {
 }
 
 fn tool_render(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
-    let path = arg_str(args, "path")?;
+    let path = checked_read_path(ctx, arg_str(args, "path")?)?;
+    if args.get("page").is_some() && args.get("pages").is_some() {
+        return Err("page와 pages는 함께 지정할 수 없습니다".into());
+    }
+    let format = match arg_str_opt(args, "format")?.unwrap_or("png") {
+        "png" => hwp_cli::cli::RenderFormat::Png,
+        "svg" => hwp_cli::cli::RenderFormat::Svg,
+        "pdf" => hwp_cli::cli::RenderFormat::Pdf,
+        other => return Err(format!("알 수 없는 format: {other} (png|svg|pdf)")),
+    };
     let page = usize::try_from(arg_u64(args, "page", 1)?)
         .map_err(|_| "page가 플랫폼 범위를 넘습니다".to_string())?;
     let dpi = crate::commands::render::validated_dpi(arg_f64(args, "dpi", 120.0)?)
         .map_err(|error| error.to_string())?;
-    let doc = load_document(Path::new(path)).map_err(|e| e.to_string())?;
-    let out = hwp_render::render_document_pages(
-        &doc,
-        &hwp_render::RenderOptions {
-            dpi,
-            font_dirs: font_dirs_for(args, ctx)?,
-        },
-        Some(&[page]),
-    )
-    .map_err(|e| e.to_string())?;
-    let pixmap = &out.pages[0];
-    let png = pixmap
-        .encode_png()
-        .ok()
-        .ok_or_else(|| "PNG 인코딩 실패".to_string())?;
-    const MAX_MCP_PNG_BYTES: usize = 16 * 1024 * 1024;
-    if png.len() > MAX_MCP_PNG_BYTES {
-        return Err(format!(
-            "MCP 렌더 PNG가 응답 상한 {MAX_MCP_PNG_BYTES} bytes를 초과합니다: {} bytes",
-            png.len()
-        ));
+    let output_path = arg_str_opt(args, "output_path")?;
+    let doc = load_document(&path).map_err(|e| e.to_string())?;
+    let opts = hwp_render::RenderOptions {
+        dpi,
+        font_dirs: font_dirs_for(args, ctx)?,
+    };
+    let pages_spec = arg_str_opt(args, "pages")?;
+
+    // base64 반환 경로: png이고 output_path가 없을 때. 단일 페이지 선택만 허용한다.
+    if matches!(format, hwp_cli::cli::RenderFormat::Png) && output_path.is_none() {
+        let selected = match pages_spec {
+            // legacy 계약: page는 render_document_pages와 같은 선택 의미를 유지한다.
+            None => vec![page],
+            Some(spec) => {
+                let total = hwp_render::count_pages(&doc, &opts);
+                crate::commands::render::parse_pages(spec, total)
+                    .map_err(|error| error.to_string())?
+            }
+        };
+        if selected.len() != 1 {
+            return Err(
+                "다중 페이지 렌더는 output_path가 필요합니다 (페이지별 파일로 저장)".into(),
+            );
+        }
+        let page = selected[0];
+        let out = hwp_render::render_document_pages(&doc, &opts, Some(&[page]))
+            .map_err(|e| e.to_string())?;
+        let pixmap = &out.pages[0];
+        let png = pixmap
+            .encode_png()
+            .ok()
+            .ok_or_else(|| "PNG 인코딩 실패".to_string())?;
+        const MAX_MCP_PNG_BYTES: usize = 16 * 1024 * 1024;
+        if png.len() > MAX_MCP_PNG_BYTES {
+            return Err(format!(
+                "MCP 렌더 PNG가 응답 상한 {MAX_MCP_PNG_BYTES} bytes를 초과합니다: {} bytes",
+                png.len()
+            ));
+        }
+        let summary = format!(
+            "페이지 {page}/{} 렌더 ({}×{}px, {dpi}dpi). issues={}, info={}, complete={}, sha256={}",
+            out.total_pages,
+            pixmap.width(),
+            pixmap.height(),
+            out.report.issue_count,
+            out.report.info_count,
+            out.report.complete,
+            out.report.sha256,
+        );
+        return Ok(vec![text_content(&summary), image_content(&png)]);
     }
-    let summary = format!(
-        "페이지 {page}/{} 렌더 ({}×{}px, {dpi}dpi). issues={}, info={}, complete={}, sha256={}",
-        out.total_pages,
-        pixmap.width(),
-        pixmap.height(),
-        out.report.issue_count,
-        out.report.info_count,
-        out.report.complete,
-        out.report.sha256,
-    );
-    Ok(vec![text_content(&summary), image_content(&png)])
+
+    // 파일 게시 경로: svg/pdf 또는 다중 페이지 또는 output_path 지정. CLI render와
+    // 같은 원자적 게시 트랜잭션을 거치고 JSON 메타데이터를 반환한다.
+    let output = checked_write_path(
+        ctx,
+        output_path.ok_or(
+            "svg/pdf 또는 output_path 없는 다중 페이지 렌더는 output_path 인자가 필요합니다",
+        )?,
+    )?;
+    // CLI와 같은 페이지별 파일명 규칙으로 파생된 각 경로도 샌드박스 검사 대상이다.
+    let checked_derived = |base: &Path, page_no: usize, multi: bool| -> Result<PathBuf, String> {
+        let derived = crate::commands::render::page_path(base, page_no, multi);
+        let raw = derived
+            .to_str()
+            .ok_or_else(|| format!("출력 경로가 UTF-8이 아닙니다: {}", derived.display()))?;
+        checked_write_path(ctx, raw)
+    };
+    let (files, selected): (Vec<PathBuf>, Vec<usize>) = match format {
+        hwp_cli::cli::RenderFormat::Png => {
+            let total = hwp_render::count_pages(&doc, &opts);
+            let selected = match pages_spec {
+                Some(spec) => crate::commands::render::parse_pages(spec, total)
+                    .map_err(|error| error.to_string())?,
+                None => crate::commands::render::parse_pages(&page.to_string(), total)
+                    .map_err(|error| error.to_string())?,
+            };
+            let result = hwp_render::render_document_pages(&doc, &opts, Some(&selected))
+                .map_err(|e| e.to_string())?;
+            let multi = selected.len() > 1;
+            let mut outputs = Vec::with_capacity(selected.len());
+            let mut files = Vec::with_capacity(selected.len());
+            for (&page_no, pixmap) in selected.iter().zip(&result.pages) {
+                let derived = checked_derived(&output, page_no, multi)?;
+                let png = pixmap
+                    .encode_png()
+                    .map_err(|error| format!("PNG 인코딩 실패 ({}): {error}", derived.display()))?;
+                files.push(derived.clone());
+                outputs.push((derived, png));
+            }
+            crate::commands::render::publish_render_set(&outputs, &path)
+                .map_err(|error| error.to_string())?;
+            (files, selected)
+        }
+        hwp_cli::cli::RenderFormat::Svg => {
+            let result = hwp_render::render_document_svg(&doc, &opts);
+            let selected = match pages_spec {
+                Some(spec) => crate::commands::render::parse_pages(spec, result.pages.len())
+                    .map_err(|error| error.to_string())?,
+                None => crate::commands::render::parse_pages(&page.to_string(), result.pages.len())
+                    .map_err(|error| error.to_string())?,
+            };
+            let multi = selected.len() > 1;
+            let mut outputs = Vec::with_capacity(selected.len());
+            let mut files = Vec::with_capacity(selected.len());
+            for &page_no in &selected {
+                let derived = checked_derived(&output, page_no, multi)?;
+                files.push(derived.clone());
+                outputs.push((derived, result.pages[page_no - 1].as_bytes().to_vec()));
+            }
+            crate::commands::render::publish_render_set(&outputs, &path)
+                .map_err(|error| error.to_string())?;
+            (files, selected)
+        }
+        hwp_cli::cli::RenderFormat::Pdf => {
+            let total = hwp_render::count_pages(&doc, &opts);
+            let selected = match pages_spec {
+                Some(spec) => crate::commands::render::parse_pages(spec, total)
+                    .map_err(|error| error.to_string())?,
+                None => crate::commands::render::parse_pages(&page.to_string(), total)
+                    .map_err(|error| error.to_string())?,
+            };
+            // PNG/SVG와 달리 PDF는 단일 멀티페이지 파일이다 (페이지별 분리 없음).
+            let result = hwp_render::render_document_pdf(&doc, &opts, Some(&selected))
+                .map_err(|e| e.to_string())?;
+            crate::commands::render::write_render_bytes(&output, &path, &result.data)
+                .map_err(|error| error.to_string())?;
+            (vec![output.clone()], selected)
+        }
+    };
+    let metadata = json!({
+        "files": files,
+        "pages": selected,
+        "dpi": dpi,
+    });
+    Ok(vec![text_content(
+        &serde_json::to_string_pretty(&metadata).unwrap_or_default(),
+    )])
 }
 
-fn tool_edit(args: &Value) -> Result<Vec<Value>, String> {
-    let input = arg_str(args, "input")?;
-    let output = arg_str(args, "output")?;
+/// hwp_grep 매칭 반환 상한 — 초과분은 잘라내고 truncated=true로 표시한다.
+/// count는 항상 절단 전 전체 개수다.
+const MAX_GREP_MATCHES: usize = 200;
+
+fn grep_result(matches: Vec<String>) -> Value {
+    grep_result_capped(matches, MAX_GREP_MATCHES)
+}
+
+fn grep_result_capped(matches: Vec<String>, cap: usize) -> Value {
+    let count = matches.len();
+    let truncated = count > cap;
+    let matches: Vec<String> = matches.into_iter().take(cap).collect();
+    json!({
+        "matches": matches,
+        "count": count,
+        "truncated": truncated,
+    })
+}
+
+fn tool_grep(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
+    let path = checked_read_path(ctx, arg_str(args, "path")?)?;
+    let pattern = arg_str(args, "pattern")?;
+    let ignore_case = arg_bool(args, "ignore_case", false)?;
+    let doc = load_document(&path).map_err(|e| e.to_string())?;
+    // 0건 매칭도 오류가 아니라 정상 결과다 (CLI grep의 exit(1) 계약과 다름).
+    let matches =
+        crate::commands::grep::search(&doc, pattern, ignore_case).map_err(|e| e.to_string())?;
+    Ok(vec![text_content(
+        &serde_json::to_string_pretty(&grep_result(matches)).unwrap_or_default(),
+    )])
+}
+
+fn tool_edit(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
+    let input = checked_read_path(ctx, arg_str(args, "input")?)?;
+    let output = checked_write_path(ctx, arg_str(args, "output")?)?;
     use crate::commands::edit::TypedEditOperation as Op;
 
     let mut operations = Vec::new();
@@ -595,7 +905,7 @@ fn tool_edit(args: &Value) -> Result<Vec<Value>, String> {
         };
         operations.push(Op::InsertImage {
             anchor: required_item_str(item, "insert_image", "anchor")?.to_string(),
-            path: PathBuf::from(required_item_str(item, "insert_image", "path")?),
+            path: checked_read_path(ctx, required_item_str(item, "insert_image", "path")?)?,
             size_mm,
         });
     }
@@ -603,7 +913,7 @@ fn tool_edit(args: &Value) -> Result<Vec<Value>, String> {
         let size_mm = optional_item_f32(item, "seal", "size_mm")?;
         operations.push(Op::Seal {
             anchor: required_item_str(item, "seal", "anchor")?.to_string(),
-            path: PathBuf::from(required_item_str(item, "seal", "path")?),
+            path: checked_read_path(ctx, required_item_str(item, "seal", "path")?)?,
             size_mm,
         });
     }
@@ -691,13 +1001,133 @@ fn tool_edit(args: &Value) -> Result<Vec<Value>, String> {
             col: required_item_u16(item, "split_cell", "col")?,
         });
     }
+    for item in arg_array(args, "add_table")? {
+        // JSON 경계에서는 형태(문자열 배열의 배열)만 검증한다 — 빈 행 데이터 같은
+        // 내용 검증은 라이브러리(add_table)가 거부하고 그 오류를 그대로 올린다.
+        let rows_value = item
+            .get("rows")
+            .and_then(Value::as_array)
+            .ok_or_else(|| "add_table 항목에 rows 필요".to_string())?;
+        let mut rows = Vec::with_capacity(rows_value.len());
+        for row in rows_value {
+            let cells = row
+                .as_array()
+                .ok_or_else(|| "add_table.rows는 문자열 배열의 배열이어야 합니다".to_string())?;
+            let mut parsed_row = Vec::with_capacity(cells.len());
+            for cell in cells {
+                parsed_row.push(
+                    cell.as_str()
+                        .ok_or_else(|| "add_table.rows의 셀은 문자열이어야 합니다".to_string())?
+                        .to_string(),
+                );
+            }
+            rows.push(parsed_row);
+        }
+        operations.push(Op::AddTable {
+            anchor: required_item_str(item, "add_table", "anchor")?.to_string(),
+            rows,
+        });
+    }
+    for item in arg_array(args, "set_para")? {
+        // CLI의 line-spacing (% 정수 | Npt)를 두 수치 인자로 나눈 것 — 상호 배타적.
+        let line_spacing = match (
+            optional_item_f32(item, "set_para", "line_spacing_pct")?,
+            optional_item_f32(item, "set_para", "line_spacing_pt")?,
+        ) {
+            (Some(_), Some(_)) => {
+                return Err(
+                    "set_para는 line_spacing_pct와 line_spacing_pt를 함께 지정할 수 없습니다"
+                        .into(),
+                );
+            }
+            (Some(pct), None) => Some((0, pct as i32)),
+            (None, Some(pt)) => Some((1, (pt * 100.0).round() as i32)),
+            (None, None) => None,
+        };
+        let props = hwp_convert::ParaProps {
+            line_spacing,
+            indent: optional_item_f32(item, "set_para", "indent_mm")?
+                .map(crate::commands::edit::mm_to_hwpunit),
+            margin_left: optional_item_f32(item, "set_para", "left_mm")?
+                .map(crate::commands::edit::mm_to_hwpunit),
+            margin_right: optional_item_f32(item, "set_para", "right_mm")?
+                .map(crate::commands::edit::mm_to_hwpunit),
+            spacing_top: optional_item_f32(item, "set_para", "top_mm")?
+                .map(crate::commands::edit::mm_to_hwpunit),
+            spacing_bottom: optional_item_f32(item, "set_para", "bottom_mm")?
+                .map(crate::commands::edit::mm_to_hwpunit),
+        };
+        operations.push(Op::SetPara {
+            pattern: required_item_str(item, "set_para", "pattern")?.to_string(),
+            props,
+        });
+    }
+    // CLI의 누적 --set-page 플래그와 같이, 단일 객체를 하나의 PageProps로 합쳐 적용한다.
+    if let Some(item) = args.get("set_page") {
+        if !item.is_object() {
+            return Err("set_page는 단일 객체여야 합니다".into());
+        }
+        let props = hwp_convert::PageProps {
+            width: optional_item_f32(item, "set_page", "width_mm")?
+                .map(crate::commands::edit::mm_to_hwpunit),
+            height: optional_item_f32(item, "set_page", "height_mm")?
+                .map(crate::commands::edit::mm_to_hwpunit),
+            margin_left: optional_item_f32(item, "set_page", "margin_left_mm")?
+                .map(crate::commands::edit::mm_to_hwpunit),
+            margin_right: optional_item_f32(item, "set_page", "margin_right_mm")?
+                .map(crate::commands::edit::mm_to_hwpunit),
+            margin_top: optional_item_f32(item, "set_page", "margin_top_mm")?
+                .map(crate::commands::edit::mm_to_hwpunit),
+            margin_bottom: optional_item_f32(item, "set_page", "margin_bottom_mm")?
+                .map(crate::commands::edit::mm_to_hwpunit),
+            landscape: optional_item_str(item, "set_page", "orientation")?
+                .map(|value| match value.trim().to_ascii_lowercase().as_str() {
+                    "landscape" | "가로" => Ok(true),
+                    "portrait" | "세로" => Ok(false),
+                    other => Err(format!(
+                        "알 수 없는 용지 방향: {other:?} (portrait/landscape)"
+                    )),
+                })
+                .transpose()?,
+        };
+        operations.push(Op::SetPage { props });
+    }
+    for item in arg_array(args, "delete_image")? {
+        operations.push(Op::DeleteImage {
+            anchor: required_item_str(item, "delete_image", "anchor")?.to_string(),
+        });
+    }
+    for item in arg_array(args, "delete_table")? {
+        let index = optional_item_usize(item, "delete_table", "index")?;
+        let anchor = optional_item_str(item, "delete_table", "anchor")?.map(str::to_string);
+        match (&index, &anchor) {
+            (Some(_), Some(_)) => {
+                return Err("delete_table 항목은 index와 anchor 중 하나만 지정해야 합니다".into());
+            }
+            (None, None) => {
+                return Err("delete_table 항목에 index 또는 anchor가 필요합니다".into());
+            }
+            _ => {}
+        }
+        operations.push(Op::DeleteTable { index, anchor });
+    }
+    for item in arg_array(args, "delete_field")? {
+        operations.push(Op::DeleteField {
+            name: required_item_str(item, "delete_field", "name")?.to_string(),
+        });
+    }
+    for item in arg_array(args, "delete_bookmark")? {
+        operations.push(Op::DeleteBookmark {
+            name: required_item_str(item, "delete_bookmark", "name")?.to_string(),
+        });
+    }
 
     let plan = crate::commands::edit::EditPlan::from_typed(
         operations,
         true,
         arg_bool(args, "allow_partial", false)?,
     );
-    let report = crate::commands::edit::execute(Path::new(input), Path::new(output), &plan)
+    let report = crate::commands::edit::execute(&input, &output, &plan)
         .map_err(|error| format!("{error:#}"))?;
     Ok(vec![text_content(
         &serde_json::to_string_pretty(&json!({
@@ -710,35 +1140,95 @@ fn tool_edit(args: &Value) -> Result<Vec<Value>, String> {
     )])
 }
 
-fn tool_convert(args: &Value) -> Result<Vec<Value>, String> {
-    let input = arg_str(args, "input")?;
-    let output = arg_str(args, "output")?;
-    let embed_bin = arg_bool(args, "embed_bin", false)?;
-    let strict = arg_bool(args, "strict", true)?;
+/// hwp_convert 인자 → convert::execute 파라미터 매핑 (렌더 없이 검증하는 테스트 심).
+#[derive(Debug)]
+struct ConvertRequest {
+    input: PathBuf,
+    output: PathBuf,
+    to: Option<hwp_cli::cli::ConvertFormat>,
+    strict: bool,
+    embed_bin: bool,
+    media_dir: Option<PathBuf>,
+    with_header_footer: bool,
+    with_hidden: bool,
+    font_dirs: Vec<PathBuf>,
+}
+
+fn parse_convert_format(value: &str) -> Result<hwp_cli::cli::ConvertFormat, String> {
+    use hwp_cli::cli::ConvertFormat as F;
+    match value {
+        "hwp" => Ok(F::Hwp),
+        "hwpx" => Ok(F::Hwpx),
+        "md" | "markdown" => Ok(F::Md),
+        "json" => Ok(F::Json),
+        "html" => Ok(F::Html),
+        "pdf" => Ok(F::Pdf),
+        "odt" => Ok(F::Odt),
+        "txt" => Ok(F::Txt),
+        "csv" => Ok(F::Csv),
+        "docx" => Ok(F::Docx),
+        other => Err(format!(
+            "알 수 없는 to: {other} (hwp|hwpx|md|json|html|pdf|odt|txt|csv|docx)"
+        )),
+    }
+}
+
+fn convert_request(args: &Value, ctx: &Ctx) -> Result<ConvertRequest, String> {
+    let input = checked_read_path(ctx, arg_str(args, "input")?)?;
+    let output = checked_write_path(ctx, arg_str(args, "output")?)?;
+    // to를 주면 CLI --to와 같이 출력 확장자 추론보다 우선한다.
+    let to = arg_str_opt(args, "to")?
+        .map(parse_convert_format)
+        .transpose()?;
+    // media_dir는 markdown 이미지 추출 디렉터리 — 쓰기 경로로 검사한다.
+    let media_dir = arg_str_opt(args, "media_dir")?
+        .map(|raw| checked_write_path(ctx, raw))
+        .transpose()?;
+    Ok(ConvertRequest {
+        input,
+        output,
+        to,
+        strict: arg_bool(args, "strict", true)?,
+        embed_bin: arg_bool(args, "embed_bin", false)?,
+        media_dir,
+        with_header_footer: arg_bool(args, "with_header_footer", false)?,
+        with_hidden: arg_bool(args, "with_hidden", false)?,
+        // 기동 --font-dir + 호출당 font_dir 병합 목록을 그대로 넘긴다 — 이전에는
+        // 항상 빈 목록이라 MCP 서버 기동 시 지정한 폰트가 PDF 변환에 적용되지 않았다.
+        font_dirs: font_dirs_for(args, ctx)?,
+    })
+}
+
+fn tool_convert(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
+    let request = convert_request(args, ctx)?;
     let report = crate::commands::convert::execute(
-        Path::new(input),
-        Path::new(output),
-        None,
-        strict,
+        &request.input,
+        &request.output,
+        request.to,
+        request.strict,
         false,
-        embed_bin,
-        &crate::commands::convert::MdOpts::default(),
-        Vec::new(),
+        request.embed_bin,
+        &crate::commands::convert::MdOpts {
+            media_dir: request.media_dir.as_deref(),
+            with_header_footer: request.with_header_footer,
+            with_hidden: request.with_hidden,
+        },
+        request.font_dirs,
     )
     .map_err(|error| format!("{error:#}"))?;
     Ok(vec![text_content(
         &serde_json::to_string_pretty(&json!({
-            "input": input,
-            "output": output,
-            "strict": strict,
+            "input": request.input,
+            "output": request.output,
+            "strict": request.strict,
             "warnings": report.warnings,
         }))
         .unwrap_or_default(),
     )])
 }
 
-fn tool_new(args: &Value) -> Result<Vec<Value>, String> {
-    let output = arg_str(args, "output")?;
+fn tool_new(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
+    let output = checked_write_path(ctx, arg_str(args, "output")?)?;
     let input = match (arg_str_opt(args, "markdown")?, arg_str_opt(args, "json")?) {
         (Some(_), Some(_)) => return Err("markdown과 json은 동시에 지정할 수 없습니다".into()),
         (Some(markdown), None) => crate::commands::new::NewInput::Markdown {
@@ -758,7 +1248,7 @@ fn tool_new(args: &Value) -> Result<Vec<Value>, String> {
             ))
         })
         .collect::<Result<Vec<_>, String>>()?;
-    let report = crate::commands::new::execute(Path::new(output), input, &metadata, None, false)
+    let report = crate::commands::new::execute(&output, input, &metadata, None, false)
         .map_err(|error| format!("{error:#}"))?;
     Ok(vec![text_content(
         &serde_json::to_string_pretty(&json!({
@@ -769,7 +1259,7 @@ fn tool_new(args: &Value) -> Result<Vec<Value>, String> {
     )])
 }
 
-fn tool_compose(args: &Value) -> Result<Vec<Value>, String> {
+fn tool_compose(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
     let object = args
         .as_object()
         .ok_or_else(|| "arguments는 객체여야 합니다".to_string())?;
@@ -786,7 +1276,7 @@ fn tool_compose(args: &Value) -> Result<Vec<Value>, String> {
         return Err(format!("알 수 없는 hwp_compose 인자: {unknown}"));
     }
 
-    let output = arg_str(args, "output")?;
+    let output = checked_write_path(ctx, arg_str(args, "output")?)?;
     let explicit_format = arg_str_opt(args, "format")?
         .map(parse_spec_format)
         .transpose()?;
@@ -806,36 +1296,39 @@ fn tool_compose(args: &Value) -> Result<Vec<Value>, String> {
                 };
                 let format =
                     explicit_format.unwrap_or(hwp_cli::document_spec::SpecInputFormat::Json);
-                let base_dir = arg_str_opt(args, "base_dir")?
-                    .map_or_else(|| PathBuf::from("."), PathBuf::from);
+                let base_dir = match arg_str_opt(args, "base_dir")? {
+                    Some(raw) => checked_read_path(ctx, raw)?,
+                    None => checked_read_path(ctx, ".")?,
+                };
                 (input, format, base_dir, None)
             }
             (None, Some(spec_path)) => {
                 if args.get("base_dir").is_some() {
                     return Err("spec_path 사용 시 base_dir는 지정할 수 없습니다".into());
                 }
-                let path = Path::new(spec_path);
-                let input = crate::commands::compose::read_bounded(path)
+                let path = checked_read_path(ctx, spec_path)?;
+                let input = crate::commands::compose::read_bounded(&path)
                     .map_err(|error| format!("{error:#}"))?;
                 let format = explicit_format
                     .map(Ok)
-                    .unwrap_or_else(|| hwp_cli::document_spec::infer_input_format(path))
+                    .unwrap_or_else(|| hwp_cli::document_spec::infer_input_format(&path))
                     .map_err(|error| error.to_string())?;
                 let base_dir = path
                     .parent()
                     .unwrap_or_else(|| Path::new("."))
                     .to_path_buf();
-                (input, format, base_dir, Some(path.to_path_buf()))
+                (input, format, base_dir, Some(path))
             }
         };
     let report = crate::commands::compose::execute_text_with_source(
         &input,
         format,
         &base_dir,
-        Path::new(output),
+        &output,
         arg_bool(args, "dry_run", false)?,
         arg_bool(args, "allow_visual_fallback", false)?,
         source_path.as_deref(),
+        &ctx.roots,
     )
     .map_err(|error| format!("{error:#}"))?;
     Ok(vec![text_content(
@@ -843,7 +1336,7 @@ fn tool_compose(args: &Value) -> Result<Vec<Value>, String> {
     )])
 }
 
-fn tool_template(args: &Value) -> Result<Vec<Value>, String> {
+fn tool_template(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
     let object = args
         .as_object()
         .ok_or_else(|| "arguments는 객체여야 합니다".to_string())?;
@@ -861,7 +1354,7 @@ fn tool_template(args: &Value) -> Result<Vec<Value>, String> {
     if let Some(unknown) = object.keys().find(|key| !ALLOWED.contains(&key.as_str())) {
         return Err(format!("알 수 없는 hwp_template 인자: {unknown}"));
     }
-    let output = arg_str(args, "output")?;
+    let output = checked_write_path(ctx, arg_str(args, "output")?)?;
     let explicit_template_format = arg_str_opt(args, "template_format")?
         .map(parse_spec_format)
         .transpose()?;
@@ -880,15 +1373,17 @@ fn tool_template(args: &Value) -> Result<Vec<Value>, String> {
                 let input = inline_contract_input(template, "template")?;
                 let format = explicit_template_format
                     .unwrap_or(hwp_cli::document_spec::SpecInputFormat::Json);
-                let base = arg_str_opt(args, "base_dir")?
-                    .map_or_else(|| PathBuf::from("."), PathBuf::from);
+                let base = match arg_str_opt(args, "base_dir")? {
+                    Some(raw) => checked_read_path(ctx, raw)?,
+                    None => checked_read_path(ctx, ".")?,
+                };
                 (input, format, base)
             }
             (None, Some(path)) => {
                 if args.get("base_dir").is_some() {
                     return Err("template_path 사용 시 base_dir는 지정할 수 없습니다".into());
                 }
-                let path = PathBuf::from(path);
+                let path = checked_read_path(ctx, path)?;
                 let input = crate::commands::template::read_bounded(
                     &path,
                     hwp_cli::template_spec::MAX_TEMPLATE_BYTES,
@@ -915,7 +1410,7 @@ fn tool_template(args: &Value) -> Result<Vec<Value>, String> {
             explicit_data_format.unwrap_or(hwp_cli::document_spec::SpecInputFormat::Json),
         ),
         (None, Some(path)) => {
-            let path = PathBuf::from(path);
+            let path = checked_read_path(ctx, path)?;
             let input = crate::commands::template::read_bounded(
                 &path,
                 hwp_cli::template_spec::MAX_DATA_BYTES,
@@ -937,9 +1432,10 @@ fn tool_template(args: &Value) -> Result<Vec<Value>, String> {
         &data_input,
         data_format,
         &base_dir,
-        Path::new(output),
+        &output,
         arg_bool(args, "dry_run", false)?,
         &source_paths,
+        &ctx.roots,
     )
     .map_err(|error| format!("{error:#}"))?;
     Ok(vec![text_content(
@@ -965,13 +1461,13 @@ fn parse_spec_format(value: &str) -> Result<hwp_cli::document_spec::SpecInputFor
 }
 
 fn tool_diff(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
-    let input = arg_str(args, "input")?;
-    let reference = arg_str(args, "ref")?;
+    let input = checked_read_path(ctx, arg_str(args, "input")?)?;
+    let reference = checked_read_path(ctx, arg_str(args, "ref")?)?;
     let page = usize::try_from(arg_u64(args, "page", 1)?)
         .map_err(|_| "page가 플랫폼 범위를 넘습니다".to_string())?;
     let dpi = crate::commands::render::validated_dpi(arg_f64(args, "dpi", 120.0)?)
         .map_err(|error| error.to_string())?;
-    let doc = load_document(Path::new(input)).map_err(|e| e.to_string())?;
+    let doc = load_document(&input).map_err(|e| e.to_string())?;
     let out = hwp_render::render_document_pages(
         &doc,
         &hwp_render::RenderOptions {
@@ -981,7 +1477,7 @@ fn tool_diff(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
         Some(&[page]),
     )
     .map_err(|e| e.to_string())?;
-    let refpx = hwp_render::load_png(Path::new(reference)).map_err(|e| e.to_string())?;
+    let refpx = hwp_render::load_png(&reference).map_err(|e| e.to_string())?;
     let (rep, _) = hwp_render::compare(&out.pages[0], &refpx, 16)?;
     let v = json!({
         "ink_ratio": rep.ink_ratio,
@@ -1008,13 +1504,25 @@ fn tool_defs() -> Vec<Value> {
         }),
         json!({
             "name": "hwp_read",
-            "description": "본문을 추출한다. format=json이면 전체 IR(구조)을, markdown/plain이면 텍스트를 반환.",
+            "description": "본문을 추출한다. format=json이면 전체 IR(구조)을, markdown/plain이면 텍스트를, html/csv면 해당 직렬화를 반환. with_header_footer/with_hidden은 plain/markdown에만 적용(cat과 동일). with_segments는 markdown 전용으로 {markdown, segments} JSON 봉투를 반환(오프셋은 전체 기준 절대 문자 위치).",
             "inputSchema": {"type": "object", "properties": {
                 "path": {"type": "string"},
-                "format": {"type": "string", "enum": ["plain", "markdown", "json"], "description": "기본 plain"},
+                "format": {"type": "string", "enum": ["plain", "markdown", "json", "html", "csv"], "description": "기본 plain"},
+                "with_header_footer": {"type": "boolean", "description": "머리말/꼬리말 포함(plain/markdown, 기본 false)"},
+                "with_hidden": {"type": "boolean", "description": "숨은 설명 포함(plain/markdown, 기본 false)"},
+                "with_segments": {"type": "boolean", "description": "markdown 전용. 문단 원본 좌표 세그먼트 맵 포함"},
                 "offset": {"type": "integer", "minimum": 0, "description": "UTF-8 byte offset, 기본 0"},
                 "max_bytes": {"type": "integer", "minimum": 1, "maximum": 1048576, "description": "반환 byte 상한, 기본 262144"}
             }, "required": ["path"]}
+        }),
+        json!({
+            "name": "hwp_grep",
+            "description": "문단 텍스트 검색(본문·표 셀·글상자 재귀). {matches, count, truncated} 반환 — matches는 최대 200건, count는 전체 매칭 수, 0건 매칭도 정상 결과.",
+            "inputSchema": {"type": "object", "properties": {
+                "path": {"type": "string"},
+                "pattern": {"type": "string", "description": "검색할 부분 문자열"},
+                "ignore_case": {"type": "boolean", "description": "대소문자 무시, 기본 false"}
+            }, "required": ["path", "pattern"]}
         }),
         json!({
             "name": "hwp_list_fields",
@@ -1032,10 +1540,13 @@ fn tool_defs() -> Vec<Value> {
         }),
         json!({
             "name": "hwp_render",
-            "description": "지정 페이지를 PNG 이미지로 렌더해 반환(에이전트가 문서를 직접 본다).",
+            "description": "페이지를 렌더한다. 기본은 단일 페이지 PNG를 base64 이미지로 반환(에이전트가 문서를 직접 본다). format=svg/pdf 또는 다중 페이지 선택(pages)은 output_path가 필요하고, 파일로 저장 뒤 {files, pages, dpi} JSON을 반환한다(16MiB 응답 상한 우회). 페이지별 파일명은 CLI와 같이 <stem>-<N>.<ext>(단일 페이지면 경로 그대로), pdf는 단일 멀티페이지 파일.",
             "inputSchema": {"type": "object", "properties": {
                 "path": {"type": "string"},
-                "page": {"type": "integer", "description": "1-기반, 기본 1"},
+                "page": {"type": "integer", "description": "1-기반, 기본 1. pages와 함께 지정 불가"},
+                "pages": {"type": "string", "description": "페이지 범위 spec: \"1\", \"1-3\", \"all\". page와 함께 지정 불가"},
+                "format": {"type": "string", "enum": ["png", "svg", "pdf"], "description": "기본 png"},
+                "output_path": {"type": "string", "description": "출력 파일 경로. svg/pdf·다중 페이지 필수. png 다중 페이지는 페이지별 <stem>-<N>.png"},
                 "dpi": {"type": "number", "minimum": hwp_render::MIN_DPI, "maximum": hwp_render::MAX_DPI, "description": "기본 120"},
                 "font_dir": {"type": "string", "description": "추가 폰트 디렉터리(선택)"}
             }, "required": ["path"]}
@@ -1112,14 +1623,52 @@ fn tool_defs() -> Vec<Value> {
                 "split_cell": {"type": "array", "items": {"type": "object", "properties": {
                     "table": {"type": "integer"}, "row": {"type": "integer"}, "col": {"type": "integer"}},
                     "required": ["table", "row", "col"]}},
+                "add_table": {"type": "array", "items": {"type": "object", "properties": {
+                    "anchor": {"type": "string"},
+                    "rows": {"type": "array", "items": {"type": "array", "items": {"type": "string"}}}},
+                    "required": ["anchor", "rows"]},
+                    "description": "앵커 문단 뒤에 균일 표 삽입(rows는 행(문자열 배열)의 배열)"},
+                "set_para": {"type": "array", "items": {"type": "object", "properties": {
+                    "pattern": {"type": "string"},
+                    "line_spacing_pct": {"type": "number", "description": "줄간격 비율(%)"},
+                    "line_spacing_pt": {"type": "number", "description": "고정 줄간격(pt) — pct와 함께 지정 불가"},
+                    "indent_mm": {"type": "number"}, "left_mm": {"type": "number"},
+                    "right_mm": {"type": "number"}, "top_mm": {"type": "number"},
+                    "bottom_mm": {"type": "number"}},
+                    "required": ["pattern"]},
+                    "description": "문단모양(매칭 문단): 줄간격(비율% 또는 고정pt)·들여쓰기·여백(mm)"},
+                "set_page": {"type": "object", "properties": {
+                    "width_mm": {"type": "number"}, "height_mm": {"type": "number"},
+                    "margin_left_mm": {"type": "number"}, "margin_right_mm": {"type": "number"},
+                    "margin_top_mm": {"type": "number"}, "margin_bottom_mm": {"type": "number"},
+                    "orientation": {"type": "string", "enum": ["portrait", "landscape", "가로", "세로"]}},
+                    "description": "페이지 설정(모든 구역 정의에 적용): 용지 크기·여백(mm)·방향"},
+                "delete_image": {"type": "array", "items": {"type": "object", "properties": {
+                    "anchor": {"type": "string"}}, "required": ["anchor"]},
+                    "description": "앵커 문단의 그림 삭제"},
+                "delete_table": {"type": "array", "items": {"type": "object", "properties": {
+                    "index": {"type": "integer", "description": "0-기반 표 인덱스"},
+                    "anchor": {"type": "string", "description": "앵커 텍스트가 든 문단의 표"}}},
+                    "description": "표 삭제 — index와 anchor 중 정확히 하나"},
+                "delete_field": {"type": "array", "items": {"type": "object", "properties": {
+                    "name": {"type": "string"}}, "required": ["name"]},
+                    "description": "이름으로 필드 삭제(hwp_list_fields로 이름 확인)"},
+                "delete_bookmark": {"type": "array", "items": {"type": "object", "properties": {
+                    "name": {"type": "string"}}, "required": ["name"]},
+                    "description": "이름으로 책갈피 삭제(hwp_list_bookmarks로 이름 확인)"},
                 "allow_partial": {"type": "boolean", "description": "true면 일치한 요청만 게시; 기본 false"}
             }, "required": ["input", "output"]}
         }),
         json!({
             "name": "hwp_convert",
-            "description": "포맷 변환. 출력 확장자(.hwp/.hwpx/.json/.md/.html/.pdf/.odt)로 결정. pdf는 텍스트 선택가능 벡터(이미지 포함). embed_bin이면 JSON에 이미지 base64 임베드.",
+            "description": "포맷 변환. 기본은 출력 확장자(.hwp/.hwpx/.json/.md/.html/.pdf/.odt/.txt/.csv/.docx)로 결정하고 to가 있으면 CLI --to처럼 확장자보다 우선한다. pdf는 텍스트 선택가능 벡터(이미지 포함). embed_bin이면 JSON에 이미지 base64 임베드. media_dir/with_header_footer/with_hidden은 markdown 출력 전용.",
             "inputSchema": {"type": "object", "properties": {
                 "input": {"type": "string"}, "output": {"type": "string"},
+                "to": {"type": "string", "enum": ["hwp", "hwpx", "md", "json", "html", "pdf", "odt", "txt", "csv", "docx"], "description": "대상 포맷(선택). 지정 시 출력 확장자 추론보다 우선"},
+                "media_dir": {"type": "string", "description": "markdown 이미지 추출 디렉터리(선택, 기본 \"<출력스템>.media\")"},
+                "with_header_footer": {"type": "boolean", "description": "markdown에 머리말/꼬리말 포함, 기본 false"},
+                "with_hidden": {"type": "boolean", "description": "markdown에 숨은 설명 포함, 기본 false"},
+                "font_dir": {"type": "string", "description": "추가 폰트 디렉터리(선택) — pdf 렌더에 적용"},
                 "embed_bin": {"type": "boolean"},
                 "strict": {"type": "boolean", "description": "HWP/HWPX DROP 경고를 실패 처리; MCP 기본 true"}
             }, "required": ["input", "output"]}
@@ -1259,6 +1808,15 @@ mod tests {
                 env!("CARGO_MANIFEST_DIR"),
                 "/../../fonts"
             ))],
+            roots: Vec::new(),
+        }
+    }
+
+    /// 주어진 root(호출 측에서 canonicalize)만 허용하는 샌드박스 컨텍스트.
+    fn ctx_with_roots(roots: Vec<PathBuf>) -> Ctx {
+        Ctx {
+            font_dirs: Vec::new(),
+            roots,
         }
     }
 
@@ -1285,8 +1843,36 @@ mod tests {
         let v = call(r#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#);
         assert_eq!(v["jsonrpc"], "2.0");
         assert_eq!(v["id"], 1);
-        assert_eq!(v["result"]["protocolVersion"], PROTOCOL_VERSION);
+        assert_eq!(
+            v["result"]["protocolVersion"],
+            SUPPORTED_PROTOCOL_VERSIONS[0]
+        );
         assert!(v["result"]["serverInfo"]["name"].is_string());
+    }
+
+    #[test]
+    fn initialize_프로토콜_버전_협상() {
+        // 지원하는 버전은 그대로 에코한다.
+        for version in SUPPORTED_PROTOCOL_VERSIONS {
+            let v = call(&format!(
+                r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"protocolVersion":"{version}"}}}}"#
+            ));
+            assert_eq!(v["result"]["protocolVersion"], version);
+        }
+        // 미지원 버전이면 최신 버전으로 응답한다.
+        let v = call(
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"1999-01-01"}}"#,
+        );
+        assert_eq!(
+            v["result"]["protocolVersion"],
+            SUPPORTED_PROTOCOL_VERSIONS[0]
+        );
+        // protocolVersion 파라미터가 없어도 최신 버전으로 응답한다.
+        let v = call(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#);
+        assert_eq!(
+            v["result"]["protocolVersion"],
+            SUPPORTED_PROTOCOL_VERSIONS[0]
+        );
     }
 
     #[test]
@@ -1314,6 +1900,7 @@ mod tests {
         for expected in [
             "hwp_info",
             "hwp_read",
+            "hwp_grep",
             "hwp_render",
             "hwp_edit",
             "hwp_convert",
@@ -1368,20 +1955,23 @@ mod tests {
                 .unwrap_or("test")
                 .replace(':', "-")
         ));
-        let result = tool_compose(&json!({
-            "spec": {
-                "version": "1.0",
-                "sections": [{
-                    "blocks": [{
-                        "type": "paragraph",
-                        "runs": [{"type": "text", "text": "본문"}]
+        let result = tool_compose(
+            &json!({
+                "spec": {
+                    "version": "1.0",
+                    "sections": [{
+                        "blocks": [{
+                            "type": "paragraph",
+                            "runs": [{"type": "text", "text": "본문"}]
+                        }]
                     }]
-                }]
-            },
-            "output": output,
-            "dry_run": true,
-            "allow_visual_fallback": true
-        }))
+                },
+                "output": output,
+                "dry_run": true,
+                "allow_visual_fallback": true
+            }),
+            &ctx(),
+        )
         .expect("compose dry-run");
         let report: Value = serde_json::from_str(result[0]["text"].as_str().unwrap()).unwrap();
         assert_eq!(report["dry_run"], true);
@@ -1391,22 +1981,25 @@ mod tests {
 
     #[test]
     fn compose_v2_rejects_deprecated_global_fallback_policy() {
-        let error = tool_compose(&json!({
-            "spec": {
-                "version": "2.0",
-                "document": {
-                    "version": "1.0",
-                    "sections": [{"blocks": [{
-                        "type": "paragraph",
-                        "runs": [{"type": "text", "text": "본문"}]
-                    }]}]
+        let error = tool_compose(
+            &json!({
+                "spec": {
+                    "version": "2.0",
+                    "document": {
+                        "version": "1.0",
+                        "sections": [{"blocks": [{
+                            "type": "paragraph",
+                            "runs": [{"type": "text", "text": "본문"}]
+                        }]}]
+                    },
+                    "visuals": []
                 },
-                "visuals": []
-            },
-            "output": "out.hwpx",
-            "dry_run": true,
-            "allow_visual_fallback": true
-        }))
+                "output": "out.hwpx",
+                "dry_run": true,
+                "allow_visual_fallback": true
+            }),
+            &ctx(),
+        )
         .unwrap_err();
         assert!(error.contains("\"code\": \"policy_conflict\""), "{error}");
         assert!(error.contains("$.policy"), "{error}");
@@ -1425,13 +2018,65 @@ mod tests {
 
     #[test]
     fn compose_rejects_unknown_argument() {
-        let error = tool_compose(&json!({
-            "spec": {"version": "1.0", "sections": []},
-            "output": "out.hwpx",
-            "unknown": true
-        }))
+        let error = tool_compose(
+            &json!({
+                "spec": {"version": "1.0", "sections": []},
+                "output": "out.hwpx",
+                "unknown": true
+            }),
+            &ctx(),
+        )
         .unwrap_err();
         assert!(error.contains("unknown"));
+    }
+
+    #[test]
+    fn compose_binds_spec_image_assets_to_sandbox_roots() {
+        let directory = std::env::temp_dir().join(format!(
+            "hwp-mcp-compose-roots-{}-{}",
+            std::process::id(),
+            std::thread::current()
+                .name()
+                .unwrap_or("test")
+                .replace(':', "-")
+        ));
+        let _ = std::fs::remove_dir_all(&directory);
+        std::fs::create_dir_all(directory.join("assets")).unwrap();
+        std::fs::write(
+            directory.join("assets/image.gif"),
+            b"GIF89a\x02\x00\x01\x00",
+        )
+        .unwrap();
+        let sandbox = ctx_with_roots(vec![std::fs::canonicalize(&directory).unwrap()]);
+        let output = directory.join("out.hwpx");
+
+        // 샌드박스 루트 아래 에셋을 참조하는 spec은 그대로 합성된다(roots 전달 검증).
+        let result = tool_compose(
+            &json!({
+                "spec": {
+                    "version": "1.0",
+                    "sections": [{
+                        "blocks": [{
+                            "type": "image",
+                            "path": "assets/image.gif",
+                            "width_mm": 20,
+                            "height_mm": 10,
+                            "placement": "inline"
+                        }]
+                    }]
+                },
+                "base_dir": directory,
+                "output": output,
+                "dry_run": true
+            }),
+            &sandbox,
+        )
+        .expect("image under sandbox root composes");
+        let report: Value = serde_json::from_str(result[0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(report["dry_run"], true);
+        assert_eq!(report["images"], 1);
+
+        let _ = std::fs::remove_dir_all(&directory);
     }
 
     #[test]
@@ -1445,24 +2090,27 @@ mod tests {
                 .replace(':', "-")
         ));
         let _ = std::fs::remove_file(&output);
-        let result = tool_template(&json!({
-            "template": {
-                "version": "1.0",
-                "variables": {"title": {"type": "string", "required": true}},
-                "source": {"mode": "compose", "document": {
+        let result = tool_template(
+            &json!({
+                "template": {
                     "version": "1.0",
-                    "sections": [{"blocks": [{
-                        "type": "paragraph",
-                        "runs": [{"type": "text", "text": {
-                            "node": "value", "pointer": "/values/title", "as": "text"
-                        }}]
-                    }]}]
-                }}
-            },
-            "data": {"version": "1.0", "values": {"title": "MCP"}},
-            "output": output,
-            "dry_run": true
-        }))
+                    "variables": {"title": {"type": "string", "required": true}},
+                    "source": {"mode": "compose", "document": {
+                        "version": "1.0",
+                        "sections": [{"blocks": [{
+                            "type": "paragraph",
+                            "runs": [{"type": "text", "text": {
+                                "node": "value", "pointer": "/values/title", "as": "text"
+                            }}]
+                        }]}]
+                    }}
+                },
+                "data": {"version": "1.0", "values": {"title": "MCP"}},
+                "output": output,
+                "dry_run": true
+            }),
+            &ctx(),
+        )
         .expect("template dry-run");
         let report: Value = serde_json::from_str(result[0]["text"].as_str().unwrap()).unwrap();
         assert_eq!(report["schema_version"], "1.0");
@@ -1479,7 +2127,7 @@ mod tests {
             "data": {"version": "1.0", "values": {}},
             "output": "out.hwpx",
             "unknown": true
-        }))
+        }), &ctx())
         .unwrap_err();
         assert!(error.contains("unknown"));
     }
@@ -1617,28 +2265,37 @@ mod tests {
         create_hwpx(&source, "{{수신}} 본문");
 
         std::fs::write(&edit_destination, b"EDIT ORIGINAL").unwrap();
-        let edit = tool_edit(&json!({
-            "input": source,
-            "output": edit_destination,
-            "replace": [{"from": "없는본문", "to": "값"}]
-        }));
+        let edit = tool_edit(
+            &json!({
+                "input": source,
+                "output": edit_destination,
+                "replace": [{"from": "없는본문", "to": "값"}]
+            }),
+            &ctx(),
+        );
         assert!(edit.is_err(), "0건 편집은 MCP도 실패");
         assert_eq!(std::fs::read(&edit_destination).unwrap(), b"EDIT ORIGINAL");
 
         std::fs::write(&fill_destination, b"FILL ORIGINAL").unwrap();
-        let fill = tool_fill(&json!({
-            "input": source,
-            "output": fill_destination,
-            "values": {"없는키": "값"}
-        }));
+        let fill = tool_fill(
+            &json!({
+                "input": source,
+                "output": fill_destination,
+                "values": {"없는키": "값"}
+            }),
+            &ctx(),
+        );
         assert!(fill.is_err(), "0건 fill은 MCP도 실패");
         assert_eq!(std::fs::read(&fill_destination).unwrap(), b"FILL ORIGINAL");
 
         std::fs::write(&convert_destination, b"CONVERT ORIGINAL").unwrap();
-        let convert = tool_convert(&json!({
-            "input": source,
-            "output": convert_destination
-        }));
+        let convert = tool_convert(
+            &json!({
+                "input": source,
+                "output": convert_destination
+            }),
+            &ctx(),
+        );
         assert!(convert.is_err(), "미지원 확장자 변환은 실패");
         assert_eq!(
             std::fs::read(&convert_destination).unwrap(),
@@ -1667,12 +2324,15 @@ mod tests {
         )
         .unwrap();
         let out = temp_file("fill-parts-out.hwpx");
-        let result = tool_fill(&json!({
-            "input": template,
-            "output": out,
-            "values": {},
-            "parts": {"본문": part.display().to_string()}
-        }));
+        let result = tool_fill(
+            &json!({
+                "input": template,
+                "output": out,
+                "values": {},
+                "parts": {"본문": part.display().to_string()}
+            }),
+            &ctx(),
+        );
         let content = result.expect("parts fill 성공");
         let text = content[0]["text"].as_str().unwrap_or_default();
         assert!(text.contains("\"parts\""), "리포트 모드: {text}");
@@ -1716,10 +2376,13 @@ mod tests {
             },
         );
         let document_json = hwp_convert::to_json(&doc, true, false).unwrap();
-        let result = tool_new(&json!({
-            "output": destination,
-            "json": document_json,
-        }));
+        let result = tool_new(
+            &json!({
+                "output": destination,
+                "json": document_json,
+            }),
+            &ctx(),
+        );
         assert!(
             result
                 .as_ref()
@@ -1735,15 +2398,18 @@ mod tests {
         let source = temp_file("partial-source.hwpx");
         let destination = temp_file("partial-destination.hwpx");
         create_hwpx(&source, "있는본문");
-        let content = tool_edit(&json!({
-            "input": source,
-            "output": destination,
-            "replace": [
-                {"from": "있는본문", "to": "바뀐본문"},
-                {"from": "없는본문", "to": "값"}
-            ],
-            "allow_partial": true
-        }))
+        let content = tool_edit(
+            &json!({
+                "input": source,
+                "output": destination,
+                "replace": [
+                    {"from": "있는본문", "to": "바뀐본문"},
+                    {"from": "없는본문", "to": "값"}
+                ],
+                "allow_partial": true
+            }),
+            &ctx(),
+        )
         .expect("allow_partial MCP edit");
         let report: Value = serde_json::from_str(content[0]["text"].as_str().unwrap()).unwrap();
         assert_eq!(report["applied"], 1);
@@ -1761,22 +2427,28 @@ mod tests {
     fn mcp_read_is_utf8_bounded_and_pageable() {
         let source = temp_file("bounded-read.hwpx");
         create_hwpx(&source, "가나다라마바사");
-        let first = tool_read(&json!({
-            "path": source,
-            "format": "plain",
-            "max_bytes": 7
-        }))
+        let first = tool_read(
+            &json!({
+                "path": source,
+                "format": "plain",
+                "max_bytes": 7
+            }),
+            &ctx(),
+        )
         .unwrap();
         assert!(first[0]["text"].as_str().unwrap().len() <= 7);
         let metadata: Value = serde_json::from_str(first[1]["text"].as_str().unwrap()).unwrap();
         assert_eq!(metadata["truncated"], true);
         let next = metadata["next_offset"].as_u64().unwrap();
-        let second = tool_read(&json!({
-            "path": source,
-            "format": "plain",
-            "offset": next,
-            "max_bytes": 7
-        }))
+        let second = tool_read(
+            &json!({
+                "path": source,
+                "format": "plain",
+                "offset": next,
+                "max_bytes": 7
+            }),
+            &ctx(),
+        )
         .unwrap();
         assert!(!second[0]["text"].as_str().unwrap().is_empty());
         let _ = std::fs::remove_file(source);
@@ -1788,11 +2460,14 @@ mod tests {
         let destination = temp_file("delimiter-destination.hwpx");
         create_hwpx(&source, "A=>B");
 
-        tool_edit(&json!({
-            "input": source,
-            "output": destination,
-            "replace": [{"from": "A=>B", "to": "X=Y=>Z"}]
-        }))
+        tool_edit(
+            &json!({
+                "input": source,
+                "output": destination,
+                "replace": [{"from": "A=>B", "to": "X=Y=>Z"}]
+            }),
+            &ctx(),
+        )
         .expect("구조화 치환");
 
         let edited = load_document(&destination).unwrap();
@@ -1809,15 +2484,18 @@ mod tests {
         let destination = temp_file("typed-structural-destination.hwpx");
         create_hwpx(&source, "Anchor=>Here");
 
-        tool_edit(&json!({
-            "input": source,
-            "output": destination,
-            "set_meta": [{"key": "title", "value": "A=B=>C"}],
-            "insert_para": [{
-                "anchor": "Anchor=>Here",
-                "text": "New=>Text=1"
-            }]
-        }))
+        tool_edit(
+            &json!({
+                "input": source,
+                "output": destination,
+                "set_meta": [{"key": "title", "value": "A=B=>C"}],
+                "insert_para": [{
+                    "anchor": "Anchor=>Here",
+                    "text": "New=>Text=1"
+                }]
+            }),
+            &ctx(),
+        )
         .expect("구조화 metadata/문단 편집");
 
         let edited = load_document(&destination).unwrap();
@@ -1844,5 +2522,932 @@ mod tests {
         );
         assert_eq!(content[1]["type"], "image");
         let _ = std::fs::remove_file(source);
+    }
+
+    /// 샌드박스 테스트용 (base, root, outside) 디렉터리를 만든다.
+    /// Windows CI 호환: 실제 temp dir만 쓰고, root는 ctx에 넣기 전에 canonicalize한다.
+    fn sandbox_dirs(tag: &str) -> (PathBuf, PathBuf, PathBuf) {
+        let base =
+            std::env::temp_dir().join(format!("hwp-cli-mcp-sandbox-{tag}-{}", std::process::id()));
+        let root = base.join("root");
+        let outside = base.join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        (base, root, outside)
+    }
+
+    #[test]
+    fn sandbox_루트없으면_검사없이_통과() {
+        let ctx = ctx_with_roots(Vec::new());
+        // 존재하지 않는 경로도, '..'도 기존 동작 그대로 통과한다.
+        let read = checked_read_path(&ctx, "no/such/file.hwpx").unwrap();
+        assert_eq!(read, PathBuf::from("no/such/file.hwpx"));
+        let write = checked_write_path(&ctx, "../out.hwpx").unwrap();
+        assert_eq!(write, PathBuf::from("../out.hwpx"));
+    }
+
+    #[test]
+    fn sandbox_루트밖_읽기_거부() {
+        let (base, root, outside) = sandbox_dirs("read");
+        let document = outside.join("doc.hwpx");
+        create_hwpx(&document, "본문");
+        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let error = tool_read(&json!({"path": document}), &ctx).unwrap_err();
+        assert!(error.contains("--root"), "{error}");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn sandbox_루트밖_쓰기_거부() {
+        let (base, root, outside) = sandbox_dirs("write");
+        let source = root.join("source.hwpx");
+        create_hwpx(&source, "{{이름}}");
+        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let output = outside.join("out.hwpx");
+        let error = tool_fill(
+            &json!({
+                "input": source,
+                "output": output,
+                "values": {"이름": "값"}
+            }),
+            &ctx,
+        )
+        .unwrap_err();
+        assert!(error.contains("--root"), "{error}");
+        assert!(!output.exists());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn sandbox_상위경로_쓰기_거부() {
+        let (base, root, _outside) = sandbox_dirs("dotdot");
+        let source = root.join("source.hwpx");
+        create_hwpx(&source, "{{이름}}");
+        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let error = tool_fill(
+            &json!({
+                "input": source,
+                "output": root.join("sub").join("..").join("escape.hwpx"),
+                "values": {"이름": "값"}
+            }),
+            &ctx,
+        )
+        .unwrap_err();
+        assert!(error.contains(".."), "{error}");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sandbox_심볼링크_덮어쓰기_우회_거부() {
+        let (base, root, outside) = sandbox_dirs("symlink");
+        let source = root.join("source.hwpx");
+        create_hwpx(&source, "{{이름}}");
+        let victim = outside.join("victim.hwpx");
+        std::fs::write(&victim, b"VICTIM").unwrap();
+        let link = root.join("link.hwpx");
+        std::os::unix::fs::symlink(&victim, &link).unwrap();
+        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let error = tool_fill(
+            &json!({
+                "input": source,
+                "output": link,
+                "values": {"이름": "값"}
+            }),
+            &ctx,
+        )
+        .unwrap_err();
+        assert!(error.contains("--root"), "{error}");
+        assert_eq!(std::fs::read(&victim).unwrap(), b"VICTIM");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn sandbox_루트안_읽기쓰기_허용() {
+        let (base, root, _outside) = sandbox_dirs("inside");
+        let source = root.join("source.hwpx");
+        create_hwpx(&source, "{{이름}}");
+        let output = root.join("out.hwpx");
+        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        tool_fill(
+            &json!({
+                "input": source,
+                "output": output,
+                "values": {"이름": "값"}
+            }),
+            &ctx,
+        )
+        .expect("루트 안 fill");
+        let doc = load_document(&output).unwrap();
+        assert!(doc.plain_text().contains("값"));
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn sandbox_호출당_font_dir도_검사() {
+        let (base, root, outside) = sandbox_dirs("fontdir");
+        let source = root.join("source.hwpx");
+        create_hwpx(&source, "본문");
+        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let error = tool_render(&json!({"path": source, "font_dir": outside}), &ctx).unwrap_err();
+        assert!(error.contains("--root"), "{error}");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn sandbox_edit_중첩_이미지경로_거부() {
+        let (base, root, outside) = sandbox_dirs("edit-image");
+        let source = root.join("source.hwpx");
+        create_hwpx(&source, "앵커");
+        let image = outside.join("image.png");
+        std::fs::write(&image, b"PNG").unwrap();
+        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let error = tool_edit(
+            &json!({
+                "input": source,
+                "output": root.join("out.hwpx"),
+                "insert_image": [{"anchor": "앵커", "path": image}]
+            }),
+            &ctx,
+        )
+        .unwrap_err();
+        assert!(error.contains("--root"), "{error}");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// 본문·표 셀·글상자 재귀로 매칭되는 컨트롤 수를 센다(typed edit 왕복 검증용).
+    fn count_controls(
+        doc: &hwp_model::Document,
+        matches: fn(&hwp_model::Control) -> bool,
+    ) -> usize {
+        fn in_para(para: &hwp_model::Paragraph, matches: fn(&hwp_model::Control) -> bool) -> usize {
+            let mut n = 0;
+            for control in &para.controls {
+                if matches(control) {
+                    n += 1;
+                }
+                match control {
+                    hwp_model::Control::Table(table) => {
+                        for cell in &table.cells {
+                            for p in &cell.paragraphs {
+                                n += in_para(p, matches);
+                            }
+                        }
+                    }
+                    hwp_model::Control::Generic(g) => {
+                        for list in &g.paragraph_lists {
+                            for p in &list.paragraphs {
+                                n += in_para(p, matches);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            n
+        }
+        doc.sections
+            .iter()
+            .flat_map(|section| &section.paragraphs)
+            .map(|para| in_para(para, matches))
+            .sum()
+    }
+
+    #[test]
+    fn tools_list_exposes_typed_edit_parity_args() {
+        let tools = tool_defs();
+        let edit = tools
+            .iter()
+            .find(|tool| tool["name"] == "hwp_edit")
+            .unwrap();
+        let properties = &edit["inputSchema"]["properties"];
+        for key in [
+            "add_table",
+            "set_para",
+            "set_page",
+            "delete_image",
+            "delete_table",
+            "delete_field",
+            "delete_bookmark",
+        ] {
+            assert!(
+                properties.get(key).is_some(),
+                "hwp_edit 스키마에 {key} 누락"
+            );
+        }
+        // set_page는 단일 객체, 나머지는 배열이다.
+        assert_eq!(properties["set_page"]["type"], "object");
+        assert_eq!(properties["add_table"]["type"], "array");
+    }
+
+    #[test]
+    fn mcp_typed_add_table_then_delete_table_round_trip() {
+        let source = temp_file("typed-add-table-source.hwpx");
+        let mid = temp_file("typed-add-table-mid.hwpx");
+        let out = temp_file("typed-add-table-out.hwpx");
+        create_hwpx(&source, "머리말\n\n끝말");
+
+        tool_edit(
+            &json!({
+                "input": source,
+                "output": mid,
+                "add_table": [{"anchor": "머리말", "rows": [["가", "나"], ["1", "2"]]}]
+            }),
+            &ctx(),
+        )
+        .expect("add_table 편집");
+        let doc = load_document(&mid).unwrap();
+        assert_eq!(
+            count_controls(&doc, |c| matches!(c, hwp_model::Control::Table(_))),
+            1,
+            "표가 하나 있어야 한다"
+        );
+        let plain = doc.plain_text();
+        assert!(
+            plain.contains('가') && plain.contains('1'),
+            "셀 텍스트: {plain}"
+        );
+
+        tool_edit(
+            &json!({
+                "input": mid,
+                "output": out,
+                "delete_table": [{"index": 0}]
+            }),
+            &ctx(),
+        )
+        .expect("delete_table 편집");
+        let doc = load_document(&out).unwrap();
+        assert_eq!(
+            count_controls(&doc, |c| matches!(c, hwp_model::Control::Table(_))),
+            0,
+            "표가 삭제되어야 한다"
+        );
+        let plain = doc.plain_text();
+        assert!(
+            !plain.contains('가') && plain.contains("끝말"),
+            "결과: {plain}"
+        );
+        for path in [&source, &mid, &out] {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn mcp_typed_set_para_and_set_page_round_trip() {
+        let source = temp_file("typed-set-para-source.hwpx");
+        let out = temp_file("typed-set-para-out.hwpx");
+        create_hwpx(&source, "본문 문단입니다.");
+
+        tool_edit(
+            &json!({
+                "input": source,
+                "output": out,
+                "set_para": [{"pattern": "본문", "line_spacing_pct": 130, "indent_mm": 5}],
+                "set_page": {"width_mm": 200, "orientation": "landscape"}
+            }),
+            &ctx(),
+        )
+        .expect("set_para/set_page 편집");
+
+        let doc = load_document(&out).unwrap();
+        let para = doc.sections[0]
+            .paragraphs
+            .iter()
+            .find(|p| p.plain_text().contains("본문"))
+            .expect("본문 문단");
+        let shape = &doc.header.para_shapes[para.para_shape.0 as usize];
+        assert_eq!(shape.line_spacing_type, 0, "비율 줄간격");
+        assert_eq!(shape.line_spacing, 130);
+        // IR은 HWPUNIT의 2배 단위(hwp5 PARA_SHAPE)다.
+        assert_eq!(shape.indent, 2 * crate::commands::edit::mm_to_hwpunit(5.0));
+
+        let page = doc.sections[0]
+            .paragraphs
+            .iter()
+            .flat_map(|p| &p.controls)
+            .find_map(|c| match c {
+                hwp_model::Control::SectionDef(secd) => secd.page.as_ref(),
+                _ => None,
+            })
+            .expect("구역 정의의 용지 정보");
+        assert_eq!(page.width.0, crate::commands::edit::mm_to_hwpunit(200.0));
+        assert_eq!(page.attr & 1, 1, "landscape 비트");
+        for path in [&source, &out] {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn mcp_typed_delete_image_round_trip() {
+        let source = temp_file("typed-delete-image-source.hwpx");
+        let mid = temp_file("typed-delete-image-mid.hwpx");
+        let out = temp_file("typed-delete-image-out.hwpx");
+        let png = temp_file("typed-delete-image.png");
+        create_hwpx(&source, "사진: 여기");
+        // 최소 PNG 헤더(IHDR 96x96) — insert_image는 크기만 파싱한다.
+        let mut bytes = b"\x89PNG\r\n\x1a\n".to_vec();
+        bytes.extend([0, 0, 0, 13]);
+        bytes.extend(b"IHDR");
+        bytes.extend(96u32.to_be_bytes());
+        bytes.extend(96u32.to_be_bytes());
+        bytes.extend([0u8; 8]);
+        std::fs::write(&png, &bytes).unwrap();
+
+        tool_edit(
+            &json!({
+                "input": source,
+                "output": mid,
+                "insert_image": [{"anchor": "사진:", "path": png}]
+            }),
+            &ctx(),
+        )
+        .expect("insert_image 편집");
+        let doc = load_document(&mid).unwrap();
+        assert_eq!(
+            count_controls(&doc, |c| matches!(c, hwp_model::Control::Picture(_))),
+            1,
+            "그림이 하나 있어야 한다"
+        );
+
+        tool_edit(
+            &json!({
+                "input": mid,
+                "output": out,
+                "delete_image": [{"anchor": "사진:"}]
+            }),
+            &ctx(),
+        )
+        .expect("delete_image 편집");
+        let doc = load_document(&out).unwrap();
+        assert_eq!(
+            count_controls(&doc, |c| matches!(c, hwp_model::Control::Picture(_))),
+            0,
+            "그림이 삭제되어야 한다"
+        );
+        for path in [&source, &mid, &out, &png] {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn mcp_typed_delete_field_and_bookmark_round_trip() {
+        let source = temp_file("typed-delete-field-source.hwpx");
+        let mid = temp_file("typed-delete-field-mid.hwpx");
+        let out = temp_file("typed-delete-field-out.hwpx");
+        create_hwpx(&source, "참조: 본문");
+
+        tool_edit(
+            &json!({
+                "input": source,
+                "output": mid,
+                "create_field": [{"anchor": "참조:", "name": "수신", "value": "홍길동"}],
+                "create_bookmark": [{"anchor": "참조:", "name": "참조점"}]
+            }),
+            &ctx(),
+        )
+        .expect("create_field/create_bookmark 편집");
+        let doc = load_document(&mid).unwrap();
+        assert!(
+            hwp_convert::list_fields(&doc)
+                .iter()
+                .any(|f| f.name.as_deref() == Some("수신")),
+            "필드가 생성되어야 한다"
+        );
+        assert!(
+            hwp_convert::list_bookmarks(&doc)
+                .iter()
+                .any(|b| b.name == "참조점"),
+            "책갈피가 생성되어야 한다"
+        );
+
+        let content = tool_edit(
+            &json!({
+                "input": mid,
+                "output": out,
+                "delete_field": [{"name": "수신"}],
+                "delete_bookmark": [{"name": "참조점"}]
+            }),
+            &ctx(),
+        )
+        .expect("delete_field/delete_bookmark 편집");
+        let report: Value = serde_json::from_str(content[0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(report["applied"], 2);
+        let doc = load_document(&out).unwrap();
+        assert!(
+            !hwp_convert::list_fields(&doc)
+                .iter()
+                .any(|f| f.name.as_deref() == Some("수신")),
+            "필드가 삭제되어야 한다"
+        );
+        assert!(
+            !hwp_convert::list_bookmarks(&doc)
+                .iter()
+                .any(|b| b.name == "참조점"),
+            "책갈피가 삭제되어야 한다"
+        );
+        for path in [&source, &mid, &out] {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn mcp_typed_edit_validation_errors() {
+        // 경계 검증 오류는 파일을 읽기 전에 발생한다(input/output은 더미 경로).
+        let dummy = json!({"input": "in.hwpx", "output": "out.hwpx"});
+
+        let mut args = dummy.clone();
+        args["delete_table"] = json!([{"index": 0, "anchor": "표"}]);
+        let error = tool_edit(&args, &ctx()).unwrap_err();
+        assert!(error.contains("delete_table"), "{error}");
+
+        let mut args = dummy.clone();
+        args["delete_table"] = json!([{}]);
+        let error = tool_edit(&args, &ctx()).unwrap_err();
+        assert!(error.contains("delete_table"), "{error}");
+
+        let mut args = dummy.clone();
+        args["set_para"] =
+            json!([{"pattern": "본문", "line_spacing_pct": 130, "line_spacing_pt": 14}]);
+        let error = tool_edit(&args, &ctx()).unwrap_err();
+        assert!(error.contains("line_spacing"), "{error}");
+
+        let mut args = dummy.clone();
+        args["set_page"] = json!({"orientation": "sideways"});
+        let error = tool_edit(&args, &ctx()).unwrap_err();
+        assert!(error.contains("용지 방향"), "{error}");
+
+        let mut args = dummy.clone();
+        args["set_page"] = json!([{"width_mm": 200}]);
+        let error = tool_edit(&args, &ctx()).unwrap_err();
+        assert!(error.contains("객체"), "{error}");
+
+        let mut args = dummy.clone();
+        args["add_table"] = json!([{"anchor": "머리말", "rows": [["a"], [1]]}]);
+        let error = tool_edit(&args, &ctx()).unwrap_err();
+        assert!(error.contains("add_table"), "{error}");
+
+        let mut args = dummy.clone();
+        args["add_table"] = json!([{"anchor": "머리말", "rows": "x"}]);
+        let error = tool_edit(&args, &ctx()).unwrap_err();
+        assert!(error.contains("add_table"), "{error}");
+
+        // 빈 rows는 형태는 맞지만 내용이 없다 — 라이브러리가 거부하고 그 오류가 올라온다.
+        let source = temp_file("typed-add-table-empty-source.hwpx");
+        let out = temp_file("typed-add-table-empty-out.hwpx");
+        create_hwpx(&source, "머리말");
+        let error = tool_edit(
+            &json!({
+                "input": source,
+                "output": out,
+                "add_table": [{"anchor": "머리말", "rows": []}]
+            }),
+            &ctx(),
+        )
+        .unwrap_err();
+        assert!(error.contains("표 행 데이터"), "{error}");
+        assert!(!out.exists(), "실패한 편집은 출력을 게시하지 않는다");
+        let _ = std::fs::remove_file(&source);
+    }
+
+    // ---- read/convert/render parity + hwp_grep (WI-4) ----
+
+    #[test]
+    fn mcp_read_html_and_csv_formats() {
+        let source = temp_file("read-html-csv.hwpx");
+        create_hwpx(
+            &source,
+            "본문\n\n<table>\n<tr><td>가</td><td>나</td></tr>\n</table>\n",
+        );
+        let html = tool_read(&json!({"path": source, "format": "html"}), &ctx()).unwrap();
+        let html_text = html[0]["text"].as_str().unwrap();
+        assert!(html_text.contains('<'), "html 출력: {html_text}");
+        let csv = tool_read(&json!({"path": source, "format": "csv"}), &ctx()).unwrap();
+        let csv_text = csv[0]["text"].as_str().unwrap();
+        assert!(
+            csv_text.contains('가') && csv_text.contains('나'),
+            "csv 출력: {csv_text}"
+        );
+        let _ = std::fs::remove_file(source);
+    }
+
+    /// 머리말/숨은 설명 컨트롤이 든 IR을 만든다 (.json으로 저장하면 load_document가
+    /// 그대로 역직렬화하므로 writer DROP 없이 왕복된다).
+    fn create_ir_json_with_hidden_and_header(path: &Path) {
+        let mut doc = hwp_convert::from_markdown("본문\n\n숨은메모\n\n머리말텍스트");
+        let hidden_para = doc.sections[0].paragraphs.remove(1);
+        let header_para = doc.sections[0].paragraphs.remove(1);
+        let body = &mut doc.sections[0].paragraphs[0];
+        // from_markdown 문단은 이미 컨트롤(구역 정의 등)을 갖고 있으므로 인덱스는
+        // push 시점에 잡는다.
+        let hidden_index = body.controls.len() as u32;
+        body.controls
+            .push(hwp_model::Control::Generic(hwp_model::GenericControl {
+                ctrl_id: *b"hcnt",
+                data: Vec::new(),
+                paragraph_lists: vec![hwp_model::ParagraphList {
+                    header_data: Vec::new(),
+                    paragraphs: vec![hidden_para],
+                }],
+                extras: Vec::new(),
+                raw_children: Vec::new(),
+                gso_shapes: Vec::new(),
+                equation: None,
+                column_def: None,
+            }));
+        let header_index = body.controls.len() as u32;
+        body.controls
+            .push(hwp_model::Control::Generic(hwp_model::GenericControl {
+                ctrl_id: *b"head",
+                data: Vec::new(),
+                paragraph_lists: vec![hwp_model::ParagraphList {
+                    header_data: Vec::new(),
+                    paragraphs: vec![header_para],
+                }],
+                extras: Vec::new(),
+                raw_children: Vec::new(),
+                gso_shapes: Vec::new(),
+                equation: None,
+                column_def: None,
+            }));
+        body.chars.insert(
+            0,
+            hwp_model::HwpChar::ExtCtrl {
+                code: hwp_model::ctrl_char::HEADER_FOOTER,
+                ctrl_id: *b"head",
+                payload: vec![0; 12],
+                ctrl_index: Some(header_index),
+            },
+        );
+        body.chars.insert(
+            0,
+            hwp_model::HwpChar::ExtCtrl {
+                code: hwp_model::ctrl_char::HIDDEN_COMMENT,
+                ctrl_id: *b"hcnt",
+                payload: vec![0; 12],
+                ctrl_index: Some(hidden_index),
+            },
+        );
+        let document_json = hwp_convert::to_json(&doc, true, false).unwrap();
+        std::fs::write(path, document_json).unwrap();
+    }
+
+    #[test]
+    fn mcp_read_with_hidden_and_header_footer_flags() {
+        let source = temp_file("read-with-flags.json");
+        create_ir_json_with_hidden_and_header(&source);
+
+        let plain = tool_read(&json!({"path": source, "format": "plain"}), &ctx()).unwrap();
+        let text = plain[0]["text"].as_str().unwrap();
+        assert!(!text.contains("숨은메모"), "기본은 숨은 설명 제외: {text}");
+        assert!(!text.contains("머리말텍스트"), "기본은 머리말 제외: {text}");
+
+        let hidden = tool_read(
+            &json!({"path": source, "format": "plain", "with_hidden": true}),
+            &ctx(),
+        )
+        .unwrap();
+        let text = hidden[0]["text"].as_str().unwrap();
+        assert!(text.contains("숨은메모"), "with_hidden: {text}");
+        assert!(!text.contains("머리말텍스트"), "with_hidden만: {text}");
+
+        let header = tool_read(
+            &json!({"path": source, "format": "markdown", "with_header_footer": true}),
+            &ctx(),
+        )
+        .unwrap();
+        let text = header[0]["text"].as_str().unwrap();
+        assert!(text.contains("머리말텍스트"), "with_header_footer: {text}");
+        assert!(!text.contains("숨은메모"), "with_header_footer만: {text}");
+        let _ = std::fs::remove_file(source);
+    }
+
+    #[test]
+    fn mcp_read_with_segments_envelope_and_absolute_offsets() {
+        let source = temp_file("read-segments.hwpx");
+        create_hwpx(&source, "가나다\n\n마바사");
+
+        let full = tool_read(
+            &json!({"path": source, "format": "markdown", "with_segments": true}),
+            &ctx(),
+        )
+        .unwrap();
+        let envelope: Value =
+            serde_json::from_str(full[0]["text"].as_str().unwrap()).expect("JSON 봉투");
+        let markdown = envelope["markdown"].as_str().unwrap();
+        assert!(
+            markdown.contains("가나다") && markdown.contains("마바사"),
+            "{markdown}"
+        );
+        let full_segments = envelope["segments"].as_array().unwrap();
+        assert!(
+            full_segments.len() >= 2,
+            "문단별 세그먼트: {full_segments:?}"
+        );
+
+        // 두 번째 문단 중간("바")부터 2문자 창 — 세그먼트 오프셋은 전체 기준 절대값이어야 한다.
+        let offset = markdown.find("바").unwrap();
+        let window = tool_read(
+            &json!({
+                "path": source,
+                "format": "markdown",
+                "with_segments": true,
+                "offset": offset,
+                "max_bytes": 6
+            }),
+            &ctx(),
+        )
+        .unwrap();
+        let windowed: Value = serde_json::from_str(window[0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(windowed["markdown"].as_str().unwrap(), "바사");
+        let window_segments = windowed["segments"].as_array().unwrap();
+        assert!(!window_segments.is_empty(), "창과 교차하는 세그먼트");
+        assert!(
+            window_segments.len() < full_segments.len(),
+            "창 밖 세그먼트는 걸러야: {window_segments:?}"
+        );
+        // 절대 오프셋 증명: 창 기준 재매핑이었다면 start가 0 부근이지만, 절대값은
+        // 전체 markdown에서의 문자 위치를 그대로 가리킨다.
+        let char_start = markdown[..offset].chars().count();
+        let char_end = char_start + 2;
+        for segment in window_segments {
+            let start = segment["start"].as_u64().unwrap() as usize;
+            let end = segment["end"].as_u64().unwrap() as usize;
+            assert!(
+                start < char_end && end > char_start,
+                "창 [{char_start}, {char_end})과 교차해야: {segment}"
+            );
+            assert!(
+                full_segments.contains(segment),
+                "오프셋이 전체 기준 절대값으로 동일해야: {segment}"
+            );
+        }
+        // 페이지네이션 메타데이터는 두 번째 content로 유지된다.
+        let metadata: Value = serde_json::from_str(window[1]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(metadata["truncated"], true);
+        let _ = std::fs::remove_file(source);
+    }
+
+    #[test]
+    fn mcp_read_with_segments_requires_markdown() {
+        let source = temp_file("read-segments-reject.hwpx");
+        create_hwpx(&source, "본문");
+        for format in ["plain", "json", "html", "csv"] {
+            let error = tool_read(
+                &json!({"path": source, "format": format, "with_segments": true}),
+                &ctx(),
+            )
+            .unwrap_err();
+            assert!(error.contains("markdown"), "{format}: {error}");
+        }
+        let _ = std::fs::remove_file(source);
+    }
+
+    #[test]
+    fn mcp_convert_to_overrides_extension_and_accepts_markdown_options() {
+        let source = temp_file("convert-to-source.hwpx");
+        let output = temp_file("convert-to-output.txt");
+        create_hwpx(&source, "본문");
+        // to=json이 .txt 확장자보다 우선한다 (CLI --to와 같은 우선순위).
+        tool_convert(
+            &json!({
+                "input": source,
+                "output": output,
+                "to": "json",
+                "media_dir": "convert-to-media",
+                "with_header_footer": true,
+                "with_hidden": true
+            }),
+            &ctx(),
+        )
+        .expect("to 명시 변환");
+        let written: Value =
+            serde_json::from_str(&std::fs::read_to_string(&output).unwrap()).expect("JSON 출력");
+        assert!(written["sections"].is_array(), "IR JSON: {written}");
+        for path in [&source, &output] {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn mcp_convert_request_merges_font_dirs_and_maps_args() {
+        // 렌더 없이 검증하는 심: pdf 대상 변환이 기동/호출당 폰트 디렉터리를 받는다.
+        let mut sandbox_ctx = ctx();
+        sandbox_ctx.font_dirs = vec![PathBuf::from("/launch-fonts")];
+        let request = convert_request(
+            &json!({
+                "input": "in.hwpx",
+                "output": "out.pdf",
+                "to": "pdf",
+                "font_dir": "/call-fonts",
+                "media_dir": "media",
+                "with_header_footer": true,
+                "with_hidden": true
+            }),
+            &sandbox_ctx,
+        )
+        .expect("convert_request");
+        assert!(matches!(request.to, Some(hwp_cli::cli::ConvertFormat::Pdf)));
+        assert_eq!(
+            request.font_dirs,
+            vec![PathBuf::from("/launch-fonts"), PathBuf::from("/call-fonts")],
+            "PDF 변환은 병합된 폰트 디렉터리를 받아야 한다"
+        );
+        assert_eq!(request.media_dir, Some(PathBuf::from("media")));
+        assert!(request.with_header_footer && request.with_hidden);
+
+        let error = convert_request(
+            &json!({"input": "in.hwpx", "output": "out.x", "to": "bogus"}),
+            &ctx(),
+        )
+        .unwrap_err();
+        assert!(error.contains("to"), "{error}");
+    }
+
+    #[test]
+    fn mcp_convert_media_dir_is_sandbox_checked() {
+        let (base, root, outside) = sandbox_dirs("convert-media");
+        let source = root.join("source.hwpx");
+        create_hwpx(&source, "본문");
+        let sandbox = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let error = convert_request(
+            &json!({
+                "input": source,
+                "output": root.join("out.md"),
+                "media_dir": outside.join("media")
+            }),
+            &sandbox,
+        )
+        .unwrap_err();
+        assert!(error.contains("--root"), "{error}");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// 3쪽 합성 문서 (기존 mcp_render_rasterizes 테스트와 같은 break_type 트릭).
+    fn create_three_page_hwpx(path: &Path) {
+        let mut doc = hwp_convert::from_markdown("첫 쪽\n\n둘째 쪽\n\n셋째 쪽\n");
+        doc.sections[0].paragraphs[1].header.break_type |= 0x04;
+        doc.sections[0].paragraphs[2].header.break_type |= 0x04;
+        hwpx::write_document(&doc, path).unwrap();
+    }
+
+    #[test]
+    fn mcp_render_rejects_conflicting_or_missing_page_args() {
+        let source = temp_file("render-args.hwpx");
+        // 3쪽 문서여야 "1-2" 선택이 실제 다중 페이지가 된다 (parse_pages는 총쪽수로 자른다).
+        create_three_page_hwpx(&source);
+        // page와 pages는 상호 배타적이다.
+        let error =
+            tool_render(&json!({"path": source, "page": 1, "pages": "1-2"}), &ctx()).unwrap_err();
+        assert!(error.contains("pages"), "{error}");
+        // svg/pdf는 output_path가 필수다.
+        for format in ["svg", "pdf"] {
+            let error =
+                tool_render(&json!({"path": source, "format": format}), &ctx()).unwrap_err();
+            assert!(error.contains("output_path"), "{format}: {error}");
+        }
+        // 다중 페이지 png도 output_path가 필수다.
+        let error =
+            tool_render(&json!({"path": source, "pages": "1-2", "dpi": 36}), &ctx()).unwrap_err();
+        assert!(error.contains("output_path"), "{error}");
+        let _ = std::fs::remove_file(source);
+    }
+
+    #[test]
+    fn mcp_render_multi_page_png_writes_numbered_files_and_metadata() {
+        let source = temp_file("render-multi-source.hwpx");
+        let output = temp_file("render-multi.png");
+        create_three_page_hwpx(&source);
+        let content = tool_render(
+            &json!({"path": source, "pages": "2-3", "dpi": 36, "output_path": output}),
+            &ctx(),
+        )
+        .expect("다중 페이지 png");
+        // base64 경로와 달리 이미지 콘텐츠 없이 JSON 메타데이터만 반환한다.
+        assert_eq!(content.len(), 1);
+        assert_eq!(content[0]["type"], "text");
+        let metadata: Value = serde_json::from_str(content[0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(metadata["pages"], json!([2, 3]));
+        assert_eq!(metadata["dpi"].as_f64(), Some(36.0));
+        let page2 = output.with_file_name("render-multi-2.png");
+        let page3 = output.with_file_name("render-multi-3.png");
+        let files: Vec<PathBuf> = metadata["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|f| PathBuf::from(f.as_str().unwrap()))
+            .collect();
+        assert_eq!(files, vec![page2.clone(), page3.clone()]);
+        for path in [&page2, &page3] {
+            let bytes = std::fs::read(path).expect("페이지 파일 존재");
+            assert!(
+                bytes.starts_with(b"\x89PNG"),
+                "PNG 매직: {}",
+                path.display()
+            );
+        }
+        assert!(!output.exists(), "다중 페이지는 번호 파일만 쓴다");
+        for path in [&source, &page2, &page3] {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn mcp_render_svg_and_pdf_write_files_with_output_path() {
+        let source = temp_file("render-vector-source.hwpx");
+        create_three_page_hwpx(&source);
+
+        // 단일 페이지 svg는 output_path 그대로 쓴다.
+        let svg = temp_file("render-single.svg");
+        let content = tool_render(
+            &json!({"path": source, "format": "svg", "dpi": 36, "output_path": svg}),
+            &ctx(),
+        )
+        .expect("svg 단일 페이지");
+        let metadata: Value = serde_json::from_str(content[0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(metadata["pages"], json!([1]));
+        assert_eq!(metadata["files"], json!([svg.to_str().unwrap()]));
+        let bytes = std::fs::read(&svg).unwrap();
+        assert!(
+            bytes.windows(4).any(|w| w == b"<svg"),
+            "SVG 마크업: {}",
+            svg.display()
+        );
+
+        // pdf는 선택 페이지를 단일 멀티페이지 파일로 쓴다.
+        let pdf = temp_file("render-all.pdf");
+        let content = tool_render(
+            &json!({"path": source, "format": "pdf", "pages": "all", "dpi": 36, "output_path": pdf}),
+            &ctx(),
+        )
+        .expect("pdf 전체 페이지");
+        let metadata: Value = serde_json::from_str(content[0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(metadata["pages"], json!([1, 2, 3]));
+        assert_eq!(metadata["files"], json!([pdf.to_str().unwrap()]));
+        let bytes = std::fs::read(&pdf).unwrap();
+        assert!(bytes.starts_with(b"%PDF"), "PDF 매직: {}", pdf.display());
+        for path in [&source, &svg, &pdf] {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn mcp_grep_match_zero_match_and_ignore_case() {
+        let source = temp_file("grep-source.hwpx");
+        create_hwpx(&source, "사과 바나나\n\n둘째 사과\n\nHello World");
+
+        let content =
+            tool_grep(&json!({"path": source, "pattern": "사과"}), &ctx()).expect("grep 매칭");
+        let result: Value = serde_json::from_str(content[0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(result["count"], 2);
+        assert_eq!(result["truncated"], false);
+        assert_eq!(result["matches"].as_array().unwrap().len(), 2);
+
+        // 0건 매칭도 오류가 아니라 정상 결과다 (isError=false).
+        let zero = call_tool(
+            "hwp_grep",
+            &json!({"path": source, "pattern": "없는문구"}),
+            &ctx(),
+        );
+        assert_eq!(zero["isError"], false);
+        let result: Value =
+            serde_json::from_str(zero["content"][0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(result["count"], 0);
+        assert_eq!(result["matches"].as_array().unwrap().len(), 0);
+
+        // ignore_case는 대소문자를 무시한다.
+        let content = tool_grep(
+            &json!({"path": source, "pattern": "hello", "ignore_case": true}),
+            &ctx(),
+        )
+        .unwrap();
+        let result: Value = serde_json::from_str(content[0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(result["count"], 1, "ignore_case 매칭: {result}");
+        let content = tool_grep(&json!({"path": source, "pattern": "hello"}), &ctx()).unwrap();
+        let result: Value = serde_json::from_str(content[0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(result["count"], 0, "대소문자 구분: {result}");
+        let _ = std::fs::remove_file(source);
+    }
+
+    #[test]
+    fn mcp_grep_truncation_cap_logic() {
+        let matches: Vec<String> = (0..201).map(|i| format!("m{i}")).collect();
+        let capped = grep_result(matches);
+        assert_eq!(capped["count"], 201, "count는 절단 전 전체 개수");
+        assert_eq!(capped["truncated"], true);
+        assert_eq!(
+            capped["matches"].as_array().unwrap().len(),
+            MAX_GREP_MATCHES
+        );
+        assert_eq!(MAX_GREP_MATCHES, 200);
+
+        // 상한 이하는 그대로다.
+        let uncapped = grep_result_capped(vec!["a".into(), "b".into()], 2);
+        assert_eq!(uncapped["count"], 2);
+        assert_eq!(uncapped["truncated"], false);
+        let capped = grep_result_capped(vec!["a".into(), "b".into(), "c".into()], 2);
+        assert_eq!(capped["count"], 3);
+        assert_eq!(capped["truncated"], true);
+        assert_eq!(capped["matches"].as_array().unwrap().len(), 2);
     }
 }

--- a/crates/hwp-cli/src/commands/mcp.rs
+++ b/crates/hwp-cli/src/commands/mcp.rs
@@ -13,16 +13,16 @@ use serde_json::{Value, json};
 
 use crate::commands::cat::load_document;
 
-/// 지원하는 MCP 프로토콜 버전(최신 순). initialize 협상에서 쓴다.
+/// Supported MCP protocol versions (newest first). Used in initialize negotiation.
 const SUPPORTED_PROTOCOL_VERSIONS: [&str; 3] = ["2025-06-18", "2025-03-26", "2024-11-05"];
 const MAX_REQUEST_LINE_BYTES: usize = 1024 * 1024;
 const DEFAULT_READ_BYTES: usize = 256 * 1024;
 const MAX_READ_BYTES: usize = 1024 * 1024;
 
-/// 서버 컨텍스트 (렌더/diff 기본 폰트 디렉터리, `--root` 파일 접근 샌드박스).
+/// Server context (default font directories for render/diff, `--root` file access sandbox).
 pub struct Ctx {
     pub font_dirs: Vec<PathBuf>,
-    /// canonicalize된 허용 루트. 비어 있으면 파일 접근 무제한(기존 동작).
+    /// Canonicalized allowed roots. Empty means unrestricted file access (previous behavior).
     pub roots: Vec<PathBuf>,
 }
 
@@ -102,7 +102,7 @@ pub fn handle_request(line: &str, ctx: &Ctx) -> Option<String> {
 
     match method {
         "initialize" => {
-            // 프로토콜 협상: 클라이언트 요청 버전을 지원하면 그대로, 아니면 최신 버전으로 응답.
+            // Protocol negotiation: echo the client-requested version if supported, otherwise respond with the newest version.
             let requested = req
                 .get("params")
                 .and_then(|params| params.get("protocolVersion"))
@@ -330,9 +330,9 @@ fn optional_item_f32(item: &Value, operation: &str, key: &str) -> Result<Option<
         .transpose()
 }
 
-// ---- 경로 샌드박스 (`--root`) ----
+// ---- Path sandbox (`--root`) ----
 
-/// canonical 경로가 허용 root 중 하나 아래인지 확인한다.
+/// Checks that a canonical path sits below one of the allowed roots.
 fn under_any_root(ctx: &Ctx, canonical: &Path, raw: &str) -> Result<PathBuf, String> {
     if ctx.roots.iter().any(|root| canonical.starts_with(root)) {
         Ok(canonical.to_path_buf())
@@ -344,8 +344,8 @@ fn under_any_root(ctx: &Ctx, canonical: &Path, raw: &str) -> Result<PathBuf, Str
     }
 }
 
-/// 읽기 경로 검증: 실존해야 하며(canonicalize), canonical 결과가 root 아래여야 한다.
-/// roots가 비어 있으면 검사 없이 통과(기존 동작).
+/// Read-path validation: the path must exist (canonicalize) and the canonical result
+/// must sit below a root. Empty roots pass without a check (previous behavior).
 fn checked_read_path(ctx: &Ctx, raw: &str) -> Result<PathBuf, String> {
     if ctx.roots.is_empty() {
         return Ok(PathBuf::from(raw));
@@ -355,9 +355,10 @@ fn checked_read_path(ctx: &Ctx, raw: &str) -> Result<PathBuf, String> {
     under_any_root(ctx, &canonical, raw)
 }
 
-/// 쓰기 경로 검증: `..` 구성요소와 파일 이름 누락을 거부하고, 기존 파일이면
-/// canonicalize(심볼링크 덮어쓰기 우회 차단), 새 파일이면 부모를 canonicalize해 붙인 뒤
-/// root 검사를 한다. roots가 비어 있으면 검사 없이 통과(기존 동작).
+/// Write-path validation: rejects `..` components and a missing file name, then
+/// canonicalizes an existing file (blocking symlink-overwrite bypasses) or, for a new
+/// file, canonicalizes the parent and rejoins, before the root check.
+/// Empty roots pass without a check (previous behavior).
 fn checked_write_path(ctx: &Ctx, raw: &str) -> Result<PathBuf, String> {
     if ctx.roots.is_empty() {
         return Ok(PathBuf::from(raw));
@@ -394,7 +395,7 @@ fn checked_write_path(ctx: &Ctx, raw: &str) -> Result<PathBuf, String> {
 fn font_dirs_for(args: &Value, ctx: &Ctx) -> Result<Vec<PathBuf>, String> {
     let mut dirs = ctx.font_dirs.clone();
     if let Some(d) = arg_str_opt(args, "font_dir")? {
-        // 호출당 font_dir는 샌드박스 검사 대상(기동 시 --font-dir는 신뢰).
+        // Per-call font_dir is subject to the sandbox check (startup --font-dir is trusted).
         dirs.push(checked_read_path(ctx, d)?);
     }
     Ok(dirs)
@@ -416,8 +417,8 @@ fn tool_read(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
     let with_header_footer = arg_bool(args, "with_header_footer", false)?;
     let with_hidden = arg_bool(args, "with_hidden", false)?;
     let with_segments = arg_bool(args, "with_segments", false)?;
-    // cat과 같은 계약: with_segments는 markdown 전용이고, with_* 플래그는
-    // plain/markdown에만 적용된다 (html/json/csv는 옵션 미대상 — 받아도 무시).
+    // Same contract as cat: with_segments is markdown-only, and the with_* flags apply
+    // only to plain/markdown (html/json/csv take no options — they are ignored if given).
     if with_segments && !matches!(format, "markdown" | "md") {
         return Err(format!(
             "with_segments는 format=markdown 전용입니다 (요청: {format})"
@@ -432,7 +433,7 @@ fn tool_read(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
         text: text_options(),
         ..Default::default()
     };
-    // with_segments면 markdown과 함께 문자 범위 세그먼트 맵을 받아 둔다.
+    // With with_segments, also collect the character-range segment map alongside the markdown.
     let (text, segments) = match format {
         "plain" => (doc.plain_text_with(&text_options()), None),
         "markdown" | "md" if with_segments => {
@@ -482,9 +483,9 @@ fn tool_read(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
         "next_offset": truncated.then_some(end),
     });
     let content = match segments {
-        // cat의 한 줄 JSON 봉투와 같은 모양이다. markdown은 반환 창 구간만 담고,
-        // 세그먼트는 창과 교차하는 것만 남기되 오프셋은 전체 markdown 기준
-        // 절대값(유니코드 문자 단위)을 유지한다.
+        // Same shape as cat's single-line JSON envelope. The markdown holds only the
+        // returned window, and segments are filtered to those intersecting the window
+        // while offsets stay absolute against the full markdown (unicode characters).
         Some(segments) => {
             let char_start = text[..offset].chars().count();
             let char_end = text[..end].chars().count();
@@ -668,10 +669,10 @@ fn tool_render(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
     };
     let pages_spec = arg_str_opt(args, "pages")?;
 
-    // base64 반환 경로: png이고 output_path가 없을 때. 단일 페이지 선택만 허용한다.
+    // base64 return path: png without output_path. Only a single-page selection is allowed.
     if matches!(format, hwp_cli::cli::RenderFormat::Png) && output_path.is_none() {
         let selected = match pages_spec {
-            // legacy 계약: page는 render_document_pages와 같은 선택 의미를 유지한다.
+            // Legacy contract: page keeps the same selection semantics as render_document_pages.
             None => vec![page],
             Some(spec) => {
                 let total = hwp_render::count_pages(&doc, &opts);
@@ -712,15 +713,15 @@ fn tool_render(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
         return Ok(vec![text_content(&summary), image_content(&png)]);
     }
 
-    // 파일 게시 경로: svg/pdf 또는 다중 페이지 또는 output_path 지정. CLI render와
-    // 같은 원자적 게시 트랜잭션을 거치고 JSON 메타데이터를 반환한다.
+    // File-publish path: svg/pdf, multiple pages, or an explicit output_path. Goes through
+    // the same atomic publish transaction as the CLI render and returns JSON metadata.
     let output = checked_write_path(
         ctx,
         output_path.ok_or(
             "svg/pdf 또는 output_path 없는 다중 페이지 렌더는 output_path 인자가 필요합니다",
         )?,
     )?;
-    // CLI와 같은 페이지별 파일명 규칙으로 파생된 각 경로도 샌드박스 검사 대상이다.
+    // Each path derived from the CLI's per-page filename rule is also sandbox-checked.
     let checked_derived = |base: &Path, page_no: usize, multi: bool| -> Result<PathBuf, String> {
         let derived = crate::commands::render::page_path(base, page_no, multi);
         let raw = derived
@@ -782,7 +783,7 @@ fn tool_render(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
                 None => crate::commands::render::parse_pages(&page.to_string(), total)
                     .map_err(|error| error.to_string())?,
             };
-            // PNG/SVG와 달리 PDF는 단일 멀티페이지 파일이다 (페이지별 분리 없음).
+            // Unlike PNG/SVG, PDF is a single multi-page file (no per-page split).
             let result = hwp_render::render_document_pdf(&doc, &opts, Some(&selected))
                 .map_err(|e| e.to_string())?;
             crate::commands::render::write_render_bytes(&output, &path, &result.data)
@@ -800,8 +801,8 @@ fn tool_render(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
     )])
 }
 
-/// hwp_grep 매칭 반환 상한 — 초과분은 잘라내고 truncated=true로 표시한다.
-/// count는 항상 절단 전 전체 개수다.
+/// hwp_grep match return cap — excess matches are cut and marked truncated=true.
+/// count is always the full pre-truncation total.
 const MAX_GREP_MATCHES: usize = 200;
 
 fn grep_result(matches: Vec<String>) -> Value {
@@ -824,7 +825,7 @@ fn tool_grep(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
     let pattern = arg_str(args, "pattern")?;
     let ignore_case = arg_bool(args, "ignore_case", false)?;
     let doc = load_document(&path).map_err(|e| e.to_string())?;
-    // 0건 매칭도 오류가 아니라 정상 결과다 (CLI grep의 exit(1) 계약과 다름).
+    // Zero matches are a normal result, not an error (unlike the CLI grep exit(1) contract).
     let matches =
         crate::commands::grep::search(&doc, pattern, ignore_case).map_err(|e| e.to_string())?;
     Ok(vec![text_content(
@@ -1002,8 +1003,8 @@ fn tool_edit(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
         });
     }
     for item in arg_array(args, "add_table")? {
-        // JSON 경계에서는 형태(문자열 배열의 배열)만 검증한다 — 빈 행 데이터 같은
-        // 내용 검증은 라이브러리(add_table)가 거부하고 그 오류를 그대로 올린다.
+        // The JSON boundary validates only the shape (an array of string arrays) — content
+        // problems like empty row data are rejected by the library (add_table), whose error propagates as-is.
         let rows_value = item
             .get("rows")
             .and_then(Value::as_array)
@@ -1029,7 +1030,7 @@ fn tool_edit(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
         });
     }
     for item in arg_array(args, "set_para")? {
-        // CLI의 line-spacing (% 정수 | Npt)를 두 수치 인자로 나눈 것 — 상호 배타적.
+        // The CLI line-spacing (% integer | Npt) split into two numeric arguments — mutually exclusive.
         let line_spacing = match (
             optional_item_f32(item, "set_para", "line_spacing_pct")?,
             optional_item_f32(item, "set_para", "line_spacing_pt")?,
@@ -1062,7 +1063,7 @@ fn tool_edit(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
             props,
         });
     }
-    // CLI의 누적 --set-page 플래그와 같이, 단일 객체를 하나의 PageProps로 합쳐 적용한다.
+    // Like the CLI's cumulative --set-page flags, a single object is merged into one PageProps and applied.
     if let Some(item) = args.get("set_page") {
         if !item.is_object() {
             return Err("set_page는 단일 객체여야 합니다".into());
@@ -1140,7 +1141,7 @@ fn tool_edit(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
     )])
 }
 
-/// hwp_convert 인자 → convert::execute 파라미터 매핑 (렌더 없이 검증하는 테스트 심).
+/// Maps hwp_convert arguments to convert::execute parameters (a test seam verified without rendering).
 #[derive(Debug)]
 struct ConvertRequest {
     input: PathBuf,
@@ -1176,11 +1177,11 @@ fn parse_convert_format(value: &str) -> Result<hwp_cli::cli::ConvertFormat, Stri
 fn convert_request(args: &Value, ctx: &Ctx) -> Result<ConvertRequest, String> {
     let input = checked_read_path(ctx, arg_str(args, "input")?)?;
     let output = checked_write_path(ctx, arg_str(args, "output")?)?;
-    // to를 주면 CLI --to와 같이 출력 확장자 추론보다 우선한다.
+    // An explicit to wins over output-extension inference, like the CLI --to.
     let to = arg_str_opt(args, "to")?
         .map(parse_convert_format)
         .transpose()?;
-    // media_dir는 markdown 이미지 추출 디렉터리 — 쓰기 경로로 검사한다.
+    // media_dir is the markdown image-extraction directory — checked as a write path.
     let media_dir = arg_str_opt(args, "media_dir")?
         .map(|raw| checked_write_path(ctx, raw))
         .transpose()?;
@@ -1193,8 +1194,8 @@ fn convert_request(args: &Value, ctx: &Ctx) -> Result<ConvertRequest, String> {
         media_dir,
         with_header_footer: arg_bool(args, "with_header_footer", false)?,
         with_hidden: arg_bool(args, "with_hidden", false)?,
-        // 기동 --font-dir + 호출당 font_dir 병합 목록을 그대로 넘긴다 — 이전에는
-        // 항상 빈 목록이라 MCP 서버 기동 시 지정한 폰트가 PDF 변환에 적용되지 않았다.
+        // Passes the merged startup --font-dir + per-call font_dir list through — previously
+        // the list was always empty, so fonts set at MCP server startup never applied to PDF conversion.
         font_dirs: font_dirs_for(args, ctx)?,
     })
 }
@@ -1812,7 +1813,7 @@ mod tests {
         }
     }
 
-    /// 주어진 root(호출 측에서 canonicalize)만 허용하는 샌드박스 컨텍스트.
+    /// Sandbox context allowing only the given root (canonicalized by the caller).
     fn ctx_with_roots(roots: Vec<PathBuf>) -> Ctx {
         Ctx {
             font_dirs: Vec::new(),
@@ -1852,14 +1853,14 @@ mod tests {
 
     #[test]
     fn initialize_프로토콜_버전_협상() {
-        // 지원하는 버전은 그대로 에코한다.
+        // A supported version is echoed as-is.
         for version in SUPPORTED_PROTOCOL_VERSIONS {
             let v = call(&format!(
                 r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"protocolVersion":"{version}"}}}}"#
             ));
             assert_eq!(v["result"]["protocolVersion"], version);
         }
-        // 미지원 버전이면 최신 버전으로 응답한다.
+        // An unsupported version gets the newest version in response.
         let v = call(
             r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"1999-01-01"}}"#,
         );
@@ -1867,7 +1868,7 @@ mod tests {
             v["result"]["protocolVersion"],
             SUPPORTED_PROTOCOL_VERSIONS[0]
         );
-        // protocolVersion 파라미터가 없어도 최신 버전으로 응답한다.
+        // A missing protocolVersion parameter also gets the newest version.
         let v = call(r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#);
         assert_eq!(
             v["result"]["protocolVersion"],
@@ -2050,7 +2051,7 @@ mod tests {
         let sandbox = ctx_with_roots(vec![std::fs::canonicalize(&directory).unwrap()]);
         let output = directory.join("out.hwpx");
 
-        // 샌드박스 루트 아래 에셋을 참조하는 spec은 그대로 합성된다(roots 전달 검증).
+        // A spec referencing assets below the sandbox root composes as usual (verifies roots plumbing).
         let result = tool_compose(
             &json!({
                 "spec": {
@@ -2524,8 +2525,8 @@ mod tests {
         let _ = std::fs::remove_file(source);
     }
 
-    /// 샌드박스 테스트용 (base, root, outside) 디렉터리를 만든다.
-    /// Windows CI 호환: 실제 temp dir만 쓰고, root는 ctx에 넣기 전에 canonicalize한다.
+    /// Creates (base, root, outside) directories for sandbox tests.
+    /// Windows-CI compatible: uses only the real temp dir, and root is canonicalized before entering ctx.
     fn sandbox_dirs(tag: &str) -> (PathBuf, PathBuf, PathBuf) {
         let base =
             std::env::temp_dir().join(format!("hwp-cli-mcp-sandbox-{tag}-{}", std::process::id()));
@@ -2539,7 +2540,7 @@ mod tests {
     #[test]
     fn sandbox_루트없으면_검사없이_통과() {
         let ctx = ctx_with_roots(Vec::new());
-        // 존재하지 않는 경로도, '..'도 기존 동작 그대로 통과한다.
+        // Nonexistent paths and '..' pass through with the previous behavior.
         let read = checked_read_path(&ctx, "no/such/file.hwpx").unwrap();
         assert_eq!(read, PathBuf::from("no/such/file.hwpx"));
         let write = checked_write_path(&ctx, "../out.hwpx").unwrap();
@@ -2675,7 +2676,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&base);
     }
 
-    /// 본문·표 셀·글상자 재귀로 매칭되는 컨트롤 수를 센다(typed edit 왕복 검증용).
+    /// Counts controls matched across body, table cells, and text boxes recursively (for typed-edit round-trip checks).
     fn count_controls(
         doc: &hwp_model::Document,
         matches: fn(&hwp_model::Control) -> bool,
@@ -2735,7 +2736,7 @@ mod tests {
                 "hwp_edit 스키마에 {key} 누락"
             );
         }
-        // set_page는 단일 객체, 나머지는 배열이다.
+        // set_page is a single object; the rest are arrays.
         assert_eq!(properties["set_page"]["type"], "object");
         assert_eq!(properties["add_table"]["type"], "array");
     }
@@ -2819,7 +2820,7 @@ mod tests {
         let shape = &doc.header.para_shapes[para.para_shape.0 as usize];
         assert_eq!(shape.line_spacing_type, 0, "비율 줄간격");
         assert_eq!(shape.line_spacing, 130);
-        // IR은 HWPUNIT의 2배 단위(hwp5 PARA_SHAPE)다.
+        // The IR uses double-HWPUNIT units (hwp5 PARA_SHAPE).
         assert_eq!(shape.indent, 2 * crate::commands::edit::mm_to_hwpunit(5.0));
 
         let page = doc.sections[0]
@@ -2845,7 +2846,7 @@ mod tests {
         let out = temp_file("typed-delete-image-out.hwpx");
         let png = temp_file("typed-delete-image.png");
         create_hwpx(&source, "사진: 여기");
-        // 최소 PNG 헤더(IHDR 96x96) — insert_image는 크기만 파싱한다.
+        // Minimal PNG header (IHDR 96x96) — insert_image only parses the size.
         let mut bytes = b"\x89PNG\r\n\x1a\n".to_vec();
         bytes.extend([0, 0, 0, 13]);
         bytes.extend(b"IHDR");
@@ -2953,7 +2954,7 @@ mod tests {
 
     #[test]
     fn mcp_typed_edit_validation_errors() {
-        // 경계 검증 오류는 파일을 읽기 전에 발생한다(input/output은 더미 경로).
+        // Boundary-validation errors fire before any file is read (input/output are dummy paths).
         let dummy = json!({"input": "in.hwpx", "output": "out.hwpx"});
 
         let mut args = dummy.clone();
@@ -2992,7 +2993,7 @@ mod tests {
         let error = tool_edit(&args, &ctx()).unwrap_err();
         assert!(error.contains("add_table"), "{error}");
 
-        // 빈 rows는 형태는 맞지만 내용이 없다 — 라이브러리가 거부하고 그 오류가 올라온다.
+        // Empty rows have the right shape but no content — the library rejects them and that error propagates.
         let source = temp_file("typed-add-table-empty-source.hwpx");
         let out = temp_file("typed-add-table-empty-out.hwpx");
         create_hwpx(&source, "머리말");
@@ -3031,15 +3032,15 @@ mod tests {
         let _ = std::fs::remove_file(source);
     }
 
-    /// 머리말/숨은 설명 컨트롤이 든 IR을 만든다 (.json으로 저장하면 load_document가
-    /// 그대로 역직렬화하므로 writer DROP 없이 왕복된다).
+    /// Builds an IR containing header/hidden-note controls (saved as .json, load_document
+    /// deserializes it verbatim, so it round-trips without writer loss).
     fn create_ir_json_with_hidden_and_header(path: &Path) {
         let mut doc = hwp_convert::from_markdown("본문\n\n숨은메모\n\n머리말텍스트");
         let hidden_para = doc.sections[0].paragraphs.remove(1);
         let header_para = doc.sections[0].paragraphs.remove(1);
         let body = &mut doc.sections[0].paragraphs[0];
-        // from_markdown 문단은 이미 컨트롤(구역 정의 등)을 갖고 있으므로 인덱스는
-        // push 시점에 잡는다.
+        // from_markdown paragraphs already carry controls (section definitions, etc.),
+        // so indexes are captured at push time.
         let hidden_index = body.controls.len() as u32;
         body.controls
             .push(hwp_model::Control::Generic(hwp_model::GenericControl {
@@ -3145,7 +3146,7 @@ mod tests {
             "문단별 세그먼트: {full_segments:?}"
         );
 
-        // 두 번째 문단 중간("바")부터 2문자 창 — 세그먼트 오프셋은 전체 기준 절대값이어야 한다.
+        // A 2-character window from the middle of the second paragraph ("바") — segment offsets must stay absolute against the full markdown.
         let offset = markdown.find("바").unwrap();
         let window = tool_read(
             &json!({
@@ -3166,8 +3167,8 @@ mod tests {
             window_segments.len() < full_segments.len(),
             "창 밖 세그먼트는 걸러야: {window_segments:?}"
         );
-        // 절대 오프셋 증명: 창 기준 재매핑이었다면 start가 0 부근이지만, 절대값은
-        // 전체 markdown에서의 문자 위치를 그대로 가리킨다.
+        // Proof of absolute offsets: window-relative remapping would put start near 0,
+        // but absolute values point at the character position in the full markdown.
         let char_start = markdown[..offset].chars().count();
         let char_end = char_start + 2;
         for segment in window_segments {
@@ -3182,7 +3183,7 @@ mod tests {
                 "오프셋이 전체 기준 절대값으로 동일해야: {segment}"
             );
         }
-        // 페이지네이션 메타데이터는 두 번째 content로 유지된다.
+        // Pagination metadata is kept as the second content item.
         let metadata: Value = serde_json::from_str(window[1]["text"].as_str().unwrap()).unwrap();
         assert_eq!(metadata["truncated"], true);
         let _ = std::fs::remove_file(source);
@@ -3208,7 +3209,7 @@ mod tests {
         let source = temp_file("convert-to-source.hwpx");
         let output = temp_file("convert-to-output.txt");
         create_hwpx(&source, "본문");
-        // to=json이 .txt 확장자보다 우선한다 (CLI --to와 같은 우선순위).
+        // to=json wins over the .txt extension (same precedence as the CLI --to).
         tool_convert(
             &json!({
                 "input": source,
@@ -3231,7 +3232,7 @@ mod tests {
 
     #[test]
     fn mcp_convert_request_merges_font_dirs_and_maps_args() {
-        // 렌더 없이 검증하는 심: pdf 대상 변환이 기동/호출당 폰트 디렉터리를 받는다.
+        // Seam verified without rendering: a pdf-target conversion receives the startup/per-call font directories.
         let mut sandbox_ctx = ctx();
         sandbox_ctx.font_dirs = vec![PathBuf::from("/launch-fonts")];
         let request = convert_request(
@@ -3283,7 +3284,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&base);
     }
 
-    /// 3쪽 합성 문서 (기존 mcp_render_rasterizes 테스트와 같은 break_type 트릭).
+    /// Synthetic 3-page document (same break_type trick as the existing mcp_render_rasterizes test).
     fn create_three_page_hwpx(path: &Path) {
         let mut doc = hwp_convert::from_markdown("첫 쪽\n\n둘째 쪽\n\n셋째 쪽\n");
         doc.sections[0].paragraphs[1].header.break_type |= 0x04;
@@ -3294,19 +3295,19 @@ mod tests {
     #[test]
     fn mcp_render_rejects_conflicting_or_missing_page_args() {
         let source = temp_file("render-args.hwpx");
-        // 3쪽 문서여야 "1-2" 선택이 실제 다중 페이지가 된다 (parse_pages는 총쪽수로 자른다).
+        // The document must have 3 pages for the "1-2" selection to be genuinely multi-page (parse_pages clamps to the page count).
         create_three_page_hwpx(&source);
-        // page와 pages는 상호 배타적이다.
+        // page and pages are mutually exclusive.
         let error =
             tool_render(&json!({"path": source, "page": 1, "pages": "1-2"}), &ctx()).unwrap_err();
         assert!(error.contains("pages"), "{error}");
-        // svg/pdf는 output_path가 필수다.
+        // svg/pdf require output_path.
         for format in ["svg", "pdf"] {
             let error =
                 tool_render(&json!({"path": source, "format": format}), &ctx()).unwrap_err();
             assert!(error.contains("output_path"), "{format}: {error}");
         }
-        // 다중 페이지 png도 output_path가 필수다.
+        // Multi-page png requires output_path too.
         let error =
             tool_render(&json!({"path": source, "pages": "1-2", "dpi": 36}), &ctx()).unwrap_err();
         assert!(error.contains("output_path"), "{error}");
@@ -3323,7 +3324,7 @@ mod tests {
             &ctx(),
         )
         .expect("다중 페이지 png");
-        // base64 경로와 달리 이미지 콘텐츠 없이 JSON 메타데이터만 반환한다.
+        // Unlike the base64 path, this returns only JSON metadata without image content.
         assert_eq!(content.len(), 1);
         assert_eq!(content[0]["type"], "text");
         let metadata: Value = serde_json::from_str(content[0]["text"].as_str().unwrap()).unwrap();
@@ -3357,7 +3358,7 @@ mod tests {
         let source = temp_file("render-vector-source.hwpx");
         create_three_page_hwpx(&source);
 
-        // 단일 페이지 svg는 output_path 그대로 쓴다.
+        // A single-page svg is written to output_path as-is.
         let svg = temp_file("render-single.svg");
         let content = tool_render(
             &json!({"path": source, "format": "svg", "dpi": 36, "output_path": svg}),
@@ -3374,7 +3375,7 @@ mod tests {
             svg.display()
         );
 
-        // pdf는 선택 페이지를 단일 멀티페이지 파일로 쓴다.
+        // pdf writes the selected pages as a single multi-page file.
         let pdf = temp_file("render-all.pdf");
         let content = tool_render(
             &json!({"path": source, "format": "pdf", "pages": "all", "dpi": 36, "output_path": pdf}),
@@ -3403,7 +3404,7 @@ mod tests {
         assert_eq!(result["truncated"], false);
         assert_eq!(result["matches"].as_array().unwrap().len(), 2);
 
-        // 0건 매칭도 오류가 아니라 정상 결과다 (isError=false).
+        // Zero matches are a normal result, not an error (isError=false).
         let zero = call_tool(
             "hwp_grep",
             &json!({"path": source, "pattern": "없는문구"}),
@@ -3415,7 +3416,7 @@ mod tests {
         assert_eq!(result["count"], 0);
         assert_eq!(result["matches"].as_array().unwrap().len(), 0);
 
-        // ignore_case는 대소문자를 무시한다.
+        // ignore_case ignores letter case.
         let content = tool_grep(
             &json!({"path": source, "pattern": "hello", "ignore_case": true}),
             &ctx(),
@@ -3441,7 +3442,7 @@ mod tests {
         );
         assert_eq!(MAX_GREP_MATCHES, 200);
 
-        // 상한 이하는 그대로다.
+        // Counts at or below the cap pass through unchanged.
         let uncapped = grep_result_capped(vec!["a".into(), "b".into()], 2);
         assert_eq!(uncapped["count"], 2);
         assert_eq!(uncapped["truncated"], false);

--- a/crates/hwp-cli/src/commands/mod.rs
+++ b/crates/hwp-cli/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub mod mcp;
 pub mod new;
 pub(crate) mod output;
 pub mod render;
+pub mod skill;
 pub mod slots;
 pub mod template;
 pub mod update;

--- a/crates/hwp-cli/src/commands/render.rs
+++ b/crates/hwp-cli/src/commands/render.rs
@@ -93,14 +93,21 @@ pub(crate) fn validated_dpi(dpi: f64) -> anyhow::Result<f32> {
     hwp_render::validate_dpi(dpi as f32).map_err(Into::into)
 }
 
-fn publish_render_set(outputs: &[(PathBuf, Vec<u8>)], input: &Path) -> anyhow::Result<()> {
+pub(crate) fn publish_render_set(
+    outputs: &[(PathBuf, Vec<u8>)],
+    input: &Path,
+) -> anyhow::Result<()> {
     if let Some(warning) = crate::commands::output::write_validated_files(outputs, Some(input))? {
         eprintln!("경고: {warning}");
     }
     Ok(())
 }
 
-fn write_render_bytes(destination: &Path, input: &Path, bytes: &[u8]) -> anyhow::Result<()> {
+pub(crate) fn write_render_bytes(
+    destination: &Path,
+    input: &Path,
+    bytes: &[u8],
+) -> anyhow::Result<()> {
     crate::commands::output::write_validated(
         destination,
         Some(input),
@@ -140,7 +147,9 @@ fn infer_format(output: &Path) -> RenderFormat {
     }
 }
 
-fn page_path(base: &Path, page: usize, multi: bool) -> PathBuf {
+/// 페이지별 출력 경로: 여러 페이지면 `<stem>-<N>.<ext>`, 단일 페이지면 경로 그대로.
+/// MCP render의 output_path 파일명도 이 규칙을 따른다.
+pub(crate) fn page_path(base: &Path, page: usize, multi: bool) -> PathBuf {
     if multi {
         numbered_path(base, page)
     } else {
@@ -149,7 +158,7 @@ fn page_path(base: &Path, page: usize, multi: bool) -> PathBuf {
 }
 
 /// "all" | "3" | "1-5" → 1-기반 페이지 번호 목록.
-fn parse_pages(spec: &str, total: usize) -> anyhow::Result<Vec<usize>> {
+pub(crate) fn parse_pages(spec: &str, total: usize) -> anyhow::Result<Vec<usize>> {
     if total == 0 {
         anyhow::bail!("렌더링된 페이지가 없습니다");
     }

--- a/crates/hwp-cli/src/commands/render.rs
+++ b/crates/hwp-cli/src/commands/render.rs
@@ -147,8 +147,8 @@ fn infer_format(output: &Path) -> RenderFormat {
     }
 }
 
-/// 페이지별 출력 경로: 여러 페이지면 `<stem>-<N>.<ext>`, 단일 페이지면 경로 그대로.
-/// MCP render의 output_path 파일명도 이 규칙을 따른다.
+/// Per-page output path: `<stem>-<N>.<ext>` for multiple pages, the path as-is for a single page.
+/// MCP render output_path filenames follow the same rule.
 pub(crate) fn page_path(base: &Path, page: usize, multi: bool) -> PathBuf {
     if multi {
         numbered_path(base, page)

--- a/crates/hwp-cli/src/commands/skill.rs
+++ b/crates/hwp-cli/src/commands/skill.rs
@@ -1,12 +1,15 @@
-//! `hwp skill` — 번들된 에이전트 스킬 관리.
+//! `hwp skill` — manages the bundled agent skill.
 //!
-//! 저장소 정본 `skills/hwp/SKILL.md`를 `include_str!`로 바이너리에 임베드해 두고,
-//! `hwp skill export`가 그대로 파일로 풀어낸다(생성물이라 기존 파일은 조용히 덮어쓴다).
-//! `--install claude-code|codex`는 에이전트별 관례 디렉터리(`~/.claude/skills/hwp/`,
-//! `~/.codex/skills/hwp/`)를 골라 주는 지름길일 뿐 동작은 같다.
+//! The repository source of truth `skills/hwp/SKILL.md` is embedded into the
+//! binary with `include_str!`, and `hwp skill export` writes it out verbatim
+//! (a generated artifact, so an existing file is silently overwritten).
+//! `--install claude-code|codex` is only a shortcut that picks the per-agent
+//! conventional directory (`~/.claude/skills/hwp/`, `~/.codex/skills/hwp/`);
+//! the behavior is the same.
 //!
-//! 홈 디렉터리 해석과 대상 결정은 순수 함수로 분리해 단위 테스트한다 — 테스트가 실제
-//! `$HOME`을 만지지 않게 경로 계산만 검증하고, 파일 쓰기는 임시 디렉터리에서만 한다.
+//! Home-directory resolution and target selection are split into pure functions
+//! for unit testing — tests verify only the path computation without touching
+//! the real `$HOME`, and file writes happen only in temporary directories.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -15,7 +18,7 @@ use anyhow::Context as _;
 
 use hwp_cli::cli::InstallTarget;
 
-/// 임베드된 스킬 정본. 저장소의 `skills/hwp/SKILL.md`와 바이트 단위로 같다.
+/// Embedded skill source of truth. Byte-identical to `skills/hwp/SKILL.md` in the repository.
 pub const SKILL_MD: &str = include_str!("../../../../skills/hwp/SKILL.md");
 
 pub fn run(output: Option<PathBuf>, install: Option<InstallTarget>) -> anyhow::Result<()> {
@@ -25,8 +28,8 @@ pub fn run(output: Option<PathBuf>, install: Option<InstallTarget>) -> anyhow::R
     Ok(())
 }
 
-/// 출력 디렉터리를 정한다: `-o` 우선, `--install`이면 에이전트 스킬 디렉터리,
-/// 둘 다 없으면 `./hwp`. 둘 다 있으면 거부(clap이 `conflicts_with`로 먼저 막는다).
+/// Picks the output directory: `-o` wins, `--install` picks the agent skill directory,
+/// and with neither the default is `./hwp`. Both together are rejected (clap blocks them first via `conflicts_with`).
 fn resolve_target_dir(
     output: Option<PathBuf>,
     install: Option<InstallTarget>,
@@ -41,7 +44,7 @@ fn resolve_target_dir(
     }
 }
 
-/// `--install` 대상의 스킬 디렉터리(`home` 아래 상대 경로 조립만 — IO 없음).
+/// Skill directory for an `--install` target (only assembles the relative path below `home` — no IO).
 fn install_dir(target: InstallTarget, home: &Path) -> PathBuf {
     let agent = match target {
         InstallTarget::ClaudeCode => ".claude",
@@ -50,7 +53,7 @@ fn install_dir(target: InstallTarget, home: &Path) -> PathBuf {
     home.join(agent).join("skills").join("hwp")
 }
 
-/// 홈 디렉터리: 유닉스는 `$HOME`, Windows는 `$USERPROFILE` (새 크레이트 의존 없이).
+/// Home directory: `$HOME` on unix, `$USERPROFILE` on Windows (no new crate dependency).
 fn home_dir() -> anyhow::Result<PathBuf> {
     #[cfg(not(windows))]
     const VAR: &str = "HOME";
@@ -62,7 +65,7 @@ fn home_dir() -> anyhow::Result<PathBuf> {
         .with_context(|| format!("홈 디렉터리 환경변수 ${VAR} 가 설정되어 있지 않습니다"))
 }
 
-/// `dir/SKILL.md`에 임베드된 내용을 쓴다(디렉터리가 없으면 만든다).
+/// Writes the embedded content to `dir/SKILL.md` (creating the directory if needed).
 fn export(dir: &Path) -> anyhow::Result<PathBuf> {
     fs::create_dir_all(dir)
         .with_context(|| format!("스킬 디렉터리를 만들 수 없습니다: {}", dir.display()))?;

--- a/crates/hwp-cli/src/commands/skill.rs
+++ b/crates/hwp-cli/src/commands/skill.rs
@@ -1,0 +1,117 @@
+//! `hwp skill` — 번들된 에이전트 스킬 관리.
+//!
+//! 저장소 정본 `skills/hwp/SKILL.md`를 `include_str!`로 바이너리에 임베드해 두고,
+//! `hwp skill export`가 그대로 파일로 풀어낸다(생성물이라 기존 파일은 조용히 덮어쓴다).
+//! `--install claude-code|codex`는 에이전트별 관례 디렉터리(`~/.claude/skills/hwp/`,
+//! `~/.codex/skills/hwp/`)를 골라 주는 지름길일 뿐 동작은 같다.
+//!
+//! 홈 디렉터리 해석과 대상 결정은 순수 함수로 분리해 단위 테스트한다 — 테스트가 실제
+//! `$HOME`을 만지지 않게 경로 계산만 검증하고, 파일 쓰기는 임시 디렉터리에서만 한다.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+
+use hwp_cli::cli::InstallTarget;
+
+/// 임베드된 스킬 정본. 저장소의 `skills/hwp/SKILL.md`와 바이트 단위로 같다.
+pub const SKILL_MD: &str = include_str!("../../../../skills/hwp/SKILL.md");
+
+pub fn run(output: Option<PathBuf>, install: Option<InstallTarget>) -> anyhow::Result<()> {
+    let dir = resolve_target_dir(output, install)?;
+    let written = export(&dir)?;
+    println!("{}", written.display());
+    Ok(())
+}
+
+/// 출력 디렉터리를 정한다: `-o` 우선, `--install`이면 에이전트 스킬 디렉터리,
+/// 둘 다 없으면 `./hwp`. 둘 다 있으면 거부(clap이 `conflicts_with`로 먼저 막는다).
+fn resolve_target_dir(
+    output: Option<PathBuf>,
+    install: Option<InstallTarget>,
+) -> anyhow::Result<PathBuf> {
+    match (output, install) {
+        (Some(dir), None) => Ok(dir),
+        (None, Some(target)) => Ok(install_dir(target, &home_dir()?)),
+        (None, None) => Ok(PathBuf::from("./hwp")),
+        (Some(_), Some(_)) => {
+            anyhow::bail!("-o/--output 과 --install 은 동시에 쓸 수 없습니다")
+        }
+    }
+}
+
+/// `--install` 대상의 스킬 디렉터리(`home` 아래 상대 경로 조립만 — IO 없음).
+fn install_dir(target: InstallTarget, home: &Path) -> PathBuf {
+    let agent = match target {
+        InstallTarget::ClaudeCode => ".claude",
+        InstallTarget::Codex => ".codex",
+    };
+    home.join(agent).join("skills").join("hwp")
+}
+
+/// 홈 디렉터리: 유닉스는 `$HOME`, Windows는 `$USERPROFILE` (새 크레이트 의존 없이).
+fn home_dir() -> anyhow::Result<PathBuf> {
+    #[cfg(not(windows))]
+    const VAR: &str = "HOME";
+    #[cfg(windows)]
+    const VAR: &str = "USERPROFILE";
+    std::env::var_os(VAR)
+        .map(PathBuf::from)
+        .filter(|p| !p.as_os_str().is_empty())
+        .with_context(|| format!("홈 디렉터리 환경변수 ${VAR} 가 설정되어 있지 않습니다"))
+}
+
+/// `dir/SKILL.md`에 임베드된 내용을 쓴다(디렉터리가 없으면 만든다).
+fn export(dir: &Path) -> anyhow::Result<PathBuf> {
+    fs::create_dir_all(dir)
+        .with_context(|| format!("스킬 디렉터리를 만들 수 없습니다: {}", dir.display()))?;
+    let path = dir.join("SKILL.md");
+    fs::write(&path, SKILL_MD)
+        .with_context(|| format!("SKILL.md를 쓸 수 없습니다: {}", path.display()))?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exported_bytes_match_embedded_source() {
+        let dir = std::env::temp_dir().join(format!("hwp-cli-skill-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        let written = export(&dir).expect("export");
+        assert_eq!(
+            fs::read(&written).expect("read back"),
+            SKILL_MD.as_bytes(),
+            "exported file must byte-match the embedded source"
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn install_dir_resolves_under_given_home() {
+        let home = Path::new("home");
+        assert_eq!(
+            install_dir(InstallTarget::ClaudeCode, home),
+            Path::new("home/.claude/skills/hwp")
+        );
+        assert_eq!(
+            install_dir(InstallTarget::Codex, home),
+            Path::new("home/.codex/skills/hwp")
+        );
+    }
+
+    #[test]
+    fn target_dir_defaults_and_conflict() {
+        assert_eq!(
+            resolve_target_dir(Some(PathBuf::from("x")), None).unwrap(),
+            PathBuf::from("x")
+        );
+        assert_eq!(
+            resolve_target_dir(None, None).unwrap(),
+            PathBuf::from("./hwp")
+        );
+        assert!(resolve_target_dir(Some(PathBuf::from("x")), Some(InstallTarget::Codex)).is_err());
+    }
+}

--- a/crates/hwp-cli/src/commands/template.rs
+++ b/crates/hwp-cli/src/commands/template.rs
@@ -55,6 +55,7 @@ pub fn run(
         output,
         dry_run,
         &sources,
+        &[],
     )?;
     if print_report || dry_run {
         println!("{}", serialize_report(&report)?);
@@ -79,6 +80,7 @@ pub fn execute_text(
     output: &Path,
     dry_run: bool,
     source_paths: &[PathBuf],
+    roots: &[PathBuf],
 ) -> anyhow::Result<TemplateReport> {
     execute_text_with_fonts(
         template_input,
@@ -90,6 +92,7 @@ pub fn execute_text(
         dry_run,
         source_paths,
         None,
+        roots,
     )
 }
 
@@ -104,12 +107,13 @@ pub(crate) fn execute_text_with_fonts(
     dry_run: bool,
     source_paths: &[PathBuf],
     font_files: Option<&[PathBuf]>,
+    roots: &[PathBuf],
 ) -> anyhow::Result<TemplateReport> {
     let template =
         template_spec::parse_template(template_input, template_format).map_err(template_error)?;
     let data = template_spec::parse_data(data_input, data_format).map_err(template_error)?;
-    let expanded =
-        template_spec::expand_template(&template, &data, base_dir).map_err(template_error)?;
+    let expanded = template_spec::expand_template(&template, &data, base_dir, roots)
+        .map_err(template_error)?;
     let mut immutable_inputs = source_paths
         .iter()
         .map(PathBuf::as_path)
@@ -133,9 +137,11 @@ pub(crate) fn execute_text_with_fonts(
         dry_run,
         input_hashes,
         font_files,
+        roots,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn execute_expanded(
     expanded: ExpandedTemplate,
     template: &template_spec::TemplateSpec,
@@ -144,6 +150,7 @@ fn execute_expanded(
     dry_run: bool,
     input_hashes: InputHashes,
     font_files: Option<&[PathBuf]>,
+    roots: &[PathBuf],
 ) -> anyhow::Result<TemplateReport> {
     let mode = expanded.mode.clone();
     let plan = expanded.plan.clone();
@@ -153,7 +160,7 @@ fn execute_expanded(
     let (semantic_validation, package_validation) = match &expanded.output {
         ExpandedOutput::Compose(document) => {
             let report = crate::commands::compose::execute_spec_with_source_and_fonts(
-                document, base_dir, output, dry_run, false, None, font_files,
+                document, base_dir, output, dry_run, false, None, font_files, roots,
             )
             .map_err(|_| sanitized_downstream("compose_rejected", "/source/document"))?;
             let validation = if dry_run {
@@ -170,7 +177,7 @@ fn execute_expanded(
             fields,
         } => {
             require_hwpx_output(output)?;
-            recheck_reference(path, base_dir)?;
+            recheck_reference(path, base_dir, roots)?;
             let output_mode = if dry_run {
                 SnapshotOutputMode::ValidateOnly
             } else {
@@ -209,7 +216,7 @@ fn execute_expanded(
                     "reference regeneration requires the strict gate",
                 )));
             }
-            recheck_reference(path, base_dir)?;
+            recheck_reference(path, base_dir, roots)?;
             let output_mode = if dry_run {
                 SnapshotOutputMode::PlanOnly
             } else {
@@ -228,7 +235,7 @@ fn execute_expanded(
                         )
                     })?;
                     crate::commands::compose::execute_spec_with_source_and_fonts(
-                        document, base_dir, staged, dry_run, false, None, font_files,
+                        document, base_dir, staged, dry_run, false, None, font_files, roots,
                     )
                     .map_err(|_| sanitized_downstream("compose_rejected", "/source/document"))
                 },
@@ -376,13 +383,15 @@ fn strict_reference_gate(input: &Path, output: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn recheck_reference(path: &Path, base_dir: &Path) -> anyhow::Result<()> {
+fn recheck_reference(path: &Path, base_dir: &Path, roots: &[PathBuf]) -> anyhow::Result<()> {
     let base = std::fs::canonicalize(base_dir).context("template base directory recheck failed")?;
     let metadata = std::fs::symlink_metadata(path).context("reference recheck failed")?;
     let canonical = std::fs::canonicalize(path).context("reference canonical recheck failed")?;
+    let outside_roots = !roots.is_empty() && !roots.iter().any(|root| canonical.starts_with(root));
     if metadata.file_type().is_symlink()
         || !metadata.file_type().is_file()
         || !canonical.starts_with(base)
+        || outside_roots
     {
         return Err(sanitized_downstream("invalid_reference", "/source/path"));
     }

--- a/crates/hwp-cli/src/document_spec.rs
+++ b/crates/hwp-cli/src/document_spec.rs
@@ -1684,7 +1684,7 @@ struct EmbeddedAsset {
 struct Compiler<'a> {
     spec: &'a DocumentSpec,
     base_dir: &'a Path,
-    /// MCP 샌드박스 허용 루트(canonicalize됨). 비어 있으면 에셋 경로를 추가 검사하지 않는다.
+    /// MCP sandbox allowed roots (canonicalized). When empty, asset paths get no extra check.
     roots: &'a [PathBuf],
     document: hwp_model::Document,
     styles: BTreeMap<String, CompiledStyle>,
@@ -2412,17 +2412,16 @@ impl<'a> Compiler<'a> {
         if let Some(existing) = self.asset_paths.get(asset) {
             return Ok(existing.clone());
         }
-        crate::asset_snapshot::check_under_roots(&self.base_dir.join(asset), self.roots).map_err(
-            |error| ComposeError::Compile {
-                path: path.to_string(),
-                message: format!("asset_snapshot_{}: {error}", error.code.as_str()),
-            },
-        )?;
-        let snapshot = crate::asset_snapshot::read_contained(self.base_dir, asset, MAX_ASSET_BYTES)
-            .map_err(|error| ComposeError::Compile {
-                path: path.to_string(),
-                message: format!("asset_snapshot_{}: {error}", error.code.as_str()),
-            })?;
+        let snapshot = crate::asset_snapshot::read_contained_with_roots(
+            self.base_dir,
+            asset,
+            MAX_ASSET_BYTES,
+            self.roots,
+        )
+        .map_err(|error| ComposeError::Compile {
+            path: path.to_string(),
+            message: format!("asset_snapshot_{}: {error}", error.code.as_str()),
+        })?;
         let data = snapshot.data;
         let (extension, _) = hwp_convert::image_kind(&data);
         if extension == "bin" {
@@ -3275,7 +3274,7 @@ sections:
             placement: ImagePlacement::Inline,
         }];
 
-        // base_dir 아래지만 허용 루트 밖인 에셋은 거부한다.
+        // An asset below base_dir but outside the allowed roots is rejected.
         let sandbox_only = vec![std::fs::canonicalize(&sandbox).unwrap()];
         let error = match compile_spec(
             &spec,
@@ -3297,7 +3296,7 @@ sections:
             error.issues()
         );
 
-        // 허용 루트 아래 에셋은 그대로 합성된다.
+        // An asset under the allowed roots composes as usual.
         let parent_root = vec![std::fs::canonicalize(&root).unwrap()];
         compile_spec(
             &spec,

--- a/crates/hwp-cli/src/document_spec.rs
+++ b/crates/hwp-cli/src/document_spec.rs
@@ -1649,9 +1649,17 @@ pub fn compile_spec(
     output: &Path,
     dry_run: bool,
     allow_visual_fallback: bool,
+    roots: &[PathBuf],
 ) -> Result<CompiledSpec, ComposeError> {
     validate_spec(spec, base_dir)?;
-    let compiler = Compiler::new(spec, base_dir, output, dry_run, allow_visual_fallback)?;
+    let compiler = Compiler::new(
+        spec,
+        base_dir,
+        output,
+        dry_run,
+        allow_visual_fallback,
+        roots,
+    )?;
     compiler.compile()
 }
 
@@ -1676,6 +1684,8 @@ struct EmbeddedAsset {
 struct Compiler<'a> {
     spec: &'a DocumentSpec,
     base_dir: &'a Path,
+    /// MCP 샌드박스 허용 루트(canonicalize됨). 비어 있으면 에셋 경로를 추가 검사하지 않는다.
+    roots: &'a [PathBuf],
     document: hwp_model::Document,
     styles: BTreeMap<String, CompiledStyle>,
     resolved_styles: BTreeMap<String, StyleSpec>,
@@ -1694,6 +1704,7 @@ impl<'a> Compiler<'a> {
         output: &Path,
         dry_run: bool,
         allow_visual_fallback: bool,
+        roots: &'a [PathBuf],
     ) -> Result<Self, ComposeError> {
         let mut document = hwp_convert::from_markdown("");
         document.sections.clear();
@@ -1709,6 +1720,7 @@ impl<'a> Compiler<'a> {
         let mut compiler = Self {
             spec,
             base_dir,
+            roots,
             document,
             styles: BTreeMap::new(),
             resolved_styles: BTreeMap::new(),
@@ -2400,6 +2412,12 @@ impl<'a> Compiler<'a> {
         if let Some(existing) = self.asset_paths.get(asset) {
             return Ok(existing.clone());
         }
+        crate::asset_snapshot::check_under_roots(&self.base_dir.join(asset), self.roots).map_err(
+            |error| ComposeError::Compile {
+                path: path.to_string(),
+                message: format!("asset_snapshot_{}: {error}", error.code.as_str()),
+            },
+        )?;
         let snapshot = crate::asset_snapshot::read_contained(self.base_dir, asset, MAX_ASSET_BYTES)
             .map_err(|error| ComposeError::Compile {
                 path: path.to_string(),
@@ -3134,8 +3152,15 @@ sections:
             format: RunFormatSpec::default(),
         }];
 
-        let compiled = compile_spec(&spec, Path::new("."), Path::new("out.hwpx"), true, false)
-            .expect("compile");
+        let compiled = compile_spec(
+            &spec,
+            Path::new("."),
+            Path::new("out.hwpx"),
+            true,
+            false,
+            &[],
+        )
+        .expect("compile");
         let paragraph = &compiled.document.sections[0].paragraphs[1];
         assert!(paragraph.chars.iter().any(|character| matches!(
             character,
@@ -3216,8 +3241,8 @@ sections:
             placement: ImagePlacement::Inline,
         }];
 
-        let compiled =
-            compile_spec(&spec, &root, &root.join("out.hwpx"), true, false).expect("compile image");
+        let compiled = compile_spec(&spec, &root, &root.join("out.hwpx"), true, false, &[])
+            .expect("compile image");
         let picture = compiled.document.sections[0].paragraphs[1]
             .controls
             .iter()
@@ -3228,6 +3253,61 @@ sections:
             .expect("picture");
         assert_eq!(picture.width.0, mm_to_hwp(20.0));
         assert_eq!(picture.height.0, mm_to_hwp(10.0));
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn sandbox_roots_bind_image_assets() {
+        let root =
+            std::env::temp_dir().join(format!("hwp-document-spec-roots-{}", std::process::id()));
+        let sandbox = root.join("sandbox");
+        std::fs::create_dir_all(&sandbox).unwrap();
+        let asset = PathBuf::from("assets/image.gif");
+        std::fs::create_dir_all(root.join("assets")).unwrap();
+        std::fs::write(root.join(&asset), b"GIF89a\x02\x00\x01\x00").unwrap();
+        let mut spec = minimal_spec();
+        spec.sections[0].blocks = vec![BlockSpec::Image {
+            path: asset,
+            width_mm: 20.0,
+            height_mm: None,
+            alt: None,
+            placement: ImagePlacement::Inline,
+        }];
+
+        // base_dir 아래지만 허용 루트 밖인 에셋은 거부한다.
+        let sandbox_only = vec![std::fs::canonicalize(&sandbox).unwrap()];
+        let error = match compile_spec(
+            &spec,
+            &root,
+            &root.join("out.hwpx"),
+            true,
+            false,
+            &sandbox_only,
+        ) {
+            Ok(_) => panic!("asset outside roots must fail"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .issues()
+                .iter()
+                .any(|issue| issue.message.contains("asset_snapshot_outside_roots")),
+            "{:?}",
+            error.issues()
+        );
+
+        // 허용 루트 아래 에셋은 그대로 합성된다.
+        let parent_root = vec![std::fs::canonicalize(&root).unwrap()];
+        compile_spec(
+            &spec,
+            &root,
+            &root.join("out.hwpx"),
+            true,
+            false,
+            &parent_root,
+        )
+        .expect("asset under roots");
 
         std::fs::remove_dir_all(root).unwrap();
     }

--- a/crates/hwp-cli/src/document_spec_v2.rs
+++ b/crates/hwp-cli/src/document_spec_v2.rs
@@ -323,7 +323,7 @@ impl TargetFormat {
 
 struct AssetStore<'a> {
     base_dir: &'a Path,
-    /// MCP 샌드박스 허용 루트(canonicalize됨). 비어 있으면 에셋 경로를 추가 검사하지 않는다.
+    /// MCP sandbox allowed roots (canonicalized). When empty, asset paths get no extra check.
     roots: &'a [PathBuf],
     by_path: BTreeMap<PathBuf, Rc<[u8]>>,
     unique_hashes: BTreeSet<[u8; 32]>,
@@ -361,21 +361,18 @@ impl<'a> AssetStore<'a> {
             }
             return Ok(Rc::clone(bytes));
         }
-        crate::asset_snapshot::check_under_roots(&self.base_dir.join(asset), self.roots).map_err(
-            |error| {
-                compile_error(
-                    issue_path,
-                    format!("asset_snapshot_{}: {error}", error.code.as_str()),
-                )
-            },
-        )?;
-        let snapshot = crate::asset_snapshot::read_contained(self.base_dir, asset, max_bytes)
-            .map_err(|error| {
-                compile_error(
-                    issue_path,
-                    format!("asset_snapshot_{}: {error}", error.code.as_str()),
-                )
-            })?;
+        let snapshot = crate::asset_snapshot::read_contained_with_roots(
+            self.base_dir,
+            asset,
+            max_bytes,
+            self.roots,
+        )
+        .map_err(|error| {
+            compile_error(
+                issue_path,
+                format!("asset_snapshot_{}: {error}", error.code.as_str()),
+            )
+        })?;
         if self.unique_hashes.insert(snapshot.sha256) {
             self.total_bytes = self.total_bytes.saturating_add(snapshot.data.len() as u64);
             if self.total_bytes > document_spec::MAX_TOTAL_ASSET_BYTES {
@@ -1353,7 +1350,7 @@ mod tests {
         }"#;
         let spec = parse_spec_v2(input, SpecInputFormat::Json).unwrap();
 
-        // base_dir 아래지만 허용 루트 밖인 에셋은 거부한다.
+        // An asset below base_dir but outside the allowed roots is rejected.
         let sandbox_only = vec![std::fs::canonicalize(&sandbox).unwrap()];
         let error = match compile_spec_v2(&spec, &root, &root.join("out.hwpx"), true, &sandbox_only)
         {
@@ -1369,7 +1366,7 @@ mod tests {
             error.issues()
         );
 
-        // 허용 루트 아래 에셋은 그대로 합성된다.
+        // An asset under the allowed roots composes as usual.
         let parent_root = vec![std::fs::canonicalize(&root).unwrap()];
         let compiled = compile_spec_v2(&spec, &root, &root.join("out.hwpx"), true, &parent_root)
             .expect("visual asset under roots");

--- a/crates/hwp-cli/src/document_spec_v2.rs
+++ b/crates/hwp-cli/src/document_spec_v2.rs
@@ -237,16 +237,17 @@ pub fn compile_spec_v2(
     base_dir: &Path,
     output: &Path,
     dry_run: bool,
+    roots: &[PathBuf],
 ) -> Result<CompiledSpecV2, ComposeError> {
     let target = TargetFormat::from_output(output)?;
     let CompiledSpec {
         mut document,
         report: base_report,
-    } = document_spec::compile_spec(&spec.document, base_dir, output, dry_run, false)?;
+    } = document_spec::compile_spec(&spec.document, base_dir, output, dry_run, false, roots)?;
     validate_v2(spec, base_dir, &document)?;
 
     let mut reports = Vec::with_capacity(spec.visuals.len());
-    let mut assets = AssetStore::new(base_dir);
+    let mut assets = AssetStore::new(base_dir, roots);
     for (index, visual) in spec.visuals.iter().enumerate() {
         let report = compile_visual(&mut document, visual, index, target, &mut assets)?;
         reports.push(report);
@@ -322,6 +323,8 @@ impl TargetFormat {
 
 struct AssetStore<'a> {
     base_dir: &'a Path,
+    /// MCP 샌드박스 허용 루트(canonicalize됨). 비어 있으면 에셋 경로를 추가 검사하지 않는다.
+    roots: &'a [PathBuf],
     by_path: BTreeMap<PathBuf, Rc<[u8]>>,
     unique_hashes: BTreeSet<[u8; 32]>,
     total_bytes: u64,
@@ -335,9 +338,10 @@ struct SvgAsset {
 }
 
 impl<'a> AssetStore<'a> {
-    fn new(base_dir: &'a Path) -> Self {
+    fn new(base_dir: &'a Path, roots: &'a [PathBuf]) -> Self {
         Self {
             base_dir,
+            roots,
             by_path: BTreeMap::new(),
             unique_hashes: BTreeSet::new(),
             total_bytes: 0,
@@ -357,6 +361,14 @@ impl<'a> AssetStore<'a> {
             }
             return Ok(Rc::clone(bytes));
         }
+        crate::asset_snapshot::check_under_roots(&self.base_dir.join(asset), self.roots).map_err(
+            |error| {
+                compile_error(
+                    issue_path,
+                    format!("asset_snapshot_{}: {error}", error.code.as_str()),
+                )
+            },
+        )?;
         let snapshot = crate::asset_snapshot::read_contained(self.base_dir, asset, max_bytes)
             .map_err(|error| {
                 compile_error(
@@ -1252,7 +1264,7 @@ mod tests {
 
         for extension in ["hwpx", "hwp"] {
             let output = root.join(format!("vector.{extension}"));
-            let compiled = compile_spec_v2(&spec, &root, &output, false).unwrap();
+            let compiled = compile_spec_v2(&spec, &root, &output, false, &[]).unwrap();
             let visual = &compiled.report.visuals[0];
             assert_eq!(
                 visual.resolved_representation,
@@ -1313,6 +1325,60 @@ mod tests {
     }
 
     #[test]
+    fn sandbox_roots_bind_visual_assets() {
+        let root = std::env::temp_dir().join(format!(
+            "hwp-v2-roots-{}-{}",
+            std::process::id(),
+            std::thread::current()
+                .name()
+                .unwrap_or("test")
+                .replace(':', "-")
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        let sandbox = root.join("sandbox");
+        std::fs::create_dir_all(&sandbox).unwrap();
+        let mut png = std::io::Cursor::new(Vec::new());
+        image::DynamicImage::ImageRgba8(image::RgbaImage::from_pixel(
+            2,
+            2,
+            image::Rgba([10, 20, 30, 255]),
+        ))
+        .write_to(&mut png, image::ImageFormat::Png)
+        .unwrap();
+        std::fs::write(root.join("asset.png"), png.into_inner()).unwrap();
+        let input = r#"{
+          "version":"2.0",
+          "document":{"version":"1.0","sections":[{"blocks":[{"type":"paragraph","runs":[{"type":"text","text":"anchor"}]}]}]},
+          "visuals":[{"id":"image","location":{"section":0,"paragraph":0},"alt":"pixel","width_mm":20,"height_mm":20,"content":{"type":"image","path":"asset.png"}}]
+        }"#;
+        let spec = parse_spec_v2(input, SpecInputFormat::Json).unwrap();
+
+        // base_dir 아래지만 허용 루트 밖인 에셋은 거부한다.
+        let sandbox_only = vec![std::fs::canonicalize(&sandbox).unwrap()];
+        let error = match compile_spec_v2(&spec, &root, &root.join("out.hwpx"), true, &sandbox_only)
+        {
+            Ok(_) => panic!("visual asset outside roots must fail"),
+            Err(error) => error,
+        };
+        assert!(
+            error
+                .issues()
+                .iter()
+                .any(|issue| issue.message.contains("asset_snapshot_outside_roots")),
+            "{:?}",
+            error.issues()
+        );
+
+        // 허용 루트 아래 에셋은 그대로 합성된다.
+        let parent_root = vec![std::fs::canonicalize(&root).unwrap()];
+        let compiled = compile_spec_v2(&spec, &root, &root.join("out.hwpx"), true, &parent_root)
+            .expect("visual asset under roots");
+        assert_eq!(compiled.report.visuals[0].kind, "image");
+
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn target_policy_is_distinct_and_fails_closed_by_default() {
         let default = VisualPolicyByTarget::default();
         assert_eq!(
@@ -1356,7 +1422,7 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(&root).unwrap();
         let output = root.join("boxes.hwpx");
-        let compiled = compile_spec_v2(&spec, &root, &output, false).unwrap();
+        let compiled = compile_spec_v2(&spec, &root, &output, false, &[]).unwrap();
         let report = serde_json::to_string(&compiled.report).unwrap();
         assert!(!report.contains("SECRET TITLE"));
         assert!(!report.contains("SECRET ALT"));
@@ -1395,7 +1461,7 @@ mod tests {
           "visuals":[{"id":"box","location":{"section":0,"paragraph":0},"policy":{"hwpx":"required_native"},"title":"\r","alt":"safe alt","width_mm":40,"height_mm":20,"content":{"type":"text_box","text":"bad\rtext"}}]
         }"#;
         let spec = parse_spec_v2(input, SpecInputFormat::Json).unwrap();
-        let error = match compile_spec_v2(&spec, Path::new("."), Path::new("out.hwpx"), true) {
+        let error = match compile_spec_v2(&spec, Path::new("."), Path::new("out.hwpx"), true, &[]) {
             Ok(_) => panic!("CR must be rejected"),
             Err(error) => error,
         };
@@ -1423,7 +1489,7 @@ mod tests {
             }}"#
         );
         let spec = parse_spec_v2(&path_input, SpecInputFormat::Json).unwrap();
-        let error = match compile_spec_v2(&spec, Path::new("."), Path::new("out.hwpx"), true) {
+        let error = match compile_spec_v2(&spec, Path::new("."), Path::new("out.hwpx"), true, &[]) {
             Ok(_) => panic!("over-byte-limit path must fail"),
             Err(error) => error,
         };
@@ -1442,7 +1508,7 @@ mod tests {
           "visuals":[{"id":"crop","location":{"section":0,"paragraph":0},"alt":"crop","width_mm":20,"height_mm":20,"content":{"type":"image","path":"missing.png","crop":{"x":0.8,"y":0.0,"width":0.3,"height":1.0}}}]
         }"#;
         let spec = parse_spec_v2(crop_input, SpecInputFormat::Json).unwrap();
-        let error = match compile_spec_v2(&spec, Path::new("."), Path::new("out.hwpx"), true) {
+        let error = match compile_spec_v2(&spec, Path::new("."), Path::new("out.hwpx"), true, &[]) {
             Ok(_) => panic!("crop sum must fail at runtime"),
             Err(error) => error,
         };
@@ -1465,7 +1531,7 @@ mod tests {
             .join("examples/document-spec-v2");
         for extension in ["hwp", "hwpx"] {
             let output = PathBuf::from(format!("contract.{extension}"));
-            let compiled = compile_spec_v2(&spec, &base_dir, &output, true)
+            let compiled = compile_spec_v2(&spec, &base_dir, &output, true, &[])
                 .expect("v2 example compiles for both targets");
             assert_eq!(compiled.report.target_format, extension);
             assert_eq!(compiled.report.visuals.len(), 1);
@@ -1493,6 +1559,7 @@ mod tests {
             &base_dir,
             Path::new("native-text-box.hwpx"),
             true,
+            &[],
         )
         .expect("native text-box example compiles for HWPX");
         assert_eq!(

--- a/crates/hwp-cli/src/i18n.rs
+++ b/crates/hwp-cli/src/i18n.rs
@@ -76,8 +76,9 @@ pub fn localize(command: Command, lang: Lang) -> Command {
     }
 }
 
-/// `path`는 서브커맨드 이름(루트는 빈 문자열)이다. 중첩 서브커맨드(`skill` 아래 `export`
-/// 등)도 단계와 무관하게 베어 이름 자체가 키다(예: `("export", …)`).
+/// `path` is the subcommand name (the root is the empty string). Nested subcommands
+/// (`export` under `skill`, etc.) are also keyed by the bare name itself, regardless
+/// of depth (e.g. `("export", …)`).
 fn translate(command: Command, path: &str) -> Command {
     let command = match lookup(path, "") {
         Some(text) => command.about(text),
@@ -576,7 +577,7 @@ pub const KO: &[(&str, &str, &str)] = &[
         "같은 버전이어도 다시 받아 교체 (손상된 설치 복구용)",
     ),
     ("update", "json", "JSON으로 출력"),
-    // skill (하위 서브커맨드 export는 베어 이름 "export"로 키잉한다)
+    // skill (the nested export subcommand is keyed by the bare name "export")
     (
         "skill",
         "",

--- a/crates/hwp-cli/src/i18n.rs
+++ b/crates/hwp-cli/src/i18n.rs
@@ -576,6 +576,27 @@ pub const KO: &[(&str, &str, &str)] = &[
         "같은 버전이어도 다시 받아 교체 (손상된 설치 복구용)",
     ),
     ("update", "json", "JSON으로 출력"),
+    // skill (하위 서브커맨드 export는 베어 이름 "export"로 키잉한다)
+    (
+        "skill",
+        "",
+        "번들된 에이전트 스킬(AI 코딩 어시스턴트용 SKILL.md) 관리",
+    ),
+    (
+        "export",
+        "",
+        "임베드된 SKILL.md를 디렉터리에 기록 (기본 ./hwp; 파일은 <DIR>/SKILL.md에 생성)",
+    ),
+    (
+        "export",
+        "output",
+        "출력 디렉터리 (--install과 동시 사용 불가)",
+    ),
+    (
+        "export",
+        "install",
+        "대신 알려진 에이전트 스킬 디렉터리에 설치",
+    ),
     // dump
     ("dump", "", "[개발자용] 레코드/패키지 구조 덤프"),
     ("dump", "file", "대상 HWP/HWPX 파일"),

--- a/crates/hwp-cli/src/i18n.rs
+++ b/crates/hwp-cli/src/i18n.rs
@@ -76,7 +76,8 @@ pub fn localize(command: Command, lang: Lang) -> Command {
     }
 }
 
-/// `path`는 서브커맨드 이름(루트는 빈 문자열)이다. 서브커맨드는 1단계뿐이라 재귀 깊이도 1이다.
+/// `path`는 서브커맨드 이름(루트는 빈 문자열)이다. 중첩 서브커맨드(`skill` 아래 `export`
+/// 등)도 단계와 무관하게 베어 이름 자체가 키다(예: `("export", …)`).
 fn translate(command: Command, path: &str) -> Command {
     let command = match lookup(path, "") {
         Some(text) => command.about(text),
@@ -551,6 +552,11 @@ pub const KO: &[(&str, &str, &str)] = &[
         "mcp",
         "font_dir",
         "렌더/diff 도구의 기본 폰트 디렉터리 (반복 가능)",
+    ),
+    (
+        "mcp",
+        "root",
+        "모든 파일 접근을 이 디렉터리 아래로 제한 (반복 가능). 기본: 제한 없음",
     ),
     // update
     (

--- a/crates/hwp-cli/src/main.rs
+++ b/crates/hwp-cli/src/main.rs
@@ -170,5 +170,10 @@ fn main() -> anyhow::Result<()> {
             report,
         } => commands::certify::run(&input, &policy, &report),
         Cmd::Corpus { manifest, report } => commands::corpus::run(&manifest, &report),
+        Cmd::Skill { cmd } => match cmd {
+            hwp_cli::cli::SkillCmd::Export { output, install } => {
+                commands::skill::run(output, install)
+            }
+        },
     }
 }

--- a/crates/hwp-cli/src/main.rs
+++ b/crates/hwp-cli/src/main.rs
@@ -4,7 +4,7 @@
 //! 생성 테스트가 명령 트리를 introspect할 수 있게 하기 위함. 여기서는 파싱과
 //! 서브커맨드 디스패치만 담당한다.
 
-// mcp.rs의 hwp_edit 도구 스키마처럼 큰 json! 리터럴은 기본 재귀 한도(128)를 넘는다.
+// Large json! literals like the hwp_edit tool schema in mcp.rs exceed the default recursion limit (128).
 #![recursion_limit = "256"]
 
 mod commands;

--- a/crates/hwp-cli/src/main.rs
+++ b/crates/hwp-cli/src/main.rs
@@ -4,6 +4,9 @@
 //! 생성 테스트가 명령 트리를 introspect할 수 있게 하기 위함. 여기서는 파싱과
 //! 서브커맨드 디스패치만 담당한다.
 
+// mcp.rs의 hwp_edit 도구 스키마처럼 큰 json! 리터럴은 기본 재귀 한도(128)를 넘는다.
+#![recursion_limit = "256"]
+
 mod commands;
 mod format;
 
@@ -99,7 +102,7 @@ fn main() -> anyhow::Result<()> {
             font_dir,
             tolerance,
         ),
-        Cmd::Mcp { font_dir } => commands::mcp::run(font_dir),
+        Cmd::Mcp { font_dir, root } => commands::mcp::run(font_dir, root),
         Cmd::Update {
             check,
             tag,

--- a/crates/hwp-cli/src/template_spec.rs
+++ b/crates/hwp-cli/src/template_spec.rs
@@ -501,6 +501,7 @@ pub fn expand_template(
     template: &TemplateSpec,
     data: &TemplateData,
     base_dir: &Path,
+    roots: &[PathBuf],
 ) -> Result<ExpandedTemplate, TemplateError> {
     let effective = validate_and_resolve(template, data)?;
     let mut expander = Expander::new(&effective);
@@ -511,7 +512,7 @@ pub fn expand_template(
             (TemplateMode::Compose, ExpandedOutput::Compose(document))
         }
         TemplateSource::ReferenceHwpx { path, bindings } => {
-            let path = resolve_reference_path(base_dir, path)?;
+            let path = resolve_reference_path(base_dir, path, roots)?;
             let (placeholders, fields) = reference_bindings(bindings, &effective, &mut expander)?;
             (
                 TemplateMode::ReferencePackagePreserving,
@@ -534,7 +535,7 @@ pub fn expand_template(
                     "reference regeneration requires strict_unsupported_objects=true",
                 ));
             }
-            let path = resolve_reference_path(base_dir, path)?;
+            let path = resolve_reference_path(base_dir, path, roots)?;
             let expanded = expander.expand_document(document)?;
             let document = deserialize_document(expanded)?;
             (
@@ -567,7 +568,11 @@ fn deserialize_document(value: Value) -> Result<DocumentSpec, TemplateError> {
     })
 }
 
-fn resolve_reference_path(base_dir: &Path, path: &Path) -> Result<PathBuf, TemplateError> {
+fn resolve_reference_path(
+    base_dir: &Path,
+    path: &Path,
+    roots: &[PathBuf],
+) -> Result<PathBuf, TemplateError> {
     use std::path::Component;
 
     if path.is_absolute()
@@ -615,6 +620,14 @@ fn resolve_reference_path(base_dir: &Path, path: &Path) -> Result<PathBuf, Templ
             "reference_escape",
             "/source/path",
             "reference package escapes the template base directory",
+        ));
+    }
+    // MCP 샌드박스 방어심층: 허용 루트가 있으면 참조 패키지가 그 아래여야 한다.
+    if !roots.is_empty() && !roots.iter().any(|root| canonical.starts_with(root)) {
+        return Err(TemplateError::single(
+            "reference_outside_roots",
+            "/source/path",
+            "reference package is outside the sandbox roots",
         ));
     }
     Ok(canonical)
@@ -2527,7 +2540,7 @@ mod tests {
     fn parse(template: &str, data: &str) -> Result<ExpandedTemplate, TemplateError> {
         let template = parse_template(template, SpecInputFormat::Json)?;
         let data = parse_data(data, SpecInputFormat::Json)?;
-        expand_template(&template, &data, Path::new("."))
+        expand_template(&template, &data, Path::new("."), &[])
     }
 
     #[test]
@@ -2760,7 +2773,7 @@ source:
         )
         .expect("yaml model");
         let data = parse_data(r#"{"version":"1.0","values":{}}"#, SpecInputFormat::Json).unwrap();
-        let error = expand_template(&template, &data, Path::new("."))
+        let error = expand_template(&template, &data, Path::new("."), &[])
             .expect_err("unused invalid declaration");
         assert!(
             error
@@ -2817,7 +2830,7 @@ source:
             SpecInputFormat::Json,
         )
         .unwrap();
-        let expanded = expand_template(&template, &data, &base).expect("reference plan");
+        let expanded = expand_template(&template, &data, &base, &[]).expect("reference plan");
         assert_eq!(expanded.plan.regions[0].id, "recipient");
 
         let escaped = parse_data(
@@ -2834,8 +2847,8 @@ source:
             SpecInputFormat::Json,
         )
         .unwrap();
-        let error =
-            expand_template(&two_targets, &escaped, &base).expect_err("replacement growth budget");
+        let error = expand_template(&two_targets, &escaped, &base, &[])
+            .expect_err("replacement growth budget");
         assert_eq!(error.issues()[0].code, "limit_exceeded");
         let _ = std::fs::remove_file(base.join("reference.hwpx"));
         let _ = std::fs::remove_dir(base);
@@ -2852,9 +2865,39 @@ source:
         )
         .unwrap();
         let data = parse_data(r#"{"version":"1.0","values":{}}"#, SpecInputFormat::Json).unwrap();
-        let error = expand_template(&template, &data, &base).expect_err("parent escape");
+        let error = expand_template(&template, &data, &base, &[]).expect_err("parent escape");
         assert_eq!(error.issues()[0].code, "invalid_reference");
         let _ = std::fs::remove_dir(base);
+    }
+
+    #[test]
+    fn sandbox_roots_bind_reference_packages() {
+        let base = std::env::temp_dir().join(format!("hwp-template-roots-{}", std::process::id()));
+        let sandbox = base.join("sandbox");
+        std::fs::create_dir_all(&sandbox).unwrap();
+        std::fs::write(base.join("reference.hwpx"), b"fixture").unwrap();
+        let template = parse_template(
+            r#"{"version":"1.0","variables":{"name":{"type":"string","required":true}},"source":{"mode":"reference_hwpx","path":"reference.hwpx","bindings":[{"region":"recipient","variable":"name","target":"field","name":"수신"}]}}"#,
+            SpecInputFormat::Json,
+        )
+        .unwrap();
+        let data = parse_data(
+            r#"{"version":"1.0","values":{"name":"홍길동"}}"#,
+            SpecInputFormat::Json,
+        )
+        .unwrap();
+
+        // base_dir 아래지만 허용 루트 밖인 참조 패키지는 거부한다.
+        let sandbox_only = vec![std::fs::canonicalize(&sandbox).unwrap()];
+        let error = expand_template(&template, &data, &base, &sandbox_only)
+            .expect_err("reference outside roots");
+        assert_eq!(error.issues()[0].code, "reference_outside_roots");
+
+        // 허용 루트 아래 참조 패키지는 그대로 확장된다.
+        let parent_root = vec![std::fs::canonicalize(&base).unwrap()];
+        expand_template(&template, &data, &base, &parent_root).expect("reference under roots");
+
+        let _ = std::fs::remove_dir_all(base);
     }
 
     #[test]
@@ -2873,6 +2916,7 @@ source:
             &template,
             &data,
             Path::new("../../../examples/template-spec-v1"),
+            &[],
         )
         .expect("checked-in example expansion");
         assert_eq!(expanded.plan.each_iterations, 2);

--- a/crates/hwp-cli/src/template_spec.rs
+++ b/crates/hwp-cli/src/template_spec.rs
@@ -622,7 +622,7 @@ fn resolve_reference_path(
             "reference package escapes the template base directory",
         ));
     }
-    // MCP 샌드박스 방어심층: 허용 루트가 있으면 참조 패키지가 그 아래여야 한다.
+    // MCP sandbox defense-in-depth: when roots are set, reference packages must sit below them.
     if !roots.is_empty() && !roots.iter().any(|root| canonical.starts_with(root)) {
         return Err(TemplateError::single(
             "reference_outside_roots",
@@ -2887,13 +2887,13 @@ source:
         )
         .unwrap();
 
-        // base_dir 아래지만 허용 루트 밖인 참조 패키지는 거부한다.
+        // A reference package below base_dir but outside the allowed roots is rejected.
         let sandbox_only = vec![std::fs::canonicalize(&sandbox).unwrap()];
         let error = expand_template(&template, &data, &base, &sandbox_only)
             .expect_err("reference outside roots");
         assert_eq!(error.issues()[0].code, "reference_outside_roots");
 
-        // 허용 루트 아래 참조 패키지는 그대로 확장된다.
+        // A reference package under the allowed roots expands as usual.
         let parent_root = vec![std::fs::canonicalize(&base).unwrap()];
         expand_template(&template, &data, &base, &parent_root).expect("reference under roots");
 

--- a/crates/hwp-cli/tests/cli_reference.rs
+++ b/crates/hwp-cli/tests/cli_reference.rs
@@ -37,9 +37,9 @@ fn cell(s: &str) -> String {
     joined.replace('|', "\\|")
 }
 
-/// GitHub 앵커: `hwp <name>` → `hwp-<name>` (이름은 단일 토큰이라 단순 치환으로 충분).
+/// GitHub 앵커: `hwp skill export` → `hwp-skill-export` (공백은 하이픈으로).
 fn anchor(name: &str) -> String {
-    format!("hwp-{name}")
+    format!("hwp-{}", name.replace(' ', "-"))
 }
 
 /// 값을 갖지 않는 액션(불리언 플래그 등)인지.
@@ -88,21 +88,24 @@ fn possible_values(arg: &Arg) -> Vec<String> {
 /// `render_usage()`를 `hwp <name> …` 형태로 정규화한다.
 /// (서브커맨드를 부모에서 꺼내면 프로그램명이 없어 `Usage: <name> …`로 나올 수 있다 —
 /// 첫 `<name>` 토큰 뒤 본문만 취해 `hwp <name> <본문>`으로 재조립한다.)
-fn usage_line(sub: &Command, name: &str) -> String {
+fn usage_line(sub: &Command, path: &str) -> String {
     let raw = sub.clone().render_usage().to_string();
     let after_label = raw
         .trim()
         .strip_prefix("Usage:")
         .map(str::trim)
         .unwrap_or_else(|| raw.trim());
-    let body = match after_label.split_once(name) {
+    // 베어이름(경로의 마지막 토큰) 뒤 본문만 취해 전체 경로로 재조립한다 —
+    // 중첩 서브커맨드(`export`)도 `hwp skill export …`로 정규화된다.
+    let bare = path.rsplit(' ').next().unwrap_or(path);
+    let body = match after_label.split_once(bare) {
         Some((_, rest)) => rest.trim_start(),
         None => "",
     };
     if body.is_empty() {
-        format!("hwp {name}")
+        format!("hwp {path}")
     } else {
-        format!("hwp {name} {body}")
+        format!("hwp {path} {body}")
     }
 }
 
@@ -183,11 +186,18 @@ fn arg_rows(sub: &Command, lang: Lang) -> Vec<String> {
 /// clap 정의에서 마크다운 레퍼런스 전문을 생성한다.
 fn generate(lang: Lang) -> String {
     let root = i18n::localize(Cli::command(), lang);
-    // 노출 대상 서브커맨드(숨김 제외), 선언 순서 유지.
-    let subs: Vec<&Command> = root
-        .get_subcommands()
-        .filter(|c| !c.is_hide_set())
-        .collect();
+    // 노출 대상 서브커맨드(숨김 제외)를 선언 순서로 평탄화 — 중첩 서브커맨드
+    // (`skill` 아래 `export`)도 전체 경로("skill export")를 단 한 항목으로 포함한다.
+    let mut subs: Vec<(String, &Command)> = Vec::new();
+    fn flatten<'a>(cmd: &'a Command, path: String, subs: &mut Vec<(String, &'a Command)>) {
+        subs.push((path.clone(), cmd));
+        for sub in cmd.get_subcommands().filter(|c| !c.is_hide_set()) {
+            flatten(sub, format!("{path} {}", sub.get_name()), subs);
+        }
+    }
+    for sub in root.get_subcommands().filter(|c| !c.is_hide_set()) {
+        flatten(sub, sub.get_name().to_string(), &mut subs);
+    }
 
     let mut out = String::new();
     match lang {
@@ -219,15 +229,13 @@ fn generate(lang: Lang) -> String {
             out.push_str("## Command index\n\n");
         }
     }
-    for sub in &subs {
-        let name = sub.get_name();
+    for (name, _) in &subs {
         out.push_str(&format!("- [`hwp {name}`](#{})\n", anchor(name)));
     }
     out.push('\n');
 
     // 명령별 섹션.
-    for sub in &subs {
-        let name = sub.get_name();
+    for (name, sub) in &subs {
         out.push_str(&format!("## `hwp {name}`\n\n"));
 
         // about / long_about (long_about 우선).
@@ -360,10 +368,16 @@ fn korean_overlay_covers_every_command_and_argument() {
 #[test]
 fn korean_overlay_has_no_stale_entries() {
     fn exists(command: &Command, path: &str, arg: &str) -> bool {
+        // 중첩 서브커맨드는 단계와 무관하게 베어 이름으로 찾는다(translate와 같은 키잉).
+        fn find<'a>(cmd: &'a Command, name: &str) -> Option<&'a Command> {
+            cmd.get_subcommands()
+                .find(|c| c.get_name() == name)
+                .or_else(|| cmd.get_subcommands().find_map(|c| find(c, name)))
+        }
         let target = if path.is_empty() {
             Some(command)
         } else {
-            command.get_subcommands().find(|c| c.get_name() == path)
+            find(command, path)
         };
         match target {
             Some(cmd) => arg.is_empty() || cmd.get_arguments().any(|a| a.get_id().as_str() == arg),

--- a/crates/hwp-cli/tests/cli_reference.rs
+++ b/crates/hwp-cli/tests/cli_reference.rs
@@ -37,7 +37,7 @@ fn cell(s: &str) -> String {
     joined.replace('|', "\\|")
 }
 
-/// GitHub 앵커: `hwp skill export` → `hwp-skill-export` (공백은 하이픈으로).
+/// GitHub anchor: `hwp skill export` → `hwp-skill-export` (spaces become hyphens).
 fn anchor(name: &str) -> String {
     format!("hwp-{}", name.replace(' ', "-"))
 }
@@ -95,8 +95,8 @@ fn usage_line(sub: &Command, path: &str) -> String {
         .strip_prefix("Usage:")
         .map(str::trim)
         .unwrap_or_else(|| raw.trim());
-    // 베어이름(경로의 마지막 토큰) 뒤 본문만 취해 전체 경로로 재조립한다 —
-    // 중첩 서브커맨드(`export`)도 `hwp skill export …`로 정규화된다.
+    // Take the body after the bare name (last path token) and reassemble it with the
+    // full path — nested subcommands (`export`) normalize to `hwp skill export …` too.
     let bare = path.rsplit(' ').next().unwrap_or(path);
     let body = match after_label.split_once(bare) {
         Some((_, rest)) => rest.trim_start(),
@@ -186,8 +186,8 @@ fn arg_rows(sub: &Command, lang: Lang) -> Vec<String> {
 /// clap 정의에서 마크다운 레퍼런스 전문을 생성한다.
 fn generate(lang: Lang) -> String {
     let root = i18n::localize(Cli::command(), lang);
-    // 노출 대상 서브커맨드(숨김 제외)를 선언 순서로 평탄화 — 중첩 서브커맨드
-    // (`skill` 아래 `export`)도 전체 경로("skill export")를 단 한 항목으로 포함한다.
+    // Flatten exposed subcommands (excluding hidden ones) in declaration order — nested
+    // subcommands (`export` under `skill`) also appear exactly once, with the full path ("skill export").
     let mut subs: Vec<(String, &Command)> = Vec::new();
     fn flatten<'a>(cmd: &'a Command, path: String, subs: &mut Vec<(String, &'a Command)>) {
         subs.push((path.clone(), cmd));
@@ -368,7 +368,7 @@ fn korean_overlay_covers_every_command_and_argument() {
 #[test]
 fn korean_overlay_has_no_stale_entries() {
     fn exists(command: &Command, path: &str, arg: &str) -> bool {
-        // 중첩 서브커맨드는 단계와 무관하게 베어 이름으로 찾는다(translate와 같은 키잉).
+        // Nested subcommands are looked up by bare name regardless of depth (same keying as translate).
         fn find<'a>(cmd: &'a Command, name: &str) -> Option<&'a Command> {
             cmd.get_subcommands()
                 .find(|c| c.get_name() == name)

--- a/crates/hwp-cli/tests/cli_surface.rs
+++ b/crates/hwp-cli/tests/cli_surface.rs
@@ -270,6 +270,7 @@ fn mcp_stdio_session() {
         "hwp_diff",
         "hwp_edit",
         "hwp_fill",
+        "hwp_grep",
         "hwp_info",
         "hwp_list_bookmarks",
         "hwp_list_fields",
@@ -283,7 +284,7 @@ fn mcp_stdio_session() {
     .iter()
     .map(|s| s.to_string())
     .collect();
-    assert_eq!(names, expect, "도구 15종");
+    assert_eq!(names, expect, "도구 16종");
 
     send(
         serde_json::json!({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -10,6 +10,7 @@
 |---|---|
 | [design/](design/) | 설계 지식 정본. 시작점은 [00-overview](design/00-overview.ko.md) |
 | [manual/cli-reference.ko.md](manual/cli-reference.ko.md) | clap 정의에서 자동 생성되는 CLI 레퍼런스(수동 편집 금지) |
+| [manual/ai-integrations.ko.md](manual/ai-integrations.ko.md) | AI 클라이언트 설정: MCP 등록, 에이전트 스킬, claude.ai 번들 |
 | [release-readiness.ko.md](release-readiness.ko.md) | 릴리스 전 게이트 체크리스트 |
 | [hancom-verification-checklist.ko.md](hancom-verification-checklist.ko.md) | 한글 실기 검증 체크리스트 |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Notes on the HWP 5.0 format specification material used when working on the pars
 |---|---|
 | [design/](design/) | The design knowledge of record. Start at [00-overview](design/00-overview.md) |
 | [manual/cli-reference.md](manual/cli-reference.md) | CLI reference generated from the clap definitions (do not edit by hand) |
+| [manual/ai-integrations.md](manual/ai-integrations.md) | AI client setup: MCP registration, the agent skill, the claude.ai bundle |
 | [release-readiness.md](release-readiness.md) | Pre-release gate checklist |
 | [hancom-verification-checklist.md](hancom-verification-checklist.md) | Checklist for verifying files in Hancom Office |
 

--- a/docs/manual/ai-integrations.ko.md
+++ b/docs/manual/ai-integrations.ko.md
@@ -1,0 +1,118 @@
+[한국어](ai-integrations.ko.md) · [English](ai-integrations.md)
+
+# AI 클라이언트 연동
+
+`hwp`는 AI 클라이언트용 연동 표면을 두 가지 제공한다:
+
+- MCP를 구사하는 클라이언트용 **MCP stdio 서버**(`hwp mcp`, 16개 도구),
+- CLI와 MCP 사용법을 에이전트에게 가르치는 **에이전트 스킬**(이 저장소의
+  `skills/hwp/SKILL.md`). 바이너리에 임베드되어 있어 `hwp skill export`로 풀어낼 수 있다.
+
+어느 표면을 쓰든 `hwp mcp --root <dir>`로 도구가 만지는 파일 경로를 지정 디렉터리 아래로
+제한하는 것을 권장하고, 에이전트가 쓴 파일은 `hwp validate`로 검증한다.
+
+## Claude Code / Claude Desktop
+
+MCP 서버를 등록한다(Claude Code: `.mcp.json` 또는 `claude mcp add`; Claude Desktop:
+`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "hwp": {
+      "command": "hwp",
+      "args": ["mcp", "--root", "/path/to/workspace"]
+    }
+  }
+}
+```
+
+도구가 접근해야 하는 디렉터리마다 `--root`를 반복한다. `--root`가 하나도 없으면 서버는
+제한 없이 동작하며 시작 시 stderr에 한 줄 경고를 출력한다.
+
+Claude Code는 에이전트 스킬을 바로 소비할 수도 있다:
+
+```sh
+hwp skill export --install claude-code   # ~/.claude/skills/hwp/SKILL.md에 기록
+```
+
+## Codex CLI
+
+`~/.codex/config.toml`에 추가한다:
+
+```toml
+[mcp_servers.hwp]
+command = "hwp"
+args = ["mcp", "--root", "/path/to/workspace"]
+```
+
+에이전트 스킬 설치:
+
+```sh
+hwp skill export --install codex         # ~/.codex/skills/hwp/SKILL.md에 기록
+```
+
+## Codex cloud
+
+Codex cloud 환경은 셋업 스크립트로 컨테이너를 만든다. 거기에 바이너리를 설치한다(Rust
+툴체인 불필요 — 사전 빌드 릴리스 아카이브를 받는다):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh | sh
+```
+
+이후 MCP 서버 등록은 위 Codex CLI와 같다.
+
+## Kiro / Kimi
+
+둘 다 표준 stdio MCP 서버 등록을 받는다 — Claude Code와 같은 형태다:
+
+```json
+{
+  "mcpServers": {
+    "hwp": {
+      "command": "hwp",
+      "args": ["mcp", "--root", "/path/to/workspace"]
+    }
+  }
+}
+```
+
+각 클라이언트의 MCP 설정에 넣는다(Kiro: `.kiro/settings/mcp.json`; Kimi: 자체 설정의 MCP 섹션).
+스킬 디렉터리 관례는 클라이언트마다 다르므로 `hwp skill export -o <dir>`로 원하는 위치에
+풀어내고 클라이언트가 그 경로를 가리키게 한다.
+
+## claude.ai (웹)
+
+claude.ai 코드 실행 샌드박스는 네트워크가 레지스트리로 제한되어 런타임에 바이너리를 받을
+수 없다. 그래서 매 릴리스에 `hwp-skill-claude-web.zip`을 함께 올린다 — `SKILL.md`(zip
+루트), `bootstrap.sh`, 그리고 Linux x86_64 `bin/hwp`를 번들로 묶은 것이다:
+
+1. [최신 릴리스](https://github.com/STAIxBWLB/hwp-cli/releases)에서
+   `hwp-skill-claude-web.zip`을 받는다.
+2. claude.ai에서 Settings → Capabilities → Skills로 가서 zip을 업로드한다.
+3. 코드 실행이 켜진 채팅에서 세션당 한 번 `bash bootstrap.sh`를 실행한다: 번들된 바이너리를
+   `~/.local/bin`에 설치하고 MCP 등록 스니펫을 출력한다. 이후 Claude는 샌드박스 안에서
+   `hwp`를 CLI로 직접 구동한다.
+
+## Amazon Quick Suite
+
+Quick Suite는 현재 로컬 MCP 표면이 없다. 먼저 문서를 변환하고 결과를 업로드한다:
+
+```sh
+hwp convert input.hwp -o output.docx   # 또는: -o output.pdf
+```
+
+원격 HTTP MCP 엔드포인트(Quick Suite가 MCP 클라이언트로 소비할 수 있는 형태)는
+[#52](https://github.com/STAIxBWLB/hwp-cli/issues/52)에서 별도 추적한다.
+
+## 업스트림 스킬 vs 다운스트림 `hwpx` 스킬
+
+이 저장소는 **범용** 스킬 [`skills/hwp/SKILL.md`](../../skills/hwp/SKILL.md)를 제공한다:
+바이너리 빠른 참조, MCP 사용법, 안전 규칙. 의도적으로 영문 단일이다(소비자는 에이전트이며,
+단일 정본 언어가 이중 유지보수를 피한다).
+
+별도 `STAIxBWLB/skills` 저장소의 한국 공문서 스킬 `skills/hwpx`는 **다운스트림**이다: 이
+범용 스킬을 감싸 워크스페이스 특화 템플릿(기안문/보고서 프리셋, 문서 관례)을 얹는다. 여기에
+합치지 않는 것도 의도적이다 — 이 저장소는 포맷/도구킷 계층으로 두고, 사이트 특화 문서
+정책은 다운스트림 계층이 담당한다.

--- a/docs/manual/ai-integrations.md
+++ b/docs/manual/ai-integrations.md
@@ -1,0 +1,120 @@
+[한국어](ai-integrations.ko.md) · [English](ai-integrations.md)
+
+# AI client integrations
+
+`hwp` ships two integration surfaces for AI clients:
+
+- an **MCP stdio server** (`hwp mcp`, 16 tools) for clients that speak the Model Context
+  Protocol, and
+- an **agent skill** (`skills/hwp/SKILL.md` in this repo) that teaches an agent the CLI and
+  MCP usage. It is embedded in the binary — `hwp skill export` materializes it.
+
+Whichever surface you use, prefer `hwp mcp --root <dir>` so every file path the tools touch
+stays under the given directories, and run `hwp validate` on any file the agent writes.
+
+## Claude Code / Claude Desktop
+
+Register the MCP server (Claude Code: `.mcp.json` or `claude mcp add`; Claude Desktop:
+`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "hwp": {
+      "command": "hwp",
+      "args": ["mcp", "--root", "/path/to/workspace"]
+    }
+  }
+}
+```
+
+Repeat `--root` for every directory the tools may touch. Without any `--root` the server is
+unrestricted and prints a one-line warning to stderr at startup.
+
+Claude Code additionally consumes the agent skill directly:
+
+```sh
+hwp skill export --install claude-code   # writes ~/.claude/skills/hwp/SKILL.md
+```
+
+## Codex CLI
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.hwp]
+command = "hwp"
+args = ["mcp", "--root", "/path/to/workspace"]
+```
+
+And install the agent skill:
+
+```sh
+hwp skill export --install codex         # writes ~/.codex/skills/hwp/SKILL.md
+```
+
+## Codex cloud
+
+Codex cloud environments build their container from a setup script. Install the binary there
+(no Rust toolchain needed — it fetches the pre-built release archive):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh | sh
+```
+
+Then register the MCP server as in Codex CLI above.
+
+## Kiro / Kimi
+
+Both accept a standard stdio MCP server registration — same shape as Claude Code:
+
+```json
+{
+  "mcpServers": {
+    "hwp": {
+      "command": "hwp",
+      "args": ["mcp", "--root", "/path/to/workspace"]
+    }
+  }
+}
+```
+
+Put it in the client's MCP config (Kiro: `.kiro/settings/mcp.json`; Kimi: the MCP section of
+its config). The skill directory conventions differ per client — export it anywhere and point
+the client at it with `hwp skill export -o <dir>`.
+
+## claude.ai (web)
+
+The claude.ai code-execution sandbox has a registry-restricted network, so the binary cannot
+be downloaded at runtime. Every release therefore attaches `hwp-skill-claude-web.zip` —
+`SKILL.md` (zip root), `bootstrap.sh`, and the Linux x86_64 `bin/hwp` bundled together:
+
+1. Download `hwp-skill-claude-web.zip` from the
+   [latest release](https://github.com/STAIxBWLB/hwp-cli/releases).
+2. In claude.ai, open Settings → Capabilities → Skills and upload the zip.
+3. In a chat with code execution, run `bash bootstrap.sh` once per session: it installs the
+   bundled binary into `~/.local/bin` and prints the MCP registration snippet. Claude then
+   drives `hwp` as a CLI inside the sandbox.
+
+## Amazon Quick Suite
+
+Quick Suite has no local MCP surface today. Convert the document first, then upload the
+result:
+
+```sh
+hwp convert input.hwp -o output.docx   # or: -o output.pdf
+```
+
+A remote HTTP MCP endpoint (which Quick Suite could consume as an MCP-aware client) is
+tracked separately in [#52](https://github.com/STAIxBWLB/hwp-cli/issues/52).
+
+## Upstream skill vs downstream `hwpx` skill
+
+This repo ships the **generic** skill at [`skills/hwp/SKILL.md`](../../skills/hwp/SKILL.md):
+binary quick reference, MCP usage, safety rules. It is English-only by design (agents consume
+it; one canonical language avoids bilingual double-maintenance).
+
+The Korean official-document (공문서) skill `skills/hwpx` in the separate `STAIxBWLB/skills`
+repository is **downstream**: it wraps this generic skill with workspace-specific templates
+(기안문/보고서 presets, document conventions). It is intentionally not merged here — this repo
+stays the format/toolkit layer, and downstream layers carry site-specific document policy.

--- a/docs/manual/cli-reference.ko.md
+++ b/docs/manual/cli-reference.ko.md
@@ -27,6 +27,8 @@
 - [`hwp corpus`](#hwp-corpus)
 - [`hwp mcp`](#hwp-mcp)
 - [`hwp update`](#hwp-update)
+- [`hwp skill`](#hwp-skill)
+- [`hwp skill export`](#hwp-skill-export)
 - [`hwp dump`](#hwp-dump)
 
 ## `hwp info`
@@ -308,6 +310,25 @@ MCP(Model Context Protocol) stdio 서버 — AI 에이전트용 도구 인터페
 | `--tag` | `<TAG>` |  | 특정 릴리스로 고정 (예: "v0.2.0" — 이전 버전으로 되돌릴 때) |
 | `--force` |  |  | 같은 버전이어도 다시 받아 교체 (손상된 설치 복구용) |
 | `--json` |  |  | JSON으로 출력 |
+
+## `hwp skill`
+
+번들된 에이전트 스킬(AI 코딩 어시스턴트용 SKILL.md) 관리
+
+**사용법:** `hwp skill <COMMAND>`
+
+_인자·플래그 없음_
+
+## `hwp skill export`
+
+임베드된 SKILL.md를 디렉터리에 기록 (기본 ./hwp; 파일은 <DIR>/SKILL.md에 생성)
+
+**사용법:** `hwp skill export [OPTIONS]`
+
+| 인자/플래그 | 값 | 기본값 | 설명 |
+|---|---|---|---|
+| `-o, --output` | `<OUTPUT>` |  | 출력 디렉터리 (--install과 동시 사용 불가) |
+| `--install` | `claude-code` \| `codex` |  | 대신 알려진 에이전트 스킬 디렉터리에 설치 |
 
 ## `hwp dump`
 

--- a/docs/manual/cli-reference.ko.md
+++ b/docs/manual/cli-reference.ko.md
@@ -294,6 +294,7 @@ MCP(Model Context Protocol) stdio 서버 — AI 에이전트용 도구 인터페
 | 인자/플래그 | 값 | 기본값 | 설명 |
 |---|---|---|---|
 | `--font-dir` | `<FONT_DIR>` |  | 렌더/diff 도구의 기본 폰트 디렉터리 (반복 가능) |
+| `--root` | `<ROOT>` |  | 모든 파일 접근을 이 디렉터리 아래로 제한 (반복 가능). 기본: 제한 없음 |
 
 ## `hwp update`
 

--- a/docs/manual/cli-reference.md
+++ b/docs/manual/cli-reference.md
@@ -294,6 +294,7 @@ MCP (Model Context Protocol) stdio server: a tool interface for AI agents
 | Argument/flag | Value | Default | Description |
 |---|---|---|---|
 | `--font-dir` | `<FONT_DIR>` |  | Default font directory for the render and diff tools (repeatable) |
+| `--root` | `<ROOT>` |  | Restrict all file access to this directory (repeatable). Default: unrestricted |
 
 ## `hwp update`
 

--- a/docs/manual/cli-reference.md
+++ b/docs/manual/cli-reference.md
@@ -27,6 +27,8 @@ This document is generated from the clap definitions of the `hwp` CLI. Do not ed
 - [`hwp corpus`](#hwp-corpus)
 - [`hwp mcp`](#hwp-mcp)
 - [`hwp update`](#hwp-update)
+- [`hwp skill`](#hwp-skill)
+- [`hwp skill export`](#hwp-skill-export)
 - [`hwp dump`](#hwp-dump)
 
 ## `hwp info`
@@ -308,6 +310,25 @@ Self-update: fetch the latest `hwp` from GitHub releases and replace the running
 | `--tag` | `<TAG>` |  | Pin a specific release (for example "v0.2.0", to roll back) |
 | `--force` |  |  | Re-download and replace even at the same version (to repair a broken install) |
 | `--json` |  |  | Print as JSON |
+
+## `hwp skill`
+
+Manage the bundled agent skill (SKILL.md for AI coding assistants)
+
+**Usage:** `hwp skill <COMMAND>`
+
+_No arguments or flags_
+
+## `hwp skill export`
+
+Write the embedded SKILL.md into a directory (default ./hwp; the file lands at <DIR>/SKILL.md)
+
+**Usage:** `hwp skill export [OPTIONS]`
+
+| Argument/flag | Value | Default | Description |
+|---|---|---|---|
+| `-o, --output` | `<OUTPUT>` |  | Output directory (mutually exclusive with --install) |
+| `--install` | `claude-code` \| `codex` |  | Install into a known agent skills directory instead |
 
 ## `hwp dump`
 

--- a/skills/hwp/SKILL.md
+++ b/skills/hwp/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: hwp
+description: Read, create, edit, convert, render and validate Hancom HWP 5.0 / HWPX documents with the hwp CLI or its MCP stdio server. Use whenever a task touches .hwp or .hwpx files — extracting text, searching, filling templates, editing content, converting to docx/pdf/html/md/json/odt/txt/csv, or rendering pages to images.
+---
+
+# hwp — HWP/HWPX document toolkit
+
+`hwp` is a single-binary toolkit for Hancom HWP documents. It reads and writes the binary
+HWP 5.0 format and the XML-based HWPX format, and exports to docx, pdf, html, markdown, json,
+odt, txt and csv. No Hancom Office installation is required.
+
+This file is English-only by design: it is consumed by agents, and one canonical language
+avoids bilingual double-maintenance.
+
+Install: `brew install staixbwlb/hwp/hwp`, or
+`curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh | sh`.
+`hwp skill export [-o DIR] [--install claude-code|codex]` materializes this skill from the binary.
+
+## Command quick reference
+
+Full flag reference: `hwp <command> --help` (generated docs: docs/manual/cli-reference.md).
+Output formats are inferred from the output extension unless `--to`/`--format` is given.
+
+- `hwp info <file> [--json]` — format, version, properties, stream list.
+- `hwp cat <file> [--format plain|markdown|json|html|csv]` — extract text. Useful flags:
+  `--preview` (PrvText only, no body parse), `--with-header-footer`, `--with-hidden`
+  (hidden comments), `--with-segments` (markdown + source coordinates as a one-line JSON
+  envelope). `--format json` exports the full IR (tables, images, formatting).
+- `hwp grep <pattern> <file> [--ignore-case]` — paragraph substring search over body, table
+  cells and text boxes. grep convention: exit code 1 when nothing matches.
+- `hwp convert <inputs...> -o <output>` — format conversion (`--to hwp|hwpx|md|json|html|pdf|
+  odt|txt|csv|docx`). `-` reads stdin / writes stdout (stdout for text formats only). Multiple
+  inputs require `--out-dir <dir>`. `--strict` fails without publishing when unpreservable
+  (opaque) data is found. PDF output delegates to the render path and needs CJK fonts:
+  `--font-dir <dir>` (repeatable; default `HWP_FONT_DIR` or `fonts/`). Markdown export flags:
+  `--media-dir`, `--with-header-footer`, `--with-hidden`, `--embed-bin` (json).
+- `hwp new -o <out.hwpx|out.hwp>` — create a document. `--from <file.md|file.json>` imports
+  markdown or a JSON IR (empty document when omitted); `--set-meta key=value` (title/author/
+  subject/keywords, repeatable); `--preset gian|report` (Korean official-document presets,
+  markdown input only); `--strict` fails when markdown import drops content.
+- `hwp edit <input> -o <output> [flags...]` — edit an existing document; images, formatting
+  and unparsed records are preserved. String flags (all repeatable): `--replace "find=>repl"`,
+  `--set-cell "t:r:c=value"` (0-based), `--set-field "name=value"`, `--set-meta "k=v"`,
+  `--create-field "anchor=>name[=value]"`, `--create-bookmark "anchor=>name"`,
+  `--create-hyperlink "anchor=>[text=>]URL"`, `--insert-image "anchor=>path[@WxH mm]"`,
+  `--seal "anchor=>path[@size mm]"`, `--set-format "find:prop=value,..."`,
+  `--set-align "find=left|right|center|justify|distribute"`. Structural flags (all
+  repeatable): `--insert-para "anchor=>text"`, `--insert-para-before`, `--delete-para "text"`,
+  `--add-row "t"` / `--add-col "t[:pos]"` / `--delete-row "t:r"` / `--delete-col "t:c"` /
+  `--merge-cells "t:r1:c1:r2:c2"` / `--split-cell "t:r:c"` / `--add-table "anchor=>[[row],...]"` /
+  `--delete-table "n|anchor"` / `--delete-image "anchor"` / `--delete-field "name"` /
+  `--delete-bookmark "name"`, paragraph shape `--set-para "find=>key:value"`
+  (line-spacing, indent, left/right/top/bottom mm) and page setup `--set-page "key:value"`
+  (width/height/margin-*/orientation). `--verify` re-reads the output; `--allow-partial`
+  relaxes the all-or-nothing rule (see Safety rules).
+- `hwp fill <template.hwpx> -o <output>` — fidelity-preserving `{{name}}` template fill
+  (package preserved). `--set "name=value"` (repeatable); `--set "name=@part.md"` splices a
+  part file (markdown + HTML table blocks) into the anchor paragraph — part-based composition
+  for large documents (`@@` escapes a literal `@`); `--data <file.json>` bulk fill
+  (`"parts": {...}` splicing, `"tables": [...]` row fill); `--json` prints the summary;
+  `--allow-partial` publishes the matched subset. List slots first with `hwp slots`.
+- `hwp compose <spec.json|yaml> -o <output>` — deterministic composition from DocumentSpec
+  v1/v2. `--dry-run` validates without writing; `--report` prints the run report as JSON.
+- `hwp template <template> --data <data> -o <output>` — typed native HWP/HWPX generation from
+  TemplateSpec/Data v1. `--dry-run` runs expansion + writer + validation without publishing;
+  `--report` prints the preservation/expansion report as JSON.
+- `hwp render <input> -o <output.png|svg|pdf>` — render pages. `--pages "1"|"1-3"|"all"`,
+  `--dpi 36..=600` (default 96), `--format png|svg|pdf`, `--font-dir <dir>` (repeatable).
+  PNG/SVG write one file per page; PDF writes a single multi-page file. Needs CJK fonts.
+- `hwp fields <file> [--json]` / `hwp bookmarks <file> [--json]` / `hwp slots <file> [--json]`
+  — list fields (name/kind/value), bookmarks (bokm), `{{name}}` template slots.
+- `hwp validate <file> [--json]` — structural validation (mimetype, required entries, XML
+  parsing); exit code 0 when valid.
+- `hwp certify <input> --policy <policy.json|yaml> --report <dir>` — certify package,
+  semantics, native render and independent import under a versioned policy; publishes the
+  report directory atomically.
+- `hwp diff <input> --ref <hancom.png> [--page N] [--dpi N] [--tolerance N] [-o diff.png]` —
+  compare a render against a Hancom reference PNG (offset, pixel difference).
+
+## MCP server
+
+`hwp mcp` speaks synchronous JSON-RPC 2.0 over stdio (line-delimited; stdout carries the
+protocol, logs go to stderr). Protocol version is negotiated at `initialize`: a client
+`protocolVersion` of `2025-06-18`, `2025-03-26` or `2024-11-05` is echoed back, anything else
+gets the latest supported version.
+
+Always start it with at least one sandbox root:
+
+```json
+{
+  "mcpServers": {
+    "hwp": {
+      "command": "hwp",
+      "args": ["mcp", "--root", "/path/to/workspace", "--font-dir", "/path/to/fonts"]
+    }
+  }
+}
+```
+
+`--root <dir>` (repeatable) restricts every file path the tools touch — inputs, outputs,
+nested image/part paths, spec `base_dir`s, per-call `font_dir`s and the certify report
+directory — to the given directories. Roots are canonicalized at startup; a missing or
+unreadable root fails fast. Without any `--root` the server is unrestricted and prints a
+one-line warning to stderr at startup — prefer `--root` whenever the client allows it.
+
+Tools (16):
+
+| Tool | Required arguments | Purpose |
+|---|---|---|
+| `hwp_info` | `path` | Format, version, properties and stream diagnostics |
+| `hwp_read` | `path` | Extract text (`format`: plain/markdown/json/html/csv; `with_header_footer`, `with_hidden`, `with_segments`); UTF-8 byte pagination |
+| `hwp_grep` | `path`, `pattern` | Paragraph substring search; `{matches, count, truncated}`; zero matches is a normal result |
+| `hwp_list_fields` | `path` | List fields |
+| `hwp_list_bookmarks` | `path` | List bookmarks (bokm) |
+| `hwp_slots` | `path` | List `{{name}}` placeholders |
+| `hwp_render` | `path` | Render pages (`format`: png/svg/pdf, `pages` range); single-page PNG returns base64, larger results write files via `output_path` |
+| `hwp_edit` | `input`, `output` | Strict atomic editing through typed JSON operations (mirrors every `hwp edit` flag, incl. `add_table`, `set_para`, `set_page`, `delete_*`) |
+| `hwp_convert` | `input`, `output` | Format conversion (`strict` defaults to true over MCP) |
+| `hwp_new` | `output` | Create a document from markdown or JSON IR plus metadata |
+| `hwp_compose` | `output`, `spec`/`spec_path` | Compose DocumentSpec v1/v2 through the same path as the CLI |
+| `hwp_template` | `output`, `template` (+`data`) | Bounded expansion of TemplateSpec/Data v1 |
+| `hwp_fill` | `input`, `output`, `values` | Fill `{{name}}` in an hwpx template (package preserved) |
+| `hwp_validate` | `path` | Structural validation, `{valid, errors, warnings}` |
+| `hwp_certify` | `input`, `policy`, `report` | Run certification and publish the report atomically |
+| `hwp_diff` | `input`, `ref` | Render one page and compare it to a reference PNG |
+
+## Safety rules (must follow)
+
+1. **Validate after every write.** After `new` / `edit` / `fill` / `compose` / `template` /
+   `convert` to hwp/hwpx (or the MCP equivalents), run `hwp validate <output>` (or
+   `hwp_validate`) and check exit code 0 before handing the file on.
+2. **Mutations are fail-closed.** Authoring commands (`new`, `edit`, `fill`) treat `DROP:`
+   warnings — content that cannot be preserved in the output — as hard failures and do not
+   publish. A failed command leaves any existing output file untouched.
+3. **Atomic publish.** Outputs are written to a private staging workspace next to the
+   destination, verified, then swapped in. There is no partial or half-written output state;
+   on failure the previous file is preserved (and restored on rollback).
+4. **All-or-nothing by default.** `edit` and `fill` fail the whole command when any requested
+   change found no target (unapplied edit / unreplaced placeholder). `--allow-partial`
+   (or the MCP `allow_partial` argument) publishes only the matched subset — use it
+   deliberately, and re-check the result.
+5. **Prefer `--root` for MCP.** Scope the server to the working directory (repeat the flag
+   for every directory the tools may legitimately touch) instead of running unrestricted.

--- a/skills/hwp/claude-web/bootstrap.sh
+++ b/skills/hwp/claude-web/bootstrap.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# hwp skill bootstrap for the claude.ai code-execution sandbox.
+#
+# The claude.ai sandbox network is registry-restricted, so this bundle ships the
+# Linux x86_64 `hwp` binary itself (bin/hwp) instead of downloading it at runtime.
+# This script installs the bundled binary into a writable location and prints the
+# MCP registration snippet.
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+dest_dir="${HWP_BIN_DIR:-$HOME/.local/bin}"
+mkdir -p "$dest_dir"
+cp "$here/bin/hwp" "$dest_dir/hwp"
+chmod +x "$dest_dir/hwp"
+
+# Smoke check — fail loudly if the bundled binary cannot run here.
+"$dest_dir/hwp" --version >/dev/null
+
+echo "installed: $dest_dir/hwp"
+cat <<EOF
+
+Register the MCP server (stdio) with:
+
+  command: $dest_dir/hwp
+  args:    ["mcp", "--root", "<allowed-dir>"]
+
+Always pass at least one --root so the file tools stay sandboxed.
+EOF


### PR DESCRIPTION
## Summary

Implements the three actionable open issues (umbrella #50's three PRs, #53, #51). #52 (remote HTTP transport) stays design-only per its own scope.

**#50 PR 1 — path sandbox + protocol hygiene**
- `hwp mcp --root <dir>` (repeatable) sandboxes every path-typed tool argument: reads, writes, nested `insert_image`/`seal`/`parts` paths, compose/template `base_dir`, per-call `font_dir`, and the certify report dir. Roots are canonicalized at startup (fail fast on missing/unreadable); write guards reject `..` and close the symlink-overwrite escape. No `--root` keeps the previous unrestricted behavior plus a one-line stderr warning.
- `initialize` negotiates the protocol version: echoes `2025-06-18`/`2025-03-26`/`2024-11-05`, otherwise replies with the latest. Capabilities stay `{"tools": {}}`.

**#53 — compose/template asset hardening**
- The roots now also bind spec-internal asset loads: DocumentSpec v1/v2 image/visual assets fail with `asset_snapshot_outside_roots`, TemplateSpec `reference_hwpx` with `reference_outside_roots`, unless the resolved file sits under a root. CLI/corpus callers pass no roots — zero behavior change outside MCP.
- Residual (out of scope, worth a follow-up issue): images referenced from markdown/HTML imported via `hwp new --from md` or fill part files (`from_markdown.rs`, `from_html.rs`) have no containment or root binding.

**#50 PR 2 — `hwp_edit` typed-operation parity**
- `add_table`, `set_para` (line_spacing_pct XOR line_spacing_pt), `set_page`, `delete_image`, `delete_table` (index XOR anchor), `delete_field`, `delete_bookmark` as structured JSON, through the same strict/atomic/re-read-verified path as the CLI. The verify canonicalizer learned the HWPX writer projections for synthesized tables and unreferenced bin streams so `add_table`/image deletion pass `--verify`.

**#50 PR 3 — read/convert/render parity + `hwp_grep` (16 tools)**
- `hwp_read`: `html`/`csv`, `with_header_footer`, `with_hidden`, `with_segments` (segments filtered to the paginated window, absolute offsets kept).
- `hwp_convert`: explicit `to`, `font_dir`, `media_dir`, header/footer/hidden options — and MCP PDF conversion now actually receives the configured font directories (bug fix).
- `hwp_render`: `format` png/svg/pdf, `pages` range (XOR with legacy `page`), `output_path` file output as the escape hatch from the 16 MiB base64 cap (single-page base64 PNG stays the default).
- New `hwp_grep`: `{matches, count, truncated}`; zero matches is a normal result.

**#51 — first-class agent skill**
- `skills/hwp/SKILL.md` (English-canonical, agent-consumed) + `hwp skill export [-o DIR] [--install claude-code|codex]` embedded via `include_str!`.
- Release packaging: `hwp-skill-claude-web.zip` (+ `.sha256`) per tag — SKILL.md, bootstrap script, bundled Linux x86_64 binary (claude.ai sandbox is registry-restricted, so bundling beats downloading).
- `docs/manual/ai-integrations.md` (+ `.ko.md`): per-client setup incl. the upstream-skill vs downstream-`skills/hwpx` boundary; linked from both READMEs and the docs index.

## Test plan

- `scripts/check.sh` (fmt + clippy -D warnings + workspace tests + structured-corpus) green locally on macOS.
- New unit/integration tests: protocol negotiation, sandbox read/write/`../`/symlink escapes (unix-gated), roots-bound spec assets (v1/v2/template), the 7 typed edits round-trip + negative validations, read segments/pagination, render pages/output_path, grep truncation, skill export byte-equality. All Windows-CI-safe (temp dirs, canonicalized comparisons, no font-dependent assertions).
- `cli_surface.rs` tool-count gate updated to 16; cli-reference regenerated; KO overlay coverage gate green.
- Not locally exercisable: the release.yml `skill-bundle` job's `gh release download/upload` steps run only on a real tag push.

Closes #50. Closes #51. Closes #53.