### PR TITLE
fix: bind markdown/HTML image references to MCP sandbox roots (#56)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: hwp-skill-claude-web.zip 조립 + 업로드
+      - name: Assemble and upload hwp-skill-claude-web.zip
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,13 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 **Fixed**
 
+- Markdown/HTML image references are now bound to the MCP `--root` sandbox (#56, the gap left
+  over from #53): `hwp_new` markdown input and `hwp_fill` part files fail closed when a
+  referenced image resolves outside every root — whether by absolute path or a `../` escape —
+  instead of following the reference and embedding the file. The check shares the
+  canonicalized startup roots with the tool-argument guards, runs before any read, and its
+  error does not leak the resolved path. CLI callers and root-less servers pass no roots and
+  keep the previous degrade-to-alt-text behavior exactly.
 - Markdown export: footnotes referenced inside an HTML-fallback table emitted their definition
   as a `<div class="hwp-footnote">` block, which the importer contract rejects — the footnote
   body was dropped in the `cat --format markdown` → `new --from` round-trip. Definitions are now

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,10 +699,12 @@ version = "0.7.1"
 dependencies = [
  "hwp-model",
  "image",
+ "libc",
  "pulldown-cmark",
  "quick-xml",
  "resvg",
  "serde_json",
+ "windows-sys",
  "zip",
 ]
 

--- a/crates/hwp-cli/src/commands/fill.rs
+++ b/crates/hwp-cli/src/commands/fill.rs
@@ -57,7 +57,7 @@ pub fn run(
         None => None,
     };
 
-    let report = execute(input, output, set, data_value.as_ref(), allow_partial)?;
+    let report = execute(input, output, set, data_value.as_ref(), allow_partial, &[])?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&report_json(&report))?);
@@ -84,6 +84,7 @@ pub fn execute(
     set: &[String],
     data_value: Option<&serde_json::Value>,
     allow_partial: bool,
+    roots: &[PathBuf],
 ) -> anyhow::Result<FillReport> {
     // 데이터에 `tables`가 (객체 항목의) 비어있지 않은 배열이면 IR 기반 표 채우기로 분기.
     // 객체-배열만 인정해, "tables"라는 이름의 평범한 자리표시자(예: 문자열 배열 값)가
@@ -130,6 +131,7 @@ pub fn execute(
             &plain_set,
             &part_paths,
             allow_partial,
+            roots,
         );
     }
 
@@ -421,6 +423,7 @@ fn fill_parts_ir(
     set: &[String],
     part_paths: &BTreeMap<String, PathBuf>,
     allow_partial: bool,
+    roots: &[PathBuf],
 ) -> anyhow::Result<FillReport> {
     let mut doc = load_document(input)?;
     let original = doc.clone();
@@ -462,13 +465,22 @@ fn fill_parts_ir(
     for (name, path) in part_paths {
         let md = std::fs::read_to_string(path)
             .with_context(|| format!("부분 파일 읽기 실패: {}", path.display()))?;
-        let part_direct = hwp_convert::from_markdown_blocks(
+        // `roots` binds image references inside the part file (MCP `--root`, #56): an
+        // outside-root reference is a hard error here, not an alt-text warning. Empty roots
+        // (CLI) keep the previous behavior.
+        let (part_direct, part_warnings) = hwp_convert::from_markdown_blocks_report(
             &md,
             &hwp_convert::MarkdownImportOptions {
                 base_dir: path.parent(),
+                roots,
                 ..Default::default()
             },
-        );
+        )
+        .map_err(|e| anyhow::anyhow!("부분 markdown 가져오기 실패 ({}): {e}", path.display()))?;
+        // Keep the previous stderr visibility (from_markdown_blocks printed import warnings).
+        for w in &part_warnings {
+            eprintln!("경고: {w}");
+        }
         // hwpx 왕복으로 writer 정규형에 맞춘다 — 템플릿은 파일에서 읽은 정규형이라,
         // 비정규 부수 필드(음영·attr1·글꼴 속성 등)가 그대로 이식되면 쓰기→재읽기
         // 의미 불변식 검증(verify_document)이 깨진다.

--- a/crates/hwp-cli/src/commands/mcp.rs
+++ b/crates/hwp-cli/src/commands/mcp.rs
@@ -595,6 +595,7 @@ fn tool_fill(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
             &set,
             None,
             arg_bool(args, "allow_partial", false)?,
+            &ctx.roots,
         )
         .map_err(|error| format!("{error:#}"))?
     } else {
@@ -1235,6 +1236,8 @@ fn tool_new(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
         (Some(markdown), None) => crate::commands::new::NewInput::Markdown {
             text: markdown,
             base_dir: None,
+            // Bind image references inside the markdown to the sandbox roots (#56).
+            roots: &ctx.roots,
         },
         (None, Some(document_json)) => crate::commands::new::NewInput::Json(document_json),
         (None, None) => crate::commands::new::NewInput::Empty,
@@ -2249,6 +2252,7 @@ mod tests {
             crate::commands::new::NewInput::Markdown {
                 text: markdown,
                 base_dir: None,
+                roots: &[],
             },
             &[],
             None,
@@ -2344,6 +2348,72 @@ mod tests {
         for path in [&template, &part, &out] {
             let _ = std::fs::remove_file(path);
         }
+    }
+
+    /// #56: image references inside `hwp_new` markdown input and `hwp_fill` part files are
+    /// bound to the `--root` sandbox — an outside-root reference fails the tool call.
+    #[test]
+    fn mcp_new_and_fill_bind_markdown_images_to_sandbox_roots() {
+        let uniq = format!(
+            "{}-{}",
+            std::process::id(),
+            std::thread::current()
+                .name()
+                .unwrap_or("test")
+                .replace(':', "-")
+        );
+        let root = std::env::temp_dir().join(format!("hwp-mcp-mdimg-root-{uniq}"));
+        let outside = std::env::temp_dir().join(format!("hwp-mcp-mdimg-outside-{uniq}"));
+        let _ = std::fs::remove_dir_all(&root);
+        let _ = std::fs::remove_dir_all(&outside);
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        // Tiny PNG (magic + IHDR with 8x8) — the file only needs to exist for the sandbox check.
+        let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+        png.extend([0, 0, 0, 13]);
+        png.extend(b"IHDR");
+        png.extend(8u32.to_be_bytes());
+        png.extend(8u32.to_be_bytes());
+        png.extend([0u8; 8]);
+        let outside_png = outside.join("out.png");
+        std::fs::write(&outside_png, &png).unwrap();
+        // Markdown link destinations treat `\` as an escape — forward slashes (Windows CI).
+        let outside_ref = outside_png.display().to_string().replace('\\', "/");
+        let sandbox = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+
+        // hwp_new: markdown referencing an absolute image outside the roots fails closed.
+        let new_out = root.join("new.hwpx");
+        let err = tool_new(
+            &json!({
+                "markdown": format!("본문\n\n![x]({outside_ref})\n"),
+                "output": new_out,
+            }),
+            &sandbox,
+        )
+        .unwrap_err();
+        assert!(err.contains("샌드박스"), "{err}");
+        assert!(!new_out.exists(), "실패 시 출력을 게시하지 않음");
+
+        // hwp_fill: a part file (itself inside the roots) referencing an outside image fails.
+        let template = root.join("template.hwpx");
+        create_hwpx(&template, "{{본문}}");
+        let part = root.join("part.md");
+        std::fs::write(&part, format!("부분\n\n![x]({outside_ref})\n")).unwrap();
+        let fill_out = root.join("fill.hwpx");
+        let err = tool_fill(
+            &json!({
+                "input": template,
+                "output": fill_out,
+                "values": {},
+                "parts": {"본문": part.display().to_string()}
+            }),
+            &sandbox,
+        )
+        .unwrap_err();
+        assert!(err.contains("샌드박스"), "{err}");
+
+        let _ = std::fs::remove_dir_all(&root);
+        let _ = std::fs::remove_dir_all(&outside);
     }
 
     #[test]

--- a/crates/hwp-cli/src/commands/new.rs
+++ b/crates/hwp-cli/src/commands/new.rs
@@ -1,6 +1,6 @@
 //! `hwp new` — 새 문서 생성 (markdown/빈 문서 → hwpx).
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use hwp_cli::cli::PresetArg;
 
@@ -8,6 +8,9 @@ pub enum NewInput<'a> {
     Markdown {
         text: &'a str,
         base_dir: Option<&'a Path>,
+        /// Sandbox roots binding image references inside the markdown (MCP `--root`, #56).
+        /// Empty = no check (CLI behavior).
+        roots: &'a [PathBuf],
     },
     Json(&'a str),
     Empty,
@@ -40,6 +43,7 @@ pub fn run(
                 NewInput::Markdown {
                     text: &owned,
                     base_dir: src.parent(),
+                    roots: &[],
                 }
             }
         }
@@ -85,11 +89,20 @@ pub fn execute(
             }
             hwp_convert::from_json(text).map_err(|e| anyhow::anyhow!("JSON IR 파싱 실패: {e}"))?
         }
-        NewInput::Markdown { text, base_dir } => {
+        NewInput::Markdown {
+            text,
+            base_dir,
+            roots,
+        } => {
             let (doc, warnings) = hwp_convert::from_markdown_report(
                 text,
-                &hwp_convert::MarkdownImportOptions { base_dir, preset },
-            );
+                &hwp_convert::MarkdownImportOptions {
+                    base_dir,
+                    roots,
+                    preset,
+                },
+            )
+            .map_err(|e| anyhow::anyhow!("markdown 가져오기 실패: {e}"))?;
             import_warnings = warnings;
             doc
         }
@@ -97,6 +110,7 @@ pub fn execute(
             "",
             &hwp_convert::MarkdownImportOptions {
                 base_dir: None,
+                roots: &[],
                 preset,
             },
         ),

--- a/crates/hwp-convert/Cargo.toml
+++ b/crates/hwp-convert/Cargo.toml
@@ -14,3 +14,10 @@ quick-xml = { workspace = true }
 resvg = { workspace = true }
 image = { workspace = true }
 zip = { workspace = true }
+libc = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61", features = [
+  "Win32_Foundation",
+  "Win32_Storage_FileSystem",
+] }

--- a/crates/hwp-convert/src/from_html.rs
+++ b/crates/hwp-convert/src/from_html.rs
@@ -830,19 +830,29 @@ impl Parser<'_> {
                     }
                 }
             };
-            // Sandbox containment (#56): an outside-root reference is a hard error that fails
+            // Sandbox containment (#56): with roots set, the check is verified against the
+            // opened file handle and the bytes are read from that same handle, so a swapped
+            // symlink cannot smuggle outside bytes in. A violation is a hard error that fails
             // the import — recorded so parse_fragment can label it FragmentError::Sandbox.
-            if let Err(message) = crate::image::check_resolved_under_roots(&resolved, self.roots) {
-                let message = format!("{message}: {src}");
-                self.sandbox_error = Some(message.clone());
-                return Err(message);
-            }
+            // The message is deliberately generic (no resolved path, no src).
+            let soft_open =
+                |e: std::io::Error| format!("이미지 읽기 실패 {}: {e}", resolved.display());
+            let mut file =
+                match crate::image::open_image_under_roots(&resolved, self.roots, soft_open) {
+                    Ok(file) => file,
+                    Err(crate::image::ImageOpenError::Soft(message)) => return Err(message),
+                    Err(crate::image::ImageOpenError::Hard(message)) => {
+                        self.sandbox_error = Some(message.clone());
+                        return Err(message);
+                    }
+                };
             if resolved
                 .extension()
                 .and_then(|ext| ext.to_str())
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("svg"))
             {
-                let text = std::fs::read_to_string(&resolved)
+                let mut text = String::new();
+                std::io::Read::read_to_string(&mut file, &mut text)
                     .map_err(|e| format!("SVG 읽기 실패 {}: {e}", resolved.display()))?;
                 let canonical = crate::svg::sanitize_svg(&text)
                     .map_err(|e| format!("SVG 검증 거부 ({}): {e}", resolved.display()))?;
@@ -877,7 +887,8 @@ impl Parser<'_> {
                 ));
                 (png, "png", w, h)
             } else {
-                let data = std::fs::read(&resolved)
+                let mut data = Vec::new();
+                std::io::Read::read_to_end(&mut file, &mut data)
                     .map_err(|e| format!("이미지 읽기 실패 {}: {e}", resolved.display()))?;
                 if data.is_empty() {
                     return Err("빈 이미지 데이터입니다".into());
@@ -1661,6 +1672,48 @@ mod tests {
         )
         .expect("루트 미설정이면 기존 동작");
         assert_eq!(doc.bin_streams.len(), 1, "루트 미설정이면 절대 경로 로드");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// #56 (handle-bound check): an in-root `<img>` symlink whose target is outside the roots
+    /// is a hard error — the verdict comes from the opened handle, not the request pathname.
+    #[cfg(unix)]
+    #[test]
+    fn 이미지_샌드박스_심링크_탈출_차단() {
+        let base = std::env::temp_dir().join(format!(
+            "from_html_img_symlink_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let root = base.join("sandbox");
+        let outside = base.join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        // Minimal PNG (magic + IHDR with 8x8).
+        let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+        png.extend([0, 0, 0, 13]);
+        png.extend(b"IHDR");
+        png.extend(8u32.to_be_bytes());
+        png.extend(8u32.to_be_bytes());
+        png.extend([0u8; 8]);
+        let secret = outside.join("secret.png");
+        std::fs::write(&secret, &png).unwrap();
+        std::os::unix::fs::symlink(&secret, root.join("escape.png")).unwrap();
+        let roots = vec![std::fs::canonicalize(&root).unwrap()];
+
+        let err = from_html_with(
+            "<p><img src=\"escape.png\"/></p>",
+            &HtmlImportOptions {
+                base_dir: Some(&root),
+                roots: &roots,
+                ..Default::default()
+            },
+        )
+        .expect_err("루트 밖을 가리키는 심링크는 하드 에러");
+        assert!(err.contains("샌드박스"), "{err}");
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/crates/hwp-convert/src/from_html.rs
+++ b/crates/hwp-convert/src/from_html.rs
@@ -35,6 +35,10 @@ pub(crate) const PALETTE_LEN: u16 = 16;
 pub struct HtmlImportOptions<'a> {
     /// Base directory for relative-path images (`<img src="fig.png">`).
     pub base_dir: Option<&'a Path>,
+    /// Sandbox roots binding image references (MCP `--root`, #56). Same contract as
+    /// `MarkdownImportOptions::roots`: empty disables the check; with roots set, an image
+    /// resolving outside every root is a hard error that fails the import.
+    pub roots: &'a [PathBuf],
     /// Seed for embedded image bin names — prevents name collisions when combining multiple
     /// fragments into one document.
     pub(crate) bin_seed: usize,
@@ -42,6 +46,22 @@ pub struct HtmlImportOptions<'a> {
     /// md-mixed path, fnref markers inside fragments are reattached to these as real
     /// footnote anchors (#47). None (standalone HTML) keeps the plain-text marker behavior.
     pub(crate) note_bodies: Option<&'a HashMap<String, Vec<Paragraph>>>,
+}
+
+/// Fragment parse failure. `Sandbox` (image reference outside the MCP `--root` sandbox, #56)
+/// must stay a hard error even where a contract violation would degrade to a warning
+/// (the from_markdown md-mixed path).
+pub(crate) enum FragmentError {
+    Contract(String),
+    Sandbox(String),
+}
+
+impl FragmentError {
+    fn into_message(self) -> String {
+        match self {
+            Self::Contract(message) | Self::Sandbox(message) => message,
+        }
+    }
 }
 
 /// Output of fragment parsing — used by both standalone document assembly (from_html) and
@@ -69,7 +89,7 @@ pub fn from_html(html: &str) -> Result<Document, String> {
 
 /// Variant that takes options. Accepts both standalone documents (`<html>`~`</html>`) and fragments.
 pub fn from_html_with(html: &str, opts: &HtmlImportOptions) -> Result<Document, String> {
-    let blocks = parse_fragment(html, opts)?;
+    let blocks = parse_fragment(html, opts).map_err(FragmentError::into_message)?;
     for w in &blocks.warnings {
         eprintln!("경고: {w}");
     }
@@ -111,7 +131,10 @@ pub fn from_html_with(html: &str, opts: &HtmlImportOptions) -> Result<Document, 
 }
 
 /// Produces the fragment parsing output (entry point of the from_markdown mixed path).
-pub(crate) fn parse_fragment(html: &str, opts: &HtmlImportOptions) -> Result<HtmlBlocks, String> {
+pub(crate) fn parse_fragment(
+    html: &str,
+    opts: &HtmlImportOptions,
+) -> Result<HtmlBlocks, FragmentError> {
     let default = from_markdown::default_header();
     let default_fonts = default.fonts[0].len();
     let mut p = Parser {
@@ -130,6 +153,8 @@ pub(crate) fn parse_fragment(html: &str, opts: &HtmlImportOptions) -> Result<Htm
         bin_streams: Vec::new(),
         bin_seed: opts.bin_seed,
         base_dir: opts.base_dir.map(Path::to_path_buf),
+        roots: opts.roots,
+        sandbox_error: None,
         note_bodies: opts.note_bodies,
         warnings: Vec::new(),
         in_cell_depth: 0,
@@ -146,7 +171,14 @@ pub(crate) fn parse_fragment(html: &str, opts: &HtmlImportOptions) -> Result<Htm
         default_fonts,
     };
     let mut reader = Reader::from_str(html);
-    p.blocks(&mut reader, None)?;
+    if let Err(e) = p.blocks(&mut reader, None) {
+        // A recorded sandbox error is the error being returned (embed_image sets it and aborts
+        // the parse immediately), so the variant switch cannot mislabel a contract violation.
+        return Err(match p.sandbox_error {
+            Some(message) => FragmentError::Sandbox(message),
+            None => FragmentError::Contract(e),
+        });
+    }
     let top = p.ctx_stack.pop().expect("최상위 컨텍스트 1개");
     Ok(HtmlBlocks {
         paragraphs: top.paragraphs,
@@ -211,6 +243,11 @@ struct Parser<'a> {
     bin_streams: Vec<BinStream>,
     bin_seed: usize,
     base_dir: Option<PathBuf>,
+    /// Sandbox roots for image containment (MCP `--root`, #56). Empty = no check.
+    roots: &'a [PathBuf],
+    /// Set when the parse aborts on a sandbox violation — parse_fragment re-labels the error
+    /// as FragmentError::Sandbox so the md-mixed path keeps it a hard error (#56).
+    sandbox_error: Option<String>,
     /// GFM footnote definition bodies for fnref marker reattachment (None on the standalone path).
     note_bodies: Option<&'a HashMap<String, Vec<Paragraph>>>,
     warnings: Vec<String>,
@@ -793,6 +830,13 @@ impl Parser<'_> {
                     }
                 }
             };
+            // Sandbox containment (#56): an outside-root reference is a hard error that fails
+            // the import — recorded so parse_fragment can label it FragmentError::Sandbox.
+            if let Err(message) = crate::image::check_resolved_under_roots(&resolved, self.roots) {
+                let message = format!("{message}: {src}");
+                self.sandbox_error = Some(message.clone());
+                return Err(message);
+            }
             if resolved
                 .extension()
                 .and_then(|ext| ext.to_str())
@@ -1537,6 +1581,88 @@ mod tests {
         .unwrap_err();
         assert!(err.contains("SVG 검증 거부"), "에러: {err}");
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// #56: `<img>` references are bound to the sandbox roots — an outside-root reference
+    /// (absolute path or `../` escape) fails the import; inside-root references embed as
+    /// usual; empty roots keeps the previous behavior (an absolute outside path still loads).
+    #[test]
+    fn 이미지_샌드박스_루트_검사() {
+        let base = std::env::temp_dir().join(format!(
+            "from_html_img_roots_{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let root = base.join("sandbox");
+        let sub = root.join("sub");
+        let outside = base.join("outside");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        // Minimal PNG (magic + IHDR with 8x8).
+        let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+        png.extend([0, 0, 0, 13]);
+        png.extend(b"IHDR");
+        png.extend(8u32.to_be_bytes());
+        png.extend(8u32.to_be_bytes());
+        png.extend([0u8; 8]);
+        std::fs::write(sub.join("in.png"), &png).unwrap();
+        let outside_png = outside.join("out.png");
+        std::fs::write(&outside_png, &png).unwrap();
+        // HTML attributes treat `\` literally, but forward slashes work everywhere (Windows CI).
+        let outside_ref = outside_png.display().to_string().replace('\\', "/");
+        // Roots are pre-canonicalized by the caller (mirrors the MCP startup).
+        let roots = vec![std::fs::canonicalize(&root).unwrap()];
+
+        // Inside the root: embeds as usual.
+        let doc = from_html_with(
+            "<p><img src=\"in.png\"/></p>",
+            &HtmlImportOptions {
+                base_dir: Some(&sub),
+                roots: &roots,
+                ..Default::default()
+            },
+        )
+        .expect("루트 안 이미지는 임베드");
+        assert_eq!(doc.bin_streams.len(), 1, "루트 안 이미지는 임베드");
+
+        // Absolute path outside the root: hard error.
+        let err = from_html_with(
+            &format!("<p><img src=\"{outside_ref}\"/></p>"),
+            &HtmlImportOptions {
+                base_dir: Some(&sub),
+                roots: &roots,
+                ..Default::default()
+            },
+        )
+        .expect_err("루트 밖 절대 경로는 하드 에러");
+        assert!(err.contains("샌드박스"), "{err}");
+
+        // `../` relative escape outside the root: hard error.
+        let err = from_html_with(
+            "<p><img src=\"../../outside/out.png\"/></p>",
+            &HtmlImportOptions {
+                base_dir: Some(&sub),
+                roots: &roots,
+                ..Default::default()
+            },
+        )
+        .expect_err("'../' 탈출은 하드 에러");
+        assert!(err.contains("샌드박스"), "{err}");
+
+        // Empty roots: previous behavior — the absolute outside path still loads.
+        let doc = from_html_with(
+            &format!("<p><img src=\"{outside_ref}\"/></p>"),
+            &HtmlImportOptions {
+                base_dir: Some(&sub),
+                ..Default::default()
+            },
+        )
+        .expect("루트 미설정이면 기존 동작");
+        assert_eq!(doc.bin_streams.len(), 1, "루트 미설정이면 절대 경로 로드");
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[test]

--- a/crates/hwp-convert/src/from_markdown.rs
+++ b/crates/hwp-convert/src/from_markdown.rs
@@ -1097,19 +1097,8 @@ impl Builder {
     /// Embeds an image reference in the current paragraph — a local file is inserted as
     /// BinStream and inline Picture (as-char, natural size) and alt is suppressed; on
     /// failure (remote/missing/unsupported) the alt text is kept after a warning.
+    /// A sandbox violation (outside `roots`, #56) is a hard import error instead.
     fn start_image(&mut self, dest_url: &str) {
-        // Sandbox check before any read (#56): with roots set, an outside-root reference is a
-        // hard import error, never an alt-text fallback. Remote URLs and base-less relative
-        // paths never touch the filesystem, so a resolution failure skips the check.
-        if !self.roots.is_empty()
-            && let Ok(resolved) = self.resolve_image_path(dest_url)
-            && let Err(e) = crate::image::check_resolved_under_roots(&resolved, &self.roots)
-        {
-            self.hard_error
-                .get_or_insert_with(|| format!("{e}: {dest_url}"));
-            self.in_image_suppress = false; // keep alt text as the fallback
-            return;
-        }
         match self.load_image(dest_url) {
             Ok((data, name, w, h)) => {
                 let idx = self.controls.len() as u32;
@@ -1136,7 +1125,12 @@ impl Builder {
                 self.bin_streams.push(BinStream { name, data });
                 self.in_image_suppress = true;
             }
-            Err(warn) => {
+            Err(crate::image::ImageOpenError::Hard(e)) => {
+                // Sandbox violation (#56) — a hard import error, never an alt-text fallback.
+                self.hard_error.get_or_insert(e);
+                self.in_image_suppress = false; // keep alt text as the fallback
+            }
+            Err(crate::image::ImageOpenError::Soft(warn)) => {
                 self.warnings.push(warn);
                 self.in_image_suppress = false; // keep alt text as the fallback
             }
@@ -1170,20 +1164,39 @@ impl Builder {
 
     /// Resolves and reads an image path. On success returns (bytes, bin name, display width, display height).
     /// Only local paths (absolute + relative to base_dir) are allowed — no network dependence on remote URLs.
-    fn load_image(&self, dest_url: &str) -> Result<(Vec<u8>, String, i32, i32), String> {
-        let resolved = self.resolve_image_path(dest_url)?;
-        let data = std::fs::read(&resolved)
-            .map_err(|e| format!("이미지 읽기 실패 {}: {e} (alt 보존)", resolved.display()))?;
+    /// With sandbox roots set, containment is verified against the opened file handle and the
+    /// bytes are read from that same handle; an outside-root reference is a `Hard` error (#56).
+    fn load_image(
+        &self,
+        dest_url: &str,
+    ) -> Result<(Vec<u8>, String, i32, i32), crate::image::ImageOpenError> {
+        use crate::image::ImageOpenError;
+        let resolved = self
+            .resolve_image_path(dest_url)
+            .map_err(ImageOpenError::Soft)?;
+        let soft =
+            |e: std::io::Error| format!("이미지 읽기 실패 {}: {e} (alt 보존)", resolved.display());
+        let mut file = crate::image::open_image_under_roots(&resolved, &self.roots, soft)?;
+        let mut data = Vec::new();
+        std::io::Read::read_to_end(&mut file, &mut data).map_err(|e| {
+            ImageOpenError::Soft(format!(
+                "이미지 읽기 실패 {}: {e} (alt 보존)",
+                resolved.display()
+            ))
+        })?;
         if data.is_empty() {
-            return Err(format!("빈 이미지 파일(alt 보존): {}", resolved.display()));
+            return Err(ImageOpenError::Soft(format!(
+                "빈 이미지 파일(alt 보존): {}",
+                resolved.display()
+            )));
         }
         // Format detection by magic bytes — unknown (.bin) is treated as unsupported (alt preserved).
         let (ext, _) = crate::image::image_kind(&data);
         if ext == "bin" {
-            return Err(format!(
+            return Err(ImageOpenError::Soft(format!(
                 "지원하지 않는 이미지 형식(alt 보존): {}",
                 resolved.display()
-            ));
+            )));
         }
         let (w, h) =
             crate::image::display_size(&data, &crate::image::ImageSize::Natural, BODY_WIDTH);
@@ -1935,6 +1948,13 @@ mod tests {
         .expect_err("HTML 블록 이미지도 하드 에러");
         assert!(err.contains("샌드박스"), "{err}");
 
+        // Missing file with roots set: still the soft alt-text fallback, not a hard error.
+        let (doc, _) =
+            from_markdown_report("![없음alt](nope.png)\n", &rooted_opts(Some(&sub), &roots))
+                .expect("없는 파일은 소프트 실패(alt 보존)");
+        assert!(doc.bin_streams.is_empty(), "임베드 없음");
+        assert!(doc.plain_text().contains("없음alt"), "alt 보존");
+
         // Empty roots: previous CLI behavior — the absolute outside path still loads.
         let (doc, _) = from_markdown_report(
             &format!("![out]({outside_ref})\n"),
@@ -1946,6 +1966,56 @@ mod tests {
         )
         .expect("루트 미설정이면 기존 동작");
         assert_eq!(doc.bin_streams.len(), 1, "루트 미설정이면 절대 경로 로드");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    /// #56 (handle-bound check): an in-root symlink whose target is outside the roots is a
+    /// hard error — the verdict comes from the opened handle, so the escape works even though
+    /// the request pathname sits inside the sandbox. An in-root symlink target still loads.
+    #[cfg(unix)]
+    #[test]
+    fn 이미지_샌드박스_심링크_탈출_차단() {
+        let base = std::env::temp_dir().join(format!(
+            "hwp-md-img-symlink-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let root = base.join("sandbox");
+        let outside = base.join("outside");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        write_png(&root, "real.png", 8, 8);
+        let secret = write_png(&outside, "secret.png", 8, 8);
+        std::os::unix::fs::symlink(&secret, root.join("escape.png")).unwrap();
+        std::os::unix::fs::symlink(root.join("real.png"), root.join("alias.png")).unwrap();
+        let roots = vec![std::fs::canonicalize(&root).unwrap()];
+
+        // The symlink itself is inside the root, but its target is not: hard error.
+        let err = from_markdown_report(
+            "![x](escape.png)\n",
+            &MarkdownImportOptions {
+                base_dir: Some(&root),
+                roots: &roots,
+                preset: None,
+            },
+        )
+        .expect_err("루트 밖을 가리키는 심링크는 하드 에러");
+        assert!(err.contains("샌드박스"), "{err}");
+
+        // Control: a symlink chain staying inside the root loads as usual.
+        let (doc, _) = from_markdown_report(
+            "![x](alias.png)\n",
+            &MarkdownImportOptions {
+                base_dir: Some(&root),
+                roots: &roots,
+                preset: None,
+            },
+        )
+        .expect("루트 안 심링크는 임베드");
+        assert_eq!(doc.bin_streams.len(), 1, "루트 안 심링크는 임베드");
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/crates/hwp-convert/src/from_markdown.rs
+++ b/crates/hwp-convert/src/from_markdown.rs
@@ -32,6 +32,11 @@ pub struct MarkdownImportOptions<'a> {
     /// Base directory for resolving relative-path images (`![](fig.png)`) (location of the md file).
     /// If `None`, relative-path images keep only the alt text after a warning (absolute paths are tried as-is).
     pub base_dir: Option<&'a Path>,
+    /// Sandbox roots binding image references (MCP `--root`, #56). Empty disables the check
+    /// (CLI behavior — zero change). Roots must be canonical (the MCP server canonicalizes
+    /// them at startup). With roots set, an image resolving outside every root is a hard
+    /// error: the report variants fail the import instead of degrading to an alt-text warning.
+    pub roots: &'a [PathBuf],
     /// Official-document preset — if set, adjusts page margins, fonts, numbering scheme, and
     /// page numbers to the regulation. `None` keeps the existing defaults (no change).
     pub preset: Option<OfficialPreset>,
@@ -387,8 +392,13 @@ pub fn from_markdown(md: &str) -> Document {
 /// Variant that takes options. If `base_dir` is set, embeds relative-path images (`![](fig.png)`).
 /// Remote URLs, missing files, and unsupported formats keep only the alt text in the body after a warning (stderr).
 pub fn from_markdown_with(md: &str, opts: &MarkdownImportOptions) -> Document {
-    let (doc, warnings) = from_markdown_report(md, opts);
+    let (doc, warnings, hard_error) = from_markdown_inner(md, opts, true);
     print_warnings(&warnings);
+    if let Some(e) = hard_error {
+        // Infallible entry point — the sandbox violation still surfaces on stderr, but the
+        // document build itself cannot fail here. Fail-closed callers use the report variants.
+        print_warnings(&[e]);
+    }
     doc
 }
 
@@ -396,8 +406,12 @@ pub fn from_markdown_with(md: &str, opts: &MarkdownImportOptions) -> Document {
 /// The block is grafted into the middle of a composed document, so injecting a section definition
 /// would split the document in two. Used by `hwp fill --set name=@part.md` (template + part filling).
 pub fn from_markdown_blocks(md: &str, opts: &MarkdownImportOptions) -> Document {
-    let (doc, warnings) = from_markdown_blocks_report(md, opts);
+    let (doc, warnings, hard_error) = from_markdown_inner(md, opts, false);
     print_warnings(&warnings);
+    if let Some(e) = hard_error {
+        // Same policy as from_markdown_with — see there.
+        print_warnings(&[e]);
+    }
     doc
 }
 
@@ -410,24 +424,41 @@ fn print_warnings(warnings: &[String]) {
 
 /// Like [`from_markdown_with`], but also returns the import warnings (image failures, HTML block
 /// contract violations, ...) instead of only printing them to stderr. Lets callers (`hwp new`,
-/// MCP `hwp_new`) surface them in their reports.
-pub fn from_markdown_report(md: &str, opts: &MarkdownImportOptions) -> (Document, Vec<String>) {
-    from_markdown_inner(md, opts, true)
+/// MCP `hwp_new`) surface them in their reports. A sandbox violation (image reference outside
+/// the `roots` option, #56) is a hard error and fails the import with `Err`.
+pub fn from_markdown_report(
+    md: &str,
+    opts: &MarkdownImportOptions,
+) -> Result<(Document, Vec<String>), String> {
+    let (doc, warnings, hard_error) = from_markdown_inner(md, opts, true);
+    match hard_error {
+        Some(e) => Err(e),
+        None => Ok((doc, warnings)),
+    }
 }
 
-/// [`from_markdown_blocks`] variant that also returns the import warnings.
+/// [`from_markdown_blocks`] variant that also returns the import warnings. A sandbox violation
+/// (image reference outside the `roots` option, #56) is a hard error (`Err`).
 pub fn from_markdown_blocks_report(
     md: &str,
     opts: &MarkdownImportOptions,
-) -> (Document, Vec<String>) {
-    from_markdown_inner(md, opts, false)
+) -> Result<(Document, Vec<String>), String> {
+    let (doc, warnings, hard_error) = from_markdown_inner(md, opts, false);
+    match hard_error {
+        Some(e) => Err(e),
+        None => Ok((doc, warnings)),
+    }
 }
 
+/// Returns the document and the import warnings, plus the first sandbox violation if any.
+/// The build never aborts mid-way: a rejected image is dropped like a soft failure and the
+/// violation is reported through the third tuple element, so the infallible entry points can
+/// still return a document (only reachable with a non-empty `roots` option).
 fn from_markdown_inner(
     md: &str,
     opts: &MarkdownImportOptions,
     inject: bool,
-) -> (Document, Vec<String>) {
+) -> (Document, Vec<String>, Option<String>) {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_TABLES);
     // Parses strikethrough (`~~`) and footnotes (`[^N]`). Task lists (TASKLISTS) are excluded — no corresponding IR meaning.
@@ -443,6 +474,7 @@ fn from_markdown_inner(
     let mut b = Builder {
         note_bodies,
         base_dir: opts.base_dir.map(Path::to_path_buf),
+        roots: opts.roots.to_vec(),
         ..Builder::default()
     };
     for event in &events {
@@ -492,6 +524,7 @@ fn from_markdown_inner(
             hwp5_doc_history: Vec::new(),
         },
         b.warnings,
+        b.hard_error,
     )
 }
 
@@ -642,6 +675,11 @@ struct Builder {
     skip_note_def: u32,
     // images: relative-path base directory + embedded binaries + warnings + alt suppression state.
     base_dir: Option<PathBuf>,
+    /// Sandbox roots for image containment (MCP `--root`, #56). Empty = no check.
+    roots: Vec<PathBuf>,
+    /// First sandbox violation (image reference outside `roots`) — a hard import error that
+    /// fails the report variants, never degraded to an alt-text warning (#56).
+    hard_error: Option<String>,
     bin_streams: Vec<BinStream>,
     warnings: Vec<String>,
     // HTML blocks (tables/images — contract docs/design/18): buffer of consecutive Html events +
@@ -925,6 +963,7 @@ impl Builder {
     /// Parses the block HTML collected in the buffer and merges it into paragraphs (contract
     /// docs/design/18). A parse failure (contract violation) is left as a warning without aborting
     /// document generation — the existing policy of letting markdown conversion itself succeed (same as image failure warnings).
+    /// A sandbox violation (image reference outside `roots`, #56) is the exception: it stays a hard error.
     fn flush_html(&mut self) {
         let html = std::mem::take(&mut self.html_buf);
         if html.trim().is_empty() {
@@ -933,6 +972,7 @@ impl Builder {
         self.flush_paragraph();
         let opts = crate::from_html::HtmlImportOptions {
             base_dir: self.base_dir.as_deref(),
+            roots: &self.roots,
             bin_seed: self.bin_streams.len(),
             // fnref markers inside the fragment reattach to the pre-collected GFM bodies (#47).
             note_bodies: Some(&self.note_bodies),
@@ -940,7 +980,10 @@ impl Builder {
         let parsed = crate::from_html::parse_fragment(&html, &opts);
         match parsed {
             Ok(blocks) => self.merge_html_blocks(blocks),
-            Err(e) => self
+            Err(crate::from_html::FragmentError::Sandbox(e)) => {
+                self.hard_error.get_or_insert(e);
+            }
+            Err(crate::from_html::FragmentError::Contract(e)) => self
                 .warnings
                 .push(format!("HTML 블록을 무시합니다(계약 위반): {e}")),
         }
@@ -1055,6 +1098,18 @@ impl Builder {
     /// BinStream and inline Picture (as-char, natural size) and alt is suppressed; on
     /// failure (remote/missing/unsupported) the alt text is kept after a warning.
     fn start_image(&mut self, dest_url: &str) {
+        // Sandbox check before any read (#56): with roots set, an outside-root reference is a
+        // hard import error, never an alt-text fallback. Remote URLs and base-less relative
+        // paths never touch the filesystem, so a resolution failure skips the check.
+        if !self.roots.is_empty()
+            && let Ok(resolved) = self.resolve_image_path(dest_url)
+            && let Err(e) = crate::image::check_resolved_under_roots(&resolved, &self.roots)
+        {
+            self.hard_error
+                .get_or_insert_with(|| format!("{e}: {dest_url}"));
+            self.in_image_suppress = false; // keep alt text as the fallback
+            return;
+        }
         match self.load_image(dest_url) {
             Ok((data, name, w, h)) => {
                 let idx = self.controls.len() as u32;
@@ -1088,9 +1143,10 @@ impl Builder {
         }
     }
 
-    /// Resolves and reads an image path. On success returns (bytes, bin name, display width, display height).
-    /// Only local paths (absolute + relative to base_dir) are allowed — no network dependence on remote URLs.
-    fn load_image(&self, dest_url: &str) -> Result<(Vec<u8>, String, i32, i32), String> {
+    /// Resolves an image reference to a local path: the `file://` prefix is stripped, absolute
+    /// paths are taken as-is, and relative paths are joined onto `base_dir`. Remote URLs and
+    /// base-less relative paths are soft rejections (alt text kept after a warning).
+    fn resolve_image_path(&self, dest_url: &str) -> Result<PathBuf, String> {
         let lower = dest_url.to_ascii_lowercase();
         if lower.starts_with("http://") || lower.starts_with("https://") {
             return Err(format!(
@@ -1100,18 +1156,22 @@ impl Builder {
         // Strip the file: scheme prefix and treat it as a local path.
         let raw = dest_url.strip_prefix("file://").unwrap_or(dest_url);
         let path = Path::new(raw);
-        let resolved: PathBuf = if path.is_absolute() {
-            path.to_path_buf()
+        if path.is_absolute() {
+            Ok(path.to_path_buf())
         } else {
             match &self.base_dir {
-                Some(dir) => dir.join(path),
-                None => {
-                    return Err(format!(
-                        "상대 경로 이미지의 기준 디렉터리를 알 수 없습니다(alt 보존): {dest_url}"
-                    ));
-                }
+                Some(dir) => Ok(dir.join(path)),
+                None => Err(format!(
+                    "상대 경로 이미지의 기준 디렉터리를 알 수 없습니다(alt 보존): {dest_url}"
+                )),
             }
-        };
+        }
+    }
+
+    /// Resolves and reads an image path. On success returns (bytes, bin name, display width, display height).
+    /// Only local paths (absolute + relative to base_dir) are allowed — no network dependence on remote URLs.
+    fn load_image(&self, dest_url: &str) -> Result<(Vec<u8>, String, i32, i32), String> {
+        let resolved = self.resolve_image_path(dest_url)?;
         let data = std::fs::read(&resolved)
             .map_err(|e| format!("이미지 읽기 실패 {}: {e} (alt 보존)", resolved.display()))?;
         if data.is_empty() {
@@ -1733,6 +1793,7 @@ mod tests {
             &MarkdownImportOptions {
                 base_dir: Some(&dir),
                 preset: None,
+                ..Default::default()
             },
         );
         assert_eq!(doc.bin_streams.len(), 1, "BinStream 1개 임베드");
@@ -1764,6 +1825,7 @@ mod tests {
             &MarkdownImportOptions {
                 base_dir: Some(&dir),
                 preset: None,
+                ..Default::default()
             },
         );
         assert!(d1.bin_streams.is_empty(), "임베드 없음");
@@ -1790,6 +1852,7 @@ mod tests {
             &MarkdownImportOptions {
                 base_dir: Some(&dir),
                 preset: None,
+                ..Default::default()
             },
         );
         let media = dir.join("out_media");
@@ -1806,6 +1869,85 @@ mod tests {
         let extracted = std::fs::read(media.join("image1.png")).expect("추출 이미지");
         assert_eq!(extracted, orig, "추출 이미지 바이트 == 원본(무손실)");
         let _ = std::fs::remove_dir_all(&media);
+    }
+
+    /// #56: with sandbox roots set, an image reference resolving outside every root (absolute
+    /// path or `../` escape) is a hard import error; inside-root references embed as usual;
+    /// empty roots keeps the CLI behavior (an absolute outside path still loads).
+    #[test]
+    fn 이미지_샌드박스_루트_검사() {
+        let base = std::env::temp_dir().join(format!(
+            "hwp-md-img-roots-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        let root = base.join("sandbox");
+        let sub = root.join("sub");
+        let outside = base.join("outside");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::create_dir_all(&outside).unwrap();
+        write_png(&sub, "in.png", 8, 8);
+        let outside_png = write_png(&outside, "out.png", 8, 8);
+        // Markdown link destinations treat `\` as an escape — use forward slashes (Windows CI).
+        let outside_ref = outside_png.display().to_string().replace('\\', "/");
+        // Roots are pre-canonicalized by the caller (mirrors the MCP startup).
+        let roots = vec![std::fs::canonicalize(&root).unwrap()];
+        // A fn (not a closure) so the two reference lifetimes unify by name.
+        fn rooted_opts<'a>(
+            base_dir: Option<&'a std::path::Path>,
+            roots: &'a [PathBuf],
+        ) -> MarkdownImportOptions<'a> {
+            MarkdownImportOptions {
+                base_dir,
+                roots,
+                preset: None,
+            }
+        }
+
+        // Inside the root: embeds as usual.
+        let (doc, _) = from_markdown_report("![in](in.png)\n", &rooted_opts(Some(&sub), &roots))
+            .expect("루트 안 이미지는 임베드");
+        assert_eq!(doc.bin_streams.len(), 1, "루트 안 이미지는 임베드");
+
+        // Absolute path outside the root: hard error (not an alt-text warning).
+        let err = from_markdown_report(
+            &format!("![out]({outside_ref})\n"),
+            &rooted_opts(Some(&sub), &roots),
+        )
+        .expect_err("루트 밖 절대 경로는 하드 에러");
+        assert!(err.contains("샌드박스"), "{err}");
+
+        // `../` relative escape outside the root: hard error.
+        let err = from_markdown_report(
+            "![esc](../../outside/out.png)\n",
+            &rooted_opts(Some(&sub), &roots),
+        )
+        .expect_err("'../' 탈출은 하드 에러");
+        assert!(err.contains("샌드박스"), "{err}");
+
+        // Same through an HTML block inside markdown (the flush_html path).
+        let err = from_markdown_report(
+            &format!("<p><img src=\"{outside_ref}\"/></p>\n"),
+            &rooted_opts(Some(&sub), &roots),
+        )
+        .expect_err("HTML 블록 이미지도 하드 에러");
+        assert!(err.contains("샌드박스"), "{err}");
+
+        // Empty roots: previous CLI behavior — the absolute outside path still loads.
+        let (doc, _) = from_markdown_report(
+            &format!("![out]({outside_ref})\n"),
+            &MarkdownImportOptions {
+                base_dir: Some(&sub),
+                preset: None,
+                ..Default::default()
+            },
+        )
+        .expect("루트 미설정이면 기존 동작");
+        assert_eq!(doc.bin_streams.len(), 1, "루트 미설정이면 절대 경로 로드");
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// GI-4: inline code `code` → HCR Dotum (face_id=1) + light-gray shading char-shape run.
@@ -2008,6 +2150,7 @@ mod tests {
         let opts = |p| MarkdownImportOptions {
             base_dir: None,
             preset: p,
+            ..Default::default()
         };
         let page_of = |doc: &Document| {
             doc.sections[0].paragraphs[0]

--- a/crates/hwp-convert/src/image.rs
+++ b/crates/hwp-convert/src/image.rs
@@ -4,7 +4,7 @@
 //! (hwpx→hwp와 동일한 검증된 경로), 여기서는 최소 Picture + BinStream + 앵커 ExtCtrl만
 //! 만든다. bin_ref=ItemRef(name)로 hwpx 출력·hwp5 합성·렌더가 모두 바이트를 해석한다.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use hwp_model::{BinRef, BinStream, Control, Document, HwpChar, HwpUnit, Paragraph, Picture};
 
@@ -126,6 +126,26 @@ pub(crate) fn display_size(data: &[u8], size: &ImageSize, max_w: i32) -> (i32, i
                 (w as i32, h as i32)
             }
         }
+    }
+}
+
+/// Sandbox containment check for an image path resolved from a markdown/HTML reference (#56).
+/// No-op when `roots` is empty (CLI, or an MCP server without `--root`). Roots are expected
+/// canonical already (the MCP server canonicalizes them at startup). A path that fails to
+/// canonicalize (missing file, ...) passes here and is handled by the caller's ordinary
+/// unreadable-file path instead, so missing-file semantics stay unchanged.
+pub(crate) fn check_resolved_under_roots(resolved: &Path, roots: &[PathBuf]) -> Result<(), String> {
+    if roots.is_empty() {
+        return Ok(());
+    }
+    let Ok(canonical) = std::fs::canonicalize(resolved) else {
+        return Ok(());
+    };
+    if roots.iter().any(|root| canonical.starts_with(root)) {
+        Ok(())
+    } else {
+        // Deliberately generic: a sandbox error must not leak the resolved filesystem layout.
+        Err("이미지 경로가 샌드박스 루트(--root) 밖에 있어 거부합니다".to_string())
     }
 }
 

--- a/crates/hwp-convert/src/image.rs
+++ b/crates/hwp-convert/src/image.rs
@@ -129,23 +129,160 @@ pub(crate) fn display_size(data: &[u8], size: &ImageSize, max_w: i32) -> (i32, i
     }
 }
 
-/// Sandbox containment check for an image path resolved from a markdown/HTML reference (#56).
-/// No-op when `roots` is empty (CLI, or an MCP server without `--root`). Roots are expected
-/// canonical already (the MCP server canonicalizes them at startup). A path that fails to
-/// canonicalize (missing file, ...) passes here and is handled by the caller's ordinary
-/// unreadable-file path instead, so missing-file semantics stay unchanged.
-pub(crate) fn check_resolved_under_roots(resolved: &Path, roots: &[PathBuf]) -> Result<(), String> {
+/// Why an image reference could not be loaded (#56). `Soft` keeps the ordinary
+/// degrade-to-alt-text (markdown) / contract-error (HTML) behavior; `Hard` is a sandbox
+/// violation and must abort the import — it is never degraded to a warning.
+pub(crate) enum ImageOpenError {
+    /// Ordinary failure (resolution, missing file, permissions, dangling symlink, ...) —
+    /// the caller's usual soft warning, so missing-file semantics stay unchanged.
+    Soft(String),
+    /// Sandbox violation — a deliberately generic message (no resolved path, no reference
+    /// string): a sandbox error must not leak the filesystem layout.
+    Hard(String),
+}
+
+/// Generic sandbox-violation message for image references (#56).
+fn sandbox_error() -> String {
+    "이미지 경로가 샌드박스 루트(--root) 밖에 있어 거부합니다".to_string()
+}
+
+/// Opens an image file referenced from markdown/HTML, binding it to the sandbox roots (#56).
+/// The caller must read from the returned handle: with roots non-empty, containment is judged
+/// from the opened handle (never the request pathname), so a symlink swapped between check and
+/// read cannot smuggle outside bytes in — a symlink to an outside target opens the target, and
+/// the handle-derived path is the target's path, which fails closed. Roots are expected
+/// canonical already (the MCP server canonicalizes them at startup). Empty roots skip the
+/// check entirely (CLI behavior — zero change). Ordinary open failures are mapped through
+/// `soft` so each caller keeps its existing warning message.
+pub(crate) fn open_image_under_roots(
+    resolved: &Path,
+    roots: &[PathBuf],
+    soft: impl FnOnce(std::io::Error) -> String,
+) -> Result<std::fs::File, ImageOpenError> {
+    let file = std::fs::File::open(resolved).map_err(|e| ImageOpenError::Soft(soft(e)))?;
     if roots.is_empty() {
-        return Ok(());
+        return Ok(file);
     }
-    let Ok(canonical) = std::fs::canonicalize(resolved) else {
-        return Ok(());
+    // Judge the roots against the opened handle, not the request pathname (same policy as
+    // hwp-cli's asset_snapshot): resolving the path from the descriptor keeps the check bound
+    // to the file that was actually opened even when a path component was renamed or a symlink
+    // was swapped between the open and this point.
+    #[cfg(any(unix, windows))]
+    check_opened_under_roots(&file, roots)?;
+    // Pathname-based fallback for targets without a handle-to-path mechanism — the open there
+    // is pathname-based already, so the roots check is too.
+    #[cfg(not(any(unix, windows)))]
+    check_resolved_under_roots(resolved, roots)?;
+    Ok(file)
+}
+
+/// Containment from the opened handle: the handle-derived path (canonicalized to wash out
+/// residual symlink components) must sit under at least one root. With roots set there is no
+/// fail-open path — any resolution failure is a hard error (#56).
+#[cfg(any(unix, windows))]
+fn check_opened_under_roots(file: &std::fs::File, roots: &[PathBuf]) -> Result<(), ImageOpenError> {
+    let canonical = std::fs::canonicalize(
+        opened_handle_path(file).map_err(|_| ImageOpenError::Hard(sandbox_error()))?,
+    )
+    .map_err(|_| ImageOpenError::Hard(sandbox_error()))?;
+    #[cfg(unix)]
+    let contained = roots.iter().any(|root| canonical.starts_with(root));
+    #[cfg(windows)]
+    let contained = roots
+        .iter()
+        .any(|root| windows_path_is_within(&canonical, root));
+    if contained {
+        Ok(())
+    } else {
+        Err(ImageOpenError::Hard(sandbox_error()))
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn opened_handle_path(file: &std::fs::File) -> Result<PathBuf, ImageOpenError> {
+    use std::os::fd::AsRawFd as _;
+    std::fs::read_link(format!("/proc/self/fd/{}", file.as_raw_fd()))
+        .map_err(|_| ImageOpenError::Hard(sandbox_error()))
+}
+
+#[cfg(target_os = "macos")]
+fn opened_handle_path(file: &std::fs::File) -> Result<PathBuf, ImageOpenError> {
+    use std::os::fd::AsRawFd as _;
+    use std::os::unix::ffi::OsStrExt as _;
+
+    let mut buffer = vec![0 as libc::c_char; libc::MAXPATHLEN as usize];
+    // Safety: the caller holds `file` open, so the descriptor is valid, and the
+    // buffer is MAXPATHLEN writable bytes as F_GETPATH requires; on success the
+    // kernel writes a NUL-terminated path into it.
+    let result = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETPATH, buffer.as_mut_ptr()) };
+    if result == -1 {
+        return Err(ImageOpenError::Hard(sandbox_error()));
+    }
+    let path = unsafe { std::ffi::CStr::from_ptr(buffer.as_ptr()) };
+    Ok(PathBuf::from(std::ffi::OsStr::from_bytes(path.to_bytes())))
+}
+
+#[cfg(all(unix, not(any(target_os = "linux", target_os = "macos"))))]
+fn opened_handle_path(_file: &std::fs::File) -> Result<PathBuf, ImageOpenError> {
+    // No portable handle-to-path mechanism on this target: fail closed (this
+    // is only reached with a non-empty roots list).
+    Err(ImageOpenError::Hard(sandbox_error()))
+}
+
+#[cfg(windows)]
+fn opened_handle_path(file: &std::fs::File) -> Result<PathBuf, ImageOpenError> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::OsStringExt as _;
+    use std::os::windows::io::AsRawHandle as _;
+    use windows_sys::Win32::Storage::FileSystem::{GetFinalPathNameByHandleW, VOLUME_NAME_DOS};
+
+    let mut buffer = vec![0_u16; 32_768];
+    let length = unsafe {
+        GetFinalPathNameByHandleW(
+            file.as_raw_handle(),
+            buffer.as_mut_ptr(),
+            buffer.len() as u32,
+            VOLUME_NAME_DOS,
+        )
     };
+    if length == 0 || length as usize >= buffer.len() {
+        return Err(ImageOpenError::Hard(sandbox_error()));
+    }
+    Ok(PathBuf::from(OsString::from_wide(
+        &buffer[..length as usize],
+    )))
+}
+
+/// Case-insensitive, prefix-normalized containment for Windows handle paths (`\\?\`-style).
+#[cfg(windows)]
+fn windows_path_is_within(candidate: &Path, base: &Path) -> bool {
+    fn normalized(path: &Path) -> String {
+        let value = path.as_os_str().to_string_lossy();
+        let value = value.strip_prefix(r"\\?\UNC\").map_or_else(
+            || value.strip_prefix(r"\\?\").unwrap_or(&value).to_string(),
+            |suffix| format!(r"\\{suffix}"),
+        );
+        value.trim_end_matches(['\\', '/']).to_lowercase()
+    }
+
+    let candidate = normalized(candidate);
+    let base = normalized(base);
+    candidate == base
+        || candidate
+            .strip_prefix(&base)
+            .is_some_and(|suffix| suffix.starts_with(['\\', '/']))
+}
+
+/// Pathname-based fallback for targets without a handle-to-path mechanism. The file is
+/// already open at this point, so a canonicalize failure fails closed (#56).
+#[cfg(not(any(unix, windows)))]
+fn check_resolved_under_roots(resolved: &Path, roots: &[PathBuf]) -> Result<(), ImageOpenError> {
+    let canonical =
+        std::fs::canonicalize(resolved).map_err(|_| ImageOpenError::Hard(sandbox_error()))?;
     if roots.iter().any(|root| canonical.starts_with(root)) {
         Ok(())
     } else {
-        // Deliberately generic: a sandbox error must not leak the resolved filesystem layout.
-        Err("이미지 경로가 샌드박스 루트(--root) 밖에 있어 거부합니다".to_string())
+        Err(ImageOpenError::Hard(sandbox_error()))
     }
 }
 

--- a/crates/hwp-convert/src/markdown.rs
+++ b/crates/hwp-convert/src/markdown.rs
@@ -2010,7 +2010,8 @@ mod tests {
         let (back, warnings) = crate::from_markdown::from_markdown_report(
             &md,
             &crate::from_markdown::MarkdownImportOptions::default(),
-        );
+        )
+        .unwrap();
         assert!(
             !warnings.iter().any(|w| w.contains("계약 위반")),
             "계약 위반 경고가 없어야 함: {warnings:?}"
@@ -2072,7 +2073,8 @@ mod tests {
         let (back, warnings) = crate::from_markdown::from_markdown_report(
             &md,
             &crate::from_markdown::MarkdownImportOptions::default(),
-        );
+        )
+        .unwrap();
         assert!(
             !warnings.iter().any(|w| w.contains("계약 위반")),
             "계약 위반 경고가 없어야 함: {warnings:?}"

--- a/crates/hwp-render/tests/render.rs
+++ b/crates/hwp-render/tests/render.rs
@@ -803,6 +803,7 @@ fn 쪽번호_시작_재시작_숨김() {
         &hwp_convert::MarkdownImportOptions {
             base_dir: None,
             preset: Some(hwp_convert::OfficialPreset::Gian),
+            ..Default::default()
         },
     );
     doc.header.properties.start_numbers[0] = 3;

--- a/crates/hwp5/tests/synth.rs
+++ b/crates/hwp5/tests/synth.rs
@@ -306,6 +306,7 @@ fn md_이미지_코드_hwp5_왕복() {
         &hwp_convert::MarkdownImportOptions {
             base_dir: Some(&dir),
             preset: None,
+            ..Default::default()
         },
     );
     for paragraph in &mut doc.sections[0].paragraphs {

--- a/crates/hwpx/tests/write.rs
+++ b/crates/hwpx/tests/write.rs
@@ -178,6 +178,7 @@ fn md_이미지_코드_hwpx_왕복() {
         &hwp_convert::MarkdownImportOptions {
             base_dir: Some(&dir),
             preset: None,
+            ..Default::default()
         },
     );
     let out = tmp("md_imgcode.hwpx");
@@ -235,6 +236,7 @@ fn 부유_그림_배치_hwpx_방출() {
         &hwp_convert::MarkdownImportOptions {
             base_dir: Some(&dir),
             preset: None,
+            ..Default::default()
         },
     );
     // 그림을 부유(글 앞) + 오프셋·z-order로 바꾼다(hwp5 read가 승계했을 값을 모사).


### PR DESCRIPTION
## Summary

Follow-up to #53 (the residual called out in #55). Images referenced **inside markdown/HTML text** imported via `hwp new --from md`, MCP `hwp_new` markdown input, or `hwp fill`/`hwp_fill` part files were loaded with no containment: absolute paths taken as-is, relative paths traversable with `../`. The `hwp_edit` `insert_image`/`seal` paths were already guarded at the MCP handler boundary in #55; this closes the remaining gap.

- `MarkdownImportOptions`/`HtmlImportOptions` gain `roots` (empty = no check → zero CLI behavior change; CLI callers pass none).
- With roots set, an image resolving outside every root is a **hard error** that fails the import (fail closed) — deliberately not the alt-text degradation used for ordinary unreadable files, and the error does not leak the resolved path.
- MCP `tool_new` (markdown input) and `tool_fill` (part files) pass the configured roots; checks run before any read in both the markdown and HTML-fragment loaders.
- Also rides along: English step name for the release.yml skill-bundle job (leftover from #55 review handling).

## Test plan

- `cargo test --workspace` green locally (fmt/clippy clean).
- New unit tests in hwp-convert: markdown + HTML image under roots loads; outside-root absolute and `../` references fail closed; empty roots preserves old CLI behavior.
- MCP-level test: `hwp_new` with an outside-root markdown image and `hwp_fill` with an outside-root part-file image both fail. Windows-CI-safe (temp dirs, canonicalized comparisons, no font assertions).

Closes #56.