### PR TITLE
ci(release): open a PR for the Homebrew formula update instead of pushing main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,9 @@ jobs:
           git checkout -b "$branch"
           git add Formula/hwp.rb
           git commit -m "chore(brew): formula v$ver"
+          # Give --force-with-lease its reference point on reruns: a fresh checkout only
+          # fetches main, so an existing remote branch would be rejected as "stale info".
+          git fetch origin "+refs/heads/$branch:refs/remotes/origin/$branch" 2>/dev/null || true
           git push --force-with-lease origin "$branch"
           if ! gh pr view "$branch" >/dev/null 2>&1; then
             gh pr create --base main --head "$branch" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -113,29 +114,41 @@ jobs:
             "$work/hwp-skill-claude-web.zip.sha256" \
             --clobber
 
-  # Homebrew formula(저장소 자체가 tap) 의 version/sha256 을 방금 올라온 자산 기준으로
-  # 갱신해 main 에 커밋한다. 자산이 다 올라온 뒤라야 체크섬을 받을 수 있어 마지막 잡이다.
-  # 실패해도 릴리스 자체는 유효하며, 로컬에서 scripts/update_formula.sh X.Y.Z 로 복구한다.
+  # Homebrew formula (the repo itself is the tap): update version/sha256 from the freshly
+  # uploaded assets. main is a protected branch, so the bot cannot push directly — open a PR
+  # and enable squash auto-merge instead. If the repo has no auto-merge or required checks
+  # never run for token-created PRs, the PR simply stays open for a human; the release itself
+  # is valid either way, and scripts/update_formula.sh X.Y.Z remains the local recovery path.
   update-formula:
     needs: upload-assets
     runs-on: ubuntu-latest
     steps:
-      # 태그가 아니라 main 을 체크아웃한다 — 커밋 대상이 main 이기 때문.
+      # Check out main, not the tag — the formula change targets main.
       - uses: actions/checkout@v4
         with:
           ref: main
-      - name: formula 갱신 + 커밋
+      - name: Update formula and open a PR
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          set -euo pipefail
           ver="${GITHUB_REF_NAME#v}"
+          branch="brew/formula-v$ver"
           scripts/update_formula.sh "$ver"
           if git diff --quiet Formula/hwp.rb; then
-            echo "formula 변경 없음 — 커밋 생략"
+            echo "no formula change — skipping PR"
             exit 0
           fi
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
           git add Formula/hwp.rb
-          git commit -m "정리(brew): formula v$ver"
-          git push origin HEAD:main
+          git commit -m "chore(brew): formula v$ver"
+          git push --force-with-lease origin "$branch"
+          if ! gh pr view "$branch" >/dev/null 2>&1; then
+            gh pr create --base main --head "$branch" \
+              --title "chore(brew): formula v$ver" \
+              --body "Update the Homebrew formula version/sha256 from the $GITHUB_REF_NAME release assets. Opened by the release workflow because main is protected against direct bot pushes."
+          fi
+          gh pr merge --auto --squash "$branch" \
+            || echo "auto-merge unavailable — merge the formula PR manually"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ---
 
+## [Unreleased]
+
+**Fixed**
+
+- Release workflow: `update-formula` no longer pushes the Homebrew formula commit directly to
+  main — branch protection rejects the Actions token (first seen on the v0.8.0 tag). The job
+  now opens a `brew/formula-vX.Y.Z` PR and enables squash auto-merge; when the repository has
+  no auto-merge or required checks never run for a token-created PR, the PR stays open for a
+  human merge. `scripts/update_formula.sh X.Y.Z` remains the local recovery path.
+
+---
+
 ## [0.8.0]
 
 **Added**


### PR DESCRIPTION
## Summary

The v0.8.0 release run failed only at `update-formula`: main is now a protected branch, so the Actions token's direct push was rejected (GH006 — "Changes must be made through a pull request"). The release itself and all assets (including the new skill bundle) published fine; the formula was recovered locally via the documented `scripts/update_formula.sh` path.

This PR makes the job protection-aware:

- commits the formula update to `brew/formula-vX.Y.Z`, opens a PR, and enables squash auto-merge
- when auto-merge is unavailable (repo setting off, or required checks that never run because token-created PRs don't trigger workflows) the PR simply stays open for a human — the release stays valid regardless
- adds `pull-requests: write` to the workflow permissions
- job comments migrate to English per the language policy

## Test plan

- YAML parses clean; the embedded run script is plain bash (`set -euo pipefail`, idempotent: no-change → skip, existing branch → force-with-lease, existing PR → skip create).
- Not exercisable end-to-end until the next tag push; the failure modes degrade to an open PR + the documented local recovery path.