### PR TITLE
ci: skip docs/formula-only runs; soft-fail blocked formula PR creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,29 @@
 name: CI
 
+# Path filter: documentation-only and formula-only changes skip CI entirely — no Rust
+# input changes, so fmt/clippy/test outcomes cannot change. Three .md files are re-included
+# because they ARE build/test inputs: skills/hwp/SKILL.md (include_str! into the binary) and
+# docs/manual/cli-reference{,.ko}.md (compared byte-for-byte by tests/cli_reference.rs).
+# The same list must be kept identical under push and pull_request (GitHub Actions does not
+# support YAML anchors). workflow_call (release gate) is unaffected by path filters.
 on:
   push:
     branches: [main]
+    paths:
+      - "**"
+      - "!**.md"
+      - "!Formula/**"
+      - "skills/hwp/SKILL.md"
+      - "docs/manual/cli-reference.md"
+      - "docs/manual/cli-reference.ko.md"
   pull_request:
+    paths:
+      - "**"
+      - "!**.md"
+      - "!Formula/**"
+      - "skills/hwp/SKILL.md"
+      - "docs/manual/cli-reference.md"
+      - "docs/manual/cli-reference.ko.md"
   # release.yml 이 태그 릴리스 전에 이 test 잡을 재사용(테스트 통과 게이트)한다.
   workflow_call:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ on:
       - "skills/hwp/SKILL.md"
       - "docs/manual/cli-reference.md"
       - "docs/manual/cli-reference.ko.md"
-  # release.yml 이 태그 릴리스 전에 이 test 잡을 재사용(테스트 통과 게이트)한다.
+  # release.yml reuses this test job as the pass gate before a tag release.
   workflow_call:
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,13 +150,18 @@ jobs:
           git push --force-with-lease origin "$branch"
           if ! gh pr view "$branch" >/dev/null 2>&1; then
             # The org may forbid Actions from creating PRs ("GitHub Actions is not
-            # permitted to create or approve pull requests"). Degrade gracefully:
-            # the branch is already pushed, so a human opens the PR with one click.
-            if ! gh pr create --base main --head "$branch" \
+            # permitted to create or approve pull requests"). Degrade gracefully for
+            # that specific rejection — the branch is already pushed, so a human opens
+            # the PR with one click. Any other failure still fails the job.
+            if ! err=$(gh pr create --base main --head "$branch" \
               --title "chore(brew): formula v$ver" \
-              --body "Update the Homebrew formula version/sha256 from the $GITHUB_REF_NAME release assets. Opened by the release workflow because main is protected against direct bot pushes."; then
-              echo "::warning::PR creation blocked (org policy). Open it manually: https://github.com/$GITHUB_REPOSITORY/compare/main...$branch"
-              exit 0
+              --body "Update the Homebrew formula version/sha256 from the $GITHUB_REF_NAME release assets. Opened by the release workflow because main is protected against direct bot pushes." 2>&1); then
+              echo "$err"
+              if grep -qi "not permitted to create or approve pull requests" <<<"$err"; then
+                echo "::warning::PR creation blocked (org policy). Open it manually: https://github.com/$GITHUB_REPOSITORY/compare/main...$branch"
+                exit 0
+              fi
+              exit 1
             fi
           fi
           gh pr merge --auto --squash "$branch" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,9 +149,15 @@ jobs:
           git fetch origin "+refs/heads/$branch:refs/remotes/origin/$branch" 2>/dev/null || true
           git push --force-with-lease origin "$branch"
           if ! gh pr view "$branch" >/dev/null 2>&1; then
-            gh pr create --base main --head "$branch" \
+            # The org may forbid Actions from creating PRs ("GitHub Actions is not
+            # permitted to create or approve pull requests"). Degrade gracefully:
+            # the branch is already pushed, so a human opens the PR with one click.
+            if ! gh pr create --base main --head "$branch" \
               --title "chore(brew): formula v$ver" \
-              --body "Update the Homebrew formula version/sha256 from the $GITHUB_REF_NAME release assets. Opened by the release workflow because main is protected against direct bot pushes."
+              --body "Update the Homebrew formula version/sha256 from the $GITHUB_REF_NAME release assets. Opened by the release workflow because main is protected against direct bot pushes."; then
+              echo "::warning::PR creation blocked (org policy). Open it manually: https://github.com/$GITHUB_REPOSITORY/compare/main...$branch"
+              exit 0
+            fi
           fi
           gh pr merge --auto --squash "$branch" \
             || echo "auto-merge unavailable — merge the formula PR manually"


### PR DESCRIPTION
## Problem

1. Docs-only and formula-only changes run the full 3-OS CI matrix (~15–30 min) even though no Rust input changes — e.g. #65 (formula bump) and every docs PR.
2. The v0.8.1 release failed at `update-formula`: the org policy **Allow GitHub Actions to create and approve pull requests** is off, so `gh pr create` errors and `set -euo pipefail` fails the whole job (after the branch was already pushed).

## Changes

- **ci.yml** — path filters on `push` and `pull_request`: ignore `**.md` and `Formula/**`, but re-include the three markdown files that are build/test inputs:
  - `skills/hwp/SKILL.md` (`include_str!` into the binary)
  - `docs/manual/cli-reference.md` / `.ko.md` (byte-compared by `tests/cli_reference.rs`)

  `workflow_call` (release test gate) is unaffected by path filters, so tag releases still run the full test job. Branch protection has no required status checks, so skipped runs don't block merges.
- **release.yml** — wrap `gh pr create` in a soft-fail: on org-policy rejection, emit a `::warning` with the one-click compare URL and `exit 0`. The formula branch is pushed either way; auto-merge attempt below is already soft.

## Notes

- Restoring full formula automation needs the org toggle flipped (Settings → Actions → General → *Allow GitHub Actions to create and approve pull requests*). This PR just makes the release green either way.
- Workflow YAML can't be exercised by `scripts/check.sh`; both files validated with a YAML parser and against the GitHub path-filter ordering rules (later patterns win).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>