### PR TITLE
Fix Amazon Quick Windows MCP path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ---
 
+## [Unreleased]
+
+**Fixed**
+
+- Amazon Quick Desktop on Windows: normalize canonical MCP paths back to ordinary drive/UNC
+  spelling before filesystem I/O, so Quick's sandbox accepts atomic output staging under its
+  `C:\TEMP` exchange root. Also document separate JSON arguments and recovery from the
+  `Access is denied` handshake loop that causes Quick to auto-disable the connector.
+
 ## [0.8.1]
 
 **Added**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+**Added**
+
+- A bilingual, copy-paste Amazon Quick Desktop runbook now covers Windows binary verification,
+  connector import, skill and agent setup, an end-to-end create/validate smoke test, daily file
+  staging, and symptom-driven recovery for quoting, stale tool IDs, auto-disable, rendering, and
+  sandbox path failures.
+
 **Fixed**
 
 - Amazon Quick Desktop on Windows: normalize canonical MCP paths back to ordinary drive/UNC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,13 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 **Fixed**
 
-- Amazon Quick Desktop on Windows: normalize canonical MCP paths back to ordinary drive/UNC
-  spelling before filesystem I/O, so Quick's sandbox accepts atomic output staging under its
-  `C:\TEMP` exchange root. Also document separate JSON arguments and recovery from the
-  `Access is denied` handshake loop that causes Quick to auto-disable the connector.
+- Amazon Quick Desktop on Windows: keep canonical MCP paths in verbatim form for sandbox
+  authorization, then use ordinary drive/UNC spelling for filesystem I/O only when every component
+  has equivalent Win32 semantics. Paths with trailing dots/spaces, reserved device names, or other
+  verbatim-only semantics remain verbatim or fail closed. This lets Quick accept atomic output
+  staging under its `C:\TEMP` exchange root without weakening root containment. Also document
+  separate JSON arguments and recovery from the `Access is denied` handshake loop that causes Quick
+  to auto-disable the connector.
 
 ## [0.8.1]
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -344,6 +344,8 @@ hwp new --from report.json -o regen.hwpx # JSON IR → 신규 문서
 클라이언트별 설정(Claude Code/Desktop, Codex CLI/cloud, Kiro, Kimi, claude.ai 스킬 업로드,
 Amazon Quick Desktop)과 번들 에이전트 스킬(`hwp skill export`):
 [docs/manual/ai-integrations.ko.md](docs/manual/ai-integrations.ko.md).
+Windows 복사·실행 설정, 생성·검증 acceptance test, 재사용 가능한 에이전트 지침, 증상별 복구는 전용
+[Amazon Quick Desktop 가이드](docs/manual/amazon-quick-desktop.ko.md)에 정리했다.
 
 Amazon Quick Desktop은 로컬 stdio 서버를 실행해 16개 도구를 모두 노출할 수 있다. publish-safe
 스킬은 활성 프로필에 다음과 같이 설치한다.
@@ -354,7 +356,7 @@ hwp skill export --install amazon-quick
 
 Windows에서는 Quick 샌드박스가 쓸 수 있는 `C:\TEMP` 교환 디렉터리를 MCP `--root`로 사용한다.
 Quick의 로컬 폴더 권한에 추가한 사용자 프로필 폴더도 로컬 MCP 자식 프로세스에는 접근 불가할 수
-있다. 플랫폼별 JSON과 복구 절차는 연동 매뉴얼에 정리했다.
+있다. 전용 가이드의 import JSON과 복구 절차를 따른다.
 
 Amazon Quick Web은 로컬 stdio 프로세스를 시작할 수 없다. 인증된 Streamable HTTP, tenant 격리,
 artifact 전송 요구사항은 후속 작업용 [Remote MCP transport](docs/design/20-remote-mcp.ko.md)에

--- a/README.ko.md
+++ b/README.ko.md
@@ -352,6 +352,10 @@ Amazon Quick Desktop은 로컬 stdio 서버를 실행해 16개 도구를 모두 
 hwp skill export --install amazon-quick
 ```
 
+Windows에서는 Quick 샌드박스가 쓸 수 있는 `C:\TEMP` 교환 디렉터리를 MCP `--root`로 사용한다.
+Quick의 로컬 폴더 권한에 추가한 사용자 프로필 폴더도 로컬 MCP 자식 프로세스에는 접근 불가할 수
+있다. 플랫폼별 JSON과 복구 절차는 연동 매뉴얼에 정리했다.
+
 Amazon Quick Web은 로컬 stdio 프로세스를 시작할 수 없다. 인증된 Streamable HTTP, tenant 격리,
 artifact 전송 요구사항은 후속 작업용 [Remote MCP transport](docs/design/20-remote-mcp.ko.md)에
 정리했으며 현재 릴리스에는 HTTP runtime이 없다.

--- a/README.md
+++ b/README.md
@@ -373,6 +373,9 @@ the latest supported version. stdout carries the protocol; logs go to stderr.
 Per-client setup (Claude Code/Desktop, Codex CLI/cloud, Kiro, Kimi, claude.ai skill upload,
 and Amazon Quick Desktop) and the bundled agent skill (`hwp skill export`):
 [docs/manual/ai-integrations.md](docs/manual/ai-integrations.md).
+The copy-paste Windows setup, create/validate acceptance test, reusable agent instructions, and
+symptom-driven recovery are in the dedicated
+[Amazon Quick Desktop runbook](docs/manual/amazon-quick-desktop.md).
 
 Amazon Quick Desktop can launch this local stdio server and expose all 16 tools. Install the
 publish-safe skill into its active profile with:
@@ -383,7 +386,7 @@ hwp skill export --install amazon-quick
 
 On Windows, use Quick's sandbox-writable `C:\TEMP` exchange directory as the MCP `--root`.
 A user-profile folder added to Quick's local-folder permissions may still be inaccessible to the
-local MCP child; the platform-specific JSON and recovery steps are in the integration manual.
+local MCP child; use the dedicated runbook's import JSON and recovery steps.
 
 Amazon Quick Web cannot launch a local stdio process. Authenticated Streamable HTTP, tenant
 isolation and artifact transfer are specified for future work in

--- a/README.md
+++ b/README.md
@@ -381,6 +381,10 @@ publish-safe skill into its active profile with:
 hwp skill export --install amazon-quick
 ```
 
+On Windows, use Quick's sandbox-writable `C:\TEMP` exchange directory as the MCP `--root`.
+A user-profile folder added to Quick's local-folder permissions may still be inaccessible to the
+local MCP child; the platform-specific JSON and recovery steps are in the integration manual.
+
 Amazon Quick Web cannot launch a local stdio process. Authenticated Streamable HTTP, tenant
 isolation and artifact transfer are specified for future work in
 [Remote MCP transport](docs/design/20-remote-mcp.md); no HTTP runtime is included today.

--- a/crates/hwp-cli/src/certification.rs
+++ b/crates/hwp-cli/src/certification.rs
@@ -34,6 +34,9 @@ pub const MAX_PUBLISHED_TREE_ENTRIES: usize = MAX_MANIFEST_FILES + 1;
 /// reports still use the exact 257/258/259 limits above.
 pub const MAX_ARTIFACTS: usize = 260;
 pub const MAX_ARTIFACT_TOTAL_BYTES: u64 = 512 * 1024 * 1024;
+/// Maximum UTF-16 path expansion beyond the requested report destination for
+/// the private certification workspace and its deepest fixed artifact path.
+pub const WINDOWS_CERTIFICATION_TREE_OVERHEAD_UTF16: usize = 101;
 pub const ORACLE_TIMEOUT: Duration = Duration::from_secs(120);
 const MAX_ORACLE_RESULT_BYTES: u64 = 64 * 1024;
 const MAX_LOG_BYTES_RECORDED: u64 = 64 * 1024;
@@ -2691,6 +2694,79 @@ fn build_artifact_manifest(files: &[ArtifactReport], files_total: u64) -> Result
     anyhow::bail!("manifest self-size did not converge")
 }
 
+#[cfg(windows)]
+fn exact_ordinary_spelling(canonical: &Path) -> Option<PathBuf> {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::{OsStrExt as _, OsStringExt as _};
+
+    const SLASH: u16 = b'\\' as u16;
+    const VERBATIM: [u16; 4] = [SLASH, SLASH, b'?' as u16, SLASH];
+    const VERBATIM_UNC: [u16; 8] = [
+        SLASH,
+        SLASH,
+        b'?' as u16,
+        SLASH,
+        b'U' as u16,
+        b'N' as u16,
+        b'C' as u16,
+        SLASH,
+    ];
+
+    let wide: Vec<u16> = canonical.as_os_str().encode_wide().collect();
+    if wide.starts_with(&VERBATIM_UNC) {
+        let mut ordinary = Vec::with_capacity(wide.len() - VERBATIM_UNC.len() + 2);
+        ordinary.extend_from_slice(&[SLASH, SLASH]);
+        ordinary.extend_from_slice(&wide[VERBATIM_UNC.len()..]);
+        return Some(PathBuf::from(OsString::from_wide(&ordinary)));
+    }
+    if wide.starts_with(&VERBATIM)
+        && wide.get(5) == Some(&(b':' as u16))
+        && wide
+            .get(4)
+            .is_some_and(|letter| matches!(*letter, 65..=90 | 97..=122))
+    {
+        return Some(PathBuf::from(OsString::from_wide(&wide[VERBATIM.len()..])));
+    }
+    None
+}
+
+#[cfg(windows)]
+fn can_preserve_ordinary_certification_parent(
+    requested_parent: &Path,
+    canonical_parent: &Path,
+    report_name: &std::ffi::OsStr,
+) -> bool {
+    use std::os::windows::ffi::OsStrExt as _;
+
+    const LEGACY_MAX_PATH_UTF16: usize = 248;
+    if !requested_parent.is_absolute()
+        || exact_ordinary_spelling(canonical_parent).as_deref() != Some(requested_parent)
+    {
+        return false;
+    }
+    let same_identity = matches!(
+        (
+            windows_path_info(requested_parent),
+            windows_path_info(canonical_parent)
+        ),
+        (Some(requested), Some(canonical))
+            if requested.volume == canonical.volume && requested.index == canonical.index
+    );
+    if !same_identity {
+        return false;
+    }
+
+    requested_parent
+        .as_os_str()
+        .encode_wide()
+        .count()
+        .checked_add(1)
+        .and_then(|units| units.checked_add(report_name.encode_wide().count()))
+        .and_then(|units| units.checked_add(WINDOWS_CERTIFICATION_TREE_OVERHEAD_UTF16))
+        .and_then(|units| units.checked_add(1))
+        .is_some_and(|units_with_nul| units_with_nul < LEGACY_MAX_PATH_UTF16)
+}
+
 struct AtomicCertificationDir {
     root: PathBuf,
     destination: PathBuf,
@@ -2708,12 +2784,28 @@ impl AtomicCertificationDir {
             .filter(|name| !name.is_empty())
             .context("report directory needs a final component")?;
         let requested_parent = destination.parent().unwrap_or_else(|| Path::new("."));
-        let parent = requested_parent
+        let canonical_parent = requested_parent
             .canonicalize()
             .context("report parent directory is unavailable")?;
-        if !fs::metadata(&parent)?.is_dir() {
+        if !fs::metadata(&canonical_parent)?.is_dir() {
             anyhow::bail!("report parent is not a directory");
         }
+        #[cfg(windows)]
+        let parent = if can_preserve_ordinary_certification_parent(
+            requested_parent,
+            &canonical_parent,
+            name,
+        ) {
+            // MCP may already have selected an ordinary Win32 spelling that stays
+            // below the legacy path threshold. Preserve it only when it is exactly
+            // the canonical path without its verbatim prefix and handle identity
+            // proves the final directory did not change.
+            requested_parent.to_path_buf()
+        } else {
+            canonical_parent
+        };
+        #[cfg(not(windows))]
+        let parent = canonical_parent;
         let destination = parent.join(name);
         if fs::symlink_metadata(&destination).is_ok() {
             anyhow::bail!("certification report directory must not already exist");
@@ -3961,6 +4053,35 @@ mod tests {
         ));
         let _ = fs::remove_file(&path);
         path
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn canonical_parent_ordinary_spelling_does_not_accept_ancestor_aliases() {
+        let canonical = Path::new(r"\\?\C:\target\child");
+        assert_eq!(
+            exact_ordinary_spelling(canonical).unwrap(),
+            PathBuf::from(r"C:\target\child")
+        );
+        assert_ne!(
+            exact_ordinary_spelling(canonical).unwrap(),
+            PathBuf::from(r"C:\base\junction\child")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn atomic_certification_preserves_verified_ordinary_parent_spelling() {
+        let parent = scratch("ordinary-parent");
+        fs::create_dir_all(&parent).unwrap();
+        let destination = parent.join("report");
+
+        let stage = AtomicCertificationDir::new(&destination).unwrap();
+        assert_eq!(stage.parent, parent);
+        assert!(stage.root.starts_with(&stage.parent));
+        assert_eq!(stage.destination, destination);
+        drop(stage);
+        fs::remove_dir_all(parent).unwrap();
     }
 
     /// 하드링크 별칭 판정. Windows에서는 링크 수를 핸들에서만 읽을 수 있어 구현이 갈리므로

--- a/crates/hwp-cli/src/certification.rs
+++ b/crates/hwp-cli/src/certification.rs
@@ -4072,10 +4072,16 @@ mod tests {
     #[cfg(windows)]
     #[test]
     fn atomic_certification_preserves_verified_ordinary_parent_spelling() {
-        let parent = scratch("ordinary-parent");
-        fs::create_dir_all(&parent).unwrap();
+        let requested_parent = scratch("ordinary-parent");
+        fs::create_dir_all(&requested_parent).unwrap();
+        let canonical_parent = requested_parent.canonicalize().unwrap();
+        let parent = exact_ordinary_spelling(&canonical_parent).unwrap();
         let destination = parent.join("report");
 
+        // Hosted Windows runners may expose the temp directory through an 8.3
+        // alias (for example, RUNNER~1). Build the requested ordinary spelling
+        // from the canonical path so this test exercises the exact-equivalence
+        // branch rather than correctly falling back to verbatim spelling.
         let stage = AtomicCertificationDir::new(&destination).unwrap();
         assert_eq!(stage.parent, parent);
         assert!(stage.root.starts_with(&stage.parent));

--- a/crates/hwp-cli/src/commands/mcp.rs
+++ b/crates/hwp-cli/src/commands/mcp.rs
@@ -26,30 +26,146 @@ pub struct Ctx {
     pub roots: Vec<PathBuf>,
 }
 
-/// Resolve a path for sandbox containment checks and subsequent filesystem I/O.
+/// Canonicalize a path for sandbox authorization.
 ///
-/// Windows `std::fs::canonicalize` returns verbatim paths such as
-/// `\\?\C:\workspace`. Some desktop-client sandboxes authorize the ordinary
-/// drive/UNC spelling but reject that equivalent verbatim spelling. Strip only
-/// the two canonical prefixes that have an exact ordinary representation; the
-/// path remains absolute and fully resolved.
+/// Keep Windows canonical paths in their verbatim spelling here. Lower-level
+/// template and asset checks also use `std::fs::canonicalize`, so the roots in
+/// `Ctx` must retain the same security identity. A sandbox-compatible spelling
+/// is derived only after containment succeeds.
 fn canonicalize_mcp_path(path: &Path) -> std::io::Result<PathBuf> {
-    let canonical = std::fs::canonicalize(path)?;
+    std::fs::canonicalize(path)
+}
+
+/// Derive the spelling used for downstream read-only filesystem I/O from an
+/// already authorized canonical path.
+fn sandbox_compatible_mcp_path(canonical: &Path) -> PathBuf {
     #[cfg(windows)]
     {
-        Ok(strip_windows_verbatim_prefix(canonical))
+        strip_windows_verbatim_prefix(canonical.to_path_buf())
     }
     #[cfg(not(windows))]
     {
-        Ok(canonical)
+        canonical.to_path_buf()
+    }
+}
+
+/// Derive a spelling that remains ordinary even after the atomic writer adds
+/// its private sibling workspace and staged filename.
+fn sandbox_compatible_mcp_write_path(canonical: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        use std::os::windows::ffi::OsStrExt as _;
+
+        // Compared with the destination, StagedOutput's longest current path adds:
+        // leading dot + marker + max u32 pid + max u64 sequence + separators +
+        // 32-char random token + `.tmp` + workspace separator, then either repeats
+        // the destination filename or uses `destination.backup`. Certification has
+        // a deeper fixed report tree, so reserve its larger relative expansion too.
+        const ATOMIC_STAGING_FIXED_OVERHEAD_UTF16: usize = 82;
+        const ATOMIC_STAGING_MIN_CHILD_NAME_UTF16: usize = 18;
+        let file_name_units = canonical
+            .file_name()
+            .map(|name| name.encode_wide().count())
+            .unwrap_or(0);
+        let output_staging_budget = ATOMIC_STAGING_FIXED_OVERHEAD_UTF16
+            .saturating_add(file_name_units.max(ATOMIC_STAGING_MIN_CHILD_NAME_UTF16));
+        strip_windows_verbatim_prefix_with_budget(
+            canonical.to_path_buf(),
+            output_staging_budget
+                .max(hwp_cli::certification::WINDOWS_CERTIFICATION_TREE_OVERHEAD_UTF16),
+        )
+    }
+    #[cfg(not(windows))]
+    {
+        canonical.to_path_buf()
     }
 }
 
 #[cfg(windows)]
+fn windows_ordinary_component_is_safe(component: &std::ffi::OsStr) -> bool {
+    let Some(text) = component.to_str() else {
+        return false;
+    };
+    if text.is_empty() || text.ends_with('.') || text.ends_with(' ') {
+        return false;
+    }
+    if text.chars().any(|character| {
+        character.is_control()
+            || matches!(
+                character,
+                '<' | '>' | ':' | '"' | '/' | '\\' | '|' | '?' | '*'
+            )
+    }) {
+        return false;
+    }
+
+    let stem = text
+        .split('.')
+        .next()
+        .unwrap_or_default()
+        .to_ascii_uppercase();
+    if matches!(
+        stem.as_str(),
+        "CON" | "PRN" | "AUX" | "NUL" | "CONIN$" | "CONOUT$" | "CLOCK$"
+    ) {
+        return false;
+    }
+    for prefix in ["COM", "LPT"] {
+        if stem.strip_prefix(prefix).is_some_and(|suffix| {
+            matches!(
+                suffix,
+                "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" | "¹" | "²" | "³"
+            )
+        }) {
+            return false;
+        }
+    }
+    true
+}
+
+#[cfg(windows)]
+fn windows_verbatim_components_are_ordinary_safe(path: &Path) -> bool {
+    use std::path::{Component, Prefix};
+
+    let mut components = path.components();
+    match components.next() {
+        Some(Component::Prefix(prefix)) => match prefix.kind() {
+            Prefix::VerbatimDisk(_) => {}
+            Prefix::VerbatimUNC(server, share) => {
+                if !windows_ordinary_component_is_safe(server)
+                    || !windows_ordinary_component_is_safe(share)
+                {
+                    return false;
+                }
+            }
+            _ => return false,
+        },
+        _ => return false,
+    }
+    components.all(|component| match component {
+        Component::RootDir => true,
+        Component::Normal(component) => windows_ordinary_component_is_safe(component),
+        _ => false,
+    })
+}
+
+#[cfg(windows)]
 fn strip_windows_verbatim_prefix(path: PathBuf) -> PathBuf {
+    strip_windows_verbatim_prefix_with_budget(path, 0)
+}
+
+#[cfg(windows)]
+fn strip_windows_verbatim_prefix_with_budget(
+    path: PathBuf,
+    additional_utf16_units: usize,
+) -> PathBuf {
     use std::ffi::OsString;
     use std::os::windows::ffi::{OsStrExt as _, OsStringExt as _};
 
+    // Rust's Windows path layer switches ordinary absolute paths back to verbatim
+    // spelling at this legacy directory-path threshold. Leave room for the NUL
+    // terminator and for any downstream path expansion supplied by the caller.
+    const LEGACY_MAX_PATH_UTF16: usize = 248;
     const SLASH: u16 = b'\\' as u16;
     const VERBATIM: [u16; 4] = [SLASH, SLASH, b'?' as u16, SLASH];
     const VERBATIM_UNC: [u16; 8] = [
@@ -63,12 +179,25 @@ fn strip_windows_verbatim_prefix(path: PathBuf) -> PathBuf {
         SLASH,
     ];
 
+    if !windows_verbatim_components_are_ordinary_safe(&path) {
+        return path;
+    }
+
+    let fits_ordinary_io = |ordinary_units: usize| {
+        ordinary_units
+            .checked_add(additional_utf16_units)
+            .and_then(|units| units.checked_add(1))
+            .is_some_and(|units_with_nul| units_with_nul < LEGACY_MAX_PATH_UTF16)
+    };
     let wide: Vec<u16> = path.as_os_str().encode_wide().collect();
     if wide.starts_with(&VERBATIM_UNC) {
         let mut ordinary = Vec::with_capacity(wide.len() - VERBATIM_UNC.len() + 2);
         ordinary.extend_from_slice(&[SLASH, SLASH]);
         ordinary.extend_from_slice(&wide[VERBATIM_UNC.len()..]);
-        return PathBuf::from(OsString::from_wide(&ordinary));
+        if fits_ordinary_io(ordinary.len()) {
+            return PathBuf::from(OsString::from_wide(&ordinary));
+        }
+        return path;
     }
     if wide.starts_with(&VERBATIM)
         && wide.get(5) == Some(&(b':' as u16))
@@ -76,7 +205,10 @@ fn strip_windows_verbatim_prefix(path: PathBuf) -> PathBuf {
             .get(4)
             .is_some_and(|letter| matches!(*letter, 65..=90 | 97..=122))
     {
-        return PathBuf::from(OsString::from_wide(&wide[VERBATIM.len()..]));
+        let ordinary = &wide[VERBATIM.len()..];
+        if fits_ordinary_io(ordinary.len()) {
+            return PathBuf::from(OsString::from_wide(ordinary));
+        }
     }
     path
 }
@@ -406,6 +538,9 @@ fn under_any_root(ctx: &Ctx, canonical: &Path, raw: &str) -> Result<PathBuf, Str
 fn canonical_path_starts_with(path: &Path, root: &Path) -> bool {
     #[cfg(windows)]
     {
+        if path.starts_with(root) {
+            return true;
+        }
         let path = strip_windows_verbatim_prefix(path.to_path_buf());
         let root = strip_windows_verbatim_prefix(root.to_path_buf());
         path.starts_with(root)
@@ -424,7 +559,8 @@ fn checked_read_path(ctx: &Ctx, raw: &str) -> Result<PathBuf, String> {
     }
     let canonical = canonicalize_mcp_path(Path::new(raw))
         .map_err(|error| format!("경로를 확인할 수 없습니다: {raw} ({error})"))?;
-    under_any_root(ctx, &canonical, raw)
+    let authorized = under_any_root(ctx, &canonical, raw)?;
+    Ok(sandbox_compatible_mcp_path(&authorized))
 }
 
 /// Write-path validation: rejects `..` components and a missing file name, then
@@ -461,7 +597,8 @@ fn checked_write_path(ctx: &Ctx, raw: &str) -> Result<PathBuf, String> {
         })?;
         canonical_parent.join(file_name)
     };
-    under_any_root(ctx, &resolved, raw)
+    let authorized = under_any_root(ctx, &resolved, raw)?;
+    Ok(sandbox_compatible_mcp_write_path(&authorized))
 }
 
 fn font_dirs_for(args: &Value, ctx: &Ctx) -> Result<Vec<PathBuf>, String> {
@@ -1898,11 +2035,103 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn windows_mcp_root_check_accepts_equivalent_verbatim_spelling() {
+    fn windows_mcp_paths_retain_verbatim_spelling_when_semantics_can_change() {
+        for raw in [
+            r"\\?\C:\root.\document.hwpx",
+            r"\\?\C:\root \document.hwpx",
+            r"\\?\C:\NUL\document.hwpx",
+            r"\\?\C:\CON.txt\document.hwpx",
+            r"\\?\C:\COM1\document.hwpx",
+            r"\\?\C:\LPT9.log\document.hwpx",
+            r"\\?\UNC\server\share.\document.hwpx",
+        ] {
+            let path = PathBuf::from(raw);
+            assert_eq!(strip_windows_verbatim_prefix(path.clone()), path, "{raw}");
+        }
+
+        let long = PathBuf::from(format!(r"\\?\C:\{}", "a".repeat(260)));
+        assert_eq!(strip_windows_verbatim_prefix(long.clone()), long);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_mcp_paths_reserve_ordinary_length_for_atomic_staging() {
+        let below_direct_limit = PathBuf::from(format!(r"\\?\C:\{}", "a".repeat(243)));
+        assert_ne!(
+            strip_windows_verbatim_prefix(below_direct_limit.clone()),
+            below_direct_limit
+        );
+        let at_direct_limit = PathBuf::from(format!(r"\\?\C:\{}", "a".repeat(244)));
+        assert_eq!(
+            strip_windows_verbatim_prefix(at_direct_limit.clone()),
+            at_direct_limit
+        );
+
+        let below_write_limit = PathBuf::from(format!(r"\\?\C:\{}\x", "a".repeat(140)));
+        assert_ne!(
+            sandbox_compatible_mcp_write_path(&below_write_limit),
+            below_write_limit
+        );
+        let at_write_limit = PathBuf::from(format!(r"\\?\C:\{}\x", "a".repeat(141)));
+        assert_eq!(
+            sandbox_compatible_mcp_write_path(&at_write_limit),
+            at_write_limit
+        );
+
+        let long_filename_output = PathBuf::from(format!(r"\\?\C:\{}\out.hwpx", "a".repeat(180)));
+        assert_ne!(
+            strip_windows_verbatim_prefix(long_filename_output.clone()),
+            long_filename_output
+        );
+        assert_eq!(
+            sandbox_compatible_mcp_write_path(&long_filename_output),
+            long_filename_output
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_mcp_root_check_accepts_only_semantically_equivalent_spellings() {
         assert!(canonical_path_starts_with(
             Path::new(r"C:\Temp\workspace\document.hwpx"),
             Path::new(r"\\?\C:\Temp\workspace")
         ));
+        assert!(!canonical_path_starts_with(
+            Path::new(r"C:\root\document.hwpx"),
+            Path::new(r"\\?\C:\root.")
+        ));
+        assert!(canonical_path_starts_with(
+            Path::new(r"\\?\C:\root.\document.hwpx"),
+            Path::new(r"\\?\C:\root.")
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_mcp_roots_keep_canonical_identity_for_downstream_checks() {
+        let base =
+            std::env::temp_dir().join(format!("hwp-cli-mcp-canonical-root-{}", std::process::id()));
+        let root = base.join("root");
+        let document = root.join("document.hwpx");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(&document, b"test").unwrap();
+
+        let canonical_root = canonicalize_mcp_path(&root).unwrap();
+        let canonical_document = std::fs::canonicalize(&document).unwrap();
+        assert!(canonical_document.starts_with(&canonical_root));
+
+        let ctx = ctx_with_roots(vec![canonical_root.clone()]);
+        assert_eq!(
+            checked_read_path(&ctx, document.to_str().unwrap()).unwrap(),
+            strip_windows_verbatim_prefix(canonical_document)
+        );
+
+        let unsafe_output = canonical_root.join("report.hwpx.");
+        assert_eq!(
+            checked_write_path(&ctx, unsafe_output.to_str().unwrap()).unwrap(),
+            unsafe_output
+        );
+        let _ = std::fs::remove_dir_all(base);
     }
 
     fn ctx() -> Ctx {
@@ -2478,7 +2707,7 @@ mod tests {
         std::fs::write(&outside_png, &png).unwrap();
         // Markdown link destinations treat `\` as an escape — forward slashes (Windows CI).
         let outside_ref = outside_png.display().to_string().replace('\\', "/");
-        let sandbox = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let sandbox = ctx_with_roots(vec![canonicalize_mcp_path(&root).unwrap()]);
 
         // hwp_new: markdown referencing an absolute image outside the roots fails closed.
         let new_out = root.join("new.hwpx");
@@ -2721,7 +2950,7 @@ mod tests {
         let (base, root, outside) = sandbox_dirs("read");
         let document = outside.join("doc.hwpx");
         create_hwpx(&document, "본문");
-        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let ctx = ctx_with_roots(vec![canonicalize_mcp_path(&root).unwrap()]);
         let error = tool_read(&json!({"path": document}), &ctx).unwrap_err();
         assert!(error.contains("--root"), "{error}");
         let _ = std::fs::remove_dir_all(&base);
@@ -2732,7 +2961,7 @@ mod tests {
         let (base, root, outside) = sandbox_dirs("write");
         let source = root.join("source.hwpx");
         create_hwpx(&source, "{{이름}}");
-        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let ctx = ctx_with_roots(vec![canonicalize_mcp_path(&root).unwrap()]);
         let output = outside.join("out.hwpx");
         let error = tool_fill(
             &json!({
@@ -2753,7 +2982,7 @@ mod tests {
         let (base, root, _outside) = sandbox_dirs("dotdot");
         let source = root.join("source.hwpx");
         create_hwpx(&source, "{{이름}}");
-        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let ctx = ctx_with_roots(vec![canonicalize_mcp_path(&root).unwrap()]);
         let error = tool_fill(
             &json!({
                 "input": source,
@@ -2777,7 +3006,7 @@ mod tests {
         std::fs::write(&victim, b"VICTIM").unwrap();
         let link = root.join("link.hwpx");
         std::os::unix::fs::symlink(&victim, &link).unwrap();
-        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let ctx = ctx_with_roots(vec![canonicalize_mcp_path(&root).unwrap()]);
         let error = tool_fill(
             &json!({
                 "input": source,
@@ -2798,7 +3027,7 @@ mod tests {
         let source = root.join("source.hwpx");
         create_hwpx(&source, "{{이름}}");
         let output = root.join("out.hwpx");
-        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let ctx = ctx_with_roots(vec![canonicalize_mcp_path(&root).unwrap()]);
         tool_fill(
             &json!({
                 "input": source,
@@ -2818,7 +3047,7 @@ mod tests {
         let (base, root, outside) = sandbox_dirs("fontdir");
         let source = root.join("source.hwpx");
         create_hwpx(&source, "본문");
-        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let ctx = ctx_with_roots(vec![canonicalize_mcp_path(&root).unwrap()]);
         let error = tool_render(&json!({"path": source, "font_dir": outside}), &ctx).unwrap_err();
         assert!(error.contains("--root"), "{error}");
         let _ = std::fs::remove_dir_all(&base);
@@ -2831,7 +3060,7 @@ mod tests {
         create_hwpx(&source, "앵커");
         let image = outside.join("image.png");
         std::fs::write(&image, b"PNG").unwrap();
-        let ctx = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let ctx = ctx_with_roots(vec![canonicalize_mcp_path(&root).unwrap()]);
         let error = tool_edit(
             &json!({
                 "input": source,
@@ -3439,7 +3668,7 @@ mod tests {
         let (base, root, outside) = sandbox_dirs("convert-media");
         let source = root.join("source.hwpx");
         create_hwpx(&source, "본문");
-        let sandbox = ctx_with_roots(vec![std::fs::canonicalize(&root).unwrap()]);
+        let sandbox = ctx_with_roots(vec![canonicalize_mcp_path(&root).unwrap()]);
         let error = convert_request(
             &json!({
                 "input": source,

--- a/crates/hwp-cli/src/commands/mcp.rs
+++ b/crates/hwp-cli/src/commands/mcp.rs
@@ -26,11 +26,66 @@ pub struct Ctx {
     pub roots: Vec<PathBuf>,
 }
 
+/// Resolve a path for sandbox containment checks and subsequent filesystem I/O.
+///
+/// Windows `std::fs::canonicalize` returns verbatim paths such as
+/// `\\?\C:\workspace`. Some desktop-client sandboxes authorize the ordinary
+/// drive/UNC spelling but reject that equivalent verbatim spelling. Strip only
+/// the two canonical prefixes that have an exact ordinary representation; the
+/// path remains absolute and fully resolved.
+fn canonicalize_mcp_path(path: &Path) -> std::io::Result<PathBuf> {
+    let canonical = std::fs::canonicalize(path)?;
+    #[cfg(windows)]
+    {
+        Ok(strip_windows_verbatim_prefix(canonical))
+    }
+    #[cfg(not(windows))]
+    {
+        Ok(canonical)
+    }
+}
+
+#[cfg(windows)]
+fn strip_windows_verbatim_prefix(path: PathBuf) -> PathBuf {
+    use std::ffi::OsString;
+    use std::os::windows::ffi::{OsStrExt as _, OsStringExt as _};
+
+    const SLASH: u16 = b'\\' as u16;
+    const VERBATIM: [u16; 4] = [SLASH, SLASH, b'?' as u16, SLASH];
+    const VERBATIM_UNC: [u16; 8] = [
+        SLASH,
+        SLASH,
+        b'?' as u16,
+        SLASH,
+        b'U' as u16,
+        b'N' as u16,
+        b'C' as u16,
+        SLASH,
+    ];
+
+    let wide: Vec<u16> = path.as_os_str().encode_wide().collect();
+    if wide.starts_with(&VERBATIM_UNC) {
+        let mut ordinary = Vec::with_capacity(wide.len() - VERBATIM_UNC.len() + 2);
+        ordinary.extend_from_slice(&[SLASH, SLASH]);
+        ordinary.extend_from_slice(&wide[VERBATIM_UNC.len()..]);
+        return PathBuf::from(OsString::from_wide(&ordinary));
+    }
+    if wide.starts_with(&VERBATIM)
+        && wide.get(5) == Some(&(b':' as u16))
+        && wide
+            .get(4)
+            .is_some_and(|letter| matches!(*letter, 65..=90 | 97..=122))
+    {
+        return PathBuf::from(OsString::from_wide(&wide[VERBATIM.len()..]));
+    }
+    path
+}
+
 /// stdio JSON-RPC 루프. EOF까지 한 줄씩 처리한다.
 pub fn run(font_dirs: Vec<PathBuf>, roots: Vec<PathBuf>) -> anyhow::Result<()> {
     let mut canonical_roots = Vec::with_capacity(roots.len());
     for root in &roots {
-        let canonical = std::fs::canonicalize(root).map_err(|error| {
+        let canonical = canonicalize_mcp_path(root).map_err(|error| {
             anyhow::anyhow!(
                 "--root 경로를 확인할 수 없습니다: {} ({error})",
                 root.display()
@@ -334,7 +389,11 @@ fn optional_item_f32(item: &Value, operation: &str, key: &str) -> Result<Option<
 
 /// Checks that a canonical path sits below one of the allowed roots.
 fn under_any_root(ctx: &Ctx, canonical: &Path, raw: &str) -> Result<PathBuf, String> {
-    if ctx.roots.iter().any(|root| canonical.starts_with(root)) {
+    if ctx
+        .roots
+        .iter()
+        .any(|root| canonical_path_starts_with(canonical, root))
+    {
         Ok(canonical.to_path_buf())
     } else {
         Err(format!(
@@ -344,13 +403,26 @@ fn under_any_root(ctx: &Ctx, canonical: &Path, raw: &str) -> Result<PathBuf, Str
     }
 }
 
+fn canonical_path_starts_with(path: &Path, root: &Path) -> bool {
+    #[cfg(windows)]
+    {
+        let path = strip_windows_verbatim_prefix(path.to_path_buf());
+        let root = strip_windows_verbatim_prefix(root.to_path_buf());
+        path.starts_with(root)
+    }
+    #[cfg(not(windows))]
+    {
+        path.starts_with(root)
+    }
+}
+
 /// Read-path validation: the path must exist (canonicalize) and the canonical result
 /// must sit below a root. Empty roots pass without a check (previous behavior).
 fn checked_read_path(ctx: &Ctx, raw: &str) -> Result<PathBuf, String> {
     if ctx.roots.is_empty() {
         return Ok(PathBuf::from(raw));
     }
-    let canonical = std::fs::canonicalize(raw)
+    let canonical = canonicalize_mcp_path(Path::new(raw))
         .map_err(|error| format!("경로를 확인할 수 없습니다: {raw} ({error})"))?;
     under_any_root(ctx, &canonical, raw)
 }
@@ -374,14 +446,14 @@ fn checked_write_path(ctx: &Ctx, raw: &str) -> Result<PathBuf, String> {
         .file_name()
         .ok_or_else(|| format!("출력 경로에 파일 이름이 없습니다: {raw}"))?;
     let resolved = if path.exists() {
-        std::fs::canonicalize(path)
+        canonicalize_mcp_path(path)
             .map_err(|error| format!("출력 경로를 확인할 수 없습니다: {raw} ({error})"))?
     } else {
         let parent = path
             .parent()
             .filter(|parent| !parent.as_os_str().is_empty())
             .unwrap_or_else(|| Path::new("."));
-        let canonical_parent = std::fs::canonicalize(parent).map_err(|error| {
+        let canonical_parent = canonicalize_mcp_path(parent).map_err(|error| {
             format!(
                 "출력 경로의 부모 디렉터리를 확인할 수 없습니다: {} ({error})",
                 parent.display()
@@ -1805,6 +1877,33 @@ fn tool_defs() -> Vec<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_mcp_paths_use_sandbox_compatible_drive_spelling() {
+        assert_eq!(
+            strip_windows_verbatim_prefix(PathBuf::from(r"\\?\C:\Temp\document.hwpx")),
+            PathBuf::from(r"C:\Temp\document.hwpx")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_mcp_paths_use_sandbox_compatible_unc_spelling() {
+        assert_eq!(
+            strip_windows_verbatim_prefix(PathBuf::from(r"\\?\UNC\server\share\document.hwpx")),
+            PathBuf::from(r"\\server\share\document.hwpx")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_mcp_root_check_accepts_equivalent_verbatim_spelling() {
+        assert!(canonical_path_starts_with(
+            Path::new(r"C:\Temp\workspace\document.hwpx"),
+            Path::new(r"\\?\C:\Temp\workspace")
+        ));
+    }
 
     fn ctx() -> Ctx {
         Ctx {

--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -11,6 +11,7 @@
 | [design/](design/) | 설계 지식 정본. 시작점은 [00-overview](design/00-overview.ko.md) |
 | [manual/cli-reference.ko.md](manual/cli-reference.ko.md) | clap 정의에서 자동 생성되는 CLI 레퍼런스(수동 편집 금지) |
 | [manual/ai-integrations.ko.md](manual/ai-integrations.ko.md) | AI 클라이언트 설정: MCP 등록, 에이전트 스킬, claude.ai 번들 |
+| [manual/amazon-quick-desktop.ko.md](manual/amazon-quick-desktop.ko.md) | Amazon Quick Desktop 설정, end-to-end 검증, 에이전트 지침, 문제 해결 |
 | [release-readiness.ko.md](release-readiness.ko.md) | 릴리스 전 게이트 체크리스트 |
 | [hancom-verification-checklist.ko.md](hancom-verification-checklist.ko.md) | 한글 실기 검증 체크리스트 |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Notes on the HWP 5.0 format specification material used when working on the pars
 | [design/](design/) | The design knowledge of record. Start at [00-overview](design/00-overview.md) |
 | [manual/cli-reference.md](manual/cli-reference.md) | CLI reference generated from the clap definitions (do not edit by hand) |
 | [manual/ai-integrations.md](manual/ai-integrations.md) | AI client setup: MCP registration, the agent skill, the claude.ai bundle |
+| [manual/amazon-quick-desktop.md](manual/amazon-quick-desktop.md) | Amazon Quick Desktop setup, end-to-end verification, agent instructions, and troubleshooting |
 | [release-readiness.md](release-readiness.md) | Pre-release gate checklist |
 | [hancom-verification-checklist.md](hancom-verification-checklist.md) | Checklist for verifying files in Hancom Office |
 

--- a/docs/manual/ai-integrations.ko.md
+++ b/docs/manual/ai-integrations.ko.md
@@ -125,7 +125,7 @@ Apple Silicon Homebrew에서는 흔히 `/opt/homebrew/bin/hwp`가 나온다. 이
 |---|---|
 | Name | `hwp` |
 | Command | `command -v hwp`에서 확인한 절대 경로 |
-| Arguments | `mcp --font-dir /System/Library/Fonts --root /path/to/workspace` |
+| Arguments (macOS 예시) | `mcp --font-dir /System/Library/Fonts --root /path/to/workspace` |
 | Description | `Read, write, edit, render, validate, and convert HWP/HWPX documents.` |
 | Timeout | `30`초(일반적으로 기본값이면 충분) |
 
@@ -157,6 +157,39 @@ Apple Silicon Homebrew에서는 흔히 `/opt/homebrew/bin/hwp`가 나온다. 이
   }
 }
 ```
+
+#### Windows 샌드박스 호환 설정
+
+Windows에서는 사용자 프로필 아래 폴더 대신 Quick이 쓸 수 있는 `C:\TEMP` 교환 디렉터리로
+시작한다.
+
+```json
+{
+  "mcpServers": {
+    "hwp": {
+      "command": "C:\\absolute\\path\\to\\hwp.exe",
+      "args": [
+        "mcp",
+        "--font-dir",
+        "C:\\Windows\\Fonts",
+        "--root",
+        "C:\\TEMP"
+      ]
+    }
+  }
+}
+```
+
+각 인자는 JSON 배열의 별도 항목으로 유지하고 Windows 경로에 셸 따옴표를 덧붙이지 않는다.
+Quick의 **Local folders and access permissions**는 내장 파일 도구의 접근을 제어하지만, 로컬 MCP
+자식 프로세스는 사용자 프로필의 실제 경로를 canonicalize하지 못할 수 있다. 이 경우 `hwp`가
+`--root ... Access is denied (os error 5)`로 종료되고 MCP handshake가 닫히며, 재시도 뒤 Quick이
+커넥터를 자동으로 비활성화한다. `C:\TEMP`는 Quick의 Windows 샌드박스가 지원하는 특수 임시
+디렉터리다. HWP 작업 전 입력 파일을 이곳으로 옮기거나 복사하고, MCP 입력과 출력을 이 root
+아래에 유지한 다음 완성된 artifact를 승인된 목적 폴더로 복사한다.
+
+자동 비활성화된 커넥터의 설정을 바꾼 뒤에는 명시적으로 다시 활성화한다. 복구되면
+**Connected**, **16 tools available**가 표시되고 새로고침 뒤에도 활성 상태를 유지한다.
 
 ### 3. publish-safe HWP 스킬 설치
 
@@ -204,7 +237,8 @@ HTML로 오인할 수 있는 angle-bracket markup을 포함하지 않는다.
 - `hwp --version`이 의도한 최신 바이너리를 표시함
 - 커넥터 테스트가 **Connected**, **16 tools available**을 표시함
 - 새로고침 뒤에도 커넥터가 활성화되어 있고 **16 tools, Connected**를 표시함
-- 테스트 HWPX에서 `hwp_new`, `hwp_read`, `hwp_validate`, `hwp_render`가 성공함
+- 테스트 HWPX에서 `hwp_new`, `hwp_read`, `hwp_validate`, `hwp_render`가 성공함(Windows에서는
+  `C:\TEMP` 아래에서 테스트)
 - HWP 전용 에이전트가 하나만 존재하며 prohibited HTML/script 오류 없이 publish됨
 
 ## Amazon Quick Web

--- a/docs/manual/ai-integrations.ko.md
+++ b/docs/manual/ai-integrations.ko.md
@@ -101,6 +101,10 @@ Amazon Quick Desktop은 `hwp mcp`를 로컬 stdio 커넥터로 실행할 수 있
 모두 노출되는 연결을 실기 확인했다. Quick 릴리스에 따라 UI 이름은 달라질 수 있으며 아래 명칭은
 현재 Desktop 흐름 기준이다.
 
+바이너리 검증, 에이전트 지침, 실제 생성·검증 smoke test, 증상별 복구까지 포함한 Windows 중심
+복사·실행 절차는 전용 [Amazon Quick Desktop 가이드](amazon-quick-desktop.ko.md)를 사용한다. 아래
+요약은 다른 AI 클라이언트와 비교하기 위한 짧은 레퍼런스로 유지한다.
+
 ### 1. 최신 바이너리 하나로 정리
 
 커넥터에는 실행 파일 절대 경로를 넣는다. Quick의 PATH 앞쪽에 남은 구버전을 실행하는 문제를

--- a/docs/manual/ai-integrations.md
+++ b/docs/manual/ai-integrations.md
@@ -126,7 +126,7 @@ Open **Settings → Capabilities → Connectors → + Create → MCP server → 
 |---|---|
 | Name | `hwp` |
 | Command | the absolute path from `command -v hwp` |
-| Arguments | `mcp --font-dir /System/Library/Fonts --root /path/to/workspace` |
+| Arguments (macOS example) | `mcp --font-dir /System/Library/Fonts --root /path/to/workspace` |
 | Description | `Read, write, edit, render, validate, and convert HWP/HWPX documents.` |
 | Timeout | `30` seconds (the default is normally sufficient) |
 
@@ -158,6 +158,39 @@ Equivalent import JSON:
   }
 }
 ```
+
+#### Windows sandbox-compatible setup
+
+On Windows, start with Quick's writable `C:\TEMP` exchange directory instead of a directory
+under the user profile:
+
+```json
+{
+  "mcpServers": {
+    "hwp": {
+      "command": "C:\\absolute\\path\\to\\hwp.exe",
+      "args": [
+        "mcp",
+        "--font-dir",
+        "C:\\Windows\\Fonts",
+        "--root",
+        "C:\\TEMP"
+      ]
+    }
+  }
+}
+```
+
+Keep each argument as a separate JSON array item; do not add shell quotes around Windows paths.
+Quick's **Local folders and access permissions** control its built-in file tools, but a local MCP
+child can still be unable to canonicalize a direct user-profile path. In that case `hwp` exits
+with `--root ... Access is denied (os error 5)`, the MCP handshake closes, and Quick eventually
+auto-disables the connector. `C:\TEMP` is a special temporary directory supported by Quick's
+Windows sandbox. Move or copy inputs into it before an HWP operation, keep MCP inputs and outputs
+under that root, and copy final artifacts to the intended approved folder afterward.
+
+After changing an auto-disabled connector, explicitly enable it again. A successful recovery
+reports **Connected** and **16 tools available** and remains enabled after refresh.
 
 ### 3. Install the publish-safe HWP skill
 
@@ -207,7 +240,8 @@ contain no angle-bracket markup that Quick can misclassify as HTML.
 - `hwp --version` reports the intended current binary.
 - Connector test reports **Connected** and **16 tools available**.
 - After refresh, the connector remains enabled and reports **16 tools, Connected**.
-- `hwp_new`, `hwp_read`, `hwp_validate`, and `hwp_render` succeed on a test HWPX document.
+- `hwp_new`, `hwp_read`, `hwp_validate`, and `hwp_render` succeed on a test HWPX document (under
+  `C:\TEMP` on Windows).
 - Exactly one HWP-focused agent exists, and it publishes without the prohibited HTML/script error.
 
 ## Amazon Quick Web

--- a/docs/manual/ai-integrations.md
+++ b/docs/manual/ai-integrations.md
@@ -102,6 +102,11 @@ Amazon Quick Desktop can launch `hwp mcp` as a local stdio connector. The connec
 verified with all 16 HWP tools available. Quick UI labels may change between releases; the
 following names match the current Desktop flow.
 
+For a Windows-first, copy-paste procedure that includes binary verification, agent instructions,
+an actual create/validate smoke test, and symptom-based recovery, use the dedicated
+[Amazon Quick Desktop runbook](amazon-quick-desktop.md). The shorter reference below is retained for
+cross-client comparison.
+
 ### 1. Verify one current binary
 
 Use an absolute executable path in the connector. This prevents a stale installation earlier in

--- a/docs/manual/amazon-quick-desktop.ko.md
+++ b/docs/manual/amazon-quick-desktop.ko.md
@@ -1,0 +1,275 @@
+[한국어](amazon-quick-desktop.ko.md) · [English](amazon-quick-desktop.md)
+
+# Amazon Quick Desktop: HWP MCP 설정과 문제 해결
+
+이 문서는 Amazon Quick Desktop에 `hwp`를 로컬 MCP 커넥터로 설정하는 사람과 AI 에이전트를 위한
+실행 절차다. Windows에서 실제로 확인한 전체 흐름 — 최신 바이너리 하나 설치, HWP 스킬 설치,
+커넥터 등록, 실제 파일 쓰기 검증, Quick이 커넥터를 비활성화하거나 잃어버렸을 때의 복구 — 을
+순서대로 다룬다.
+
+Quick 릴리스에 따라 UI 이름과 내부 파일명이 바뀔 수 있다. Quick 내부 설정 파일을 직접 편집하기보다
+이 문서의 UI 절차와 import JSON을 사용한다.
+
+## 정상 구성 요소
+
+| 구성요소 | 역할 | Windows 확인값 |
+|---|---|---|
+| `hwp.exe` | MCP stdio 서버 실행 | 안정된 절대 경로의 최신 바이너리 하나 |
+| HWP MCP 커넥터 | HWP 도구 16개 노출 | `hwp.exe mcp ...` |
+| HWP 스킬 | Quick 에이전트에게 도구 사용 시점과 방법 안내 | 활성 Quick 프로필의 `skills/hwp/SKILL.md` |
+| 교환 root | Quick과 MCP 자식 프로세스가 파일을 주고받는 경계 | `C:\TEMP` |
+| 폰트 디렉터리 | Windows 렌더링 폰트 공급 | `C:\Windows\Fonts` |
+
+커넥터와 스킬은 서로 별개다. 스킬 설치는 바이너리를 설치하거나 커넥터를 만들지 않는다. 커넥터에
+도구 16개가 표시된 뒤에도 파일 쓰기는 실패할 수 있으므로, 실제 생성·검증 smoke test까지 해야 한다.
+
+## 1. 최신 `hwp.exe` 하나 설치하고 확인
+
+[최신 릴리스](https://github.com/STAIxBWLB/hwp-cli/releases)에서 Windows x86_64 아카이브와
+`.sha256` 파일을 받는다.
+
+- `hwp-vX.Y.Z-x86_64-pc-windows-msvc.zip`
+- `hwp-vX.Y.Z-x86_64-pc-windows-msvc.sha256`
+
+압축을 풀기 전에 체크섬을 대조한다. 아래 예시 경로는 실제로 받은 버전에 맞게 바꾼다.
+
+```powershell
+$Archive = "C:\path\to\hwp-vX.Y.Z-x86_64-pc-windows-msvc.zip"
+$Expected = ((Get-Content -LiteralPath "$Archive.sha256") -split '\s+')[0].ToLowerInvariant()
+$Actual = (Get-FileHash -LiteralPath $Archive -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($Actual -ne $Expected) { throw "hwp archive checksum mismatch" }
+```
+
+`hwp.exe`를 Quick이 실행할 수 있는 안정된 위치에 압축 해제하고, 커넥터 등록 뒤에는 옮기지 않는다.
+Windows Quick에서 확인한 배치 예시는 다음과 같다.
+
+```text
+%USERPROFILE%\.quickwork\profiles\PROFILE_ID\skills\hwp\bin\hwp.exe
+```
+
+`PROFILE_ID`는 `%USERPROFILE%\.quickwork\profiles.json`의 활성 항목이다. Quick이 접근할 수 있는 다른
+안정된 위치도 사용할 수 있다. 정확한 절대 경로를 기록하고 PowerShell에서 바이너리를 확인한다.
+
+```powershell
+$Hwp = "C:\absolute\path\to\hwp.exe"
+& $Hwp --version
+```
+
+Quick에도 이 경로를 그대로 입력한다. 다른 터미널의 PATH에 의존하면 Quick이 남아 있는 구버전을
+실행할 수 있다. 첫 파일 쓰기가 `\\?\C:\...` 같은 Windows verbatim 경로와 함께 계속 실패하면
+Amazon Quick Windows canonical-path 정규화 수정이 포함된 릴리스로 업그레이드한다.
+
+## 2. Windows 교환 root 만들기
+
+Quick 내장 파일 도구와 로컬 MCP 자식 프로세스는 항상 같은 파일 권한을 받지 않는다. **Local folders
+and access permissions**에 사용자 프로필 폴더를 추가해도 MCP 자식 프로세스가 거부될 수 있다.
+확인된 샌드박스 교환 디렉터리부터 사용한다.
+
+```powershell
+New-Item -ItemType Directory -Path C:\TEMP -Force
+```
+
+커넥터의 `--root`를 `C:\TEMP`로 지정한다. HWP 도구를 부르기 전에 입력 `.hwp`, `.hwpx`, Markdown,
+JSON, 이미지, 템플릿을 이곳으로 복사한다. 모든 MCP 입력·출력 경로를 이 root 아래에 유지하고, 작업이
+끝나면 Quick 내장 파일 도구나 Explorer로 최종 artifact를 목적 폴더에 복사한다.
+
+`--root`는 호환 설정인 동시에 보안 경계다. 권한 오류를 피하려고 제거하지 않는다.
+
+## 3. 활성 Quick 프로필에 HWP 스킬 설치
+
+현재 바이너리를 실행한다.
+
+```powershell
+& $Hwp skill export --install amazon-quick
+```
+
+이 명령은 `%USERPROFILE%\.quickwork\profiles.json`을 읽어 유효한 `last_active` 프로필 또는 유일한
+유효 프로필을 고르고, 그 안의 `skills\hwp\SKILL.md`만 쓴다. `hwp.exe`를 복사하거나 MCP 커넥터·
+에이전트를 만들거나 publish하지 않는다.
+
+Quick 프로필이 여러 개이거나 자동 선택이 모호하면 프로필 ID 또는 절대 프로필 디렉터리를 지정한다.
+
+```powershell
+& $Hwp skill export --install amazon-quick --quick-profile enterprise-example
+& $Hwp skill export --install amazon-quick --quick-profile "C:\absolute\path\to\quick\profile"
+```
+
+스킬을 설치하거나 교체한 뒤 Quick을 재시작하거나 새로고침한다.
+
+## 4. 로컬 MCP 커넥터 등록
+
+Quick Desktop에서 **Settings → Capabilities → Connectors → + Create → MCP server → Local**로
+이동한다. 릴리스에 따라 이름이 조금 다를 수 있다. 인자 경계를 정확하게 보존하는 import JSON을
+권장한다.
+
+```json
+{
+  "mcpServers": {
+    "hwp": {
+      "command": "C:\\absolute\\path\\to\\hwp.exe",
+      "args": [
+        "mcp",
+        "--font-dir",
+        "C:\\Windows\\Fonts",
+        "--root",
+        "C:\\TEMP"
+      ]
+    }
+  }
+}
+```
+
+`command`만 실제 경로로 바꾼다. JSON에서 이중 백슬래시는 일반 Windows 백슬래시를 표현할 뿐,
+실제 경로를 바꾸지 않는다.
+
+직접 입력할 때는 다음 값을 사용한다.
+
+| 항목 | 값 |
+|---|---|
+| Name | `hwp` |
+| Command | 앞에서 검증한 정확한 `hwp.exe` 절대 경로 |
+| Arguments | `mcp --font-dir C:\Windows\Fonts --root C:\TEMP` |
+| Description | `Read, write, edit, render, validate, and convert HWP/HWPX documents.` |
+| Timeout | `30`초 |
+
+Arguments 입력란은 셸이 아니다. 경로 앞뒤에 작은따옴표나 큰따옴표 문자를 넣지 않는다. 다음은 잘못된
+예다.
+
+```text
+mcp --font-dir 'C:\Windows\Fonts' --root 'C:\TEMP'
+```
+
+Quick은 이 따옴표를 제거하지 않고 그대로 넘길 수 있다. 그러면 `hwp`는 따옴표가 이름에 포함된 폴더를
+찾고, root 확인에 실패해 즉시 종료하며 MCP handshake가 닫힌다. JSON 형식은 각 token을 배열의 별도
+항목으로 유지해 이 문제를 피한다.
+
+**Test connection**을 선택하고 Quick의 명령 실행 확인을 승인한다. **Connected**, **16 tools
+available**이 표시되어야 한다. 이어서 **Add MCP**를 선택하고 다시 승인한 뒤 연결을 새로고침한다.
+`hwp`가 활성화되어 있고 **16 tools, Connected**로 표시되는지 확인한다.
+
+## 5. 실제 end-to-end smoke test 실행
+
+“16 tools available”에서 멈추지 않는다. 새 Quick 대화를 열고 다음 prompt를 붙여넣는다.
+
+```text
+셸 명령이 아니라 HWP MCP 도구를 사용하라.
+1. 다음 Markdown으로 hwp_new를 호출해 C:\TEMP\quick-hwp-smoke.hwpx를 생성하라.
+   # Quick MCP smoke test
+
+   Amazon Quick can create HWPX files through hwp MCP.
+2. C:\TEMP\quick-hwp-smoke.hwpx에 hwp_validate를 호출하라.
+3. 같은 파일에 plain 형식으로 hwp_read를 호출하라.
+4. 정확한 출력 경로와 검증 결과를 보고하라. valid가 true가 아니면 성공이라고 말하지 마라.
+```
+
+정상 설치는 파일을 만들고 다음과 같은 검증 결과를 반환한다.
+
+```json
+{
+  "valid": true,
+  "errors": [],
+  "warnings": []
+}
+```
+
+시각 결과가 중요하면 1쪽에 `hwp_render`를 추가로 호출하고 출력도 `C:\TEMP` 아래에 쓴다. 이 단계는
+문서 생성과 별도로 폰트 접근·렌더링을 확인한다.
+
+## 6. Quick 에이전트에 지속 지침 추가
+
+중복 이름이나 오래된 커넥터 지침이 남지 않도록 HWP 역할의 에이전트는 하나만 유지한다. HWP 커넥터와
+설치된 HWP 스킬을 활성화하고 다음과 같은 instructions를 추가한다.
+
+```text
+.hwp 또는 .hwpx 작업에는 설치된 hwp 스킬과 HWP MCP 도구를 사용한다.
+Windows에서는 활성 커넥터가 다른 root를 명시적으로 노출하지 않는 한 C:\TEMP 아래 경로만 사용한다.
+HWP 작업 전에 입력을 C:\TEMP로 복사하고 최종 artifact의 C:\TEMP 경로를 사용자에게 반환한다.
+hwp_new, hwp_edit, hwp_fill, hwp_convert, hwp_compose, hwp_template 뒤에는 항상 hwp_validate를 호출한다.
+페이지 모양이 중요하면 hwp_render도 호출해 요청된 페이지를 확인한다.
+자동 생성된 MCP 서버 prefix를 하드코딩하지 말고 hwp_new/hwp_read 같은 도구 이름으로 선택한다.
+Access is denied가 나오면 시도한 경로와 설정 root를 보고한다. root 제한을 제거하지 않는다.
+커넥터 탐색만으로 성공이라 말하지 말고 요청 작업과 검증이 모두 통과해야 성공으로 판정한다.
+```
+
+OneDrive나 SharePoint 커넥터는 선택 사항이다. 원본이나 완성 파일을 `C:\TEMP` 안팎으로 복사할 때만
+사용하며, 로컬 HWP MCP 커넥터를 대체하지 않는다.
+
+## 일상 작업 흐름
+
+1. 모든 원본 파일과 참조 asset을 `C:\TEMP`로 복사한다.
+2. Quick에 정확한 입력·출력 경로를 준다. 예: “`C:\TEMP\input.hwpx`를 읽어 초안을 최종으로
+   바꾸고 `C:\TEMP\final.hwpx`에 저장하라.”
+3. 모든 쓰기 뒤 `hwp_validate`를 요구한다. 레이아웃이 중요하면 `hwp_render`도 요구한다.
+4. 반환된 경로와 검증 결과를 확인한 뒤 artifact를 열거나 검사한다.
+5. 검증한 출력을 `C:\TEMP`에서 승인된 목적지로 복사한다. 목적지 사본을 확인한 뒤에만 교환 파일을
+   정리한다.
+
+활용 prompt 예:
+
+- “`C:\TEMP\input.hwp`를 요약하고 표 목록을 보여줘.”
+- “`C:\TEMP\input.hwpx`를 `C:\TEMP\input.md`로 변환해줘.”
+- “이 Markdown으로 `C:\TEMP\report.hwpx`를 만들고 검증한 뒤 1쪽을 렌더해줘.”
+- “`C:\TEMP\template.hwpx`의 slot을 채워 `C:\TEMP\filled.hwpx`에 쓰고 검증해줘.”
+
+## 증상별 문제 해결
+
+| 증상 | 예상 원인 | 복구 |
+|---|---|---|
+| `hwp.exe`가 시작하지 않거나 `--version`이 실패함 | 잘못된 바이너리·아키텍처, 차단되거나 불완전한 압축 해제 | 다시 다운로드하고 SHA-256을 확인한 뒤 Windows x86_64 아카이브를 풀고 정확한 절대 command를 테스트한다 |
+| Test connection에 도구가 없거나 서버가 즉시 종료함 | 없거나 읽을 수 없는 `--root`, Arguments 안의 따옴표 문자, 오타, 오래된 command 경로 | `C:\TEMP` 존재 확인, 위 JSON import, 셸 따옴표 제거, `hwp.exe --version` 검증 |
+| **Connected, 16 tools**인데 `hwp_new`가 `Access is denied (os error 5)`를 반환함 | 전송은 정상이나 MCP 자식이 요청 경로를 쓸 수 없거나, 구버전이 `\\?\...`를 Quick 샌드박스에 전달함 | 입력·출력을 모두 `C:\TEMP` 아래로 옮기고 `--root C:\TEMP` 유지, `hwp` 업그레이드, 재시작 뒤 smoke test |
+| **Local folders and access permissions**에 추가한 경로도 실패함 | 그 설정은 Quick 내장 파일 도구를 제어하며 로컬 MCP 자식에는 동일하게 적용되지 않을 수 있음 | 내장 도구로 파일을 `C:\TEMP`에 복사한 뒤 그곳에서 HWP 도구를 호출한다 |
+| `os error 2` | 경로가 실제로 없음. Desktop이 OneDrive로 이동됐을 수 있음 | 실제 경로 확인, 목적 디렉터리 생성, 또는 `C:\TEMP`에 staging |
+| 반복 실패 뒤 커넥터가 비활성화됨 | 시작·handshake 실패가 반복되어 Quick이 자동 비활성화함 | command/root 수정·저장, 커넥터를 명시적으로 다시 활성화, 새로고침, 필요하면 Quick 재시작 |
+| 커넥터 수정·재import 뒤 `Unknown tool` | Quick이 새 내부 커넥터/tool prefix를 만들었으나 대화는 예전 이름을 보유함 | 연결 새로고침과 새 대화 시작, 예전 생성 이름 대신 HWP 스킬·도구 다시 로드 |
+| 에이전트 publish 때 `assetDescriptor contains prohibited HTML/script content` | 구버전 스킬의 angle-bracket placeholder를 Quick이 markup으로 분류함 | 최신 `hwp`에서 스킬 재설치, Quick 새로고침, 다시 publish |
+| 생성은 되지만 렌더링 실패 | 폰트 디렉터리가 없거나 접근 불가 | 먼저 `--font-dir` 없이 생성 검증, 그다음 `C:\Windows\Fonts`를 추가하고 `hwp_render` 재시도 |
+| Path is outside allowed roots | MCP root 정책이 정상적으로 경로를 거부함 | asset을 `C:\TEMP`로 복사하거나 실제 지원되는 root 추가. 모든 root를 제거하지 않는다 |
+
+### Windows 경로 수정이 필요한 이유
+
+Rust의 Windows canonicalization은 같은 경로를 `\\?\C:\TEMP\quick-hwp-smoke.hwpx` 같은 verbatim
+형식으로 반환할 수 있다. Quick은 MCP handshake 때 일반 `C:\TEMP` root를 받아들이고도, 이후 `hwp`가
+private atomic staging 디렉터리를 만들 때 이 verbatim 표기를 거부할 수 있다. 현재 `hwp`는 downstream
+파일 I/O 전에 verbatim drive/UNC 경로를 일반 Windows 표기로 정규화하면서 root containment 검사는
+fail-closed 상태로 유지한다.
+
+이 차이 때문에 커넥터 탐색은 성공하지만 첫 쓰기만 실패하는 혼동이 생긴다. 항상 `hwp_new`와
+`hwp_validate`로 data plane까지 검증한다.
+
+## 선택적 로컬 진단
+
+진단 목적으로만 사용한다. Quick 실행 중 내부 파일을 직접 편집하지 않는다.
+
+- 활성 프로필 레지스트리: `%USERPROFILE%\.quickwork\profiles.json`
+- 프로필별 MCP snapshot: `%USERPROFILE%\.quickwork\profiles\PROFILE_ID\mcp_config.json`
+- 일반적인 Windows backend log: `%LOCALAPPDATA%\Temp\quickwork-backend.log`
+
+저장된 커넥터 key는 `hwp`가 아니라 `hwp-...`처럼 생성될 수 있고, Quick은 `autoDisabled`를 포함한
+내부 `_quick` metadata를 추가할 수 있다. 이는 Quick 구현 상세이므로 직접 수정하지 말고 UI에서
+커넥터를 고치고 활성화한다.
+
+선택적 log 확인 명령:
+
+```powershell
+Get-Content "$env:LOCALAPPDATA\Temp\quickwork-backend.log" -Tail 300 |
+  Select-String "UserMCP|Loaded.*servers|total tools|hwp"
+```
+
+정상 기동 시 “Started ... with 16 tools”, “Loaded 1/1 servers (0 failed), 16 total tools”와 같은
+메시지가 보인다. 로그 문구와 위치는 안정된 API 계약이 아니다.
+
+## 완료 체크리스트
+
+- 커넥터 command가 검증한 `hwp.exe` 절대 경로 하나를 사용함
+- 커넥터가 분리된 JSON 인자를 사용하며 셸 따옴표가 들어 있지 않음
+- `C:\TEMP`가 존재하고 Windows MCP root로 설정됨
+- 현재 HWP 스킬이 활성 Quick 프로필에 설치됨
+- Test connection이 **Connected**, **16 tools available**을 표시함
+- 새로고침·재시작 뒤에도 커넥터가 활성 상태임
+- `C:\TEMP\quick-hwp-smoke.hwpx`에서 `hwp_new`, `hwp_validate`, `hwp_read`가 성공함
+- `hwp_validate`가 `valid: true`를 반환하고, 모양이 중요하면 렌더링도 확인함
+- 에이전트가 모든 쓰기 뒤 검증하고 최종 artifact 경로를 반환함
+
+Amazon Quick Web은 이 로컬 stdio 흐름을 실행할 수 없다. 현재 변환·업로드 방법과 계획된 remote MCP
+구조는 [AI 클라이언트 연동](ai-integrations.ko.md#amazon-quick-web)을 참고한다.

--- a/docs/manual/amazon-quick-desktop.ko.md
+++ b/docs/manual/amazon-quick-desktop.ko.md
@@ -26,7 +26,7 @@ Quick 릴리스에 따라 UI 이름과 내부 파일명이 바뀔 수 있다. Qu
 ## 1. 최신 `hwp.exe` 하나 설치하고 확인
 
 [최신 릴리스](https://github.com/STAIxBWLB/hwp-cli/releases)에서 Windows x86_64 아카이브와
-`.sha256` 파일을 받는다.
+`.sha256` 파일을 받는다. Amazon Quick Windows 경로 정규화에는 hwp-cli v0.8.2 이상이 필요하다.
 
 - `hwp-vX.Y.Z-x86_64-pc-windows-msvc.zip`
 - `hwp-vX.Y.Z-x86_64-pc-windows-msvc.sha256`
@@ -35,7 +35,8 @@ Quick 릴리스에 따라 UI 이름과 내부 파일명이 바뀔 수 있다. Qu
 
 ```powershell
 $Archive = "C:\path\to\hwp-vX.Y.Z-x86_64-pc-windows-msvc.zip"
-$Expected = ((Get-Content -LiteralPath "$Archive.sha256") -split '\s+')[0].ToLowerInvariant()
+$Checksum = [IO.Path]::ChangeExtension($Archive, ".sha256")
+$Expected = ((Get-Content -LiteralPath $Checksum) -split '\s+')[0].ToLowerInvariant()
 $Actual = (Get-FileHash -LiteralPath $Archive -Algorithm SHA256).Hash.ToLowerInvariant()
 if ($Actual -ne $Expected) { throw "hwp archive checksum mismatch" }
 ```
@@ -57,7 +58,7 @@ $Hwp = "C:\absolute\path\to\hwp.exe"
 
 Quick에도 이 경로를 그대로 입력한다. 다른 터미널의 PATH에 의존하면 Quick이 남아 있는 구버전을
 실행할 수 있다. 첫 파일 쓰기가 `\\?\C:\...` 같은 Windows verbatim 경로와 함께 계속 실패하면
-Amazon Quick Windows canonical-path 정규화 수정이 포함된 릴리스로 업그레이드한다.
+`hwp --version`이 v0.8.2 이상인지 확인한다.
 
 ## 2. Windows 교환 root 만들기
 

--- a/docs/manual/amazon-quick-desktop.md
+++ b/docs/manual/amazon-quick-desktop.md
@@ -27,7 +27,8 @@ create-and-validate smoke test is required.
 ## 1. Install and verify one current `hwp.exe`
 
 Download the Windows x86_64 archive and its `.sha256` file from the
-[latest release](https://github.com/STAIxBWLB/hwp-cli/releases):
+[latest release](https://github.com/STAIxBWLB/hwp-cli/releases). Amazon Quick Windows path
+normalization requires hwp-cli v0.8.2 or later:
 
 - `hwp-vX.Y.Z-x86_64-pc-windows-msvc.zip`
 - `hwp-vX.Y.Z-x86_64-pc-windows-msvc.sha256`
@@ -36,7 +37,8 @@ Verify the archive before extracting it. Replace the example paths with the down
 
 ```powershell
 $Archive = "C:\path\to\hwp-vX.Y.Z-x86_64-pc-windows-msvc.zip"
-$Expected = ((Get-Content -LiteralPath "$Archive.sha256") -split '\s+')[0].ToLowerInvariant()
+$Checksum = [IO.Path]::ChangeExtension($Archive, ".sha256")
+$Expected = ((Get-Content -LiteralPath $Checksum) -split '\s+')[0].ToLowerInvariant()
 $Actual = (Get-FileHash -LiteralPath $Archive -Algorithm SHA256).Hash.ToLowerInvariant()
 if ($Actual -ne $Expected) { throw "hwp archive checksum mismatch" }
 ```
@@ -59,8 +61,7 @@ $Hwp = "C:\absolute\path\to\hwp.exe"
 
 Use this same path in Quick. Do not rely on the PATH seen by a different terminal, because Quick
 can otherwise start an older duplicate installation. If the first file write still fails with a
-Windows verbatim path such as `\\?\C:\...`, upgrade to a release containing the Amazon Quick
-Windows canonical-path normalization fix.
+Windows verbatim path such as `\\?\C:\...`, confirm that `hwp --version` reports v0.8.2 or later.
 
 ## 2. Create the Windows exchange root
 

--- a/docs/manual/amazon-quick-desktop.md
+++ b/docs/manual/amazon-quick-desktop.md
@@ -1,0 +1,282 @@
+[한국어](amazon-quick-desktop.ko.md) · [English](amazon-quick-desktop.md)
+
+# Amazon Quick Desktop: HWP MCP setup and troubleshooting
+
+This runbook is for a person or an AI assistant configuring `hwp` as a local MCP connector in
+Amazon Quick Desktop. It covers the complete Windows path that was verified in practice: install
+one current binary, install the HWP skill, register the connector, prove an actual file write, and
+recover the connector when Quick disables or loses it.
+
+Quick UI labels and internal file names can change between Desktop releases. Prefer the UI and the
+import JSON in this guide over editing Quick's internal configuration files.
+
+## What a working setup contains
+
+| Component | Purpose | Known-good Windows value |
+|---|---|---|
+| `hwp.exe` | Runs the MCP stdio server | One current binary at a stable absolute path |
+| HWP MCP connector | Exposes the 16 HWP tools | `hwp.exe mcp ...` |
+| HWP skill | Tells the Quick agent when and how to use the tools | `skills/hwp/SKILL.md` in the active Quick profile |
+| Exchange root | Shared file boundary between Quick and the MCP child | `C:\TEMP` |
+| Font directory | Supplies Windows fonts for rendering | `C:\Windows\Fonts` |
+
+The connector and the skill are separate. Installing the skill does not install the binary or
+create the connector. A connector can also show 16 tools while later file writes fail, so a real
+create-and-validate smoke test is required.
+
+## 1. Install and verify one current `hwp.exe`
+
+Download the Windows x86_64 archive and its `.sha256` file from the
+[latest release](https://github.com/STAIxBWLB/hwp-cli/releases):
+
+- `hwp-vX.Y.Z-x86_64-pc-windows-msvc.zip`
+- `hwp-vX.Y.Z-x86_64-pc-windows-msvc.sha256`
+
+Verify the archive before extracting it. Replace the example paths with the downloaded version:
+
+```powershell
+$Archive = "C:\path\to\hwp-vX.Y.Z-x86_64-pc-windows-msvc.zip"
+$Expected = ((Get-Content -LiteralPath "$Archive.sha256") -split '\s+')[0].ToLowerInvariant()
+$Actual = (Get-FileHash -LiteralPath $Archive -Algorithm SHA256).Hash.ToLowerInvariant()
+if ($Actual -ne $Expected) { throw "hwp archive checksum mismatch" }
+```
+
+Extract `hwp.exe` to a stable location that Quick can execute and do not move it after registering
+the connector. A layout verified with Quick on Windows is:
+
+```text
+%USERPROFILE%\.quickwork\profiles\PROFILE_ID\skills\hwp\bin\hwp.exe
+```
+
+`PROFILE_ID` is the active entry in `%USERPROFILE%\.quickwork\profiles.json`. Another stable,
+Quick-accessible location is also valid. Record the exact absolute path and verify the binary in
+PowerShell:
+
+```powershell
+$Hwp = "C:\absolute\path\to\hwp.exe"
+& $Hwp --version
+```
+
+Use this same path in Quick. Do not rely on the PATH seen by a different terminal, because Quick
+can otherwise start an older duplicate installation. If the first file write still fails with a
+Windows verbatim path such as `\\?\C:\...`, upgrade to a release containing the Amazon Quick
+Windows canonical-path normalization fix.
+
+## 2. Create the Windows exchange root
+
+Quick's built-in file tools and its local MCP child do not necessarily receive the same filesystem
+permissions. A user-profile folder added under **Local folders and access permissions** can still
+be rejected by the MCP child. Start with the verified sandbox exchange directory:
+
+```powershell
+New-Item -ItemType Directory -Path C:\TEMP -Force
+```
+
+Use `C:\TEMP` as the connector's `--root`. Copy input `.hwp`, `.hwpx`, Markdown, JSON, images, and
+templates into that directory before calling an HWP tool. Keep every MCP input and output path
+under that root, then use Quick's file tools or Explorer to copy the final artifact to its intended
+destination.
+
+`--root` is a security boundary as well as a compatibility setting. Do not remove it to work around
+a permission error.
+
+## 3. Install the HWP skill into the active Quick profile
+
+Run the current binary:
+
+```powershell
+& $Hwp skill export --install amazon-quick
+```
+
+The command reads `%USERPROFILE%\.quickwork\profiles.json`, selects its valid `last_active` profile
+or the only valid profile, and writes only `skills\hwp\SKILL.md` inside it. It does not copy
+`hwp.exe`, register the MCP connector, create an agent, or publish anything.
+
+If Quick has several profiles or automatic selection is ambiguous, pass the profile ID or absolute
+profile directory:
+
+```powershell
+& $Hwp skill export --install amazon-quick --quick-profile enterprise-example
+& $Hwp skill export --install amazon-quick --quick-profile "C:\absolute\path\to\quick\profile"
+```
+
+Restart or refresh Quick after installing or replacing the skill.
+
+## 4. Register the local MCP connector
+
+In Quick Desktop, open **Settings → Capabilities → Connectors → + Create → MCP server → Local**.
+The labels can vary slightly by release. Importing JSON is recommended because it preserves the
+argument boundaries exactly:
+
+```json
+{
+  "mcpServers": {
+    "hwp": {
+      "command": "C:\\absolute\\path\\to\\hwp.exe",
+      "args": [
+        "mcp",
+        "--font-dir",
+        "C:\\Windows\\Fonts",
+        "--root",
+        "C:\\TEMP"
+      ]
+    }
+  }
+}
+```
+
+Replace only `command`. In JSON, doubled backslashes encode ordinary Windows backslashes; they do
+not change the real path.
+
+For manual entry, use:
+
+| Field | Value |
+|---|---|
+| Name | `hwp` |
+| Command | the exact absolute `hwp.exe` path verified above |
+| Arguments | `mcp --font-dir C:\Windows\Fonts --root C:\TEMP` |
+| Description | `Read, write, edit, render, validate, and convert HWP/HWPX documents.` |
+| Timeout | `30` seconds |
+
+The Arguments field is not a shell. Do not type single or double quote characters around paths.
+For example, this is wrong:
+
+```text
+mcp --font-dir 'C:\Windows\Fonts' --root 'C:\TEMP'
+```
+
+Quick can pass those quote characters literally, causing `hwp` to look for a directory whose name
+contains quotes. The root then fails fast and the MCP handshake closes. The JSON form avoids this
+failure by keeping every token as a separate array item.
+
+Select **Test connection**, approve Quick's command-execution confirmation, and expect
+**Connected** and **16 tools available**. Then select **Add MCP**, approve the confirmation, refresh
+connections, and verify that `hwp` is enabled and reports **16 tools, Connected**.
+
+## 5. Run an end-to-end smoke test
+
+Do not stop at “16 tools available.” Start a new Quick chat and paste this prompt:
+
+```text
+Use the HWP MCP tools, not a shell command.
+1. Call hwp_new to create C:\TEMP\quick-hwp-smoke.hwpx from this Markdown:
+   # Quick MCP smoke test
+
+   Amazon Quick can create HWPX files through hwp MCP.
+2. Call hwp_validate on C:\TEMP\quick-hwp-smoke.hwpx.
+3. Call hwp_read on the same file in plain format.
+4. Report the exact output path and the validation result. Do not claim success unless valid is true.
+```
+
+A working installation produces the file and returns validation equivalent to:
+
+```json
+{
+  "valid": true,
+  "errors": [],
+  "warnings": []
+}
+```
+
+If visual output matters, follow with `hwp_render` for page 1 and write its output under
+`C:\TEMP`. This checks font access and rendering separately from document creation.
+
+## 6. Give a Quick agent durable instructions
+
+Use one HWP-focused agent rather than several agents with duplicate names or stale connector
+instructions. Enable the HWP connector and installed HWP skill, then add instructions like these:
+
+```text
+Use the installed hwp skill and HWP MCP tools for every .hwp or .hwpx task.
+On Windows, use only paths under C:\TEMP unless the active connector explicitly exposes another root.
+Copy inputs into C:\TEMP before an HWP operation and return the final artifact path under C:\TEMP.
+After hwp_new, hwp_edit, hwp_fill, hwp_convert, hwp_compose, or hwp_template, always call hwp_validate.
+When page appearance matters, also call hwp_render and inspect the requested pages.
+Never hard-code the generated MCP server prefix; select tools by their hwp_new/hwp_read/etc. names.
+If access is denied, report the attempted path and configured root. Do not remove the root restriction.
+Do not claim success from connector discovery alone; require the requested operation and validation to pass.
+```
+
+OneDrive or SharePoint connectors are optional. Use them only to copy source or completed files into
+and out of `C:\TEMP`; they do not replace the local HWP MCP connector.
+
+## Daily workflow
+
+1. Copy every source file and referenced asset into `C:\TEMP`.
+2. Give Quick the exact input and output paths. For example: “Read
+   `C:\TEMP\input.hwpx`, replace Draft with Final, and write `C:\TEMP\final.hwpx`.”
+3. Require `hwp_validate` after any write. Require `hwp_render` as well when layout matters.
+4. Confirm the returned path and validation result, then open or inspect the artifact.
+5. Copy the verified output from `C:\TEMP` to the approved destination. Clean up exchange files only
+   after confirming the destination copy.
+
+Useful prompts include:
+
+- “Summarize `C:\TEMP\input.hwp` and list its tables.”
+- “Convert `C:\TEMP\input.hwpx` to `C:\TEMP\input.md`.”
+- “Create `C:\TEMP\report.hwpx` from this Markdown, validate it, and render page 1.”
+- “Fill the slots in `C:\TEMP\template.hwpx`, write `C:\TEMP\filled.hwpx`, and validate it.”
+
+## Troubleshooting by symptom
+
+| Symptom | Likely cause | Recovery |
+|---|---|---|
+| `hwp.exe` does not start or `--version` fails | Wrong binary, wrong architecture, blocked or incomplete extraction | Re-download, verify SHA-256, extract the Windows x86_64 archive, and test the exact absolute command path |
+| Test connection shows no tools or the server exits immediately | Missing/unreadable `--root`, quote characters in Arguments, typo, or stale command path | Ensure `C:\TEMP` exists; import the JSON above; remove shell quotes; verify `hwp.exe --version` |
+| **Connected, 16 tools** but `hwp_new` returns `Access is denied (os error 5)` | Transport works, but the MCP child cannot use the requested filesystem path, or an older binary passes `\\?\...` to Quick's sandbox | Put both input and output under `C:\TEMP`; keep `--root C:\TEMP`; upgrade `hwp`; restart and run the smoke test |
+| A path added to **Local folders and access permissions** still fails | That setting controls Quick's built-in file tools, not necessarily the local MCP child | Use the built-in tool to copy the file into `C:\TEMP`, then call HWP tools there |
+| `os error 2` | The path does not exist; Desktop may have moved to OneDrive | Check the real path, create the intended directory, or stage the file under `C:\TEMP` |
+| Connector becomes disabled after repeated failures | Quick auto-disabled a connector whose startup/handshake repeatedly failed | Correct the command/root, save, explicitly enable the connector, refresh, and restart Quick if needed |
+| `Unknown tool` after editing or re-importing the connector | Quick generated a new internal connector/tool prefix while the conversation retained old tool names | Refresh connections and start a new chat; reload the HWP skill/tools instead of reusing the old generated name |
+| `assetDescriptor contains prohibited HTML/script content` while publishing an agent | An old exported skill contains angle-bracket placeholders that Quick classifies as markup | Reinstall the skill from a current `hwp` binary, refresh Quick, and publish again |
+| Creation works but rendering fails | Font directory is missing or inaccessible | First test without `--font-dir`; then add `C:\Windows\Fonts` and retry `hwp_render` |
+| Path is outside allowed roots | The MCP root policy is correctly rejecting it | Copy the asset into `C:\TEMP` or add a genuinely supported root; do not disable all roots |
+
+### Why the Windows path fix is necessary
+
+Rust's Windows canonicalization can return an equivalent verbatim path such as
+`\\?\C:\TEMP\quick-hwp-smoke.hwpx`. Quick can accept the ordinary `C:\TEMP` root during the MCP
+handshake yet reject the verbatim spelling later when `hwp` creates its private atomic staging
+directory. Current `hwp` normalizes verbatim drive and UNC paths back to ordinary Windows spelling
+before downstream file I/O while preserving fail-closed root containment checks.
+
+This distinction explains the misleading state where connector discovery succeeds but the first
+write fails. Always verify the data plane with `hwp_new` plus `hwp_validate`.
+
+## Optional local diagnostics
+
+Use these only for diagnosis. Do not edit Quick's internal files while Quick is running.
+
+- Active profile registry: `%USERPROFILE%\.quickwork\profiles.json`
+- Per-profile MCP snapshot: `%USERPROFILE%\.quickwork\profiles\PROFILE_ID\mcp_config.json`
+- Typical Windows backend log: `%LOCALAPPDATA%\Temp\quickwork-backend.log`
+
+The stored connector key can be generated (for example, `hwp-...`) rather than exactly `hwp`, and
+Quick can add internal `_quick` metadata including an `autoDisabled` flag. Treat those as Quick
+implementation details. Repair and enable the connector in the UI instead of hand-editing them.
+
+An optional log check is:
+
+```powershell
+Get-Content "$env:LOCALAPPDATA\Temp\quickwork-backend.log" -Tail 300 |
+  Select-String "UserMCP|Loaded.*servers|total tools|hwp"
+```
+
+A healthy startup contains messages equivalent to “Started ... with 16 tools” and “Loaded 1/1
+servers (0 failed), 16 total tools.” Log wording and location are not stable API contracts.
+
+## Completion checklist
+
+- The connector command is one verified absolute `hwp.exe` path.
+- The connector uses separate JSON arguments and has no embedded shell quotes.
+- `C:\TEMP` exists and is the Windows MCP root.
+- The current HWP skill is installed in the active Quick profile.
+- Test connection reports **Connected** and **16 tools available**.
+- The connector stays enabled after refresh or restart.
+- `hwp_new`, `hwp_validate`, and `hwp_read` succeed on `C:\TEMP\quick-hwp-smoke.hwpx`.
+- `hwp_validate` returns `valid: true`; rendering is also tested when appearance matters.
+- The agent validates after every write and returns the final artifact path.
+
+Amazon Quick Web cannot run this local stdio workflow. See
+[AI client integrations](ai-integrations.md#amazon-quick-web) for the current conversion/upload path
+and the planned remote MCP architecture.

--- a/skills/hwp/SKILL.md
+++ b/skills/hwp/SKILL.md
@@ -108,6 +108,14 @@ directory — to the given directories. Roots are canonicalized at startup; a mi
 unreadable root fails fast. Without any `--root` the server is unrestricted and prints a
 one-line warning to stderr at startup — prefer `--root` whenever the client allows it.
 
+Amazon Quick Desktop on Windows runs local MCP children inside its sandbox. Use the special
+writable exchange root `C:\TEMP` and `C:\Windows\Fonts`, with separate JSON arguments:
+`["mcp", "--font-dir", "C:\\Windows\\Fonts", "--root", "C:\\TEMP"]`. A folder added to
+Quick's local-folder permissions may still be unreadable to the MCP child. If a user-profile
+root fails with `Access is denied (os error 5)`, keep the root restriction, change it to
+`C:\TEMP`, and re-enable the connector after Quick auto-disables it. Keep all MCP inputs and
+outputs under that root and use Quick's file tools to copy artifacts into and out of it.
+
 Tools (16):
 
 | Tool | Required arguments | Purpose |

--- a/skills/hwp/SKILL.md
+++ b/skills/hwp/SKILL.md
@@ -116,6 +116,14 @@ root fails with `Access is denied (os error 5)`, keep the root restriction, chan
 `C:\TEMP`, and re-enable the connector after Quick auto-disables it. Keep all MCP inputs and
 outputs under that root and use Quick's file tools to copy artifacts into and out of it.
 
+When helping someone configure Quick, prefer JSON import and never put shell quote characters
+inside an argument. Verify three layers in order: the exact absolute binary returns a version;
+Quick reports 16 tools and stays enabled after refresh; then `hwp_new` followed by `hwp_validate`
+succeeds on `C:\TEMP\quick-hwp-smoke.hwpx`. Do not claim that discovery alone proves file access.
+After a connector edit, refresh or start a new chat instead of reusing an old generated tool prefix.
+The copy-paste operator and AI runbook is:
+`https://github.com/STAIxBWLB/hwp-cli/blob/main/docs/manual/amazon-quick-desktop.md`.
+
 Tools (16):
 
 | Tool | Required arguments | Purpose |


### PR DESCRIPTION
## Summary

- normalize Windows MCP canonical paths from verbatim drive and UNC spelling before downstream filesystem I/O
- keep root containment fail-closed across ordinary and verbatim path representations
- add a bilingual, copy-paste Amazon Quick Desktop runbook for both operators and AI assistants
- link the runbook from the READMEs, integration manual, documentation index, bundled HWP skill, and changelog

## Root cause

On Windows, `std::fs::canonicalize` can return `\\?\...` paths. Amazon Quick accepted the configured root during MCP discovery but rejected that equivalent verbatim spelling when `hwp` created its private atomic staging directory, producing `Access is denied (os error 5)`. Repeated startup failures could then cause Quick to auto-disable the connector.

## Amazon Quick findings documented

The new runbook records the configuration and failure modes found during end-to-end testing:

- use a checksum-verified, current `hwp.exe` through one stable absolute command path
- use Quick's Windows exchange root `C:\TEMP` and keep all MCP inputs and outputs under it
- import connector arguments as separate JSON array items; Quick's Arguments field is not a shell, so quote characters can become part of the path
- distinguish Quick's built-in local-folder permissions from the filesystem access granted to a local MCP child
- treat **16 tools available** as connector discovery only; require `hwp_new` followed by `hwp_validate` for acceptance
- refresh or start a new chat after connector changes so an old generated tool prefix does not produce `Unknown tool`
- explicitly re-enable a connector after Quick auto-disables it
- reinstall the current skill when agent publishing reports prohibited HTML/script content
- validate after every write and render when visual layout matters

Runbooks:

- [English Amazon Quick Desktop runbook](https://github.com/STAIxBWLB/hwp-cli/blob/codex/fix-quick-windows-mcp-paths/docs/manual/amazon-quick-desktop.md)
- [한국어 Amazon Quick Desktop 가이드](https://github.com/STAIxBWLB/hwp-cli/blob/codex/fix-quick-windows-mcp-paths/docs/manual/amazon-quick-desktop.ko.md)

## Impact

Amazon Quick Desktop on Windows can start the local MCP connector and create, read, validate, and render HWPX outputs under the supported `C:\TEMP` exchange root without removing the MCP root restriction. A person or AI assistant can now follow the same installation, verification, daily-use, and recovery procedure without relying on machine-specific paths or internal Quick configuration edits.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p hwp-cli 'commands::mcp::tests' --bin hwp --locked -j 1` — 56 passed
- `cargo test -p hwp-cli --lib --locked -j 1` — 66 passed
- release-binary JSON-RPC smoke test: `hwp_new` plus `hwp_validate` under `C:\TEMP` — valid, no warnings
- Amazon Quick Desktop restart: connector loaded 1/1 server with 16 tools
- both runbooks: balanced code fences, valid JSON examples, valid local links, and no machine-specific user/profile paths
- `git diff --check`

The full binary test suite passed 128/130. Two unrelated Windows ACL-inheritance assertions failed in this sandbox because the resulting DACL omits the `AI` descriptor flag:

- `windows_new_destination_uses_parent_default_dacl`
- `windows_new_paired_tree_uses_final_parent_inheritance_for_all_entries`