### PR TITLE
Prepare v0.8.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ---
 
-## [Unreleased]
+## [0.8.2]
 
 **Added**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ---
 
+## [Unreleased]
+
 ## [0.8.2]
 
 **Added**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "hwp-model",
  "image",
@@ -710,14 +710,14 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "hwp-render"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "flate2",
  "fontdb",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "cfb",
  "flate2",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "hwp-convert",
  "hwp-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"


### PR DESCRIPTION
## Summary
- cut the v0.8.2 CHANGELOG section
- bump all workspace crates from 0.8.1 to 0.8.2 with scripts/release.sh

## Validation
- scripts/release_notes.sh 0.8.2 produces non-empty release notes
- scripts/release.sh 0.8.2 completed and created the local annotated tag (the tag will be recreated on the merged main commit before push)