### PR TITLE
ci: deduplicate workflow tests and fix the 15-min ubuntu test anomaly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 # because they ARE build/test inputs: skills/hwp/SKILL.md (include_str! into the binary) and
 # docs/manual/cli-reference{,.ko}.md (compared byte-for-byte by tests/cli_reference.rs).
 # The same list must be kept identical under push and pull_request (GitHub Actions does not
-# support YAML anchors). workflow_call (release gate) is unaffected by path filters.
+# support YAML anchors).
 on:
   push:
     branches: [main]
@@ -24,19 +24,48 @@ on:
       - "skills/hwp/SKILL.md"
       - "docs/manual/cli-reference.md"
       - "docs/manual/cli-reference.ko.md"
-  # release.yml reuses this test job as the pass gate before a tag release.
-  workflow_call:
 
 env:
   CARGO_TERM_COLOR: always
 
-# 같은 브랜치에 새 push가 오면 이전 실행은 취소한다(낭비·지연 감소).
-# 단 main은 취소하지 않는다 — 연속 머지 시 커밋별 CI 신호(이등분 근거)를 보존.
+# A new push on the same branch cancels the previous run (less waste, less latency).
+# main is never cancelled — per-commit CI signal on consecutive merges is the bisect basis
+# (and the release gate reads it via the check-runs API).
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Gate layout: platform-independent checks run ONCE in `lint`; the 3-OS matrix in `test`
+# runs only cargo test. Same command set as scripts/check.sh (local mirror) plus the
+# structured-corpus gate — keep them in sync or "local green, CI red" drift comes back.
 jobs:
+  lint:
+    name: lint
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # MSRV pin (Cargo.toml rust-version): keeps rustfmt/clippy results deterministic
+      # (floating stable lets previously-passing code suddenly fail on version drift) and
+      # proves the declared minimum supported version actually builds.
+      - uses: dtolnay/rust-toolchain@1.93.0
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      # The checks are independent: run all of them even after a failure so every result
+      # is reported in one run (fewer debug round-trips).
+      - name: Format check
+        run: cargo fmt --all --check
+      - name: Clippy
+        if: ${{ !cancelled() }}
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      # Fonts are not committed; the script fetches them from upstream and verifies
+      # manifest hashes.
+      - name: Structured document corpus (pinned OFL fonts, offline cargo)
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: bash scripts/check-structured-corpus.sh
+
   test:
     name: test (${{ matrix.os }})
     timeout-minutes: 30
@@ -44,40 +73,21 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # 셋 다 필수 게이트: ubuntu(CI 기준선) + macOS(소유자 주 사용 플랫폼) +
-          # windows(v0.5.0부터 MSVC 빌드·테스트 안정화, 릴리스 바이너리도 여기서 나온다).
+          # All three are required gates: ubuntu (CI baseline) + macOS (owner's main
+          # platform) + windows (MSVC build/tests, and the release binaries come from here).
           - { os: ubuntu-latest }
           - { os: macos-latest }
           - { os: windows-latest }
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      # 렌더 스모크 테스트는 시스템 CJK 글리프를 쓴다. 이 스텝이 빠지면 잉크 없는
-      # 페이지가 나와 크기 단언이 깨진다(코퍼스 게이트의 고정 폰트와는 별개).
-      - name: 한국어 폰트 설치 (렌더링 테스트용)
+      # Render smoke tests need a system Korean font. fonts-nanum ships glyf-outline TTFs;
+      # the CFF-based fonts-noto-cjk made debug-build outline extraction ~100x slower
+      # (that alone was a 15-minute ubuntu test step).
+      - name: Install Korean fonts (for rendering tests)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y fonts-noto-cjk
-      # MSRV(Cargo.toml rust-version)로 고정 — rustfmt/clippy 결과를 결정적으로
-      # 만들고(stable 부동 시 버전 드리프트로 통과하던 코드가 갑자기 실패), 선언한
-      # 최소 지원 버전에서 실제로 빌드되는지 보장한다.
+        run: sudo apt-get update && sudo apt-get install -y fonts-nanum
       - uses: dtolnay/rust-toolchain@1.93.0
-        with:
-          components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
-      # 세 검사는 서로 독립이므로 앞 단계가 실패해도 모두 실행해 한 번에 보고한다
-      # (fmt 실패가 clippy/test 실패를 가리지 않게 — 디버깅 왕복 감소).
-      # 아래 4개 게이트는 scripts/check.sh(로컬 미러)와 함께 유지한다.
-      # 한쪽만 바꾸면 "로컬 green, CI red" 드리프트가 재발한다.
-      - name: 포맷 검사
-        run: cargo fmt --all --check
-      - name: Clippy
-        if: ${{ !cancelled() }}
-        run: cargo clippy --workspace --all-targets -- -D warnings
-      - name: 테스트
-        if: ${{ !cancelled() }}
+      - name: Test
         run: cargo test --workspace
-      # 폰트는 커밋하지 않고 스크립트가 upstream에서 받아 manifest hash로 검증한다.
-      - name: 구조 문서 코퍼스 (명시 OFL 폰트, offline cargo)
-        if: ${{ !cancelled() }}
-        shell: bash
-        run: bash scripts/check-structured-corpus.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,64 +1,91 @@
 name: Release
 
-# vX.Y.Z 태그를 푸시하면: (1) 테스트 통과 (2) 태그↔Cargo.toml 버전 일치 를 확인한
-# 뒤에만, 플랫폼별 `hwp` 바이너리를 빌드해 GitHub Release(아카이브 + sha256)로 게시한다.
-# 릴리스 절차: scripts/release.sh X.Y.Z  →  git push origin main && git push origin vX.Y.Z
+# Pushing a vX.Y.Z tag publishes platform `hwp` binaries to a GitHub Release (archive +
+# sha256) only after (1) the tagged commit already has a green CI run and (2) the tag
+# matches the Cargo.toml version.
+# Release flow: scripts/release.sh X.Y.Z  ->  git push origin main && git push origin vX.Y.Z
 on:
   push:
-    # glob 패턴(정규식 아님) — 멀티자리/프리릴리스 모두 매칭(v10.2.3, v0.2.0-rc1).
-    # 정확한 버전 검증은 아래 verify-version 잡이 담당한다.
+    # glob pattern (not regex) — matches multi-digit and prerelease tags (v10.2.3, v0.2.0-rc1).
+    # Exact version verification is the verify-version job's job.
     tags: ["v*.*.*"]
 
 permissions:
   contents: write
   pull-requests: write
+  checks: read # verify-ci reads the tagged commit's check runs
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  # 테스트 통과 게이트 — ci.yml 의 fmt/clippy/test 잡을 그대로 재사용(단일 진실).
-  test:
-    uses: ./.github/workflows/ci.yml
+  # Pass gate: the tagged commit must already have a green CI run (ci.yml runs on every
+  # main push, and release.sh always tags main HEAD). Re-running the whole matrix here
+  # duplicated ~25 runner-minutes per release; reading the check-runs API gives the same
+  # guarantee. The job names below must stay in sync with ci.yml.
+  verify-ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tagged commit has green CI
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          expected=("lint" "test (ubuntu-latest)" "test (macos-latest)" "test (windows-latest)")
+          runs="$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?filter=latest&per_page=100")"
+          failed=0
+          for name in "${expected[@]}"; do
+            conclusion="$(jq -r --arg n "$name" \
+              '[.check_runs[] | select(.name == $n)] | sort_by(.completed_at) | .[-1].conclusion // "absent"' \
+              <<<"$runs")"
+            echo "$name: $conclusion"
+            [ "$conclusion" = "success" ] || failed=1
+          done
+          if [ "$failed" -ne 0 ]; then
+            echo "::error::Tagged commit $GITHUB_SHA has no green CI. Let the CI workflow pass on main, then re-run this workflow."
+            exit 1
+          fi
 
-  # 버전 관리 게이트 — 태그가 Cargo.toml [workspace.package] version 과 일치해야 릴리스.
+  # Version gate — the tag must match the Cargo.toml [workspace.package] version.
   verify-version:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: 태그 ↔ Cargo.toml 버전 일치 확인
+      - name: Tag matches Cargo.toml version
         run: |
           tag="${GITHUB_REF_NAME#v}"
           ver=$(awk '/^\[workspace\.package\]/{p=1;next} /^\[/{p=0} p&&/^version[[:space:]]*=/{sub(/^version[[:space:]]*=[[:space:]]*"/,"");sub(/".*/,"");print;exit}' Cargo.toml)
           echo "tag=$tag  Cargo.toml=$ver"
           if [ "$tag" != "$ver" ]; then
-            echo "::error::태그 v$tag 가 Cargo.toml [workspace.package] version=$ver 와 불일치. scripts/release.sh 로 버전 bump 후 태깅하세요."
+            echo "::error::tag v$tag does not match Cargo.toml [workspace.package] version=$ver. Bump the version with scripts/release.sh before tagging."
             exit 1
           fi
 
-  # 릴리스 셸 생성(커밋/PR 기반 자동 노트) — 한 번만. 이미 있으면 건너뜀(재실행 안전).
+  # Create the release shell once (notes come from the CHANGELOG section). Skipped if it
+  # already exists (rerun-safe).
   create-release:
-    needs: [test, verify-version]
+    needs: [verify-ci, verify-version]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: GitHub Release 생성
+      - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # 릴리스 본문은 CHANGELOG.md의 해당 버전 절(한/영 병기)을 그대로 쓴다.
-          # 절이 없으면 스크립트가 실패하므로, 릴리스 전에 CHANGELOG 갱신을 강제한다.
+          # The release body is the version's CHANGELOG.md section (bilingual) verbatim.
+          # The script fails when the section is missing, which forces a CHANGELOG update
+          # before any release.
           if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             bash scripts/release_notes.sh "$GITHUB_REF_NAME" > /tmp/release-notes.md
             gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" \
               --notes-file /tmp/release-notes.md --verify-tag
           fi
 
-  # 플랫폼별 `hwp` 바이너리 빌드 → 아카이브(tar.gz/zip) + sha256 을 릴리스에 업로드.
+  # Build platform `hwp` binaries -> upload archives (tar.gz/zip) + sha256 to the release.
   upload-assets:
     needs: create-release
     strategy:
-      fail-fast: false # 한 타깃 실패가 다른 타깃을 취소하지 않게
+      fail-fast: false # one target's failure must not cancel the others
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -72,7 +99,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      # 릴리스 바이너리는 stable 로 빌드(최신 최적화). MSRV 호환은 test 잡이 이미 보장.
+      # Release binaries build on stable (latest optimizations); MSRV compatibility is
+      # already guaranteed by CI, which builds and tests on the pinned MSRV toolchain.
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/upload-rust-binary-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,11 @@ jobs:
           runs="$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?filter=latest&per_page=100")"
           failed=0
           for name in "${expected[@]}"; do
-            conclusion="$(jq -r --arg n "$name" \
-              '[.check_runs[] | select(.name == $n)] | sort_by(.completed_at) | .[-1].conclusion // "absent"' \
+            state="$(jq -r --arg n "$name" \
+              '[.check_runs[] | select(.name == $n)] | sort_by(.completed_at) | .[-1] | if . == null then "absent" else "\(.status)/\(.conclusion // "pending")" end' \
               <<<"$runs")"
-            echo "$name: $conclusion"
-            [ "$conclusion" = "success" ] || failed=1
+            echo "$name: $state"
+            [ "$state" = "completed/success" ] || failed=1
           done
           if [ "$failed" -ne 0 ]; then
             echo "::error::Tagged commit $GITHUB_SHA has no green CI. Let the CI workflow pass on main, then re-run this workflow."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,10 +41,15 @@ HWP_FONT_DIR=$PWD/fonts python3 tools/diagnostic_corpus.py   # diagnostic corpus
   `cargo fmt --all --check` → `cargo clippy --workspace --all-targets -- -D warnings` →
   `cargo test --workspace`. For a partial run (clippy only, test only), pick the command directly
   instead of `scripts/check.sh`.
+  CI layout: fmt/clippy plus the structured-corpus gate run once in an ubuntu `lint` job; the
+  3-OS `test` matrix runs only `cargo test --workspace`. Tag releases do not re-run the matrix —
+  `release.yml` verifies the tagged commit's green CI via the check-runs API (job names there
+  must stay in sync with ci.yml).
 - Rust edition 2024, rust-version 1.93.
 - Fonts: **none are bundled** (`/fonts/` is gitignored - the diagnostic corpus and golden comparison
   use HCR Batang/Dotum if you download them locally). CI render glyphs come from system fonts
-  (noto-cjk installed on ubuntu, default CJK on macOS), so tests that run in CI must not assert on
+  (fonts-nanum on ubuntu - glyf TTFs; the CFF-based noto-cjk made debug-build rendering ~100x
+  slower - default CJK on macOS), so tests that run in CI must not assert on
   font-dependent output (glyphs, page counts).
 - `HWP_GOLDEN=1` - opt-in golden render comparison against Hangul reference PNGs. `HWP_CORPUS_DIR` -
   soak test over a large in-the-wild corpus.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,3 +53,15 @@ jsonschema = { version = "0.33", default-features = false }
 
 [profile.release]
 lto = "thin"
+
+# Keep dev/test renders fast: these crates do the hot outline parsing and path filling, and
+# unoptimized builds of them are ~100x slower on CFF-outline fonts (the CFF Noto CJK faces
+# once made the ubuntu CI test step take 15 minutes). Release binaries are unaffected.
+[profile.dev.package.ttf-parser]
+opt-level = 2
+[profile.dev.package.rustybuzz]
+opt-level = 2
+[profile.dev.package.tiny-skia]
+opt-level = 2
+[profile.dev.package.tiny-skia-path]
+opt-level = 2

--- a/README.ko.md
+++ b/README.ko.md
@@ -431,10 +431,11 @@ cargo build --all-targets
 scripts/check.sh     # 로컬 CI 미러: fmt + clippy + test + 구조 코퍼스 (PR 전 필수)
 ```
 
-CI(`.github/workflows/ci.yml`)는 `fonts-noto-cjk` 설치(ubuntu) 후 `cargo fmt --all --check` →
-`cargo clippy --workspace --all-targets -- -D warnings` → `cargo test --workspace` →
-`scripts/check-structured-corpus.sh`를 **ubuntu + macOS + windows**(모두 필수)에서
-실행한다. 로컬 미러 `scripts/check.sh`는 같은 게이트를 실행한다.
+CI(`.github/workflows/ci.yml`)는 플랫폼 무관 게이트(`cargo fmt --all --check`,
+`cargo clippy --workspace --all-targets -- -D warnings`, `scripts/check-structured-corpus.sh`)를
+ubuntu `lint` 잡에서 한 번만 실행하고, `cargo test --workspace`는 **ubuntu + macOS + windows**
+(모두 필수)에서 실행한다. ubuntu 테스트 잡은 `fonts-nanum`(glyf TTF. CFF `fonts-noto-cjk`는 디버그
+빌드 렌더링을 ~100배 느리게 만들었다)를 설치한다. 로컬 미러 `scripts/check.sh`는 같은 게이트를 실행한다.
 
 테스트는 hwp5 바이트 동일 왕복(identity/roundtrip/synth), hwpx 의미 동등 왕복, IR JSON·markdown 왕복,
 편집·필드 보정, 렌더 레이아웃·표·diff 메트릭, 구조 코퍼스 결정성을 포함한다. 정품 fixture는 저장소에

--- a/README.md
+++ b/README.md
@@ -465,10 +465,11 @@ cargo build --all-targets
 scripts/check.sh     # local CI mirror: fmt + clippy + test + structured corpus (required before a PR)
 ```
 
-CI (`.github/workflows/ci.yml`) installs `fonts-noto-cjk` on ubuntu and then runs
-`cargo fmt --all --check` → `cargo clippy --workspace --all-targets -- -D warnings` →
-`cargo test --workspace` → `scripts/check-structured-corpus.sh` on **ubuntu + macOS + windows**
-(all required). The local mirror `scripts/check.sh` runs the same gates.
+CI (`.github/workflows/ci.yml`) runs the platform-independent gates — `cargo fmt --all --check`,
+`cargo clippy --workspace --all-targets -- -D warnings`, and `scripts/check-structured-corpus.sh` —
+once in an ubuntu `lint` job, and runs `cargo test --workspace` on **ubuntu + macOS + windows**
+(all required). The ubuntu test job installs `fonts-nanum` (glyf TTFs; the CFF `fonts-noto-cjk`
+made debug-build rendering ~100x slower). The local mirror `scripts/check.sh` runs the same gates.
 
 Tests cover byte-identical hwp5 round-trips (identity/roundtrip/synth), semantically equivalent hwpx
 round-trips, IR JSON and markdown round-trips, editing and field correction, render layout, tables and

--- a/crates/hwp-cli/tests/cli_surface.rs
+++ b/crates/hwp-cli/tests/cli_surface.rs
@@ -1,13 +1,16 @@
-//! CLI 표면 커버리지 — CI에서 실행되는 서브커맨드 스모크 모음.
+//! CLI surface coverage — subcommand smokes that run in CI.
 //!
-//! 기존에는 `mcp`·`diff`·`render`·PDF 경로가 로컬 픽스처 게이트라 CI 커버리지가 0이었다.
-//! 이 스위트는 **커밋된 픽스처**(fixtures/samples/report-tables.hwpx)에 하드 의존해
-//! 스킵 없이 동작한다(신규 의존성 0 — hwp5·serde_json 기존 의존 재사용).
+//! Previously the `mcp`/`diff`/`render`/PDF paths were gated on local fixtures, so CI
+//! coverage was zero. This suite hard-depends on the **committed fixture**
+//! (fixtures/samples/report-tables.hwpx) and runs without skips (zero new dependencies —
+//! existing hwp5/serde_json deps are reused).
 //!
-//! 폰트 주의: 저장소에 동봉 폰트는 없다(`/fonts/`는 gitignore). 렌더 경로의 글리프는
-//! 시스템 폰트(ubuntu는 CI가 설치하는 noto-cjk, macOS는 기본 CJK)에서 온다. 그래서
-//! 이 스위트의 단언은 전부 **폰트 비의존**(페이지 크기=secPr 유래, 자기-diff, PDF 구조)
-//! 으로 설계돼 있다 — 글리프·페이지수 등 폰트 의존 단언을 여기 추가하지 말 것.
+//! Font note: no fonts are bundled in the repo (`/fonts/` is gitignored). Render-path
+//! glyphs come from system fonts (ubuntu CI installs fonts-nanum — glyf-outline TTFs;
+//! the CFF-based fonts-noto-cjk made debug-build rendering ~100x slower — macOS uses its
+//! default CJK fonts). Every assertion here is **font-independent** (page size derives
+//! from secPr, self-diff, PDF structure) — do not add font-dependent assertions (glyphs,
+//! page counts) here.
 
 use std::io::{BufRead, BufReader, Write as _};
 use std::path::PathBuf;


### PR DESCRIPTION
## What

CI ran the same checks too many times, and one environment-specific anomaly made every run slow. Measured on the v0.8.2 main run (31296686017):

- **ubuntu test step = 897s**, of which `tests/cli_surface.rs` alone = **795s** (a single `hwp render --pages 1` ≈ 328s). macOS 138s / Windows 156s for the whole step.
- Root cause: ubuntu installed **CFF-based `fonts-noto-cjk`**; outline extraction/shaping on CFF faces in a **debug** build is pathologically slow. macOS/Windows resolve glyf-outline fonts, and the structured-corpus gate (pinned glyf TTF `NotoSansKR[wght].ttf`) finishes its whole run in ~90s on the same runner.
- Every tag release **re-ran the full CI matrix** on the exact commit that had passed main CI minutes earlier.

## Changes

1. **`Cargo.toml`** — `opt-level = 2` for `ttf-parser` / `rustybuzz` / `tiny-skia{,-path}` in the **dev profile only**. Release binaries untouched (`[profile.release]` unchanged).
2. **`ci.yml`** — split into `lint` (ubuntu-only: fmt + clippy + structured corpus) and `test` (3-OS matrix: `cargo test` only). Same gate set as `scripts/check.sh` + corpus script. CI font package swapped `fonts-noto-cjk` → **`fonts-nanum`** (glyf TTFs; `나눔고딕`/`NanumGothic` precede Noto CJK in the renderer fallback list, and cli_surface assertions are font-independent by design). `workflow_call` trigger removed (no callers left).
3. **`release.yml`** — the tag gate `test: uses: ./.github/workflows/ci.yml` is replaced by a small `verify-ci` job that reads the tagged commit's check runs (`checks: read` permission) and requires `lint` + all three `test (*)` jobs to be green, with a clear re-run instruction on failure. Verified the query/jq logic against the v0.8.2 tag SHA (`lint: absent` there only because the job didn't exist yet — the three `test (*)` names match and report `success`).
4. **`CLAUDE.md` / `cli_surface.rs`** — document the new layout and font choice; touched comments move to English per the language policy.

## Expected effect

- Per CI run: wall clock ~17min → ~5min; runner-minutes ~26 → ~13.
- Per release: one entire duplicate 3-job matrix run eliminated (~25 runner-min + the release no longer waits on it).

## Notes

- The `verify-ci` gate fully exercises only at the next tag. If a tag is ever pushed before main CI finishes, the job fails with instructions — re-running the release workflow after CI greens is the intended recovery.
- Branch protection has no required status checks, so the job rename (`test` → `lint` + `test`) is safe.

The before/after proof is this PR's own CI run: watch the ubuntu test step time.
