### PR TITLE
Prepare v0.8.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.8.3]
+
+**Fixed**
+
+- CI no longer re-runs platform-independent gates on every OS, nor the whole test matrix on
+  every tag: `ci.yml` runs fmt, clippy, and the structured-corpus gate once in an ubuntu `lint`
+  job and only `cargo test --workspace` in the 3-OS `test` matrix, and `release.yml` verifies the
+  tagged commit's already-green CI via the check-runs API instead of re-running it. The ubuntu
+  test step also drops from ~15 minutes to ~2: render tests now resolve glyf-outline Nanum TTFs
+  instead of CFF Noto CJK fonts, and the dev profile builds ttf-parser/rustybuzz/tiny-skia with
+  opt-level 2 (release binaries unaffected).
+
 ## [0.8.2]
 
 **Added**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-cli"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "hwp-model",
  "image",
@@ -710,14 +710,14 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "hwp-render"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "flate2",
  "fontdb",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "cfb",
  "flate2",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "hwp-convert",
  "hwp-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,14 @@ license = "MIT OR Apache-2.0"
 rust-version = "1.93"
 
 [workspace.dependencies]
-# 내부 크레이트
+# Internal crates
 hwp-model = { path = "crates/hwp-model" }
 hwp5 = { path = "crates/hwp5" }
 hwpx = { path = "crates/hwpx" }
 hwp-convert = { path = "crates/hwp-convert" }
 hwp-render = { path = "crates/hwp-render" }
 
-# 공용 외부 의존성
+# Shared external dependencies
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
@@ -30,23 +30,23 @@ libc = "0.2"
 resvg = { version = "=0.47.0", default-features = false }
 regex = "1.11"
 zip = "8"
-# 자체 업데이트(hwp update)의 릴리스 아카이브 체크섬 대조 — zip이 이미 끌어오는 크레이트라
-# 의존성 그래프가 늘지 않는다.
+# Checksum verification for self-update (hwp update) release archives — already
+# pulled in via zip, so the dependency graph does not grow.
 sha2 = "0.11"
 getrandom = "0.3"
 pulldown-cmark = { version = "0.13", default-features = false }
 
-# 렌더링
+# Rendering
 tiny-skia = "0.12"
 rustybuzz = "0.20"
 fontdb = "0.23"
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "bmp", "gif"] }
 
-# PDF 백엔드
+# PDF backend
 pdf-writer = "0.15"
 subsetter = "0.2"
 
-# 테스트 전용
+# Test-only
 insta = { version = "1", features = ["json"] }
 proptest = "1"
 jsonschema = { version = "0.33", default-features = false }


### PR DESCRIPTION
Prepares the v0.8.3 patch release — primarily a live test of the new release gate merged in #70 (`release.yml` `verify-ci` now validates the tagged commit's existing green CI via the check-runs API instead of re-running the whole matrix).

- `CHANGELOG.md`: `## [0.8.3]` section covering the CI dedup/speed fix (#70); `scripts/release_notes.sh v0.8.3` extraction verified.
- `Cargo.toml` / `Cargo.lock`: workspace version 0.8.2 → 0.8.3 (`cargo update --workspace --offline`, no external dependency changes).

After merge: wait for main CI on the merge commit, then tag it `v0.8.3` and push the tag.
