### PR TITLE
Fix Amazon Quick Low-integrity MCP root guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+**Fixed**
+
+- Amazon Quick Desktop Windows guidance now uses a dedicated
+  `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` MCP root. Quick starts local MCP children at
+  Low mandatory integrity, so discovery can succeed under a normal Medium-integrity `C:\TEMP`
+  root while the first atomic document write still fails with `Access is denied (os error 5)`.
+
 ## [0.8.3]
 
 **Fixed**
@@ -36,10 +43,10 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 - Amazon Quick Desktop on Windows: keep canonical MCP paths in verbatim form for sandbox
   authorization, then use ordinary drive/UNC spelling for filesystem I/O only when every component
   has equivalent Win32 semantics. Paths with trailing dots/spaces, reserved device names, or other
-  verbatim-only semantics remain verbatim or fail closed. This lets Quick accept atomic output
-  staging under its `C:\TEMP` exchange root without weakening root containment. Also document
-  separate JSON arguments and recovery from the `Access is denied` handshake loop that causes Quick
-  to auto-disable the connector.
+  verbatim-only semantics remain verbatim or fail closed. This removes the verbatim-path failure
+  without weakening root containment. Current Quick builds also require a separate Low-integrity
+  write root. Also document separate JSON arguments and recovery from the `Access is denied`
+  handshake loop that causes Quick to auto-disable the connector.
 
 ## [0.8.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,9 +44,8 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
   authorization, then use ordinary drive/UNC spelling for filesystem I/O only when every component
   has equivalent Win32 semantics. Paths with trailing dots/spaces, reserved device names, or other
   verbatim-only semantics remain verbatim or fail closed. This removes the verbatim-path failure
-  without weakening root containment. Current Quick builds also require a separate Low-integrity
-  write root. Also document separate JSON arguments and recovery from the `Access is denied`
-  handshake loop that causes Quick to auto-disable the connector.
+  without weakening root containment. Also document separate JSON arguments and recovery from the
+  `Access is denied` handshake loop that causes Quick to auto-disable the connector.
 
 ## [0.8.1]
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -354,10 +354,11 @@ Amazon Quick Desktop은 로컬 stdio 서버를 실행해 16개 도구를 모두 
 hwp skill export --install amazon-quick
 ```
 
-Windows에서는 `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` 전용 디렉터리를 MCP
-`--root`로 사용한다. Quick은 로컬 MCP 자식을 Low mandatory integrity로 시작하므로 `C:\TEMP`에서
-도구 탐색은 통과해도 첫 쓰기가 거부될 수 있다. Quick의 로컬 폴더 권한은 이 쓰기 무결성을 바꾸지
-않으므로 전용 가이드의 생성·import JSON·복구 절차를 따른다.
+Windows에서는 `%USERPROFILE%\AppData\LocalLow` 아래에 전용 교환 root(예: `hwp-quick-workspace`)를
+만들고 그 절대 경로를 MCP `--root`로 전달한다(Quick 인자는 환경 변수를 확장하지 않는다). Quick은
+로컬 MCP 자식을 Low mandatory integrity로 시작하므로 `C:\TEMP`에서 도구 탐색은 통과해도 첫 쓰기가
+거부될 수 있다. Quick의 로컬 폴더 권한은 이 쓰기 무결성을 바꾸지 않으므로 전용 가이드의
+생성·import JSON·복구 절차를 따른다.
 
 Amazon Quick Web은 로컬 stdio 프로세스를 시작할 수 없다. 인증된 Streamable HTTP, tenant 격리,
 artifact 전송 요구사항은 후속 작업용 [Remote MCP transport](docs/design/20-remote-mcp.ko.md)에

--- a/README.ko.md
+++ b/README.ko.md
@@ -354,9 +354,10 @@ Amazon Quick Desktop은 로컬 stdio 서버를 실행해 16개 도구를 모두 
 hwp skill export --install amazon-quick
 ```
 
-Windows에서는 Quick 샌드박스가 쓸 수 있는 `C:\TEMP` 교환 디렉터리를 MCP `--root`로 사용한다.
-Quick의 로컬 폴더 권한에 추가한 사용자 프로필 폴더도 로컬 MCP 자식 프로세스에는 접근 불가할 수
-있다. 전용 가이드의 import JSON과 복구 절차를 따른다.
+Windows에서는 `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` 전용 디렉터리를 MCP
+`--root`로 사용한다. Quick은 로컬 MCP 자식을 Low mandatory integrity로 시작하므로 `C:\TEMP`에서
+도구 탐색은 통과해도 첫 쓰기가 거부될 수 있다. Quick의 로컬 폴더 권한은 이 쓰기 무결성을 바꾸지
+않으므로 전용 가이드의 생성·import JSON·복구 절차를 따른다.
 
 Amazon Quick Web은 로컬 stdio 프로세스를 시작할 수 없다. 인증된 Streamable HTTP, tenant 격리,
 artifact 전송 요구사항은 후속 작업용 [Remote MCP transport](docs/design/20-remote-mcp.ko.md)에

--- a/README.md
+++ b/README.md
@@ -384,9 +384,10 @@ publish-safe skill into its active profile with:
 hwp skill export --install amazon-quick
 ```
 
-On Windows, use Quick's sandbox-writable `C:\TEMP` exchange directory as the MCP `--root`.
-A user-profile folder added to Quick's local-folder permissions may still be inaccessible to the
-local MCP child; use the dedicated runbook's import JSON and recovery steps.
+On Windows, use a dedicated `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` directory as the
+MCP `--root`. Quick starts the local MCP child at Low mandatory integrity, so `C:\TEMP` can pass
+tool discovery but reject the first write. Quick's local-folder permissions do not change that
+write integrity; use the dedicated runbook's creation, import JSON, and recovery steps.
 
 Amazon Quick Web cannot launch a local stdio process. Authenticated Streamable HTTP, tenant
 isolation and artifact transfer are specified for future work in

--- a/README.md
+++ b/README.md
@@ -384,10 +384,12 @@ publish-safe skill into its active profile with:
 hwp skill export --install amazon-quick
 ```
 
-On Windows, use a dedicated `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` directory as the
-MCP `--root`. Quick starts the local MCP child at Low mandatory integrity, so `C:\TEMP` can pass
-tool discovery but reject the first write. Quick's local-folder permissions do not change that
-write integrity; use the dedicated runbook's creation, import JSON, and recovery steps.
+On Windows, create a dedicated exchange root under `%USERPROFILE%\AppData\LocalLow` (for example
+`hwp-quick-workspace`) and pass its absolute path as the MCP `--root` (Quick arguments do not
+expand environment variables). Quick starts the local MCP child at Low mandatory integrity, so
+`C:\TEMP` can pass tool discovery but reject the first write. Quick's local-folder permissions do
+not change that write integrity; use the dedicated runbook's creation, import JSON, and recovery
+steps.
 
 Amazon Quick Web cannot launch a local stdio process. Authenticated Streamable HTTP, tenant
 isolation and artifact transfer are specified for future work in

--- a/docs/manual/ai-integrations.ko.md
+++ b/docs/manual/ai-integrations.ko.md
@@ -164,8 +164,17 @@ Apple Silicon Homebrew에서는 흔히 `/opt/homebrew/bin/hwp`가 나온다. 이
 
 #### Windows 샌드박스 호환 설정
 
-Windows에서는 사용자 프로필 아래 폴더 대신 Quick이 쓸 수 있는 `C:\TEMP` 교환 디렉터리로
-시작한다.
+Windows에서는 커넥터를 등록하기 전에 시스템이 제공하는 Low 무결성 디렉터리 아래에 전용 자식을
+만든다.
+
+```powershell
+$QuickHwpRoot = Join-Path $env:USERPROFILE 'AppData\LocalLow\hwp-quick-workspace'
+New-Item -ItemType Directory -Path $QuickHwpRoot -Force | Out-Null
+icacls.exe $QuickHwpRoot
+```
+
+출력에 상속된 Low mandatory label이 있어야 한다. Arguments는 환경 변수를 확장하지 않으므로 아래
+커넥터 JSON의 `YOUR_NAME`을 실제 Windows 계정 폴더명으로 바꾼다.
 
 ```json
 {
@@ -177,7 +186,7 @@ Windows에서는 사용자 프로필 아래 폴더 대신 Quick이 쓸 수 있�
         "--font-dir",
         "C:\\Windows\\Fonts",
         "--root",
-        "C:\\TEMP"
+        "C:\\Users\\YOUR_NAME\\AppData\\LocalLow\\hwp-quick-workspace"
       ]
     }
   }
@@ -185,12 +194,13 @@ Windows에서는 사용자 프로필 아래 폴더 대신 Quick이 쓸 수 있�
 ```
 
 각 인자는 JSON 배열의 별도 항목으로 유지하고 Windows 경로에 셸 따옴표를 덧붙이지 않는다.
-Quick의 **Local folders and access permissions**는 내장 파일 도구의 접근을 제어하지만, 로컬 MCP
-자식 프로세스는 사용자 프로필의 실제 경로를 canonicalize하지 못할 수 있다. 이 경우 `hwp`가
-`--root ... Access is denied (os error 5)`로 종료되고 MCP handshake가 닫히며, 재시도 뒤 Quick이
-커넥터를 자동으로 비활성화한다. `C:\TEMP`는 Quick의 Windows 샌드박스가 지원하는 특수 임시
-디렉터리다. HWP 작업 전 입력 파일을 이곳으로 옮기거나 복사하고, MCP 입력과 출력을 이 root
-아래에 유지한 다음 완성된 artifact를 승인된 목적 폴더로 복사한다.
+Quick의 **Local folders and access permissions**는 내장 읽기·검색 도구를 제어하며 로컬 MCP 자식의
+쓰기 무결성은 바꾸지 않는다. Quick은 `hwp.exe`를 Low mandatory integrity(`S-1-16-4096`)로
+시작하지만 `C:\TEMP`와 `%LOCALAPPDATA%\Temp`는 보통 Medium이다. 이 불일치 때문에 커넥터 탐색은
+성공해도 첫 atomic output staging 디렉터리가 `Access is denied (os error 5)`로 거부된다.
+`AppData\LocalLow`의 자식은 광범위한 ACL 변경 없이 필요한 Low 레이블을 상속한다. HWP 작업 전에
+입력을 전용 root로 옮기거나 복사하고, MCP 입력과 출력을 그 아래에 유지한 다음 검증된 artifact를
+승인된 목적 폴더로 복사한다.
 
 자동 비활성화된 커넥터의 설정을 바꾼 뒤에는 명시적으로 다시 활성화한다. 복구되면
 **Connected**, **16 tools available**가 표시되고 새로고침 뒤에도 활성 상태를 유지한다.
@@ -242,7 +252,7 @@ HTML로 오인할 수 있는 angle-bracket markup을 포함하지 않는다.
 - 커넥터 테스트가 **Connected**, **16 tools available**을 표시함
 - 새로고침 뒤에도 커넥터가 활성화되어 있고 **16 tools, Connected**를 표시함
 - 테스트 HWPX에서 `hwp_new`, `hwp_read`, `hwp_validate`, `hwp_render`가 성공함(Windows에서는
-  `C:\TEMP` 아래에서 테스트)
+  `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` 아래에서 테스트)
 - HWP 전용 에이전트가 하나만 존재하며 prohibited HTML/script 오류 없이 publish됨
 
 ## Amazon Quick Web

--- a/docs/manual/ai-integrations.ko.md
+++ b/docs/manual/ai-integrations.ko.md
@@ -252,7 +252,7 @@ HTML로 오인할 수 있는 angle-bracket markup을 포함하지 않는다.
 - 커넥터 테스트가 **Connected**, **16 tools available**을 표시함
 - 새로고침 뒤에도 커넥터가 활성화되어 있고 **16 tools, Connected**를 표시함
 - 테스트 HWPX에서 `hwp_new`, `hwp_read`, `hwp_validate`, `hwp_render`가 성공함(Windows에서는
-  `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` 아래에서 테스트)
+  설정된 LocalLow root 아래에서 테스트. 예: `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace`)
 - HWP 전용 에이전트가 하나만 존재하며 prohibited HTML/script 오류 없이 publish됨
 
 ## Amazon Quick Web

--- a/docs/manual/ai-integrations.md
+++ b/docs/manual/ai-integrations.md
@@ -257,7 +257,7 @@ contain no angle-bracket markup that Quick can misclassify as HTML.
 - Connector test reports **Connected** and **16 tools available**.
 - After refresh, the connector remains enabled and reports **16 tools, Connected**.
 - `hwp_new`, `hwp_read`, `hwp_validate`, and `hwp_render` succeed on a test HWPX document (under
-  `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` on Windows).
+  the configured LocalLow root, e.g. `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace`, on Windows).
 - Exactly one HWP-focused agent exists, and it publishes without the prohibited HTML/script error.
 
 ## Amazon Quick Web

--- a/docs/manual/ai-integrations.md
+++ b/docs/manual/ai-integrations.md
@@ -166,8 +166,18 @@ Equivalent import JSON:
 
 #### Windows sandbox-compatible setup
 
-On Windows, start with Quick's writable `C:\TEMP` exchange directory instead of a directory
-under the user profile:
+On Windows, create a dedicated child of the system-provided Low-integrity directory before
+registering the connector:
+
+```powershell
+$QuickHwpRoot = Join-Path $env:USERPROFILE 'AppData\LocalLow\hwp-quick-workspace'
+New-Item -ItemType Directory -Path $QuickHwpRoot -Force | Out-Null
+icacls.exe $QuickHwpRoot
+```
+
+The output must include an inherited Low mandatory label. Substitute the actual Windows account
+folder for `YOUR_NAME` in the connector JSON; the argument list does not expand environment
+variables:
 
 ```json
 {
@@ -179,7 +189,7 @@ under the user profile:
         "--font-dir",
         "C:\\Windows\\Fonts",
         "--root",
-        "C:\\TEMP"
+        "C:\\Users\\YOUR_NAME\\AppData\\LocalLow\\hwp-quick-workspace"
       ]
     }
   }
@@ -187,12 +197,13 @@ under the user profile:
 ```
 
 Keep each argument as a separate JSON array item; do not add shell quotes around Windows paths.
-Quick's **Local folders and access permissions** control its built-in file tools, but a local MCP
-child can still be unable to canonicalize a direct user-profile path. In that case `hwp` exits
-with `--root ... Access is denied (os error 5)`, the MCP handshake closes, and Quick eventually
-auto-disables the connector. `C:\TEMP` is a special temporary directory supported by Quick's
-Windows sandbox. Move or copy inputs into it before an HWP operation, keep MCP inputs and outputs
-under that root, and copy final artifacts to the intended approved folder afterward.
+Quick's **Local folders and access permissions** control its built-in read/search tools, not the
+write integrity of a local MCP child. Quick starts `hwp.exe` at Low mandatory integrity
+(`S-1-16-4096`), while `C:\TEMP` and `%LOCALAPPDATA%\Temp` are normally Medium. That mismatch allows
+connector discovery but rejects the first atomic output staging directory with
+`Access is denied (os error 5)`. A child of `AppData\LocalLow` inherits the required Low label
+without broad ACL changes. Move or copy inputs into that dedicated root, keep MCP inputs and
+outputs under it, and copy validated artifacts to the approved destination afterward.
 
 After changing an auto-disabled connector, explicitly enable it again. A successful recovery
 reports **Connected** and **16 tools available** and remains enabled after refresh.
@@ -246,7 +257,7 @@ contain no angle-bracket markup that Quick can misclassify as HTML.
 - Connector test reports **Connected** and **16 tools available**.
 - After refresh, the connector remains enabled and reports **16 tools, Connected**.
 - `hwp_new`, `hwp_read`, `hwp_validate`, and `hwp_render` succeed on a test HWPX document (under
-  `C:\TEMP` on Windows).
+  `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` on Windows).
 - Exactly one HWP-focused agent exists, and it publishes without the prohibited HTML/script error.
 
 ## Amazon Quick Web

--- a/docs/manual/amazon-quick-desktop.ko.md
+++ b/docs/manual/amazon-quick-desktop.ko.md
@@ -10,6 +10,8 @@
 Quick 릴리스에 따라 UI 이름과 내부 파일명이 바뀔 수 있다. Quick 내부 설정 파일을 직접 편집하기보다
 이 문서의 UI 절차와 import JSON을 사용한다.
 
+검증 기준: 2026-08-09 Windows의 Amazon Quick Desktop `0.1000.2660`, hwp-cli `0.8.3`.
+
 ## 정상 구성 요소
 
 | 구성요소 | 역할 | Windows 확인값 |
@@ -17,7 +19,7 @@ Quick 릴리스에 따라 UI 이름과 내부 파일명이 바뀔 수 있다. Qu
 | `hwp.exe` | MCP stdio 서버 실행 | 안정된 절대 경로의 최신 바이너리 하나 |
 | HWP MCP 커넥터 | HWP 도구 16개 노출 | `hwp.exe mcp ...` |
 | HWP 스킬 | Quick 에이전트에게 도구 사용 시점과 방법 안내 | 활성 Quick 프로필의 `skills/hwp/SKILL.md` |
-| 교환 root | Quick과 MCP 자식 프로세스가 파일을 주고받는 경계 | `C:\TEMP` |
+| 교환 root | Low 무결성 MCP 자식과 파일을 주고받는 경계 | `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` |
 | 폰트 디렉터리 | Windows 렌더링 폰트 공급 | `C:\Windows\Fonts` |
 
 커넥터와 스킬은 서로 별개다. 스킬 설치는 바이너리를 설치하거나 커넥터를 만들지 않는다. 커넥터에
@@ -62,17 +64,31 @@ Quick에도 이 경로를 그대로 입력한다. 다른 터미널의 PATH에 �
 
 ## 2. Windows 교환 root 만들기
 
-Quick 내장 파일 도구와 로컬 MCP 자식 프로세스는 항상 같은 파일 권한을 받지 않는다. **Local folders
-and access permissions**에 사용자 프로필 폴더를 추가해도 MCP 자식 프로세스가 거부될 수 있다.
-확인된 샌드박스 교환 디렉터리부터 사용한다.
+Quick 내장 파일 도구와 로컬 MCP 자식 프로세스는 같은 파일 권한을 받지 않는다. 확인한 Windows
+빌드에서 Quick은 `hwp.exe`를 Low mandatory integrity(`S-1-16-4096`)로 시작한다. `C:\TEMP`와
+`%LOCALAPPDATA%\Temp` 같은 일반 폴더는 보통 Medium 무결성이다. 이 경로에서는 MCP 커넥터가
+시작하고 도구 16개를 노출해도, `hwp_new`가 private staging 디렉터리를 만드는 첫 쓰기에서
+`Access is denied (os error 5)`가 발생할 수 있다.
+
+Windows가 기본 제공하는 `LocalLow` 아래에 전용 자식 디렉터리를 만든다. 관리자 권한 없이 Low
+무결성 레이블을 상속한다.
 
 ```powershell
-New-Item -ItemType Directory -Path C:\TEMP -Force
+$QuickHwpRoot = Join-Path $env:USERPROFILE 'AppData\LocalLow\hwp-quick-workspace'
+New-Item -ItemType Directory -Path $QuickHwpRoot -Force | Out-Null
+$QuickHwpRoot
+icacls.exe $QuickHwpRoot
 ```
 
-커넥터의 `--root`를 `C:\TEMP`로 지정한다. HWP 도구를 부르기 전에 입력 `.hwp`, `.hwpx`, Markdown,
-JSON, 이미지, 템플릿을 이곳으로 복사한다. 모든 MCP 입력·출력 경로를 이 root 아래에 유지하고, 작업이
-끝나면 Quick 내장 파일 도구나 Explorer로 최종 artifact를 목적 폴더에 복사한다.
+`icacls` 출력에 `Mandatory Label\Low Mandatory Level:(I)(OI)(CI)(NW)`와 동등한 상속 항목이
+있어야 한다. 없다면 상속을 켠 상태로 `LocalLow` 아래에 새 자식 디렉터리를 만든다. `C:\TEMP` 전체의
+무결성 수준을 낮추거나, 광범위한 쓰기 권한을 추가하거나, MCP root를 제거하지 않는다.
+
+출력된 절대 경로를 커넥터의 `--root`로 지정한다. 아래 JSON과 MCP 도구 인자에서는 `YOUR_NAME`을
+실제 Windows 계정 폴더명으로 바꾼다. Quick Arguments와 MCP 도구는 셸 확장을 하지 않으므로
+`%USERPROFILE%` 문자열을 그대로 넘기지 않는다. HWP 도구를 부르기 전에 입력 `.hwp`, `.hwpx`,
+Markdown, JSON, 이미지, 템플릿을 교환 root로 복사한다. 모든 MCP 입력·출력 경로를 이 root 아래에
+유지하고, 작업이 끝나면 Quick 내장 파일 도구나 Explorer로 검증된 artifact를 목적 폴더에 복사한다.
 
 `--root`는 호환 설정인 동시에 보안 경계다. 권한 오류를 피하려고 제거하지 않는다.
 
@@ -113,15 +129,15 @@ Quick Desktop에서 **Settings → Capabilities → Connectors → + Create → 
         "--font-dir",
         "C:\\Windows\\Fonts",
         "--root",
-        "C:\\TEMP"
+        "C:\\Users\\YOUR_NAME\\AppData\\LocalLow\\hwp-quick-workspace"
       ]
     }
   }
 }
 ```
 
-`command`만 실제 경로로 바꾼다. JSON에서 이중 백슬래시는 일반 Windows 백슬래시를 표현할 뿐,
-실제 경로를 바꾸지 않는다.
+`command`와 `YOUR_NAME`을 실제 값으로 바꾼다. JSON에서 이중 백슬래시는 일반 Windows 백슬래시를
+표현할 뿐, 실제 경로를 바꾸지 않는다.
 
 직접 입력할 때는 다음 값을 사용한다.
 
@@ -129,7 +145,7 @@ Quick Desktop에서 **Settings → Capabilities → Connectors → + Create → 
 |---|---|
 | Name | `hwp` |
 | Command | 앞에서 검증한 정확한 `hwp.exe` 절대 경로 |
-| Arguments | `mcp --font-dir C:\Windows\Fonts --root C:\TEMP` |
+| Arguments | `mcp --font-dir C:\Windows\Fonts --root C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace` |
 | Description | `Read, write, edit, render, validate, and convert HWP/HWPX documents.` |
 | Timeout | `30`초 |
 
@@ -137,7 +153,7 @@ Arguments 입력란은 셸이 아니다. 경로 앞뒤에 작은따옴표나 큰
 예다.
 
 ```text
-mcp --font-dir 'C:\Windows\Fonts' --root 'C:\TEMP'
+mcp --font-dir 'C:\Windows\Fonts' --root 'C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace'
 ```
 
 Quick은 이 따옴표를 제거하지 않고 그대로 넘길 수 있다. 그러면 `hwp`는 따옴표가 이름에 포함된 폴더를
@@ -154,11 +170,11 @@ available**이 표시되어야 한다. 이어서 **Add MCP**를 선택하고 다
 
 ```text
 셸 명령이 아니라 HWP MCP 도구를 사용하라.
-1. 다음 Markdown으로 hwp_new를 호출해 C:\TEMP\quick-hwp-smoke.hwpx를 생성하라.
+1. 다음 Markdown으로 hwp_new를 호출해 C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\quick-hwp-smoke.hwpx를 생성하라.
    # Quick MCP smoke test
 
    Amazon Quick can create HWPX files through hwp MCP.
-2. C:\TEMP\quick-hwp-smoke.hwpx에 hwp_validate를 호출하라.
+2. C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\quick-hwp-smoke.hwpx에 hwp_validate를 호출하라.
 3. 같은 파일에 plain 형식으로 hwp_read를 호출하라.
 4. 정확한 출력 경로와 검증 결과를 보고하라. valid가 true가 아니면 성공이라고 말하지 마라.
 ```
@@ -173,8 +189,8 @@ available**이 표시되어야 한다. 이어서 **Add MCP**를 선택하고 다
 }
 ```
 
-시각 결과가 중요하면 1쪽에 `hwp_render`를 추가로 호출하고 출력도 `C:\TEMP` 아래에 쓴다. 이 단계는
-문서 생성과 별도로 폰트 접근·렌더링을 확인한다.
+시각 결과가 중요하면 1쪽에 `hwp_render`를 추가로 호출하고 출력도 같은 `hwp-quick-workspace`
+root 아래에 쓴다. 이 단계는 문서 생성과 별도로 폰트 접근·렌더링을 확인한다.
 
 ## 6. Quick 에이전트에 지속 지침 추가
 
@@ -183,8 +199,9 @@ available**이 표시되어야 한다. 이어서 **Add MCP**를 선택하고 다
 
 ```text
 .hwp 또는 .hwpx 작업에는 설치된 hwp 스킬과 HWP MCP 도구를 사용한다.
-Windows에서는 활성 커넥터가 다른 root를 명시적으로 노출하지 않는 한 C:\TEMP 아래 경로만 사용한다.
-HWP 작업 전에 입력을 C:\TEMP로 복사하고 최종 artifact의 C:\TEMP 경로를 사용자에게 반환한다.
+Windows Quick Desktop에서는 MCP 커넥터에 설정된 절대 LocalLow root 아래 경로만 사용한다.
+확인된 root는 C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace이며 도구 호출 전에 YOUR_NAME을 바꾼다.
+HWP 작업 전에 입력을 그 root로 복사하고 최종 artifact도 그 아래 절대 경로로 반환한다.
 hwp_new, hwp_edit, hwp_fill, hwp_convert, hwp_compose, hwp_template 뒤에는 항상 hwp_validate를 호출한다.
 페이지 모양이 중요하면 hwp_render도 호출해 요청된 페이지를 확인한다.
 자동 생성된 MCP 서버 prefix를 하드코딩하지 말고 hwp_new/hwp_read 같은 도구 이름으로 선택한다.
@@ -192,50 +209,55 @@ Access is denied가 나오면 시도한 경로와 설정 root를 보고한다. r
 커넥터 탐색만으로 성공이라 말하지 말고 요청 작업과 검증이 모두 통과해야 성공으로 판정한다.
 ```
 
-OneDrive나 SharePoint 커넥터는 선택 사항이다. 원본이나 완성 파일을 `C:\TEMP` 안팎으로 복사할 때만
-사용하며, 로컬 HWP MCP 커넥터를 대체하지 않는다.
+OneDrive나 SharePoint 커넥터는 선택 사항이다. 원본이나 완성 파일을 설정된 교환 root 안팎으로
+복사할 때만 사용하며, 로컬 HWP MCP 커넥터를 대체하지 않는다.
 
 ## 일상 작업 흐름
 
-1. 모든 원본 파일과 참조 asset을 `C:\TEMP`로 복사한다.
-2. Quick에 정확한 입력·출력 경로를 준다. 예: “`C:\TEMP\input.hwpx`를 읽어 초안을 최종으로
-   바꾸고 `C:\TEMP\final.hwpx`에 저장하라.”
+1. 모든 원본 파일과 참조 asset을 `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace`로 복사한다.
+2. Quick에 정확한 입력·출력 경로를 준다. 예:
+   “`C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\input.hwpx`를 읽어 초안을 최종으로
+   바꾸고 `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\final.hwpx`에 저장하라.”
 3. 모든 쓰기 뒤 `hwp_validate`를 요구한다. 레이아웃이 중요하면 `hwp_render`도 요구한다.
 4. 반환된 경로와 검증 결과를 확인한 뒤 artifact를 열거나 검사한다.
-5. 검증한 출력을 `C:\TEMP`에서 승인된 목적지로 복사한다. 목적지 사본을 확인한 뒤에만 교환 파일을
+5. 검증한 출력을 교환 root에서 승인된 목적지로 복사한다. 목적지 사본을 확인한 뒤에만 교환 파일을
    정리한다.
 
 활용 prompt 예:
 
-- “`C:\TEMP\input.hwp`를 요약하고 표 목록을 보여줘.”
-- “`C:\TEMP\input.hwpx`를 `C:\TEMP\input.md`로 변환해줘.”
-- “이 Markdown으로 `C:\TEMP\report.hwpx`를 만들고 검증한 뒤 1쪽을 렌더해줘.”
-- “`C:\TEMP\template.hwpx`의 slot을 채워 `C:\TEMP\filled.hwpx`에 쓰고 검증해줘.”
+- “`C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\input.hwp`를 요약하고 표 목록을 보여줘.”
+- “`C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\input.hwpx`를 `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\input.md`로 변환해줘.”
+- “이 Markdown으로 `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\report.hwpx`를 만들고 검증한 뒤 1쪽을 렌더해줘.”
+- “`C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\template.hwpx`의 slot을 채워 `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\filled.hwpx`에 쓰고 검증해줘.”
 
 ## 증상별 문제 해결
 
 | 증상 | 예상 원인 | 복구 |
 |---|---|---|
 | `hwp.exe`가 시작하지 않거나 `--version`이 실패함 | 잘못된 바이너리·아키텍처, 차단되거나 불완전한 압축 해제 | 다시 다운로드하고 SHA-256을 확인한 뒤 Windows x86_64 아카이브를 풀고 정확한 절대 command를 테스트한다 |
-| Test connection에 도구가 없거나 서버가 즉시 종료함 | 없거나 읽을 수 없는 `--root`, Arguments 안의 따옴표 문자, 오타, 오래된 command 경로 | `C:\TEMP` 존재 확인, 위 JSON import, 셸 따옴표 제거, `hwp.exe --version` 검증 |
-| **Connected, 16 tools**인데 `hwp_new`가 `Access is denied (os error 5)`를 반환함 | 전송은 정상이나 MCP 자식이 요청 경로를 쓸 수 없거나, 구버전이 `\\?\...`를 Quick 샌드박스에 전달함 | 입력·출력을 모두 `C:\TEMP` 아래로 옮기고 `--root C:\TEMP` 유지, `hwp` 업그레이드, 재시작 뒤 smoke test |
-| **Local folders and access permissions**에 추가한 경로도 실패함 | 그 설정은 Quick 내장 파일 도구를 제어하며 로컬 MCP 자식에는 동일하게 적용되지 않을 수 있음 | 내장 도구로 파일을 `C:\TEMP`에 복사한 뒤 그곳에서 HWP 도구를 호출한다 |
-| `os error 2` | 경로가 실제로 없음. Desktop이 OneDrive로 이동됐을 수 있음 | 실제 경로 확인, 목적 디렉터리 생성, 또는 `C:\TEMP`에 staging |
+| Test connection에 도구가 없거나 서버가 즉시 종료함 | 없거나 읽을 수 없는 `--root`, 바꾸지 않은 `YOUR_NAME`, Arguments 안의 따옴표 문자, 오타, 오래된 command 경로 | `LocalLow` 자식 생성, 실제 계정 절대 경로 치환, 위 JSON import, 셸 따옴표 제거, `hwp.exe --version` 검증 |
+| **Connected, 16 tools**인데 `hwp_new`가 `Access is denied (os error 5)`를 반환함 | 탐색에는 읽기 권한만 필요했다. 요청 목적지가 Medium 무결성(대표적으로 `C:\TEMP`, `%LOCALAPPDATA%\Temp`)이거나 구버전이 `\\?\...`를 전달함 | `--root`와 모든 도구 경로를 전용 `LocalLow` 자식으로 지정, `icacls`로 Low 레이블 확인, hwp-cli v0.8.2 이상 사용, 재시작 뒤 smoke test |
+| **Local folders and access permissions**에 추가한 경로도 실패함 | 이 설정은 Quick 내장 읽기·검색 도구를 제어하며 Medium 폴더를 Low 무결성 MCP 자식이 쓸 수 있게 만들지 않음 | 내장 도구나 Explorer로 파일을 설정된 `LocalLow` 교환 root에 복사한 뒤 HWP 도구 호출 |
+| `os error 2` | 경로가 실제로 없거나 `YOUR_NAME`을 바꾸지 않았거나 Desktop이 OneDrive로 파일을 이동함 | 실제 절대 경로 확인, 목적 디렉터리 생성, 또는 설정된 교환 root에 staging |
 | 반복 실패 뒤 커넥터가 비활성화됨 | 시작·handshake 실패가 반복되어 Quick이 자동 비활성화함 | command/root 수정·저장, 커넥터를 명시적으로 다시 활성화, 새로고침, 필요하면 Quick 재시작 |
 | 커넥터 수정·재import 뒤 `Unknown tool` | Quick이 새 내부 커넥터/tool prefix를 만들었으나 대화는 예전 이름을 보유함 | 연결 새로고침과 새 대화 시작, 예전 생성 이름 대신 HWP 스킬·도구 다시 로드 |
 | 에이전트 publish 때 `assetDescriptor contains prohibited HTML/script content` | 구버전 스킬의 angle-bracket placeholder를 Quick이 markup으로 분류함 | 최신 `hwp`에서 스킬 재설치, Quick 새로고침, 다시 publish |
 | 생성은 되지만 렌더링 실패 | 폰트 디렉터리가 없거나 접근 불가 | 먼저 `--font-dir` 없이 생성 검증, 그다음 `C:\Windows\Fonts`를 추가하고 `hwp_render` 재시도 |
-| Path is outside allowed roots | MCP root 정책이 정상적으로 경로를 거부함 | asset을 `C:\TEMP`로 복사하거나 실제 지원되는 root 추가. 모든 root를 제거하지 않는다 |
+| Path is outside allowed roots | MCP root 정책이 정상적으로 경로를 거부함 | asset을 설정된 `LocalLow` root로 복사하거나 실제 지원되는 Low 무결성 root 추가. 모든 root를 제거하지 않는다 |
 
-### Windows 경로 수정이 필요한 이유
+### Windows 경로 수정과 `LocalLow`가 모두 필요한 이유
 
-Rust의 Windows canonicalization은 같은 경로를 `\\?\C:\TEMP\quick-hwp-smoke.hwpx` 같은 verbatim
-형식으로 반환할 수 있다. Quick은 MCP handshake 때 일반 `C:\TEMP` root를 받아들이고도, 이후 `hwp`가
-private atomic staging 디렉터리를 만들 때 이 verbatim 표기를 거부할 수 있다. 현재 `hwp`는 downstream
-파일 I/O 전에 verbatim drive/UNC 경로를 일반 Windows 표기로 정규화하면서 root containment 검사는
-fail-closed 상태로 유지한다.
+서로 독립적인 Windows 제약 두 가지가 같은 형태의 오류를 만들었다. 첫째, Rust의 Windows
+canonicalization은 같은 경로를 `\\?\C:\...` 같은 verbatim 형식으로 반환할 수 있다. hwp-cli
+v0.8.2 이상은 downstream 파일 I/O 전에 안전한 verbatim drive/UNC 경로를 일반 Windows 표기로
+정규화하면서 root containment 검사는 fail-closed 상태로 유지한다.
 
-이 차이 때문에 커넥터 탐색은 성공하지만 첫 쓰기만 실패하는 혼동이 생긴다. 항상 `hwp_new`와
+둘째, Quick은 MCP 자식을 Low mandatory integrity(`S-1-16-4096`)로 시작한다. 일반 Medium 폴더는
+시작·도구 탐색에 필요한 읽기는 허용하면서도 쓰기에 사용하는 atomic staging 디렉터리는 거부할 수
+있다. `AppData\LocalLow`는 상속 가능한 Low 레이블을 가지므로 전용 `hwp-quick-workspace` 자식에서
+root 범위를 넓히지 않고 탐색과 쓰기를 모두 수행할 수 있다.
+
+두 제약 때문에 커넥터 탐색은 성공하지만 첫 쓰기만 실패하는 혼동이 생긴다. 항상 `hwp_new`와
 `hwp_validate`로 data plane까지 검증한다.
 
 ## 선택적 로컬 진단
@@ -264,11 +286,11 @@ Get-Content "$env:LOCALAPPDATA\Temp\quickwork-backend.log" -Tail 300 |
 
 - 커넥터 command가 검증한 `hwp.exe` 절대 경로 하나를 사용함
 - 커넥터가 분리된 JSON 인자를 사용하며 셸 따옴표가 들어 있지 않음
-- `C:\TEMP`가 존재하고 Windows MCP root로 설정됨
+- `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace`가 존재하고 Low 레이블을 상속하며 Windows MCP root로 설정됨
 - 현재 HWP 스킬이 활성 Quick 프로필에 설치됨
 - Test connection이 **Connected**, **16 tools available**을 표시함
 - 새로고침·재시작 뒤에도 커넥터가 활성 상태임
-- `C:\TEMP\quick-hwp-smoke.hwpx`에서 `hwp_new`, `hwp_validate`, `hwp_read`가 성공함
+- 절대 `LocalLow` smoke-test 경로에서 `hwp_new`, `hwp_validate`, `hwp_read`가 성공함
 - `hwp_validate`가 `valid: true`를 반환하고, 모양이 중요하면 렌더링도 확인함
 - 에이전트가 모든 쓰기 뒤 검증하고 최종 artifact 경로를 반환함
 

--- a/docs/manual/amazon-quick-desktop.ko.md
+++ b/docs/manual/amazon-quick-desktop.ko.md
@@ -19,7 +19,7 @@ Quick 릴리스에 따라 UI 이름과 내부 파일명이 바뀔 수 있다. Qu
 | `hwp.exe` | MCP stdio 서버 실행 | 안정된 절대 경로의 최신 바이너리 하나 |
 | HWP MCP 커넥터 | HWP 도구 16개 노출 | `hwp.exe mcp ...` |
 | HWP 스킬 | Quick 에이전트에게 도구 사용 시점과 방법 안내 | 활성 Quick 프로필의 `skills/hwp/SKILL.md` |
-| 교환 root | Low 무결성 MCP 자식과 파일을 주고받는 경계 | `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` |
+| 교환 root | Low 무결성 MCP 자식과 파일을 주고받는 경계 | `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace` |
 | 폰트 디렉터리 | Windows 렌더링 폰트 공급 | `C:\Windows\Fonts` |
 
 커넥터와 스킬은 서로 별개다. 스킬 설치는 바이너리를 설치하거나 커넥터를 만들지 않는다. 커넥터에
@@ -136,8 +136,9 @@ Quick Desktop에서 **Settings → Capabilities → Connectors → + Create → 
 }
 ```
 
-`command`와 `YOUR_NAME`을 실제 값으로 바꾼다. JSON에서 이중 백슬래시는 일반 Windows 백슬래시를
-표현할 뿐, 실제 경로를 바꾸지 않는다.
+`command`를 실제 값으로 바꾸고, `--root`에는 위 교환 root 생성 단계가 출력한 절대 경로를 그대로 넣는다
+(표준 프로필은 `C:\Users\<계정>\...` 형태지만, 리디렉션된 프로필은 접두사가 다르므로 반드시 출력된
+경로를 사용한다). JSON에서 이중 백슬래시는 일반 Windows 백슬래시를 표현할 뿐, 실제 경로를 바꾸지 않는다.
 
 직접 입력할 때는 다음 값을 사용한다.
 
@@ -214,7 +215,7 @@ OneDrive나 SharePoint 커넥터는 선택 사항이다. 원본이나 완성 파
 
 ## 일상 작업 흐름
 
-1. 모든 원본 파일과 참조 asset을 `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace`로 복사한다.
+1. 모든 원본 파일과 참조 asset을 설정된 교환 root(`%USERPROFILE%\AppData\LocalLow` 아래)로 복사한다.
 2. Quick에 정확한 입력·출력 경로를 준다. 예:
    “`C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\input.hwpx`를 읽어 초안을 최종으로
    바꾸고 `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\final.hwpx`에 저장하라.”

--- a/docs/manual/amazon-quick-desktop.md
+++ b/docs/manual/amazon-quick-desktop.md
@@ -20,7 +20,7 @@ Validation baseline: Amazon Quick Desktop `0.1000.2660` and hwp-cli `0.8.3` on W
 | `hwp.exe` | Runs the MCP stdio server | One current binary at a stable absolute path |
 | HWP MCP connector | Exposes the 16 HWP tools | `hwp.exe mcp ...` |
 | HWP skill | Tells the Quick agent when and how to use the tools | `skills/hwp/SKILL.md` in the active Quick profile |
-| Exchange root | Low-integrity file boundary shared with the MCP child | `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` |
+| Exchange root | Low-integrity file boundary shared with the MCP child | `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace` |
 | Font directory | Supplies Windows fonts for rendering | `C:\Windows\Fonts` |
 
 The connector and the skill are separate. Installing the skill does not install the binary or
@@ -144,8 +144,10 @@ argument boundaries exactly:
 }
 ```
 
-Replace `command` and `YOUR_NAME`. In JSON, doubled backslashes encode ordinary Windows
-backslashes; they do not change the real path.
+Replace `command`, and set `--root` to the absolute path printed by the exchange-root step
+above (a standard profile prints `C:\Users\<account>\...`; a redirected profile prints a
+different prefix, so always use the printed path). In JSON, doubled backslashes encode ordinary
+Windows backslashes; they do not change the real path.
 
 For manual entry, use:
 
@@ -223,8 +225,8 @@ and out of the configured exchange root; they do not replace the local HWP MCP c
 
 ## Daily workflow
 
-1. Copy every source file and referenced asset into
-   `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace`.
+1. Copy every source file and referenced asset into the configured exchange root (a child of
+   `%USERPROFILE%\AppData\LocalLow`).
 2. Give Quick the exact input and output paths. For example: “Read
    `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\input.hwpx`, replace Draft with Final,
    and write `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\final.hwpx`.”

--- a/docs/manual/amazon-quick-desktop.md
+++ b/docs/manual/amazon-quick-desktop.md
@@ -10,6 +10,9 @@ recover the connector when Quick disables or loses it.
 Quick UI labels and internal file names can change between Desktop releases. Prefer the UI and the
 import JSON in this guide over editing Quick's internal configuration files.
 
+Validation baseline: Amazon Quick Desktop `0.1000.2660` and hwp-cli `0.8.3` on Windows,
+2026-08-09.
+
 ## What a working setup contains
 
 | Component | Purpose | Known-good Windows value |
@@ -17,7 +20,7 @@ import JSON in this guide over editing Quick's internal configuration files.
 | `hwp.exe` | Runs the MCP stdio server | One current binary at a stable absolute path |
 | HWP MCP connector | Exposes the 16 HWP tools | `hwp.exe mcp ...` |
 | HWP skill | Tells the Quick agent when and how to use the tools | `skills/hwp/SKILL.md` in the active Quick profile |
-| Exchange root | Shared file boundary between Quick and the MCP child | `C:\TEMP` |
+| Exchange root | Low-integrity file boundary shared with the MCP child | `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` |
 | Font directory | Supplies Windows fonts for rendering | `C:\Windows\Fonts` |
 
 The connector and the skill are separate. Installing the skill does not install the binary or
@@ -65,18 +68,33 @@ Windows verbatim path such as `\\?\C:\...`, confirm that `hwp --version` reports
 
 ## 2. Create the Windows exchange root
 
-Quick's built-in file tools and its local MCP child do not necessarily receive the same filesystem
-permissions. A user-profile folder added under **Local folders and access permissions** can still
-be rejected by the MCP child. Start with the verified sandbox exchange directory:
+Quick's built-in file tools and its local MCP child do not receive the same filesystem permissions.
+On the tested Windows build, Quick starts `hwp.exe` at Low mandatory integrity
+(`S-1-16-4096`). Ordinary folders such as `C:\TEMP` and `%LOCALAPPDATA%\Temp` are normally Medium
+integrity: the MCP connector can start and expose 16 tools there, but the first write can fail with
+`Access is denied (os error 5)` when `hwp_new` creates its private staging directory.
+
+Use a dedicated child of Windows' existing `LocalLow` directory. It inherits the Low-integrity
+label without administrator rights:
 
 ```powershell
-New-Item -ItemType Directory -Path C:\TEMP -Force
+$QuickHwpRoot = Join-Path $env:USERPROFILE 'AppData\LocalLow\hwp-quick-workspace'
+New-Item -ItemType Directory -Path $QuickHwpRoot -Force | Out-Null
+$QuickHwpRoot
+icacls.exe $QuickHwpRoot
 ```
 
-Use `C:\TEMP` as the connector's `--root`. Copy input `.hwp`, `.hwpx`, Markdown, JSON, images, and
-templates into that directory before calling an HWP tool. Keep every MCP input and output path
-under that root, then use Quick's file tools or Explorer to copy the final artifact to its intended
-destination.
+The `icacls` output must include an inherited entry equivalent to
+`Mandatory Label\Low Mandatory Level:(I)(OI)(CI)(NW)`. If it does not, create a new child directory
+under `LocalLow` with inheritance enabled. Do not lower the integrity level of `C:\TEMP`, grant
+broad write access, or run the MCP server without a root.
+
+Use the printed absolute path as the connector's `--root`. In JSON and MCP tool arguments, replace
+`YOUR_NAME` in the examples below with the Windows account folder name. Do not pass the literal
+`%USERPROFILE%` variable: Quick's argument list and the MCP tools do not perform shell expansion.
+Copy input `.hwp`, `.hwpx`, Markdown, JSON, images, and templates into the exchange root before
+calling an HWP tool. Keep every MCP input and output under it, then use Quick's file tools or
+Explorer to copy the validated artifact to its intended destination.
 
 `--root` is a security boundary as well as a compatibility setting. Do not remove it to work around
 a permission error.
@@ -119,15 +137,15 @@ argument boundaries exactly:
         "--font-dir",
         "C:\\Windows\\Fonts",
         "--root",
-        "C:\\TEMP"
+        "C:\\Users\\YOUR_NAME\\AppData\\LocalLow\\hwp-quick-workspace"
       ]
     }
   }
 }
 ```
 
-Replace only `command`. In JSON, doubled backslashes encode ordinary Windows backslashes; they do
-not change the real path.
+Replace `command` and `YOUR_NAME`. In JSON, doubled backslashes encode ordinary Windows
+backslashes; they do not change the real path.
 
 For manual entry, use:
 
@@ -135,7 +153,7 @@ For manual entry, use:
 |---|---|
 | Name | `hwp` |
 | Command | the exact absolute `hwp.exe` path verified above |
-| Arguments | `mcp --font-dir C:\Windows\Fonts --root C:\TEMP` |
+| Arguments | `mcp --font-dir C:\Windows\Fonts --root C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace` |
 | Description | `Read, write, edit, render, validate, and convert HWP/HWPX documents.` |
 | Timeout | `30` seconds |
 
@@ -143,7 +161,7 @@ The Arguments field is not a shell. Do not type single or double quote character
 For example, this is wrong:
 
 ```text
-mcp --font-dir 'C:\Windows\Fonts' --root 'C:\TEMP'
+mcp --font-dir 'C:\Windows\Fonts' --root 'C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace'
 ```
 
 Quick can pass those quote characters literally, causing `hwp` to look for a directory whose name
@@ -160,11 +178,11 @@ Do not stop at “16 tools available.” Start a new Quick chat and paste this p
 
 ```text
 Use the HWP MCP tools, not a shell command.
-1. Call hwp_new to create C:\TEMP\quick-hwp-smoke.hwpx from this Markdown:
+1. Call hwp_new to create C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\quick-hwp-smoke.hwpx from this Markdown:
    # Quick MCP smoke test
 
    Amazon Quick can create HWPX files through hwp MCP.
-2. Call hwp_validate on C:\TEMP\quick-hwp-smoke.hwpx.
+2. Call hwp_validate on C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\quick-hwp-smoke.hwpx.
 3. Call hwp_read on the same file in plain format.
 4. Report the exact output path and the validation result. Do not claim success unless valid is true.
 ```
@@ -179,8 +197,9 @@ A working installation produces the file and returns validation equivalent to:
 }
 ```
 
-If visual output matters, follow with `hwp_render` for page 1 and write its output under
-`C:\TEMP`. This checks font access and rendering separately from document creation.
+If visual output matters, follow with `hwp_render` for page 1 and write its output under the same
+`hwp-quick-workspace` root. This checks font access and rendering separately from document
+creation.
 
 ## 6. Give a Quick agent durable instructions
 
@@ -189,8 +208,9 @@ instructions. Enable the HWP connector and installed HWP skill, then add instruc
 
 ```text
 Use the installed hwp skill and HWP MCP tools for every .hwp or .hwpx task.
-On Windows, use only paths under C:\TEMP unless the active connector explicitly exposes another root.
-Copy inputs into C:\TEMP before an HWP operation and return the final artifact path under C:\TEMP.
+On Windows Quick Desktop, use only the absolute LocalLow root configured in the MCP connector.
+The known-good root is C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace; replace YOUR_NAME before tool calls.
+Copy inputs into that root before an HWP operation and return the final artifact path under it.
 After hwp_new, hwp_edit, hwp_fill, hwp_convert, hwp_compose, or hwp_template, always call hwp_validate.
 When page appearance matters, also call hwp_render and inspect the requested pages.
 Never hard-code the generated MCP server prefix; select tools by their hwp_new/hwp_read/etc. names.
@@ -199,49 +219,55 @@ Do not claim success from connector discovery alone; require the requested opera
 ```
 
 OneDrive or SharePoint connectors are optional. Use them only to copy source or completed files into
-and out of `C:\TEMP`; they do not replace the local HWP MCP connector.
+and out of the configured exchange root; they do not replace the local HWP MCP connector.
 
 ## Daily workflow
 
-1. Copy every source file and referenced asset into `C:\TEMP`.
+1. Copy every source file and referenced asset into
+   `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace`.
 2. Give Quick the exact input and output paths. For example: “Read
-   `C:\TEMP\input.hwpx`, replace Draft with Final, and write `C:\TEMP\final.hwpx`.”
+   `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\input.hwpx`, replace Draft with Final,
+   and write `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\final.hwpx`.”
 3. Require `hwp_validate` after any write. Require `hwp_render` as well when layout matters.
 4. Confirm the returned path and validation result, then open or inspect the artifact.
-5. Copy the verified output from `C:\TEMP` to the approved destination. Clean up exchange files only
-   after confirming the destination copy.
+5. Copy the verified output from the exchange root to the approved destination. Clean up exchange
+   files only after confirming the destination copy.
 
 Useful prompts include:
 
-- “Summarize `C:\TEMP\input.hwp` and list its tables.”
-- “Convert `C:\TEMP\input.hwpx` to `C:\TEMP\input.md`.”
-- “Create `C:\TEMP\report.hwpx` from this Markdown, validate it, and render page 1.”
-- “Fill the slots in `C:\TEMP\template.hwpx`, write `C:\TEMP\filled.hwpx`, and validate it.”
+- “Summarize `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\input.hwp` and list its tables.”
+- “Convert `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\input.hwpx` to `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\input.md`.”
+- “Create `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\report.hwpx` from this Markdown, validate it, and render page 1.”
+- “Fill the slots in `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\template.hwpx`, write `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\filled.hwpx`, and validate it.”
 
 ## Troubleshooting by symptom
 
 | Symptom | Likely cause | Recovery |
 |---|---|---|
 | `hwp.exe` does not start or `--version` fails | Wrong binary, wrong architecture, blocked or incomplete extraction | Re-download, verify SHA-256, extract the Windows x86_64 archive, and test the exact absolute command path |
-| Test connection shows no tools or the server exits immediately | Missing/unreadable `--root`, quote characters in Arguments, typo, or stale command path | Ensure `C:\TEMP` exists; import the JSON above; remove shell quotes; verify `hwp.exe --version` |
-| **Connected, 16 tools** but `hwp_new` returns `Access is denied (os error 5)` | Transport works, but the MCP child cannot use the requested filesystem path, or an older binary passes `\\?\...` to Quick's sandbox | Put both input and output under `C:\TEMP`; keep `--root C:\TEMP`; upgrade `hwp`; restart and run the smoke test |
-| A path added to **Local folders and access permissions** still fails | That setting controls Quick's built-in file tools, not necessarily the local MCP child | Use the built-in tool to copy the file into `C:\TEMP`, then call HWP tools there |
-| `os error 2` | The path does not exist; Desktop may have moved to OneDrive | Check the real path, create the intended directory, or stage the file under `C:\TEMP` |
+| Test connection shows no tools or the server exits immediately | Missing/unreadable `--root`, literal `YOUR_NAME`, quote characters in Arguments, typo, or stale command path | Create the `LocalLow` child, substitute the absolute account path, import the JSON above, remove shell quotes, and verify `hwp.exe --version` |
+| **Connected, 16 tools** but `hwp_new` returns `Access is denied (os error 5)` | Discovery only needed read access; the requested destination is Medium integrity (commonly `C:\TEMP` or `%LOCALAPPDATA%\Temp`), or an older binary still passes `\\?\...` | Point `--root` and every tool path at the dedicated `LocalLow` child; verify its Low label with `icacls`; use hwp-cli v0.8.2 or later; restart and run the smoke test |
+| A path added to **Local folders and access permissions** still fails | That setting controls Quick's built-in read/search tools; it does not make a Medium-integrity folder writable by the Low-integrity MCP child | Use the built-in tool or Explorer to copy the file into the configured `LocalLow` exchange root, then call HWP tools there |
+| `os error 2` | The path does not exist, `YOUR_NAME` was not replaced, or Desktop moved the file to OneDrive | Check the real absolute path, create the intended directory, or stage the file under the configured exchange root |
 | Connector becomes disabled after repeated failures | Quick auto-disabled a connector whose startup/handshake repeatedly failed | Correct the command/root, save, explicitly enable the connector, refresh, and restart Quick if needed |
 | `Unknown tool` after editing or re-importing the connector | Quick generated a new internal connector/tool prefix while the conversation retained old tool names | Refresh connections and start a new chat; reload the HWP skill/tools instead of reusing the old generated name |
 | `assetDescriptor contains prohibited HTML/script content` while publishing an agent | An old exported skill contains angle-bracket placeholders that Quick classifies as markup | Reinstall the skill from a current `hwp` binary, refresh Quick, and publish again |
 | Creation works but rendering fails | Font directory is missing or inaccessible | First test without `--font-dir`; then add `C:\Windows\Fonts` and retry `hwp_render` |
-| Path is outside allowed roots | The MCP root policy is correctly rejecting it | Copy the asset into `C:\TEMP` or add a genuinely supported root; do not disable all roots |
+| Path is outside allowed roots | The MCP root policy is correctly rejecting it | Copy the asset into the configured `LocalLow` root or add a genuinely supported Low-integrity root; do not disable all roots |
 
-### Why the Windows path fix is necessary
+### Why both the path fix and `LocalLow` are necessary
 
-Rust's Windows canonicalization can return an equivalent verbatim path such as
-`\\?\C:\TEMP\quick-hwp-smoke.hwpx`. Quick can accept the ordinary `C:\TEMP` root during the MCP
-handshake yet reject the verbatim spelling later when `hwp` creates its private atomic staging
-directory. Current `hwp` normalizes verbatim drive and UNC paths back to ordinary Windows spelling
-before downstream file I/O while preserving fail-closed root containment checks.
+Two independent Windows constraints produced the same misleading error. First, Rust's Windows
+canonicalization can return an equivalent verbatim path such as `\\?\C:\...`. hwp-cli v0.8.2 and
+later normalize safe verbatim drive and UNC paths back to ordinary Windows spelling before
+downstream file I/O while preserving fail-closed root containment checks.
 
-This distinction explains the misleading state where connector discovery succeeds but the first
+Second, Quick starts the MCP child at Low mandatory integrity (`S-1-16-4096`). A normal Medium
+directory can be readable enough for startup and tool discovery but still reject the atomic staging
+directory used for a write. `AppData\LocalLow` carries an inheritable Low label, so its dedicated
+`hwp-quick-workspace` child supports both discovery and writes without broadening the MCP root.
+
+These two constraints explain the misleading state where connector discovery succeeds but the first
 write fails. Always verify the data plane with `hwp_new` plus `hwp_validate`.
 
 ## Optional local diagnostics
@@ -270,11 +296,11 @@ servers (0 failed), 16 total tools.” Log wording and location are not stable A
 
 - The connector command is one verified absolute `hwp.exe` path.
 - The connector uses separate JSON arguments and has no embedded shell quotes.
-- `C:\TEMP` exists and is the Windows MCP root.
+- `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` exists, inherits the Low label, and is the Windows MCP root.
 - The current HWP skill is installed in the active Quick profile.
 - Test connection reports **Connected** and **16 tools available**.
 - The connector stays enabled after refresh or restart.
-- `hwp_new`, `hwp_validate`, and `hwp_read` succeed on `C:\TEMP\quick-hwp-smoke.hwpx`.
+- `hwp_new`, `hwp_validate`, and `hwp_read` succeed on the absolute `LocalLow` smoke-test path.
 - `hwp_validate` returns `valid: true`; rendering is also tested when appearance matters.
 - The agent validates after every write and returns the final artifact path.
 

--- a/skills/hwp/SKILL.md
+++ b/skills/hwp/SKILL.md
@@ -108,18 +108,27 @@ directory — to the given directories. Roots are canonicalized at startup; a mi
 unreadable root fails fast. Without any `--root` the server is unrestricted and prints a
 one-line warning to stderr at startup — prefer `--root` whenever the client allows it.
 
-Amazon Quick Desktop on Windows runs local MCP children inside its sandbox. Use the special
-writable exchange root `C:\TEMP` and `C:\Windows\Fonts`, with separate JSON arguments:
-`["mcp", "--font-dir", "C:\\Windows\\Fonts", "--root", "C:\\TEMP"]`. A folder added to
-Quick's local-folder permissions may still be unreadable to the MCP child. If a user-profile
-root fails with `Access is denied (os error 5)`, keep the root restriction, change it to
-`C:\TEMP`, and re-enable the connector after Quick auto-disables it. Keep all MCP inputs and
-outputs under that root and use Quick's file tools to copy artifacts into and out of it.
+Amazon Quick Desktop on Windows starts local MCP children at Low mandatory integrity
+(`S-1-16-4096`). Use a dedicated child of the Windows `LocalLow` directory and
+`C:\Windows\Fonts`, with separate JSON arguments:
+`["mcp", "--font-dir", "C:\\Windows\\Fonts", "--root",
+"C:\\Users\\YOUR_NAME\\AppData\\LocalLow\\hwp-quick-workspace"]`. Replace `YOUR_NAME`
+with the actual account folder before configuring Quick or calling a tool; neither the argument
+list nor MCP paths expand `%USERPROFILE%`. Create the root under `AppData\LocalLow` so it inherits
+the Low mandatory label. Do not use ordinary `C:\TEMP` or `%LOCALAPPDATA%\Temp` as a write root:
+discovery may work there while `hwp_new` fails to create its private staging directory with
+`Access is denied (os error 5)`.
+
+A folder added to Quick's local-folder permissions is available to its built-in read/search tools
+but does not become writable by the Low-integrity MCP child. Keep all MCP inputs and outputs under
+the configured `LocalLow` root, use Quick's file tools or Explorer to copy artifacts into and out
+of it, and re-enable the connector if repeated startup failures caused Quick to auto-disable it.
 
 When helping someone configure Quick, prefer JSON import and never put shell quote characters
 inside an argument. Verify three layers in order: the exact absolute binary returns a version;
 Quick reports 16 tools and stays enabled after refresh; then `hwp_new` followed by `hwp_validate`
-succeeds on `C:\TEMP\quick-hwp-smoke.hwpx`. Do not claim that discovery alone proves file access.
+succeeds on the absolute `LocalLow\hwp-quick-workspace\quick-hwp-smoke.hwpx` path. Do not claim
+that discovery alone proves file access.
 After a connector edit, refresh or start a new chat instead of reusing an old generated tool prefix.
 The copy-paste operator and AI runbook is:
 `https://github.com/STAIxBWLB/hwp-cli/blob/main/docs/manual/amazon-quick-desktop.md`.

--- a/skills/hwp/SKILL.md
+++ b/skills/hwp/SKILL.md
@@ -127,7 +127,8 @@ of it, and re-enable the connector if repeated startup failures caused Quick to 
 When helping someone configure Quick, prefer JSON import and never put shell quote characters
 inside an argument. Verify three layers in order: the exact absolute binary returns a version;
 Quick reports 16 tools and stays enabled after refresh; then `hwp_new` followed by `hwp_validate`
-succeeds on the absolute `LocalLow\hwp-quick-workspace\quick-hwp-smoke.hwpx` path. Do not claim
+succeeds on an absolute path under the configured LocalLow root (for example
+`C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\quick-hwp-smoke.hwpx`). Do not claim
 that discovery alone proves file access.
 After a connector edit, refresh or start a new chat instead of reusing an old generated tool prefix.
 The copy-paste operator and AI runbook is:


### PR DESCRIPTION
## Summary

- replace the Amazon Quick Windows `C:\TEMP` recommendation with a dedicated `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` MCP root
- document the two independent failure modes: Windows verbatim-path handling fixed in hwp-cli 0.8.2+, and Quick's Low-integrity MCP child rejecting writes to normal Medium-integrity folders
- add copy-paste setup, JSON import, smoke-test, daily-use, recovery, and AI/skill guidance in English and Korean
- correct the hwp skill so agents do not treat connector discovery or Quick local-folder access as proof of MCP write access

This is a follow-up to #67 after testing the released hwp-cli 0.8.3 binary in Amazon Quick Desktop exposed the remaining Windows integrity-level constraint.

## Root cause and impact

Amazon Quick Desktop 0.1000.2660 starts the local MCP child with integrity SID `S-1-16-4096` (Low). A connector rooted at `C:\TEMP` or `%LOCALAPPDATA%\Temp` can start and advertise all 16 tools, but `hwp_new` then fails to create its atomic staging directory with `Access is denied (os error 5)`. A dedicated child under `AppData\LocalLow` inherits the Low mandatory label and supports writes without broad ACL changes or removing `--root`.

## Verification

- [x] Downloaded the official `hwp-v0.8.3-x86_64-pc-windows-msvc.zip`; SHA-256 matched the published checksum: `5e06722992226ab8468ef757e5df56f0388dcc61b1394a6dd05aebd184b80404`
- [x] Installed binary reports `hwp 0.8.3`
- [x] Restarted Amazon Quick Desktop; MCP log reports `Loaded 1/1 servers (0 failed), 16 total tools`
- [x] Loaded the installed hwp skill in a fresh Quick conversation; `load_skill` completed successfully and the agent returned the exact LocalLow root, rationale, and separate JSON arguments
- [x] Ran `hwp_new`, `hwp_validate`, `hwp_read`, and `hwp_render` through the Quick UI; all four MCP calls completed successfully
- [x] Validation returned `valid: true`, no errors or warnings; read-back text was `hwp-cli 0.8.3 Amazon Quick MCP skill test passed`; page 1 rendered to PNG
- [x] Revalidated the generated HWPX directly with the installed v0.8.3 binary
- [x] Static documentation checks: 8 edited Markdown files, 17 JSON fences parsed, balanced code fences, all non-template relative links resolved, no angle-bracket placeholders in the exported skill, and `git diff --check` clean

## Not run

- Rust workspace tests: this patch changes documentation and skill instructions only, and the Windows test environment does not have Cargo installed.