### PR TITLE
Prepare v0.8.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.8.4]
+
 **Fixed**
 
 - Amazon Quick Desktop Windows guidance now uses a dedicated

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -669,7 +669,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-cli"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -695,7 +695,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "hwp-model",
  "image",
@@ -710,14 +710,14 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "hwp-render"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "flate2",
  "fontdb",
@@ -736,7 +736,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "cfb",
  "flate2",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "hwp-convert",
  "hwp-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"


### PR DESCRIPTION
Prepares the v0.8.4 patch release (Amazon Quick Low-integrity MCP root guidance, #73).

- `CHANGELOG.md`: `## [0.8.4]` header over the existing Unreleased entry; `scripts/release_notes.sh v0.8.4` extraction verified.
- `Cargo.toml` / `Cargo.lock`: workspace version 0.8.3 → 0.8.4 (`cargo update --workspace --offline`, no external dependency changes).

After merge: wait for main CI on the merge commit, then tag it `v0.8.4` and push the tag.
