### PR TITLE
feat(pdf): parity contract, pagination truth, CI self-consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,30 @@
 /fixtures/hwp5/
 /fixtures/hwpx/
 
+# PDF parity corpus is local by default. Only the narrow public source/recipe/manifest/scoreboard
+# allowlist below may be committed; oracle exports and private corpus data stay ignored.
+/fixtures/pdf-parity/**
+!/fixtures/pdf-parity/public/
+!/fixtures/pdf-parity/public/source/
+!/fixtures/pdf-parity/public/source/**/
+!/fixtures/pdf-parity/public/source/**/*.hwp
+!/fixtures/pdf-parity/public/source/**/*.hwpx
+!/fixtures/pdf-parity/public/recipes/
+!/fixtures/pdf-parity/public/recipes/**/
+!/fixtures/pdf-parity/public/recipes/**/*.md
+!/fixtures/pdf-parity/public/recipes/**/*.json
+!/fixtures/pdf-parity/public/manifest.json
+!/fixtures/pdf-parity/public/scoreboard.json
+!/fixtures/pdf-parity/public/scoreboard.csv
+!/fixtures/pdf-parity/public/scoreboard/
+!/fixtures/pdf-parity/public/scoreboard/**/
+!/fixtures/pdf-parity/public/scoreboard/**/*.json
+!/fixtures/pdf-parity/public/scoreboard/**/*.csv
+
+# Never re-allow generated Hancom oracle exports or private-corpus paths.
+/fixtures/pdf-parity/public/oracle/**
+/fixtures/pdf-parity/private/**
+
 # HWP 5.0 스펙 문서는 한컴 저작물 — 저장소에 동봉하지 않음(공식 배포처 링크만, docs/README.md 참고).
 # 로컬 참고용으로 docs/에 두더라도 추적하지 않는다.
 /docs/*.pdf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+**Added**
+
+- PDF parity groundwork for Hancom Office 2024 equivalence
+  ([#79](https://github.com/STAIxBWLB/hwp-cli/issues/79)). The renderer now reads
+  `LineSeg.flags` bit0/bit1 (page-first / column-first line) as the first-class page/column
+  break signal for Hancom-saved documents, keeping the `v_pos` reset heuristic only as the
+  fallback for synthesized linesegs. The structured corpus run additionally renders every case
+  to PDF under the pinned font and asserts page-count parity with the PNG backend, a full
+  GID round-trip through the emitted ToUnicode CMap, and two-run byte determinism; PDF
+  artifacts are pinnable in the corpus schemas. `hwp render` now prints a font-coverage line
+  (matched/substituted/missing/subset-fallback) and warns that no parity figure may be
+  published from a substituted-font render. The durable contract — oracle, five-metric set,
+  thresholds, font gate, data policy and non-goals — is
+  [docs/design/21-pdf-parity.md](docs/design/21-pdf-parity.md).
+
 ## [0.8.4]
 
 **Fixed**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -673,6 +673,7 @@ version = "0.8.4"
 dependencies = [
  "anyhow",
  "clap",
+ "flate2",
  "getrandom 0.3.4",
  "hwp-convert",
  "hwp-model",

--- a/crates/hwp-cli/Cargo.toml
+++ b/crates/hwp-cli/Cargo.toml
@@ -23,6 +23,9 @@ serde = { workspace = true }
 serde_yaml = { workspace = true }
 sha2 = { workspace = true }
 getrandom = { workspace = true }
+# 구조화 코퍼스 PDF 검증기가 FlateDecode 스트림을 인플레이트하는 데 사용.
+# hwp-render가 이미 끌어오는 의존성이라 의존성 그래프는 커지지 않는다.
+flate2 = { workspace = true }
 regex = { workspace = true }
 image = { workspace = true }
 quick-xml = { workspace = true }

--- a/crates/hwp-cli/src/commands/corpus.rs
+++ b/crates/hwp-cli/src/commands/corpus.rs
@@ -17,6 +17,8 @@ use hwp_cli::template_spec::{MAX_DATA_BYTES, MAX_TEMPLATE_BYTES};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 
+mod pdf_roundtrip;
+
 const MANIFEST_VERSION: &str = "1.0";
 const MANIFEST_CONTRACT: &str = "hwp-structured-corpus-v1";
 const SUMMARY_CONTRACT: &str = "hwp-structured-corpus-run-v1";
@@ -37,10 +39,10 @@ const FROZEN_MANIFEST_SCHEMA_SHA256: &str =
     "b8057de94b15deebceb58f014071d57d96fd9bb61603d9cbc2fd94a4398b3b3a";
 #[cfg(test)]
 const FROZEN_RUN_SCHEMA_SHA256: &str =
-    "416466f0c197ec31c64ed76035d3a7b34dbb694c08c459605c9eccfface22706";
+    "187efe046c1a9481bafa51494464ba0e3cee2b04c29dd0772b53f0c9816f7ba0";
 #[cfg(test)]
 const FROZEN_ARTIFACT_SCHEMA_SHA256: &str =
-    "3f9effe9df788304ae39bd3f1f460a40bf4b979016d5bc4c5599db386d577c23";
+    "8735bbe43e21a40bbcf4d20f61c0b886414ffcd5c4d0c690635e191334800ef7";
 const MAX_MANIFEST_BYTES: u64 = 1024 * 1024;
 const MAX_CASES: usize = 32;
 const MAX_REQUIRED_TEXT: usize = 64;
@@ -241,8 +243,18 @@ struct FormatSummary {
     output_sha256: Option<String>,
     output_bytes: Option<u64>,
     two_run_render_identical: bool,
+    two_run_pdf_identical: bool,
+    pdf: Option<PdfSummary>,
     semantic: Option<SemanticSummary>,
     certification: Option<CertificationSummary>,
+}
+
+#[derive(Debug, PartialEq, Eq, Serialize)]
+struct PdfSummary {
+    sha256: String,
+    bytes: u64,
+    page_count: usize,
+    tounicode_roundtrip_ok: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Serialize)]
@@ -407,6 +419,7 @@ pub fn run(manifest_path: &Path, report_path: &Path) -> Result<()> {
             case,
             base,
             &policy_path,
+            policy.render.dpi,
             &font_files,
             &isolated_source_base,
             stage.root(),
@@ -675,6 +688,7 @@ fn run_case(
     case: &CorpusCase,
     base: &Path,
     policy: &Path,
+    render_dpi: f32,
     font_files: &[PathBuf],
     isolated_source_base: &Path,
     stage: &Path,
@@ -702,6 +716,7 @@ fn run_case(
             &prepared,
             *format,
             policy,
+            render_dpi,
             font_files,
             isolated_source_base,
             stage,
@@ -746,16 +761,20 @@ fn failed_format(format: CorpusFormat, reason: &'static str) -> FormatSummary {
         output_sha256: None,
         output_bytes: None,
         two_run_render_identical: false,
+        two_run_pdf_identical: false,
+        pdf: None,
         semantic: None,
         certification: None,
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_format(
     case: &CorpusCase,
     generator: &PreparedGenerator,
     format: CorpusFormat,
     policy: &Path,
+    render_dpi: f32,
     font_files: &[PathBuf],
     isolated_source_base: &Path,
     stage: &Path,
@@ -768,6 +787,8 @@ fn run_format(
         output_sha256: None,
         output_bytes: None,
         two_run_render_identical: false,
+        two_run_pdf_identical: false,
+        pdf: None,
         semantic: None,
         certification: None,
     };
@@ -864,10 +885,109 @@ fn run_format(
     } else {
         summary.reason_codes.push("two_run_render_mismatch");
     }
+    // PDF 백엔드 검증은 PNG 인증이 성공해 페이지 수 기준(total_pages)이 확정된 경우에만
+    // 실행한다. 인증 실패 시에는 앞서 기록된 사유 코드로 충분하다.
+    let expected_pdf_pages = summary
+        .certification
+        .as_ref()
+        .map(|certification| certification.total_pages);
+    if let Some(expected_pages) = expected_pdf_pages {
+        check_pdf_backend(
+            &mut summary,
+            &first,
+            &second,
+            format,
+            render_dpi,
+            font_files,
+            &case.expected.semantic.required_text,
+            expected_pages,
+            &documents_dir,
+            extension,
+        );
+    }
     if summary.reason_codes.is_empty() {
         summary.status = RunStatus::Passed;
     }
     summary
+}
+
+/// PDF 백엔드 검증 — PNG 백엔드와 페이지 수가 일치하고(세 백엔드 합의), 콘텐츠의
+/// 모든 GID가 우리가 방출한 ToUnicode CMap으로 원문 문자로 왕복하며, 같은 문서를
+/// 두 번 렌더링하면 바이트가 동일해야 한다(two_run_render_identical의 PDF 판).
+#[allow(clippy::too_many_arguments)]
+fn check_pdf_backend(
+    summary: &mut FormatSummary,
+    first: &Path,
+    second: &Path,
+    format: CorpusFormat,
+    render_dpi: f32,
+    font_files: &[PathBuf],
+    required_text: &[String],
+    expected_pages: usize,
+    documents_dir: &Path,
+    extension: &str,
+) {
+    let options = hwp_render::RenderOptions {
+        dpi: render_dpi,
+        font_dirs: Vec::new(),
+    };
+    let mut pdfs = Vec::with_capacity(2);
+    for (label, document_path) in [("run-a", first), ("run-b", second)] {
+        let Some(document) = read_generated_document(document_path, format) else {
+            summary.reason_codes.push("pdf_render_failed");
+            return;
+        };
+        let output =
+            match hwp_render::render_document_pdf_isolated(&document, &options, None, font_files) {
+                Ok(output) if output.report.issue_count == 0 => output,
+                _ => {
+                    summary.reason_codes.push("pdf_render_failed");
+                    return;
+                }
+            };
+        let path = documents_dir.join(format!("{label}-{extension}.pdf"));
+        if write_new(&path, &output.data).is_err() {
+            summary.reason_codes.push("workspace_failed");
+            return;
+        }
+        pdfs.push(output.data);
+    }
+    summary.two_run_pdf_identical = pdfs[0] == pdfs[1];
+    if !summary.two_run_pdf_identical {
+        summary.reason_codes.push("two_run_pdf_mismatch");
+    }
+    let (page_count, roundtrip_ok) = match pdf_roundtrip::inspect_pdf(&pdfs[0]) {
+        Ok(inspection) => {
+            if inspection.page_count != expected_pages {
+                summary.reason_codes.push("pdf_page_count_mismatch");
+            }
+            let roundtrip_ok = tounicode_roundtrip_matches(&inspection.decoded_text, required_text);
+            if !roundtrip_ok {
+                summary.reason_codes.push("pdf_tounicode_roundtrip_failed");
+            }
+            (inspection.page_count, roundtrip_ok)
+        }
+        Err(_) => {
+            summary.reason_codes.push("pdf_tounicode_roundtrip_failed");
+            (0, false)
+        }
+    };
+    summary.pdf = Some(PdfSummary {
+        sha256: sha256_hex(&pdfs[0]),
+        bytes: u64::try_from(pdfs[0].len()).unwrap_or(u64::MAX),
+        page_count,
+        tounicode_roundtrip_ok: roundtrip_ok,
+    });
+}
+
+/// 디코드 텍스트(공백 제거)가 모든 필수 문자열(공백 제거)을 포함하는지 확인한다.
+/// 글리프 런 분할·줄바꿈으로 공백 위치는 달라질 수 있으므로 공백을 제거하고 비교한다.
+fn tounicode_roundtrip_matches(decoded: &str, required_text: &[String]) -> bool {
+    let decoded: String = decoded.chars().filter(|ch| !ch.is_whitespace()).collect();
+    required_text.iter().all(|required| {
+        let needle: String = required.chars().filter(|ch| !ch.is_whitespace()).collect();
+        !needle.is_empty() && decoded.contains(&needle)
+    })
 }
 
 enum PreparedGenerator {
@@ -996,17 +1116,7 @@ fn read_semantic(
     format: CorpusFormat,
     expected: &SemanticAssertions,
 ) -> std::result::Result<SemanticSummary, ()> {
-    let document = match format {
-        CorpusFormat::Hwpx => hwpx::read_document(path)
-            .ok()
-            .filter(|read| read.warnings.is_empty())
-            .map(|read| read.document),
-        CorpusFormat::Hwp => hwp5::read_document(path)
-            .ok()
-            .filter(|read| read.warnings.is_empty())
-            .map(|read| read.document),
-    }
-    .ok_or(())?;
+    let document = read_generated_document(path, format).ok_or(())?;
     let text = document.plain_text();
     let stats = semantic_stats(&document);
     if expected
@@ -1029,6 +1139,20 @@ fn read_semantic(
         tables: stats.tables,
         required_text_count: expected.required_text.len(),
     })
+}
+
+/// 생성된 HWPX/HWP 문서를 경고 없이 읽는다 (read_semantic과 PDF 검증의 공통 진입).
+fn read_generated_document(path: &Path, format: CorpusFormat) -> Option<hwp_model::Document> {
+    match format {
+        CorpusFormat::Hwpx => hwpx::read_document(path)
+            .ok()
+            .filter(|read| read.warnings.is_empty())
+            .map(|read| read.document),
+        CorpusFormat::Hwp => hwp5::read_document(path)
+            .ok()
+            .filter(|read| read.warnings.is_empty())
+            .map(|read| read.document),
+    }
 }
 
 fn structural_semantic_sha256(document: &hwp_model::Document) -> std::result::Result<String, ()> {

--- a/crates/hwp-cli/src/commands/corpus.rs
+++ b/crates/hwp-cli/src/commands/corpus.rs
@@ -39,7 +39,7 @@ const FROZEN_MANIFEST_SCHEMA_SHA256: &str =
     "b8057de94b15deebceb58f014071d57d96fd9bb61603d9cbc2fd94a4398b3b3a";
 #[cfg(test)]
 const FROZEN_RUN_SCHEMA_SHA256: &str =
-    "187efe046c1a9481bafa51494464ba0e3cee2b04c29dd0772b53f0c9816f7ba0";
+    "f6b4ada36bb9151fadb5233770a6a235c106a815c7eb8567237c871deb5f10b5";
 #[cfg(test)]
 const FROZEN_ARTIFACT_SCHEMA_SHA256: &str =
     "8735bbe43e21a40bbcf4d20f61c0b886414ffcd5c4d0c690635e191334800ef7";
@@ -885,8 +885,9 @@ fn run_format(
     } else {
         summary.reason_codes.push("two_run_render_mismatch");
     }
-    // PDF 백엔드 검증은 PNG 인증이 성공해 페이지 수 기준(total_pages)이 확정된 경우에만
-    // 실행한다. 인증 실패 시에는 앞서 기록된 사유 코드로 충분하다.
+    // Run the PDF backend check only after PNG certification establishes the
+    // expected page count. Earlier reason codes already diagnose certification
+    // failures.
     let expected_pdf_pages = summary
         .certification
         .as_ref()
@@ -899,7 +900,6 @@ fn run_format(
             format,
             render_dpi,
             font_files,
-            &case.expected.semantic.required_text,
             expected_pages,
             &documents_dir,
             extension,
@@ -911,9 +911,8 @@ fn run_format(
     summary
 }
 
-/// PDF 백엔드 검증 — PNG 백엔드와 페이지 수가 일치하고(세 백엔드 합의), 콘텐츠의
-/// 모든 GID가 우리가 방출한 ToUnicode CMap으로 원문 문자로 왕복하며, 같은 문서를
-/// 두 번 렌더링하면 바이트가 동일해야 한다(two_run_render_identical의 PDF 판).
+/// Validate PDF page-count agreement, the complete pre-serialization text
+/// trace through ToUnicode, and same-platform two-run byte determinism.
 #[allow(clippy::too_many_arguments)]
 fn check_pdf_backend(
     summary: &mut FormatSummary,
@@ -922,7 +921,6 @@ fn check_pdf_backend(
     format: CorpusFormat,
     render_dpi: f32,
     font_files: &[PathBuf],
-    required_text: &[String],
     expected_pages: usize,
     documents_dir: &Path,
     extension: &str,
@@ -932,62 +930,77 @@ fn check_pdf_backend(
         font_dirs: Vec::new(),
     };
     let mut pdfs = Vec::with_capacity(2);
+    let mut expected_texts = Vec::with_capacity(2);
     for (label, document_path) in [("run-a", first), ("run-b", second)] {
         let Some(document) = read_generated_document(document_path, format) else {
             summary.reason_codes.push("pdf_render_failed");
             return;
         };
-        let output =
-            match hwp_render::render_document_pdf_isolated(&document, &options, None, font_files) {
-                Ok(output) if output.report.issue_count == 0 => output,
-                _ => {
-                    summary.reason_codes.push("pdf_render_failed");
-                    return;
-                }
-            };
+        let output = match hwp_render::render_document_pdf_isolated_with_text_trace(
+            &document, &options, None, font_files,
+        ) {
+            Ok(output) if output.report.issue_count == 0 => output,
+            _ => {
+                summary.reason_codes.push("pdf_render_failed");
+                return;
+            }
+        };
         let path = documents_dir.join(format!("{label}-{extension}.pdf"));
         if write_new(&path, &output.data).is_err() {
             summary.reason_codes.push("workspace_failed");
             return;
         }
+        expected_texts.push(output.expected_text);
         pdfs.push(output.data);
     }
     summary.two_run_pdf_identical = pdfs[0] == pdfs[1];
     if !summary.two_run_pdf_identical {
         summary.reason_codes.push("two_run_pdf_mismatch");
     }
-    let (page_count, roundtrip_ok) = match pdf_roundtrip::inspect_pdf(&pdfs[0]) {
+    let inspection = match pdf_roundtrip::inspect_pdf(&pdfs[0]) {
         Ok(inspection) => {
             if inspection.page_count != expected_pages {
                 summary.reason_codes.push("pdf_page_count_mismatch");
             }
-            let roundtrip_ok = tounicode_roundtrip_matches(&inspection.decoded_text, required_text);
+            let roundtrip_ok =
+                tounicode_trace_matches(&inspection.decoded_text, &expected_texts[0]);
             if !roundtrip_ok {
                 summary.reason_codes.push("pdf_tounicode_roundtrip_failed");
             }
-            (inspection.page_count, roundtrip_ok)
+            Some((inspection.page_count, roundtrip_ok))
         }
         Err(_) => {
             summary.reason_codes.push("pdf_tounicode_roundtrip_failed");
-            (0, false)
+            None
         }
     };
-    summary.pdf = Some(PdfSummary {
-        sha256: sha256_hex(&pdfs[0]),
-        bytes: u64::try_from(pdfs[0].len()).unwrap_or(u64::MAX),
-        page_count,
-        tounicode_roundtrip_ok: roundtrip_ok,
-    });
+    if let Some((page_count, roundtrip_ok)) = inspection {
+        summary.pdf = Some(PdfSummary {
+            sha256: sha256_hex(&pdfs[0]),
+            bytes: u64::try_from(pdfs[0].len()).unwrap_or(u64::MAX),
+            page_count,
+            tounicode_roundtrip_ok: roundtrip_ok,
+        });
+    }
 }
 
-/// 디코드 텍스트(공백 제거)가 모든 필수 문자열(공백 제거)을 포함하는지 확인한다.
-/// 글리프 런 분할·줄바꿈으로 공백 위치는 달라질 수 있으므로 공백을 제거하고 비교한다.
-fn tounicode_roundtrip_matches(decoded: &str, required_text: &[String]) -> bool {
-    let decoded: String = decoded.chars().filter(|ch| !ch.is_whitespace()).collect();
-    required_text.iter().all(|required| {
-        let needle: String = required.chars().filter(|ch| !ch.is_whitespace()).collect();
-        !needle.is_empty() && decoded.contains(&needle)
-    })
+/// Compare the complete emitted text trace while normalizing platform-neutral
+/// whitespace spellings. Whitespace cardinality is retained so a missing or
+/// incorrect space mapping cannot pass.
+fn tounicode_trace_matches(decoded: &str, expected: &str) -> bool {
+    normalize_text_trace(decoded) == normalize_text_trace(expected)
+}
+
+fn normalize_text_trace(text: &str) -> String {
+    text.chars()
+        .map(|character| {
+            if character.is_whitespace() {
+                ' '
+            } else {
+                character
+            }
+        })
+        .collect()
 }
 
 enum PreparedGenerator {
@@ -1141,7 +1154,8 @@ fn read_semantic(
     })
 }
 
-/// 생성된 HWPX/HWP 문서를 경고 없이 읽는다 (read_semantic과 PDF 검증의 공통 진입).
+/// Read a generated HWPX/HWP document without warnings. Semantic and PDF
+/// validation share this entry point.
 fn read_generated_document(path: &Path, format: CorpusFormat) -> Option<hwp_model::Document> {
     match format {
         CorpusFormat::Hwpx => hwpx::read_document(path)
@@ -2656,6 +2670,124 @@ mod tests {
                 assert!(!validator.is_valid(&malformed), "{name}: {malformed}");
             }
         }
+    }
+
+    #[test]
+    fn tounicode_trace_requires_every_character_and_whitespace_slot() {
+        assert!(tounicode_trace_matches("all text\r", "all text\n"));
+        assert!(!tounicode_trace_matches(
+            "required text X",
+            "required text Y"
+        ));
+        assert!(!tounicode_trace_matches("missing space", "missing  space"));
+    }
+
+    #[test]
+    fn failed_pdf_diagnostics_validate_while_passed_pdf_is_strict() {
+        let root = workspace_root();
+        let bytes = read_regular_bounded(
+            &root.join("schemas/structured-corpus-run-v1.schema.json"),
+            MAX_REPORT_BYTES,
+        )
+        .unwrap();
+        let corpus_schema: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let mut format_schema = corpus_schema.pointer("/$defs/format").unwrap().clone();
+        format_schema.as_object_mut().unwrap().insert(
+            "$schema".to_string(),
+            serde_json::json!("https://json-schema.org/draft/2020-12/schema"),
+        );
+        format_schema
+            .as_object_mut()
+            .unwrap()
+            .insert("$defs".to_string(), corpus_schema["$defs"].clone());
+        let validator = jsonschema::options()
+            .with_draft(jsonschema::Draft::Draft202012)
+            .build(&format_schema)
+            .unwrap();
+
+        let hash = "a".repeat(64);
+        let failed_with_diagnostics = serde_json::json!({
+            "format": "hwp",
+            "status": "failed",
+            "reason_codes": ["pdf_tounicode_roundtrip_failed"],
+            "two_run_byte_identical": true,
+            "output_sha256": hash,
+            "output_bytes": 1,
+            "two_run_render_identical": true,
+            "two_run_pdf_identical": true,
+            "pdf": {
+                "sha256": "b".repeat(64),
+                "bytes": 1,
+                "page_count": 2,
+                "tounicode_roundtrip_ok": false
+            },
+            "semantic": null,
+            "certification": null
+        });
+        assert!(validator.is_valid(&failed_with_diagnostics));
+
+        let mut failed_without_inspection = failed_with_diagnostics.clone();
+        failed_without_inspection["pdf"] = serde_json::Value::Null;
+        assert!(validator.is_valid(&failed_without_inspection));
+
+        let clear_detection = serde_json::json!({
+            "result": "not_detected",
+            "count": 0,
+            "complete": true
+        });
+        let mut passed = serde_json::json!({
+            "format": "hwp",
+            "status": "passed",
+            "reason_codes": [],
+            "two_run_byte_identical": true,
+            "output_sha256": "a".repeat(64),
+            "output_bytes": 1,
+            "two_run_render_identical": true,
+            "two_run_pdf_identical": true,
+            "pdf": {
+                "sha256": "b".repeat(64),
+                "bytes": 1,
+                "page_count": 1,
+                "tounicode_roundtrip_ok": true
+            },
+            "semantic": {
+                "plain_text_sha256": "c".repeat(64),
+                "structural_semantic_sha256": "d".repeat(64),
+                "text_chars": 80,
+                "sections": 1,
+                "paragraphs": 5,
+                "tables": 1,
+                "required_text_count": 3
+            },
+            "certification": {
+                "overall": "passed",
+                "total_pages": 1,
+                "selected_pages": [1],
+                "render_issue_count": 0,
+                "render_issue_sha256": "e".repeat(64),
+                "fonts": [{
+                    "font_file_sha256": FROZEN_FONT_SHA256,
+                    "outcome": "matched"
+                }],
+                "pages": [{
+                    "page": 1,
+                    "png_sha256": "f".repeat(64),
+                    "visual_blank": false,
+                    "outside_page_bounds": clear_detection,
+                    "possible_collision": {
+                        "result": "not_detected",
+                        "count": 0,
+                        "complete": true
+                    }
+                }]
+            }
+        });
+        assert!(validator.is_valid(&passed));
+        passed["pdf"]["page_count"] = serde_json::json!(2);
+        assert!(!validator.is_valid(&passed));
+        passed["pdf"]["page_count"] = serde_json::json!(1);
+        passed["pdf"]["tounicode_roundtrip_ok"] = serde_json::json!(false);
+        assert!(!validator.is_valid(&passed));
     }
 
     #[test]

--- a/crates/hwp-cli/src/commands/corpus/pdf_roundtrip.rs
+++ b/crates/hwp-cli/src/commands/corpus/pdf_roundtrip.rs
@@ -1,0 +1,759 @@
+//! 우리 PDF 백엔드(crates/hwp-render/src/pdf.rs)가 방출하는 바이트만 대상으로 하는
+//! 범위 한정 왕복 검사기다. 범용 PDF 텍스트 추출기가 아니다.
+//!
+//! 다루는 구조는 우리 백엔드가 보장하는 것으로 한정한다:
+//! - 고전 xref를 쓰는 비압축 간접 객체 (`N 0 obj` … `endobj`)
+//! - Type0 + Identity-H + 서브셋 CID 폰트와 ToUnicode CMap (bfchar/bfrange)
+//! - FlateDecode 또는 비압축 스트림 (`/Length`는 항상 존재)
+//! - 콘텐츠 스트림의 `Tf`/`Tj`/`TJ` 텍스트 연산자와 2바이트 BE GID 문자열
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::io::Read as _;
+
+use anyhow::{Context as _, Result, bail};
+
+/// PDF에서 추출한 검사 결과.
+pub struct PdfInspection {
+    /// 페이지 트리 `/Count`와 실제 kid 수가 일치함을 확인한 페이지 수.
+    pub page_count: usize,
+    /// 콘텐츠 스트림 순서대로 ToUnicode로 디코드한 텍스트 (페이지 사이는 개행).
+    pub decoded_text: String,
+}
+
+/// PDF 바이트를 파싱해 페이지 수와 ToUnicode 디코드 텍스트를 돌려준다.
+/// 콘텐츠에 등장하는 모든 GID가 대응 폰트의 ToUnicode에 있어야 성공한다.
+pub fn inspect_pdf(data: &[u8]) -> Result<PdfInspection> {
+    if !data.starts_with(b"%PDF-") {
+        bail!("PDF 헤더가 없습니다");
+    }
+    let objects = parse_objects(data)?;
+
+    let mut page_count = None;
+    let mut kids = Vec::new();
+    let mut pages: HashMap<u32, PageObject> = HashMap::new();
+    let mut tounicode_of_type0: HashMap<u32, u32> = HashMap::new();
+    for object in &objects {
+        match name_after(&object.tokens, "Type") {
+            Some("Pages") => {
+                page_count = Some(
+                    int_after(&object.tokens, "Count")
+                        .and_then(|count| usize::try_from(count).ok())
+                        .context("페이지 트리 /Count가 없습니다")?,
+                );
+                kids = refs_in_array_after(&object.tokens, "Kids")
+                    .context("페이지 트리 /Kids가 없습니다")?;
+            }
+            Some("Page") => {
+                let contents =
+                    ref_after(&object.tokens, "Contents").context("페이지 /Contents가 없습니다")?;
+                let fonts = font_resource_map(&object.tokens)?;
+                pages.insert(object.id, PageObject { contents, fonts });
+            }
+            Some("Font") if name_after(&object.tokens, "Subtype") == Some("Type0") => {
+                let tounicode = ref_after(&object.tokens, "ToUnicode")
+                    .context("Type0 폰트 /ToUnicode가 없습니다")?;
+                tounicode_of_type0.insert(object.id, tounicode);
+            }
+            _ => {}
+        }
+    }
+    let page_count = page_count.context("페이지 트리가 없습니다")?;
+
+    // Type0 객체 → ToUnicode CMap (GID → 유니코드 문자열).
+    let mut cmaps: HashMap<u32, HashMap<u16, String>> = HashMap::new();
+    for (&type0, &tounicode) in &tounicode_of_type0 {
+        let object = find_object(&objects, tounicode)?;
+        let bytes = stream_bytes(data, object)?;
+        cmaps.insert(
+            type0,
+            parse_tounicode(&bytes).with_context(|| format!("ToUnicode {tounicode} 파싱 실패"))?,
+        );
+    }
+
+    // 페이지 트리 순서대로 콘텐츠를 디코드한다.
+    let mut decoded_text = String::new();
+    for (index, &kid) in kids.iter().enumerate() {
+        let page = pages
+            .get(&kid)
+            .with_context(|| format!("페이지 kid {kid} 객체가 없습니다"))?;
+        let mut font_cmaps: HashMap<&str, &HashMap<u16, String>> = HashMap::new();
+        for (name, type0) in &page.fonts {
+            let cmap = cmaps
+                .get(type0)
+                .with_context(|| format!("폰트 리소스 {name}의 ToUnicode가 없습니다"))?;
+            font_cmaps.insert(name.as_str(), cmap);
+        }
+        let content_object = find_object(&objects, page.contents)?;
+        let content = stream_bytes(data, content_object)?;
+        if index > 0 {
+            decoded_text.push('\n');
+        }
+        decoded_text.push_str(&decode_content(&content, &font_cmaps)?);
+    }
+    if kids.len() != page_count {
+        bail!("페이지 트리 /Count와 실제 kid 수가 다릅니다");
+    }
+    Ok(PdfInspection {
+        page_count,
+        decoded_text,
+    })
+}
+
+struct PageObject {
+    contents: u32,
+    /// 리소스 이름 ("F0" …) → Type0 객체 번호.
+    fonts: Vec<(String, u32)>,
+}
+
+struct IndirectObject {
+    id: u32,
+    tokens: Vec<Token>,
+    /// 디코딩 전 stream 바이트 범위.
+    stream: Option<(usize, usize)>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum Tok {
+    Name(String),
+    Int(i64),
+    Real(f64),
+    Str(Vec<u8>),
+    DictOpen,
+    DictClose,
+    ArrOpen,
+    ArrClose,
+    Kw(String),
+}
+
+#[derive(Debug, Clone)]
+struct Token {
+    tok: Tok,
+    /// 토큰 직후 위치 (stream 데이터 시작 계산용).
+    end: usize,
+}
+
+impl Tok {
+    fn as_int(&self) -> Option<i64> {
+        match self {
+            Self::Int(value) => Some(*value),
+            _ => None,
+        }
+    }
+}
+
+/// 간접 객체를 순차 스캔한다. 스트림은 `/Length`만큼 건너뛰어 stream 데이터 안의
+/// 우연한 "endobj"/" obj" 바이트에 속지 않는다.
+fn parse_objects(data: &[u8]) -> Result<Vec<IndirectObject>> {
+    let mut objects = Vec::new();
+    let mut pos = 0usize;
+    while let Some(found) = find_subslice(&data[pos..], b" obj") {
+        let marker = pos + found;
+        let Some(id) = parse_object_header(data, marker) else {
+            pos = marker + 1;
+            continue;
+        };
+        let body_start = marker + 4;
+        let (tokens, stream_start, resume) = tokenize_object(data, body_start)?;
+        let (stream, next) = match stream_start {
+            Some(start) => {
+                let length = int_after(&tokens, "Length")
+                    .and_then(|length| usize::try_from(length).ok())
+                    .context("스트림 /Length가 없습니다")?;
+                let end = start.checked_add(length).context("스트림 길이 오버플로")?;
+                if end > data.len() {
+                    bail!("스트림이 파일 끝을 넘습니다");
+                }
+                let mut tail = end;
+                if data.get(tail) == Some(&b'\r') {
+                    tail += 1;
+                }
+                if data.get(tail) == Some(&b'\n') {
+                    tail += 1;
+                }
+                if !data[tail..].starts_with(b"endstream") {
+                    bail!("스트림 /Length가 endstream과 일치하지 않습니다");
+                }
+                let endobj = find_subslice(&data[tail..], b"endobj")
+                    .map(|offset| tail + offset)
+                    .context("스트림 객체의 endobj가 없습니다")?;
+                (Some((start, end)), endobj + 6)
+            }
+            None => (None, resume),
+        };
+        objects.push(IndirectObject { id, tokens, stream });
+        pos = next;
+    }
+    if objects.is_empty() {
+        bail!("간접 객체를 찾지 못했습니다");
+    }
+    Ok(objects)
+}
+
+/// " obj" 직전의 "N 0" 헤더를 확인해 객체 번호를 돌려준다. 형태가 아니면 None.
+fn parse_object_header(data: &[u8], marker: usize) -> Option<u32> {
+    if marker == 0 || data[marker - 1] != b'0' {
+        return None;
+    }
+    let mut start = marker - 1;
+    if start == 0 || !data[start - 1].is_ascii_whitespace() {
+        return None;
+    }
+    start -= 1;
+    let digits_end = start;
+    while start > 0 && data[start - 1].is_ascii_digit() {
+        start -= 1;
+    }
+    if start == digits_end {
+        return None;
+    }
+    if start > 0 && !matches!(data[start - 1], b'\n' | b'\r') {
+        return None;
+    }
+    std::str::from_utf8(&data[start..digits_end])
+        .ok()?
+        .parse()
+        .ok()
+}
+
+/// 객체 본문을 토큰화한다. stream 키워드를 만나면 EOL을 소비하고 stream 데이터
+/// 시작 위치를 돌려주며, 비스트림 객체는 endobj에서 멈추고 그 직후 위치를 돌려준다.
+fn tokenize_object(data: &[u8], start: usize) -> Result<(Vec<Token>, Option<usize>, usize)> {
+    let mut tokens = Vec::new();
+    let mut pos = start;
+    while let Some((token, next)) = next_token(data, pos)? {
+        if matches!(&token.tok, Tok::Kw(kw) if kw == "stream") {
+            let mut data_start = token.end;
+            if data.get(data_start) == Some(&b'\r') {
+                data_start += 1;
+            }
+            if data.get(data_start) != Some(&b'\n') {
+                bail!("stream 키워드 뒤에 EOL이 없습니다");
+            }
+            return Ok((tokens, Some(data_start + 1), data_start + 1));
+        }
+        let is_endobj = matches!(&token.tok, Tok::Kw(kw) if kw == "endobj");
+        let end = token.end;
+        tokens.push(token);
+        if is_endobj {
+            tokens.pop();
+            return Ok((tokens, None, end));
+        }
+        pos = next;
+    }
+    bail!("객체가 endobj 없이 끝났습니다")
+}
+
+/// 콘텐츠 스트림 전체를 토큰화한다 (EOF에서 정상 종료).
+fn tokenize_all(data: &[u8]) -> Result<Vec<Token>> {
+    let mut tokens = Vec::new();
+    let mut pos = 0usize;
+    while let Some((token, next)) = next_token(data, pos)? {
+        pos = next;
+        tokens.push(token);
+    }
+    Ok(tokens)
+}
+
+fn next_token(data: &[u8], mut pos: usize) -> Result<Option<(Token, usize)>> {
+    loop {
+        match data.get(pos) {
+            Some(byte) if byte.is_ascii_whitespace() => pos += 1,
+            Some(b'%') => {
+                while let Some(byte) = data.get(pos) {
+                    if matches!(byte, b'\n' | b'\r') {
+                        break;
+                    }
+                    pos += 1;
+                }
+            }
+            Some(_) => break,
+            None => return Ok(None),
+        }
+    }
+    let start = pos;
+    let byte = data[pos];
+    let (tok, end) = match byte {
+        b'(' => {
+            let (bytes, end) = parse_literal_string(data, pos)?;
+            (Tok::Str(bytes), end)
+        }
+        b'<' if data.get(pos + 1) == Some(&b'<') => (Tok::DictOpen, pos + 2),
+        b'<' => {
+            let (bytes, end) = parse_hex_string(data, pos)?;
+            (Tok::Str(bytes), end)
+        }
+        b'>' if data.get(pos + 1) == Some(&b'>') => (Tok::DictClose, pos + 2),
+        b'[' => (Tok::ArrOpen, pos + 1),
+        b']' => (Tok::ArrClose, pos + 1),
+        b'/' => {
+            let mut end = pos + 1;
+            while end < data.len() && !is_delimiter(data[end]) {
+                end += 1;
+            }
+            let name = String::from_utf8(data[pos + 1..end].to_vec())
+                .context("이름이 UTF-8이 아닙니다")?;
+            (Tok::Name(name), end)
+        }
+        b'+' | b'-' | b'.' | b'0'..=b'9' => {
+            let mut end = pos;
+            while end < data.len() && !is_delimiter(data[end]) {
+                end += 1;
+            }
+            let text = std::str::from_utf8(&data[pos..end]).context("숫자가 UTF-8이 아닙니다")?;
+            if let Ok(value) = text.parse::<i64>() {
+                (Tok::Int(value), end)
+            } else {
+                let value: f64 = text.parse().context("숫자 토큰이 파싱되지 않습니다")?;
+                (Tok::Real(value), end)
+            }
+        }
+        _ if !is_delimiter(byte) => {
+            let mut end = pos;
+            while end < data.len() && !is_delimiter(data[end]) {
+                end += 1;
+            }
+            let keyword = std::str::from_utf8(&data[pos..end])
+                .context("키워드가 UTF-8이 아닙니다")?
+                .to_string();
+            (Tok::Kw(keyword), end)
+        }
+        _ => bail!("토큰화할 수 없는 바이트 0x{byte:02x} (위치 {start})"),
+    };
+    Ok(Some((Token { tok, end }, end)))
+}
+
+fn is_delimiter(byte: u8) -> bool {
+    byte.is_ascii_whitespace()
+        || matches!(
+            byte,
+            b'(' | b')' | b'<' | b'>' | b'[' | b']' | b'{' | b'}' | b'/' | b'%'
+        )
+}
+
+/// 리터럴 문자열: 균형 괄호, `\n \r \t \b \f \( \) \\`, 8진수(최대 3자리),
+/// 역슬래시+개행 연속을 처리한다.
+fn parse_literal_string(data: &[u8], start: usize) -> Result<(Vec<u8>, usize)> {
+    let mut bytes = Vec::new();
+    let mut depth = 1usize;
+    let mut pos = start + 1;
+    while pos < data.len() {
+        let byte = data[pos];
+        pos += 1;
+        match byte {
+            b'(' => {
+                depth += 1;
+                bytes.push(byte);
+            }
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Ok((bytes, pos));
+                }
+                bytes.push(byte);
+            }
+            b'\\' => {
+                let Some(&escaped) = data.get(pos) else {
+                    bail!("리터럴 문자열이 역슬래시로 끝났습니다");
+                };
+                pos += 1;
+                match escaped {
+                    b'n' => bytes.push(b'\n'),
+                    b'r' => bytes.push(b'\r'),
+                    b't' => bytes.push(b'\t'),
+                    b'b' => bytes.push(0x08),
+                    b'f' => bytes.push(0x0C),
+                    b'(' | b')' | b'\\' => bytes.push(escaped),
+                    b'\n' => {}
+                    b'\r' => {
+                        if data.get(pos) == Some(&b'\n') {
+                            pos += 1;
+                        }
+                    }
+                    b'0'..=b'7' => {
+                        let mut value = u32::from(escaped - b'0');
+                        for _ in 0..2 {
+                            match data.get(pos) {
+                                Some(digit @ b'0'..=b'7') => {
+                                    value = value * 8 + u32::from(digit - b'0');
+                                    pos += 1;
+                                }
+                                _ => break,
+                            }
+                        }
+                        bytes.push(u8::try_from(value & 0xFF).unwrap_or(b'?'));
+                    }
+                    other => bytes.push(other),
+                }
+            }
+            _ => bytes.push(byte),
+        }
+    }
+    bail!("리터럴 문자열이 닫히지 않았습니다")
+}
+
+fn parse_hex_string(data: &[u8], start: usize) -> Result<(Vec<u8>, usize)> {
+    let mut bytes = Vec::new();
+    let mut high = None;
+    let mut pos = start + 1;
+    while pos < data.len() {
+        let byte = data[pos];
+        pos += 1;
+        if byte == b'>' {
+            if let Some(nibble) = high {
+                bytes.push(nibble << 4);
+            }
+            return Ok((bytes, pos));
+        }
+        if byte.is_ascii_whitespace() {
+            continue;
+        }
+        let Some(value) = (byte as char).to_digit(16) else {
+            bail!("16진 문자열에 잘못된 바이트 0x{byte:02x}가 있습니다");
+        };
+        match high {
+            None => high = Some(value as u8),
+            Some(nibble) => {
+                bytes.push(nibble << 4 | value as u8);
+                high = None;
+            }
+        }
+    }
+    bail!("16진 문자열이 닫히지 않았습니다")
+}
+
+fn stream_bytes<'a>(data: &'a [u8], object: &IndirectObject) -> Result<Cow<'a, [u8]>> {
+    let (start, end) = object
+        .stream
+        .with_context(|| format!("객체 {}는 스트림이 아닙니다", object.id))?;
+    let raw = &data[start..end];
+    let flate = object
+        .tokens
+        .iter()
+        .any(|token| matches!(&token.tok, Tok::Name(name) if name == "FlateDecode"));
+    if !flate {
+        return Ok(Cow::Borrowed(raw));
+    }
+    let mut decoded = Vec::new();
+    flate2::read::ZlibDecoder::new(raw)
+        .read_to_end(&mut decoded)
+        .context("FlateDecode 압축 해제 실패")?;
+    Ok(Cow::Owned(decoded))
+}
+
+fn find_object(objects: &[IndirectObject], id: u32) -> Result<&IndirectObject> {
+    objects
+        .iter()
+        .find(|object| object.id == id)
+        .with_context(|| format!("객체 {id}를 찾지 못했습니다"))
+}
+
+fn name_after<'t>(tokens: &'t [Token], name: &str) -> Option<&'t str> {
+    let pos = tokens
+        .iter()
+        .position(|token| matches!(&token.tok, Tok::Name(key) if key == name))?;
+    match &tokens.get(pos + 1)?.tok {
+        Tok::Name(value) => Some(value.as_str()),
+        _ => None,
+    }
+}
+
+fn int_after(tokens: &[Token], name: &str) -> Option<i64> {
+    let pos = tokens
+        .iter()
+        .position(|token| matches!(&token.tok, Tok::Name(key) if key == name))?;
+    tokens.get(pos + 1)?.tok.as_int()
+}
+
+fn ref_after(tokens: &[Token], name: &str) -> Option<u32> {
+    let pos = tokens
+        .iter()
+        .position(|token| matches!(&token.tok, Tok::Name(key) if key == name))?;
+    let object = tokens.get(pos + 1)?.tok.as_int()?;
+    tokens.get(pos + 2)?.tok.as_int()?;
+    if !matches!(&tokens.get(pos + 3)?.tok, Tok::Kw(kw) if kw == "R") {
+        return None;
+    }
+    u32::try_from(object).ok()
+}
+
+/// `/Kids [1 0 R 2 0 R]` 형태 배열의 참조 목록.
+fn refs_in_array_after(tokens: &[Token], name: &str) -> Option<Vec<u32>> {
+    let pos = tokens
+        .iter()
+        .position(|token| matches!(&token.tok, Tok::Name(key) if key == name))?;
+    if !matches!(&tokens.get(pos + 1)?.tok, Tok::ArrOpen) {
+        return None;
+    }
+    let mut refs = Vec::new();
+    let mut cursor = pos + 2;
+    while !matches!(&tokens.get(cursor)?.tok, Tok::ArrClose) {
+        let object = tokens.get(cursor)?.tok.as_int()?;
+        tokens.get(cursor + 1)?.tok.as_int()?;
+        if !matches!(&tokens.get(cursor + 2)?.tok, Tok::Kw(kw) if kw == "R") {
+            return None;
+        }
+        refs.push(u32::try_from(object).ok()?);
+        cursor += 3;
+    }
+    Some(refs)
+}
+
+/// 페이지 `/Resources` 안의 `/Font` 사전: 리소스 이름 → Type0 객체 번호.
+fn font_resource_map(tokens: &[Token]) -> Result<Vec<(String, u32)>> {
+    let pos = tokens
+        .iter()
+        .position(|token| matches!(&token.tok, Tok::Name(key) if key == "Font"))
+        .context("페이지 리소스에 /Font가 없습니다")?;
+    if !matches!(
+        &tokens.get(pos + 1).map(|token| &token.tok),
+        Some(Tok::DictOpen)
+    ) {
+        bail!("/Font가 사전이 아닙니다");
+    }
+    let mut fonts = Vec::new();
+    let mut cursor = pos + 2;
+    loop {
+        match tokens.get(cursor).map(|token| &token.tok) {
+            Some(Tok::DictClose) => break,
+            Some(Tok::Name(name)) => {
+                let object = tokens
+                    .get(cursor + 1)
+                    .and_then(|token| token.tok.as_int())
+                    .context("폰트 리소스 값이 참조가 아닙니다")?;
+                tokens
+                    .get(cursor + 2)
+                    .and_then(|token| token.tok.as_int())
+                    .context("폰트 리소스 값이 참조가 아닙니다")?;
+                if !matches!(&tokens.get(cursor + 3).map(|token| &token.tok), Some(Tok::Kw(kw)) if kw == "R")
+                {
+                    bail!("폰트 리소스 값이 참조가 아닙니다");
+                }
+                fonts.push((name.clone(), u32::try_from(object)?));
+                cursor += 4;
+            }
+            _ => bail!("/Font 사전이 닫히지 않았습니다"),
+        }
+    }
+    Ok(fonts)
+}
+
+/// 콘텐츠 스트림의 shown 문자열을 현재 폰트의 ToUnicode로 디코드해 이어 붙인다.
+fn decode_content(content: &[u8], fonts: &HashMap<&str, &HashMap<u16, String>>) -> Result<String> {
+    let tokens = tokenize_all(content)?;
+    let mut current_font: Option<&str> = None;
+    let mut pending: Vec<&[u8]> = Vec::new();
+    let mut out = String::new();
+    for (index, token) in tokens.iter().enumerate() {
+        match &token.tok {
+            Tok::Str(bytes) => pending.push(bytes),
+            Tok::ArrOpen | Tok::ArrClose => pending.clear(),
+            Tok::Kw(keyword) => {
+                match keyword.as_str() {
+                    "Tf" => {
+                        current_font = index
+                            .checked_sub(2)
+                            .and_then(|pos| tokens.get(pos))
+                            .and_then(|token| match &token.tok {
+                                Tok::Name(name) => Some(name.as_str()),
+                                _ => None,
+                            });
+                        if current_font.is_none() {
+                            bail!("Tf의 폰트 피연산자가 없습니다");
+                        }
+                    }
+                    "Tj" => {
+                        let bytes = pending.last().context("Tj의 문자열이 없습니다")?;
+                        out.push_str(&decode_shown(bytes, current_font, fonts)?);
+                    }
+                    "TJ" => {
+                        for bytes in &pending {
+                            out.push_str(&decode_shown(bytes, current_font, fonts)?);
+                        }
+                    }
+                    _ => {}
+                }
+                pending.clear();
+            }
+            _ => {}
+        }
+    }
+    Ok(out)
+}
+
+/// 2바이트 BE GID 문자열을 ToUnicode로 디코드한다. 매핑이 없는 GID는 오류다.
+fn decode_shown(
+    bytes: &[u8],
+    current_font: Option<&str>,
+    fonts: &HashMap<&str, &HashMap<u16, String>>,
+) -> Result<String> {
+    if !bytes.len().is_multiple_of(2) {
+        bail!("shown 문자열 길이가 짝수가 아닙니다");
+    }
+    let font = current_font.context("Tf 없이 텍스트를 그렸습니다")?;
+    let cmap = fonts
+        .get(font)
+        .with_context(|| format!("알 수 없는 폰트 리소스 {font}입니다"))?;
+    let mut out = String::new();
+    for pair in bytes.chunks_exact(2) {
+        let gid = u16::from_be_bytes([pair[0], pair[1]]);
+        let text = cmap
+            .get(&gid)
+            .with_context(|| format!("ToUnicode에 GID {gid}가 없습니다"))?;
+        out.push_str(text);
+    }
+    Ok(out)
+}
+
+/// ToUnicode CMap 본문(bfchar/bfrange)을 GID → 유니코드 문자열 맵으로 파싱한다.
+fn parse_tounicode(cmap: &[u8]) -> Result<HashMap<u16, String>> {
+    let text = std::str::from_utf8(cmap).context("ToUnicode CMap이 UTF-8이 아닙니다")?;
+    #[derive(PartialEq)]
+    enum Mode {
+        None,
+        Bfchar,
+        Bfrange,
+    }
+    let mut mode = Mode::None;
+    let mut map = HashMap::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.ends_with("beginbfchar") {
+            mode = Mode::Bfchar;
+            continue;
+        }
+        if line.ends_with("beginbfrange") {
+            mode = Mode::Bfrange;
+            continue;
+        }
+        if line.starts_with("endbfchar") || line.starts_with("endbfrange") {
+            mode = Mode::None;
+            continue;
+        }
+        let groups = hex_groups(line);
+        match mode {
+            Mode::Bfchar if groups.len() >= 2 => {
+                map.insert(parse_gid(groups[0])?, parse_utf16(groups[1])?);
+            }
+            Mode::Bfrange if groups.len() >= 3 => {
+                let low = parse_gid(groups[0])?;
+                let high = parse_gid(groups[1])?;
+                if high < low {
+                    bail!("bfrange 범위가 역전되었습니다");
+                }
+                if groups.len() == 3 {
+                    // 단순 형태: 연속 코드포인트로 증가.
+                    let base = parse_utf16(groups[2])?;
+                    let mut chars = base.chars();
+                    let (Some(first), None) = (chars.next(), chars.next()) else {
+                        bail!("bfrange 증가 기준이 단일 문자가 아닙니다");
+                    };
+                    for gid in low..=high {
+                        let code = u32::from(first) + u32::from(gid - low);
+                        let ch = char::from_u32(code).context("bfrange 코드포인트 오버플로")?;
+                        map.insert(gid, ch.to_string());
+                    }
+                } else {
+                    // 배열 형태: [<d1> <d2> …].
+                    if groups.len() - 2 != usize::from(high - low) + 1 {
+                        bail!("bfrange 배열 길이가 범위와 다릅니다");
+                    }
+                    for (offset, group) in groups[2..].iter().enumerate() {
+                        let gid = low + u16::try_from(offset)?;
+                        map.insert(gid, parse_utf16(group)?);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(map)
+}
+
+/// 한 줄에서 `<…>` 16진 그룹을 모은다.
+fn hex_groups(line: &str) -> Vec<&str> {
+    let mut groups = Vec::new();
+    let mut rest = line;
+    while let Some(open) = rest.find('<') {
+        let after = &rest[open + 1..];
+        let Some(close) = after.find('>') else {
+            break;
+        };
+        groups.push(&after[..close]);
+        rest = &after[close + 1..];
+    }
+    groups
+}
+
+fn parse_gid(hex: &str) -> Result<u16> {
+    if hex.len() != 4 {
+        bail!("GID는 4자리 16진이어야 합니다: {hex}");
+    }
+    Ok(u16::from_str_radix(hex, 16)?)
+}
+
+/// UTF-16BE 16진 문자열을 String으로 디코드한다 (서로게이트 쌍 포함).
+fn parse_utf16(hex: &str) -> Result<String> {
+    if hex.is_empty() || !hex.len().is_multiple_of(4) {
+        bail!("UTF-16BE 16진 길이가 올바르지 않습니다: {hex}");
+    }
+    let units = (0..hex.len() / 4)
+        .map(|index| u16::from_str_radix(&hex[index * 4..index * 4 + 4], 16))
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(char::decode_utf16(units).collect::<std::result::Result<String, _>>()?)
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn literal_string_decodes_escapes_and_octal() {
+        let (bytes, end) = parse_literal_string(br"(\000\005A\(B\\))", 0).unwrap();
+        assert_eq!(bytes, vec![0x00, 0x05, b'A', b'(', b'B', b'\\']);
+        assert_eq!(end, 16);
+        let (nested, _) = parse_literal_string(b"(a(b)c)", 0).unwrap();
+        assert_eq!(nested, b"a(b)c");
+        let (continuation, _) = parse_literal_string(b"(ab\\\r\ncd)", 0).unwrap();
+        assert_eq!(continuation, b"abcd");
+    }
+
+    #[test]
+    fn hex_string_decodes_with_padding() {
+        let (bytes, _) = parse_hex_string(b"<00C8>", 0).unwrap();
+        assert_eq!(bytes, vec![0x00, 0xC8]);
+        let (padded, _) = parse_hex_string(b"<0>", 0).unwrap();
+        assert_eq!(padded, vec![0x00]);
+    }
+
+    #[test]
+    fn tounicode_parses_bfchar_and_bfrange() {
+        let cmap = b"1 beginbfchar\n<0003> <0020>\n<0004> <D55C>\nendbfchar\n2 beginbfrange\n<0005> <0006> <AC00>\n<0007> <0008> [<D55C><D55D>]\nendbfrange\n";
+        let map = parse_tounicode(cmap).unwrap();
+        assert_eq!(map.get(&3).map(String::as_str), Some(" "));
+        assert_eq!(map.get(&4).map(String::as_str), Some("한"));
+        assert_eq!(map.get(&5).map(String::as_str), Some("가"));
+        assert_eq!(map.get(&6).map(String::as_str), Some("각"));
+        assert_eq!(map.get(&7).map(String::as_str), Some("한"));
+        assert_eq!(map.get(&8).map(String::as_str), Some("핝"));
+    }
+
+    #[test]
+    fn shown_gids_must_exist_in_tounicode() {
+        let mut cmap = HashMap::new();
+        cmap.insert(1u16, "가".to_string());
+        let mut fonts = HashMap::new();
+        fonts.insert("F0", &cmap);
+        let decoded = decode_shown(&[0x00, 0x01], Some("F0"), &fonts).unwrap();
+        assert_eq!(decoded, "가");
+        assert!(decode_shown(&[0x00, 0x02], Some("F0"), &fonts).is_err());
+        assert!(decode_shown(&[0x00], Some("F0"), &fonts).is_err());
+        assert!(decode_shown(&[0x00, 0x01], Some("F9"), &fonts).is_err());
+    }
+}

--- a/crates/hwp-cli/src/commands/corpus/pdf_roundtrip.rs
+++ b/crates/hwp-cli/src/commands/corpus/pdf_roundtrip.rs
@@ -1,11 +1,11 @@
-//! 우리 PDF 백엔드(crates/hwp-render/src/pdf.rs)가 방출하는 바이트만 대상으로 하는
-//! 범위 한정 왕복 검사기다. 범용 PDF 텍스트 추출기가 아니다.
+//! Scoped round-trip inspector for bytes emitted by our PDF backend
+//! (`crates/hwp-render/src/pdf.rs`). This is not a general PDF text extractor.
 //!
-//! 다루는 구조는 우리 백엔드가 보장하는 것으로 한정한다:
-//! - 고전 xref를 쓰는 비압축 간접 객체 (`N 0 obj` … `endobj`)
-//! - Type0 + Identity-H + 서브셋 CID 폰트와 ToUnicode CMap (bfchar/bfrange)
-//! - FlateDecode 또는 비압축 스트림 (`/Length`는 항상 존재)
-//! - 콘텐츠 스트림의 `Tf`/`Tj`/`TJ` 텍스트 연산자와 2바이트 BE GID 문자열
+//! Supported structures are deliberately limited to backend invariants:
+//! - uncompressed indirect objects (`N 0 obj` ... `endobj`) with classic xref
+//! - Type0 + Identity-H subset CID fonts and ToUnicode CMaps (bfchar/bfrange)
+//! - FlateDecode or uncompressed streams with an explicit `/Length`
+//! - `Tf`/`Tj`/`TJ` text operators with two-byte big-endian GID strings
 
 use std::borrow::Cow;
 use std::collections::HashMap;
@@ -13,16 +13,16 @@ use std::io::Read as _;
 
 use anyhow::{Context as _, Result, bail};
 
-/// PDF에서 추출한 검사 결과.
+/// Inspection result extracted from a PDF.
 pub struct PdfInspection {
-    /// 페이지 트리 `/Count`와 실제 kid 수가 일치함을 확인한 페이지 수.
+    /// Page count after verifying `/Count` against the actual kid count.
     pub page_count: usize,
-    /// 콘텐츠 스트림 순서대로 ToUnicode로 디코드한 텍스트 (페이지 사이는 개행).
+    /// ToUnicode-decoded text in content-stream order, with newlines between pages.
     pub decoded_text: String,
 }
 
-/// PDF 바이트를 파싱해 페이지 수와 ToUnicode 디코드 텍스트를 돌려준다.
-/// 콘텐츠에 등장하는 모든 GID가 대응 폰트의 ToUnicode에 있어야 성공한다.
+/// Parse PDF bytes and return the page count and ToUnicode-decoded text.
+/// Every GID shown in a content stream must exist in the corresponding CMap.
 pub fn inspect_pdf(data: &[u8]) -> Result<PdfInspection> {
     if !data.starts_with(b"%PDF-") {
         bail!("PDF 헤더가 없습니다");
@@ -60,7 +60,7 @@ pub fn inspect_pdf(data: &[u8]) -> Result<PdfInspection> {
     }
     let page_count = page_count.context("페이지 트리가 없습니다")?;
 
-    // Type0 객체 → ToUnicode CMap (GID → 유니코드 문자열).
+    // Type0 object -> ToUnicode CMap (GID -> Unicode string).
     let mut cmaps: HashMap<u32, HashMap<u16, String>> = HashMap::new();
     for (&type0, &tounicode) in &tounicode_of_type0 {
         let object = find_object(&objects, tounicode)?;
@@ -71,7 +71,7 @@ pub fn inspect_pdf(data: &[u8]) -> Result<PdfInspection> {
         );
     }
 
-    // 페이지 트리 순서대로 콘텐츠를 디코드한다.
+    // Decode content in page-tree order.
     let mut decoded_text = String::new();
     for (index, &kid) in kids.iter().enumerate() {
         let page = pages
@@ -102,14 +102,14 @@ pub fn inspect_pdf(data: &[u8]) -> Result<PdfInspection> {
 
 struct PageObject {
     contents: u32,
-    /// 리소스 이름 ("F0" …) → Type0 객체 번호.
+    /// Resource name ("F0", ...) -> Type0 object number.
     fonts: Vec<(String, u32)>,
 }
 
 struct IndirectObject {
     id: u32,
     tokens: Vec<Token>,
-    /// 디코딩 전 stream 바이트 범위.
+    /// Raw stream byte range before decoding.
     stream: Option<(usize, usize)>,
 }
 
@@ -129,7 +129,7 @@ enum Tok {
 #[derive(Debug, Clone)]
 struct Token {
     tok: Tok,
-    /// 토큰 직후 위치 (stream 데이터 시작 계산용).
+    /// Position immediately after the token, used to locate stream data.
     end: usize,
 }
 
@@ -142,8 +142,8 @@ impl Tok {
     }
 }
 
-/// 간접 객체를 순차 스캔한다. 스트림은 `/Length`만큼 건너뛰어 stream 데이터 안의
-/// 우연한 "endobj"/" obj" 바이트에 속지 않는다.
+/// Scan indirect objects sequentially. Stream bytes are skipped using `/Length`
+/// so embedded `endobj` or ` obj` byte sequences cannot confuse the scanner.
 fn parse_objects(data: &[u8]) -> Result<Vec<IndirectObject>> {
     let mut objects = Vec::new();
     let mut pos = 0usize;
@@ -190,7 +190,7 @@ fn parse_objects(data: &[u8]) -> Result<Vec<IndirectObject>> {
     Ok(objects)
 }
 
-/// " obj" 직전의 "N 0" 헤더를 확인해 객체 번호를 돌려준다. 형태가 아니면 None.
+/// Parse an `N 0 obj` header immediately before the marker.
 fn parse_object_header(data: &[u8], marker: usize) -> Option<u32> {
     if marker == 0 || data[marker - 1] != b'0' {
         return None;
@@ -216,8 +216,8 @@ fn parse_object_header(data: &[u8], marker: usize) -> Option<u32> {
         .ok()
 }
 
-/// 객체 본문을 토큰화한다. stream 키워드를 만나면 EOL을 소비하고 stream 데이터
-/// 시작 위치를 돌려주며, 비스트림 객체는 endobj에서 멈추고 그 직후 위치를 돌려준다.
+/// Tokenize an object body. For streams, consume the EOL after `stream` and
+/// return the data start; otherwise stop immediately after `endobj`.
 fn tokenize_object(data: &[u8], start: usize) -> Result<(Vec<Token>, Option<usize>, usize)> {
     let mut tokens = Vec::new();
     let mut pos = start;
@@ -244,7 +244,7 @@ fn tokenize_object(data: &[u8], start: usize) -> Result<(Vec<Token>, Option<usiz
     bail!("객체가 endobj 없이 끝났습니다")
 }
 
-/// 콘텐츠 스트림 전체를 토큰화한다 (EOF에서 정상 종료).
+/// Tokenize a complete content stream, treating EOF as normal termination.
 fn tokenize_all(data: &[u8]) -> Result<Vec<Token>> {
     let mut tokens = Vec::new();
     let mut pos = 0usize;
@@ -331,8 +331,8 @@ fn is_delimiter(byte: u8) -> bool {
         )
 }
 
-/// 리터럴 문자열: 균형 괄호, `\n \r \t \b \f \( \) \\`, 8진수(최대 3자리),
-/// 역슬래시+개행 연속을 처리한다.
+/// Parse literal strings with balanced parentheses, standard escapes, up to
+/// three octal digits, and backslash-newline continuation.
 fn parse_literal_string(data: &[u8], start: usize) -> Result<(Vec<u8>, usize)> {
     let mut bytes = Vec::new();
     let mut depth = 1usize;
@@ -477,7 +477,7 @@ fn ref_after(tokens: &[Token], name: &str) -> Option<u32> {
     u32::try_from(object).ok()
 }
 
-/// `/Kids [1 0 R 2 0 R]` 형태 배열의 참조 목록.
+/// Parse references from an array such as `/Kids [1 0 R 2 0 R]`.
 fn refs_in_array_after(tokens: &[Token], name: &str) -> Option<Vec<u32>> {
     let pos = tokens
         .iter()
@@ -499,7 +499,7 @@ fn refs_in_array_after(tokens: &[Token], name: &str) -> Option<Vec<u32>> {
     Some(refs)
 }
 
-/// 페이지 `/Resources` 안의 `/Font` 사전: 리소스 이름 → Type0 객체 번호.
+/// Parse a page `/Resources` font dictionary into resource-name -> Type0 object.
 fn font_resource_map(tokens: &[Token]) -> Result<Vec<(String, u32)>> {
     let pos = tokens
         .iter()
@@ -538,16 +538,21 @@ fn font_resource_map(tokens: &[Token]) -> Result<Vec<(String, u32)>> {
     Ok(fonts)
 }
 
-/// 콘텐츠 스트림의 shown 문자열을 현재 폰트의 ToUnicode로 디코드해 이어 붙인다.
+/// Decode shown strings with the current font's ToUnicode CMap.
 fn decode_content(content: &[u8], fonts: &HashMap<&str, &HashMap<u16, String>>) -> Result<String> {
     let tokens = tokenize_all(content)?;
     let mut current_font: Option<&str> = None;
     let mut pending: Vec<&[u8]> = Vec::new();
+    let mut in_array = false;
     let mut out = String::new();
     for (index, token) in tokens.iter().enumerate() {
         match &token.tok {
             Tok::Str(bytes) => pending.push(bytes),
-            Tok::ArrOpen | Tok::ArrClose => pending.clear(),
+            Tok::ArrOpen => {
+                pending.clear();
+                in_array = true;
+            }
+            Tok::ArrClose => in_array = false,
             Tok::Kw(keyword) => {
                 match keyword.as_str() {
                     "Tf" => {
@@ -575,13 +580,14 @@ fn decode_content(content: &[u8], fonts: &HashMap<&str, &HashMap<u16, String>>) 
                 }
                 pending.clear();
             }
+            _ if !in_array => pending.clear(),
             _ => {}
         }
     }
     Ok(out)
 }
 
-/// 2바이트 BE GID 문자열을 ToUnicode로 디코드한다. 매핑이 없는 GID는 오류다.
+/// Decode a two-byte big-endian GID string; missing mappings are errors.
 fn decode_shown(
     bytes: &[u8],
     current_font: Option<&str>,
@@ -605,7 +611,7 @@ fn decode_shown(
     Ok(out)
 }
 
-/// ToUnicode CMap 본문(bfchar/bfrange)을 GID → 유니코드 문자열 맵으로 파싱한다.
+/// Parse bfchar/bfrange entries into a GID -> Unicode string map.
 fn parse_tounicode(cmap: &[u8]) -> Result<HashMap<u16, String>> {
     let text = std::str::from_utf8(cmap).context("ToUnicode CMap이 UTF-8이 아닙니다")?;
     #[derive(PartialEq)]
@@ -642,7 +648,7 @@ fn parse_tounicode(cmap: &[u8]) -> Result<HashMap<u16, String>> {
                     bail!("bfrange 범위가 역전되었습니다");
                 }
                 if groups.len() == 3 {
-                    // 단순 형태: 연속 코드포인트로 증가.
+                    // Simple form: increment consecutive code points.
                     let base = parse_utf16(groups[2])?;
                     let mut chars = base.chars();
                     let (Some(first), None) = (chars.next(), chars.next()) else {
@@ -654,7 +660,7 @@ fn parse_tounicode(cmap: &[u8]) -> Result<HashMap<u16, String>> {
                         map.insert(gid, ch.to_string());
                     }
                 } else {
-                    // 배열 형태: [<d1> <d2> …].
+                    // Array form: [<d1> <d2> ...].
                     if groups.len() - 2 != usize::from(high - low) + 1 {
                         bail!("bfrange 배열 길이가 범위와 다릅니다");
                     }
@@ -670,7 +676,7 @@ fn parse_tounicode(cmap: &[u8]) -> Result<HashMap<u16, String>> {
     Ok(map)
 }
 
-/// 한 줄에서 `<…>` 16진 그룹을 모은다.
+/// Collect `<...>` hexadecimal groups from one line.
 fn hex_groups(line: &str) -> Vec<&str> {
     let mut groups = Vec::new();
     let mut rest = line;
@@ -692,7 +698,7 @@ fn parse_gid(hex: &str) -> Result<u16> {
     Ok(u16::from_str_radix(hex, 16)?)
 }
 
-/// UTF-16BE 16진 문자열을 String으로 디코드한다 (서로게이트 쌍 포함).
+/// Decode a UTF-16BE hexadecimal string, including surrogate pairs.
 fn parse_utf16(hex: &str) -> Result<String> {
     if hex.is_empty() || !hex.len().is_multiple_of(4) {
         bail!("UTF-16BE 16진 길이가 올바르지 않습니다: {hex}");
@@ -755,5 +761,18 @@ mod tests {
         assert!(decode_shown(&[0x00, 0x02], Some("F0"), &fonts).is_err());
         assert!(decode_shown(&[0x00], Some("F0"), &fonts).is_err());
         assert!(decode_shown(&[0x00, 0x01], Some("F9"), &fonts).is_err());
+    }
+
+    #[test]
+    fn text_showing_operators_decode_tj_and_tj_arrays() {
+        let mut cmap = HashMap::new();
+        cmap.insert(1u16, "가".to_string());
+        cmap.insert(2u16, "나".to_string());
+        cmap.insert(3u16, "다".to_string());
+        let mut fonts = HashMap::new();
+        fonts.insert("F0", &cmap);
+
+        let content = b"/F0 10 Tf <0001> Tj [<0002> -120 <0003>] TJ";
+        assert_eq!(decode_content(content, &fonts).unwrap(), "가나다");
     }
 }

--- a/crates/hwp-cli/src/commands/render.rs
+++ b/crates/hwp-cli/src/commands/render.rs
@@ -129,6 +129,18 @@ fn report(report: &hwp_render::RenderIssueReport) {
     for issue in report.info.iter().chain(&report.issues) {
         eprintln!("렌더: {issue}");
     }
+    let coverage = report.font_coverage();
+    if coverage.matched > 0 || !coverage.substitution_free() {
+        eprintln!(
+            "렌더: 글꼴 커버리지 matched={} substituted={} missing={} subset_fallback={}",
+            coverage.matched, coverage.substituted, coverage.missing, coverage.subset_fallback
+        );
+    }
+    if !coverage.substitution_free() {
+        eprintln!(
+            "렌더: 글꼴 대체/실패 발생 — 이 출력으로 잰 parity 수치는 발행할 수 없습니다(F1 게이트)"
+        );
+    }
     if !report.complete {
         eprintln!("렌더: issue accumulator incomplete");
     }

--- a/crates/hwp-render/src/issues.rs
+++ b/crates/hwp-render/src/issues.rs
@@ -187,6 +187,29 @@ pub struct RenderIssueReport {
     pub sha256: String,
 }
 
+/// 렌더 한 번의 글꼴 해석 결과 집계. matched는 info 채널(FontMatched),
+/// 나머지는 issues 채널에서 모은다. 공개 parity 수치는
+/// `substitution_free()`가 true일 때만 발행할 수 있다(F1 하드 게이트).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct FontCoverage {
+    /// 요청 글꼴이 그대로 해석된 횟수 (FontMatched, info).
+    pub matched: u64,
+    /// 다른 글꼴로 대체된 횟수 (FontSubstituted).
+    pub substituted: u64,
+    /// 해석 실패 횟수 (FontMissing).
+    pub missing: u64,
+    /// 서브셋 생성 실패로 전체 글꼴을 심은 횟수 (FontSubsetFallback).
+    pub subset_fallback: u64,
+}
+
+impl FontCoverage {
+    /// parity 수치 발행 게이트: 대체·실패·서브셋 폴백이 모두 0건이어야 한다.
+    /// 대체 글꼴로 잰 수치는 advance/줄바꿈/글리프 형태가 모두 달라 의미가 없다(F1).
+    pub const fn substitution_free(&self) -> bool {
+        self.substituted == 0 && self.missing == 0 && self.subset_fallback == 0
+    }
+}
+
 impl RenderIssueReport {
     pub fn has_required_failure(&self) -> bool {
         !self.complete
@@ -196,6 +219,21 @@ impl RenderIssueReport {
                     RenderIssueSeverity::Incomplete | RenderIssueSeverity::Fatal
                 )
             })
+    }
+
+    /// 글꼴 해석 이슈를 집계해 FontCoverage로 요약한다.
+    pub fn font_coverage(&self) -> FontCoverage {
+        let mut coverage = FontCoverage::default();
+        for summary in self.info.iter().chain(&self.issues) {
+            match summary.code {
+                RenderIssueCode::FontMatched => coverage.matched += summary.count,
+                RenderIssueCode::FontSubstituted => coverage.substituted += summary.count,
+                RenderIssueCode::FontMissing => coverage.missing += summary.count,
+                RenderIssueCode::FontSubsetFallback => coverage.subset_fallback += summary.count,
+                _ => {}
+            }
+        }
+        coverage
     }
 }
 
@@ -472,5 +510,29 @@ mod tests {
             canonical_issue_sha256(&[]),
             "7ae3724fbab92218a9d2bf86fca465264e88ca44311bb2d07e4f48083fadaceb"
         );
+    }
+
+    #[test]
+    fn font_coverage_aggregates_resolution_codes_and_gates_parity() {
+        let mut issues = RenderIssueAccumulator::new();
+        issues.push(RenderIssueCode::FontMatched, "font-a");
+        issues.push(RenderIssueCode::FontMatched, "font-a");
+        issues.push(RenderIssueCode::FontMatched, "font-b");
+        issues.push(RenderIssueCode::FontSubstituted, "font-c");
+        issues.push(RenderIssueCode::FontMissing, "font-d");
+        issues.push(RenderIssueCode::FontSubsetFallback, "font-e");
+        issues.push(RenderIssueCode::ShapingFailed, "not-a-font-code");
+        let coverage = issues.finish().font_coverage();
+        assert_eq!(coverage.matched, 3);
+        assert_eq!(coverage.substituted, 1);
+        assert_eq!(coverage.missing, 1);
+        assert_eq!(coverage.subset_fallback, 1);
+        assert!(!coverage.substitution_free());
+
+        let mut clean = RenderIssueAccumulator::new();
+        clean.push(RenderIssueCode::FontMatched, "font-a");
+        let coverage = clean.finish().font_coverage();
+        assert_eq!(coverage.matched, 1);
+        assert!(coverage.substitution_free());
     }
 }

--- a/crates/hwp-render/src/issues.rs
+++ b/crates/hwp-render/src/issues.rs
@@ -187,24 +187,23 @@ pub struct RenderIssueReport {
     pub sha256: String,
 }
 
-/// 렌더 한 번의 글꼴 해석 결과 집계. matched는 info 채널(FontMatched),
-/// 나머지는 issues 채널에서 모은다. 공개 parity 수치는
-/// `substitution_free()`가 true일 때만 발행할 수 있다(F1 하드 게이트).
+/// Aggregated font-resolution outcomes for one render. Successful matches come
+/// from the info channel; all other outcomes come from the issue channel.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct FontCoverage {
-    /// 요청 글꼴이 그대로 해석된 횟수 (FontMatched, info).
+    /// Requests resolved to the requested font.
     pub matched: u64,
-    /// 다른 글꼴로 대체된 횟수 (FontSubstituted).
+    /// Requests resolved through substitution.
     pub substituted: u64,
-    /// 해석 실패 횟수 (FontMissing).
+    /// Requests with no resolvable font.
     pub missing: u64,
-    /// 서브셋 생성 실패로 전체 글꼴을 심은 횟수 (FontSubsetFallback).
+    /// Fonts embedded in full because subsetting failed.
     pub subset_fallback: u64,
 }
 
 impl FontCoverage {
-    /// parity 수치 발행 게이트: 대체·실패·서브셋 폴백이 모두 0건이어야 한다.
-    /// 대체 글꼴로 잰 수치는 advance/줄바꿈/글리프 형태가 모두 달라 의미가 없다(F1).
+    /// Gate parity publication on zero substitutions, misses, and subset
+    /// fallbacks because each changes metrics relevant to layout or glyphs.
     pub const fn substitution_free(&self) -> bool {
         self.substituted == 0 && self.missing == 0 && self.subset_fallback == 0
     }
@@ -221,7 +220,7 @@ impl RenderIssueReport {
             })
     }
 
-    /// 글꼴 해석 이슈를 집계해 FontCoverage로 요약한다.
+    /// Aggregate font-resolution entries into parity coverage counters.
     pub fn font_coverage(&self) -> FontCoverage {
         let mut coverage = FontCoverage::default();
         for summary in self.info.iter().chain(&self.issues) {

--- a/crates/hwp-render/src/layout.rs
+++ b/crates/hwp-render/src/layout.rs
@@ -787,8 +787,8 @@ pub fn layout_document(
 
         // 다단(multi-column): 섹션의 첫 cold 컨트롤 ColumnDef로 단 기하 설정(v1: 섹션당 1구성).
         // 한글 line_seg는 col_start=0(단 상대)·seg_width=단폭이므로 단 x는 밴드 인덱스로 계산한다.
-        // 경계 판정: flags bit0/bit1이 있으면 그것이 곧 페이지/단 넘김, 없으면
-        // v_pos 리셋마다 밴드를 올려 colCount번째 밴드에서 페이지를 넘긴다.
+        // Boundary detection prefers flags bit0/bit1. Without either flag,
+        // each v_pos reset advances a band and every colCount-th band starts a page.
         let col_def = section
             .paragraphs
             .iter()
@@ -804,7 +804,11 @@ pub fn layout_document(
         } else {
             body_width
         };
-        let mut col_band = 0usize; // 단 넘김마다 증가, 페이지 넘김에서 0으로 리셋되는 단 밴드 인덱스
+        let mut col_band = 0usize;
+        // Flow state, not display items, proves that the current page/column has
+        // been consumed. Empty lines and paragraphs must preserve explicit
+        // blank pages and columns.
+        let mut has_flow_in_current_band = false;
 
         // 머리말/꼬리말: 구역에서 처음 정의된 것을 모든 페이지에 반복
         let mut header_ctrl = None;
@@ -880,6 +884,8 @@ pub fn layout_document(
                 content_bottom = body_top;
                 prev_v_pos = -1;
                 paras_on_page = 0;
+                col_band = 0;
+                has_flow_in_current_band = false;
             }
 
             // 쪽 나누기 (PARA_HEADER break_type bit2 / hp:p pageBreak)
@@ -903,6 +909,8 @@ pub fn layout_document(
                 content_bottom = body_top;
                 prev_v_pos = -1;
                 paras_on_page = 0;
+                col_band = 0;
+                has_flow_in_current_band = false;
             }
             page_numbers.apply_controls(para, warnings);
             paras_on_page += 1;
@@ -1027,15 +1035,16 @@ pub fn layout_document(
                         warnings,
                     );
                 }
+                has_flow_in_current_band = true;
                 continue;
             }
 
             let last_content = last_content_seg(para);
             for (i, seg) in para.line_segs.iter().enumerate() {
-                // 페이지/단 경계 판정. Hancom이 저장한 lineseg는 flags bit0(페이지
-                // 첫 줄)/bit1(단 첫 줄)을 직접 박아준다(F3) — 이를 1급 근거로 쓴다.
-                // flags가 없는 합성 lineseg(lineseg.rs의 0x0006_0000)는 기존
-                // v_pos 리셋 휴리스틱으로 폴백한다.
+                // Hancom-saved linesegs use bit0 (first line of a page) and
+                // bit1 (first line of a column) as authoritative boundaries.
+                // Synthesized linesegs use 0x0006_0000 and therefore fall back
+                // to the v_pos-reset heuristic.
                 let (is_boundary, page_break) = if seg.flags & 0x3 != 0 {
                     (true, seg.flags & 0x1 != 0)
                 } else if seg.v_pos < prev_v_pos {
@@ -1044,9 +1053,9 @@ pub fn layout_document(
                 } else {
                     (false, false)
                 };
-                if is_boundary && !page.items.is_empty() {
-                    // 경계를 걸치기 전, 이 페이지/단에 쌓인 배경 조각을 먼저 그린다(GC-9).
-                    // 조각 하단 = 현 content_bottom, 걸친 경계쪽 테두리(하변)는 긋지 않는다.
+                if is_boundary && has_flow_in_current_band {
+                    // Finish the current page/column background slice before
+                    // crossing the boundary (GC-9), without drawing its lower edge.
                     if let Some(top) = bg_slice_top {
                         draw_para_bg_slice(
                             doc,
@@ -1064,7 +1073,7 @@ pub fn layout_document(
                         bg_first_slice = false;
                     }
                     if page_break {
-                        // 페이지 넘김: 새 페이지의 첫 단(band 0)부터 시작.
+                        // A page starts in band zero.
                         col_band = 0;
                         render_page_notes(
                             doc,
@@ -1083,15 +1092,17 @@ pub fn layout_document(
                         }
                         paras_on_page = 0;
                     } else {
-                        // 단 넘김: 페이지는 유지하고 다음 단으로 x 이동.
+                        // A column boundary advances within the current page.
                         col_band += 1;
                     }
                     content_bottom = body_top;
-                    // 새 조각: 다음 줄 배치 때 상단을 잡고, 삽입 지점은 (넘겨진) 현재 page 기준.
+                    // The next line establishes the new slice top and insertion
+                    // point on the current page.
                     bg_slice_top = None;
                     bg_slice_insert = page.items.len();
                 }
                 prev_v_pos = seg.v_pos;
+                has_flow_in_current_band = true;
 
                 let line_start = seg.text_start;
                 let line_end = para

--- a/crates/hwp-render/src/layout.rs
+++ b/crates/hwp-render/src/layout.rs
@@ -787,7 +787,8 @@ pub fn layout_document(
 
         // 다단(multi-column): 섹션의 첫 cold 컨트롤 ColumnDef로 단 기하 설정(v1: 섹션당 1구성).
         // 한글 line_seg는 col_start=0(단 상대)·seg_width=단폭이므로 단 x는 밴드 인덱스로 계산한다.
-        // v_pos 리셋이 단 넘김과 페이지 넘김을 겸하며, colCount번째 밴드마다 페이지가 넘어간다.
+        // 경계 판정: flags bit0/bit1이 있으면 그것이 곧 페이지/단 넘김, 없으면
+        // v_pos 리셋마다 밴드를 올려 colCount번째 밴드에서 페이지를 넘긴다.
         let col_def = section
             .paragraphs
             .iter()
@@ -803,7 +804,7 @@ pub fn layout_document(
         } else {
             body_width
         };
-        let mut col_band = 0usize; // v_pos 리셋마다 증가하는 단 밴드 인덱스
+        let mut col_band = 0usize; // 단 넘김마다 증가, 페이지 넘김에서 0으로 리셋되는 단 밴드 인덱스
 
         // 머리말/꼬리말: 구역에서 처음 정의된 것을 모든 페이지에 반복
         let mut header_ctrl = None;
@@ -1031,8 +1032,19 @@ pub fn layout_document(
 
             let last_content = last_content_seg(para);
             for (i, seg) in para.line_segs.iter().enumerate() {
-                // v_pos 리셋: 다단이면 단 넘김(같은 페이지) vs 페이지 넘김을 밴드로 구분.
-                if seg.v_pos < prev_v_pos && !page.items.is_empty() {
+                // 페이지/단 경계 판정. Hancom이 저장한 lineseg는 flags bit0(페이지
+                // 첫 줄)/bit1(단 첫 줄)을 직접 박아준다(F3) — 이를 1급 근거로 쓴다.
+                // flags가 없는 합성 lineseg(lineseg.rs의 0x0006_0000)는 기존
+                // v_pos 리셋 휴리스틱으로 폴백한다.
+                let (is_boundary, page_break) = if seg.flags & 0x3 != 0 {
+                    (true, seg.flags & 0x1 != 0)
+                } else if seg.v_pos < prev_v_pos {
+                    let band = col_band + 1;
+                    (true, col_count == 1 || band.is_multiple_of(col_count))
+                } else {
+                    (false, false)
+                };
+                if is_boundary && !page.items.is_empty() {
                     // 경계를 걸치기 전, 이 페이지/단에 쌓인 배경 조각을 먼저 그린다(GC-9).
                     // 조각 하단 = 현 content_bottom, 걸친 경계쪽 테두리(하변)는 긋지 않는다.
                     if let Some(top) = bg_slice_top {
@@ -1051,12 +1063,9 @@ pub fn layout_document(
                         );
                         bg_first_slice = false;
                     }
-                    col_band += 1;
-                    if col_count > 1 && !col_band.is_multiple_of(col_count) {
-                        // 단 넘김: 커서만 페이지 상단으로, 페이지는 유지(다음 단으로 x 이동).
-                        content_bottom = body_top;
-                    } else {
-                        // 페이지 넘김(마지막 단 소진 또는 단일 단).
+                    if page_break {
+                        // 페이지 넘김: 새 페이지의 첫 단(band 0)부터 시작.
+                        col_band = 0;
                         render_page_notes(
                             doc,
                             store,
@@ -1072,9 +1081,12 @@ pub fn layout_document(
                         if !push_page_checked(&mut pages, &mut page, Some((w, h)), warnings) {
                             return DisplayList { pages };
                         }
-                        content_bottom = body_top;
                         paras_on_page = 0;
+                    } else {
+                        // 단 넘김: 페이지는 유지하고 다음 단으로 x 이동.
+                        col_band += 1;
                     }
+                    content_bottom = body_top;
                     // 새 조각: 다음 줄 배치 때 상단을 잡고, 삽입 지점은 (넘겨진) 현재 page 기준.
                     bg_slice_top = None;
                     bg_slice_insert = page.items.len();

--- a/crates/hwp-render/src/lib.rs
+++ b/crates/hwp-render/src/lib.rs
@@ -298,6 +298,15 @@ pub struct PdfOutput {
     pub report: RenderIssueReport,
 }
 
+/// PDF output plus the pre-serialization text sequence used by corpus
+/// validation. Existing PDF render APIs intentionally keep returning
+/// [`PdfOutput`].
+pub struct PdfValidationOutput {
+    pub data: Vec<u8>,
+    pub report: RenderIssueReport,
+    pub expected_text: String,
+}
+
 /// 문서를 단일 멀티페이지 PDF로 렌더링한다 (폰트 임베드 + 검색 가능 텍스트).
 /// `pages`는 1-기반 페이지 번호 목록; `None`이면 전체 페이지.
 pub fn render_document_pdf(
@@ -309,9 +318,9 @@ pub fn render_document_pdf(
     finish_pdf(list, report, pages)
 }
 
-/// 인증 전용 격리 PDF 렌더. 시스템 글꼴을 탐색하지 않고 `font_files`만 사용한다.
-/// 구조화 코퍼스처럼 폰트를 hash로 고정하는 경로에서 PNG 격리 렌더와 같은
-/// 글꼴 집합으로 PDF를 만들 때 사용한다.
+/// Isolated PDF render for certification. It searches only `font_files`, not
+/// ambient system fonts, so the PDF and PNG corpus paths use the same pinned
+/// font set.
 pub fn render_document_pdf_isolated(
     doc: &Document,
     opts: &RenderOptions,
@@ -322,25 +331,64 @@ pub fn render_document_pdf_isolated(
     finish_pdf(list, report, pages)
 }
 
+/// Isolated PDF render with a pre-serialization text trace for corpus
+/// validation. The trace is independent of the emitted ToUnicode CMap and
+/// therefore detects incorrect mappings, not only missing mappings.
+pub fn render_document_pdf_isolated_with_text_trace(
+    doc: &Document,
+    opts: &RenderOptions,
+    pages: Option<&[usize]>,
+    font_files: &[std::path::PathBuf],
+) -> Result<PdfValidationOutput, RenderError> {
+    let (list, report, _, _) = build_display_list_with_font_scope(doc, opts, false, font_files);
+    finish_pdf_with_text_trace(list, report, pages)
+}
+
 fn finish_pdf(
     mut list: display::DisplayList,
     mut report: RenderIssueAccumulator,
     pages: Option<&[usize]>,
 ) -> Result<PdfOutput, RenderError> {
-    if let Some(sel) = pages {
-        let mut taken: Vec<Option<display::PageList>> = list.pages.into_iter().map(Some).collect();
-        let mut picked = Vec::with_capacity(sel.len());
-        for &n in sel {
-            if let Some(page) = taken.get_mut(n.wrapping_sub(1)).and_then(Option::take) {
-                picked.push(page);
-            }
-        }
-        list = display::DisplayList { pages: picked };
-    }
+    select_pdf_pages(&mut list, pages);
     let data = pdf::render_pdf(&list, &mut report)?;
     Ok(PdfOutput {
         data,
         report: report.finish(),
+    })
+}
+
+fn select_pdf_pages(list: &mut display::DisplayList, pages: Option<&[usize]>) {
+    let Some(selected) = pages else {
+        return;
+    };
+    let mut available: Vec<Option<display::PageList>> = std::mem::take(&mut list.pages)
+        .into_iter()
+        .map(Some)
+        .collect();
+    let mut picked = Vec::with_capacity(selected.len());
+    for &number in selected {
+        if let Some(page) = available
+            .get_mut(number.wrapping_sub(1))
+            .and_then(Option::take)
+        {
+            picked.push(page);
+        }
+    }
+    list.pages = picked;
+}
+
+fn finish_pdf_with_text_trace(
+    mut list: display::DisplayList,
+    mut report: RenderIssueAccumulator,
+    pages: Option<&[usize]>,
+) -> Result<PdfValidationOutput, RenderError> {
+    select_pdf_pages(&mut list, pages);
+    let expected_text = pdf::expected_text_trace(&list)?;
+    let data = pdf::render_pdf(&list, &mut report)?;
+    Ok(PdfValidationOutput {
+        data,
+        report: report.finish(),
+        expected_text,
     })
 }
 

--- a/crates/hwp-render/src/lib.rs
+++ b/crates/hwp-render/src/lib.rs
@@ -32,7 +32,7 @@ pub use diff::{DiffReport, compare};
 pub use error::RenderError;
 pub use fonts::{FontResolution, FontResolutionOutcome, FontStore};
 pub use issues::{
-    RenderIssueAccumulator, RenderIssueCode, RenderIssueReport, RenderIssueSeverity,
+    FontCoverage, RenderIssueAccumulator, RenderIssueCode, RenderIssueReport, RenderIssueSeverity,
     RenderIssueStage, RenderIssueSummary,
 };
 
@@ -305,7 +305,28 @@ pub fn render_document_pdf(
     opts: &RenderOptions,
     pages: Option<&[usize]>,
 ) -> Result<PdfOutput, RenderError> {
-    let (mut list, mut report, _, _) = build_display_list(doc, opts);
+    let (list, report, _, _) = build_display_list(doc, opts);
+    finish_pdf(list, report, pages)
+}
+
+/// 인증 전용 격리 PDF 렌더. 시스템 글꼴을 탐색하지 않고 `font_files`만 사용한다.
+/// 구조화 코퍼스처럼 폰트를 hash로 고정하는 경로에서 PNG 격리 렌더와 같은
+/// 글꼴 집합으로 PDF를 만들 때 사용한다.
+pub fn render_document_pdf_isolated(
+    doc: &Document,
+    opts: &RenderOptions,
+    pages: Option<&[usize]>,
+    font_files: &[std::path::PathBuf],
+) -> Result<PdfOutput, RenderError> {
+    let (list, report, _, _) = build_display_list_with_font_scope(doc, opts, false, font_files);
+    finish_pdf(list, report, pages)
+}
+
+fn finish_pdf(
+    mut list: display::DisplayList,
+    mut report: RenderIssueAccumulator,
+    pages: Option<&[usize]>,
+) -> Result<PdfOutput, RenderError> {
     if let Some(sel) = pages {
         let mut taken: Vec<Option<display::PageList>> = list.pages.into_iter().map(Some).collect();
         let mut picked = Vec::with_capacity(sel.len());

--- a/crates/hwp-render/src/pdf.rs
+++ b/crates/hwp-render/src/pdf.rs
@@ -320,6 +320,39 @@ pub fn render_pdf(
     Ok(pdf.finish())
 }
 
+/// Return the text sequence that the PDF backend is expected to emit through
+/// text-showing operators. This is intentionally derived before ToUnicode
+/// serialization so corpus validation can detect an incorrect CMap mapping.
+///
+/// Decorative shadow and emboss/engrave passes emit the same glyphs again, so
+/// their repetitions are included to match the content stream exactly.
+pub(crate) fn expected_text_trace(list: &DisplayList) -> Result<String, RenderError> {
+    let mut trace = String::new();
+    for (page_index, page) in list.pages.iter().enumerate() {
+        if page_index > 0 {
+            trace.push('\n');
+        }
+        for item in &page.items {
+            let Item::Glyphs { run, .. } = item else {
+                continue;
+            };
+            if !run.glyphs.is_empty() && run.text.is_empty() {
+                return Err(RenderError::Pdf(
+                    "source text is unavailable for an emitted glyph run".to_string(),
+                ));
+            }
+            if run.shadow.is_some() {
+                trace.push_str(&run.text);
+            }
+            if run.emboss || run.engrave {
+                trace.push_str(&run.text);
+            }
+            trace.push_str(&run.text);
+        }
+    }
+    Ok(trace)
+}
+
 /// 폰트 1개의 PDF 객체(FontFile·Descriptor·CIDFont·Type0·ToUnicode)를 쓴다.
 fn write_font(pdf: &mut Pdf, f: &FontInfo) -> Result<(), RenderError> {
     let face = ttf_parser::Face::parse(&f.data, f.index)

--- a/crates/hwp-render/tests/render.rs
+++ b/crates/hwp-render/tests/render.rs
@@ -218,6 +218,39 @@ fn 멀티페이지_lineseg_페이지_상대_v_pos() {
     );
 }
 
+/// Hancom이 저장한 lineseg는 flags bit0(페이지 첫 줄)/bit1(단 첫 줄)으로 경계를
+/// 명시한다(F3). flags가 v_pos 휴리스틱과 충돌하면 flags를 따라야 한다:
+/// v_pos가 단조 증가해 리셋 감지가 무력해도 bit0이 박힌 줄은 새 페이지를 시작한다.
+#[test]
+fn lineseg_flags가_v_pos_휴리스틱에_우선() {
+    let mut doc = hwp_convert::from_markdown("첫 문단\n\n둘째 문단\n\n셋째 문단\n");
+    let mut store = hwp_render::FontStore::new();
+    let mut warns = hwp_render::RenderIssueAccumulator::new();
+    hwp_render::lineseg::synthesize_linesegs(&mut doc, &mut store, &mut warns);
+
+    // 세 문단 모두 1줄. v_pos는 단조 증가시켜 리셋 휴리스틱을 무력화하고,
+    // 둘째 문단에만 bit0(페이지 첫 줄)을 박는다.
+    for (i, p) in doc.sections[0].paragraphs.iter_mut().enumerate() {
+        assert_eq!(p.line_segs.len(), 1, "문단당 1줄 가정");
+        p.line_segs[0].v_pos = (i as i32) * 2000;
+        p.line_segs[0].flags = if i == 1 { 0x0006_0001 } else { 0x0006_0000 };
+    }
+
+    let out = render_document(
+        &doc,
+        &RenderOptions {
+            dpi: 36.0,
+            font_dirs: Vec::new(),
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        out.pages.len(),
+        2,
+        "flags bit0(페이지 첫 줄)은 v_pos 증가와 무관하게 페이지를 넘겨야 한다"
+    );
+}
+
 /// 문단 위/아래 간격(spacing_top/bottom)이 합성 줄 배치 v_pos 에 반영되어야 한다.
 /// 빠지면 한글이 문단 사이 여백 없이 압축해 그린다(제목 위 여백 사라짐 등).
 /// from_markdown 은 제목에 spacing_top=600, spacing_bottom=300 을 준다.

--- a/crates/hwp-render/tests/render.rs
+++ b/crates/hwp-render/tests/render.rs
@@ -218,9 +218,9 @@ fn 멀티페이지_lineseg_페이지_상대_v_pos() {
     );
 }
 
-/// Hancom이 저장한 lineseg는 flags bit0(페이지 첫 줄)/bit1(단 첫 줄)으로 경계를
-/// 명시한다(F3). flags가 v_pos 휴리스틱과 충돌하면 flags를 따라야 한다:
-/// v_pos가 단조 증가해 리셋 감지가 무력해도 bit0이 박힌 줄은 새 페이지를 시작한다.
+/// Hancom-saved linesegs declare boundaries with bit0 (first line of a page)
+/// and bit1 (first line of a column). Flags must win when they conflict with
+/// the v_pos-reset heuristic.
 #[test]
 fn lineseg_flags가_v_pos_휴리스틱에_우선() {
     let mut doc = hwp_convert::from_markdown("첫 문단\n\n둘째 문단\n\n셋째 문단\n");
@@ -228,8 +228,8 @@ fn lineseg_flags가_v_pos_휴리스틱에_우선() {
     let mut warns = hwp_render::RenderIssueAccumulator::new();
     hwp_render::lineseg::synthesize_linesegs(&mut doc, &mut store, &mut warns);
 
-    // 세 문단 모두 1줄. v_pos는 단조 증가시켜 리셋 휴리스틱을 무력화하고,
-    // 둘째 문단에만 bit0(페이지 첫 줄)을 박는다.
+    // Keep v_pos monotonic to disable the heuristic and put bit0 only on the
+    // second paragraph.
     for (i, p) in doc.sections[0].paragraphs.iter_mut().enumerate() {
         assert_eq!(p.line_segs.len(), 1, "문단당 1줄 가정");
         p.line_segs[0].v_pos = (i as i32) * 2000;
@@ -249,6 +249,95 @@ fn lineseg_flags가_v_pos_휴리스틱에_우선() {
         2,
         "flags bit0(페이지 첫 줄)은 v_pos 증가와 무관하게 페이지를 넘겨야 한다"
     );
+}
+
+#[test]
+fn authoritative_page_flags_preserve_an_empty_page_without_a_leading_page() {
+    let mut doc = hwp_convert::from_markdown("first\n\nblank\n\nthird\n");
+    let mut store = hwp_render::FontStore::new();
+    let mut warns = hwp_render::RenderIssueAccumulator::new();
+    hwp_render::lineseg::synthesize_linesegs(&mut doc, &mut store, &mut warns);
+
+    assert_eq!(doc.sections[0].paragraphs.len(), 3);
+    doc.sections[0].paragraphs[1].chars = vec![hwp_model::HwpChar::CharCtrl(
+        hwp_model::ctrl_char::PARA_BREAK,
+    )];
+    for paragraph in &mut doc.sections[0].paragraphs {
+        assert_eq!(paragraph.line_segs.len(), 1);
+        paragraph.line_segs[0].v_pos = 0;
+        paragraph.line_segs[0].flags = 0x0006_0001;
+    }
+
+    let out = render_document(
+        &doc,
+        &RenderOptions {
+            dpi: 36.0,
+            font_dirs: Vec::new(),
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        out.pages.len(),
+        3,
+        "the initial bit0 must not add a leading page"
+    );
+    assert!(dark_pixels(&out.pages[0]) > 0);
+    assert_eq!(
+        dark_pixels(&out.pages[1]),
+        0,
+        "the empty flow band must survive"
+    );
+    assert!(dark_pixels(&out.pages[2]) > 0);
+}
+
+#[test]
+fn authoritative_column_flags_preserve_an_empty_first_column() {
+    use hwp_model::{ColumnDef, Control, GenericControl, HwpChar};
+
+    let mut doc = hwp_convert::from_markdown("blank\n\nright column\n");
+    let mut store = hwp_render::FontStore::new();
+    let mut warns = hwp_render::RenderIssueAccumulator::new();
+    hwp_render::lineseg::synthesize_linesegs(&mut doc, &mut store, &mut warns);
+
+    assert_eq!(doc.sections[0].paragraphs.len(), 2);
+    doc.sections[0].paragraphs[0].chars = vec![HwpChar::CharCtrl(hwp_model::ctrl_char::PARA_BREAK)];
+    doc.sections[0].paragraphs[0]
+        .controls
+        .push(Control::Generic(GenericControl {
+            ctrl_id: *b"cold",
+            data: Vec::new(),
+            paragraph_lists: Vec::new(),
+            extras: Vec::new(),
+            raw_children: Vec::new(),
+            gso_shapes: Vec::new(),
+            equation: None,
+            column_def: Some(ColumnDef {
+                count: 2,
+                kind: 0,
+                direction: 0,
+                same_width: true,
+                gap: 1000,
+                widths: Vec::new(),
+                divider: None,
+            }),
+        }));
+    for paragraph in &mut doc.sections[0].paragraphs {
+        assert_eq!(paragraph.line_segs.len(), 1);
+        paragraph.line_segs[0].v_pos = 0;
+        paragraph.line_segs[0].flags = 0x0006_0002;
+    }
+
+    let list = hwp_render::layout::layout_document(&doc, &mut store, &mut warns);
+    assert_eq!(list.pages.len(), 1);
+    let page = &list.pages[0];
+    assert!(page.items.iter().any(|item| matches!(
+        item,
+        hwp_render::display::Item::Glyphs { x, .. } if *x > page.width_pt / 2.0
+    )));
+    assert!(!page.items.iter().any(|item| matches!(
+        item,
+        hwp_render::display::Item::Glyphs { x, .. } if *x < page.width_pt / 2.0
+    )));
 }
 
 /// 문단 위/아래 간격(spacing_top/bottom)이 합성 줄 배치 v_pos 에 반영되어야 한다.

--- a/crates/hwp-render/tests/render.rs
+++ b/crates/hwp-render/tests/render.rs
@@ -268,26 +268,18 @@ fn authoritative_page_flags_preserve_an_empty_page_without_a_leading_page() {
         paragraph.line_segs[0].flags = 0x0006_0001;
     }
 
-    let out = render_document(
-        &doc,
-        &RenderOptions {
-            dpi: 36.0,
-            font_dirs: Vec::new(),
-        },
-    )
-    .unwrap();
+    let out = hwp_render::layout::layout_document(&doc, &mut store, &mut warns);
     assert_eq!(
         out.pages.len(),
         3,
         "the initial bit0 must not add a leading page"
     );
-    assert!(dark_pixels(&out.pages[0]) > 0);
+    assert!(!out.pages[0].items.is_empty());
     assert_eq!(
-        dark_pixels(&out.pages[1]),
+        out.pages[1].items.len(),
         0,
         "the empty flow band must survive"
     );
-    assert!(dark_pixels(&out.pages[2]) > 0);
 }
 
 #[test]

--- a/docs/design/00-overview.ko.md
+++ b/docs/design/00-overview.ko.md
@@ -83,6 +83,7 @@
 | 18 | [html-fragment-contract](18-html-fragment-contract.ko.md) | **HTML fragment 계약** — Maru 부분(part) 작성·조합용 XHTML 부분집합, 표/그림/각주 왕복 규약 |
 | 19 | [hwp5-spec-supplement](19-hwp5-spec-supplement.ko.md) | **HWP 5.0 명세 보완 색인** — 정오표·버전-레이아웃 매트릭스·적합성 체크리스트·소비 의미론 (07·03·05·10·08이 근거 데이터) |
 | 20 | [remote-mcp](20-remote-mcp.ko.md) | **Remote MCP transport 설계** - Web client용 향후 Streamable HTTP, OAuth resource server, tenant 격리, artifact 전송, limit 및 security gate |
+| 21 | [pdf-parity](21-pdf-parity.ko.md) | **PDF 동등성 계약 (한컴오피스 2024)** — parity 하네스가 읽는 오라클, 다섯 지표 집합, 임계값, 글꼴 게이트, 데이터 정책, 비목표 (issue #79) |
 
 ---
 

--- a/docs/design/00-overview.md
+++ b/docs/design/00-overview.md
@@ -87,6 +87,7 @@ width 1, inline width 8, extended width 8). Lossless round-tripping is preserved
 | 18 | [html-fragment-contract](18-html-fragment-contract.md) | **HTML fragment contract** — XHTML subset for Maru part-based authoring/assembly, table/image/footnote round-trip rules |
 | 19 | [hwp5-spec-supplement](19-hwp5-spec-supplement.md) | **HWP 5.0 spec supplement index** — errata, version-layout matrix, conformance checklist, consumption semantics (07·03·05·10·08 are the underlying data) |
 | 20 | [remote-mcp](20-remote-mcp.md) | **Remote MCP transport design** - future Streamable HTTP, OAuth resource-server, tenant isolation, artifact transfer, limits and security gates for web clients |
+| 21 | [pdf-parity](21-pdf-parity.md) | **PDF parity contract (Hancom Office 2024)** — oracle, five-metric set, thresholds, font gate, data policy and non-goals the parity harness reads (issue #79) |
 
 ---
 

--- a/docs/design/21-pdf-parity.ko.md
+++ b/docs/design/21-pdf-parity.ko.md
@@ -70,7 +70,10 @@ catalog/Info 기능 — 을 확정했다:
 
 ## 4. 게이트
 
-### 4.1 블로킹 게이트 — 공개 코퍼스 모든 페이지
+### 4.1 정본 한컴 오라클 게이트 — 향후 공개 코퍼스
+
+이는 향후 공개 한컴 오라클 채점에 적용할 정본 목표다. 현재 structured-corpus 게이트가
+아니며, 현재 자체 일관성 검사는 §4.2에 별도로 적는다.
 
 - 페이지 수: 완전 일치
 - MediaBox 차이 0.5 pt 이하
@@ -82,11 +85,20 @@ catalog/Info 기능 — 을 확정했다:
 - `pdftotext -layout` 정규화 결과가 기대 가시 텍스트·순서와 일치
 - 동일 입력·글꼴로 두 번 생성한 PDF가 byte-identical
 
-### 4.2 자체 백엔드 게이트
+### 4.2 현재 structured-corpus 자체 일관성 게이트
 
-같은 DisplayList의 PDF 래스터와 PNG 백엔드 비교: `dx`/`dy` 1 px 이하, ink ratio
-0.99–1.01, bad pixels 2 % 이하. structured corpus run(`scripts/check-structured-corpus.sh`)이
-고정 Noto Sans KR 아래 "세 백엔드 일치" 불변식을 강제한다.
+structured-corpus run(`scripts/check-structured-corpus.sh`)은 고정 Noto Sans KR 아래에서 다음
+백엔드 자체 일관성을 현재 강제한다:
+
+- PDF 페이지 수가 PNG 백엔드 페이지 수와 일치
+- 표시된 PDF 글리프 전체가 ToUnicode 매핑을 거쳐 완전한 기대 논리 텍스트로 왕복하는지 확인
+  (required-text 부분 문자열만 확인하는 검사가 아님)
+- 동일 입력·글꼴로 PDF를 두 번 렌더링한 결과가 byte-identical
+
+현재는 PDF와 PNG 출력을 서로 raster 비교하지 않는다. 따라서 `dx`, `dy`, `ink_ratio`,
+`bad_pixel_pct`, MAE는 현재 structured-corpus 임계값이 아니다. 이 값들은 §4.1의 한컴 오라클
+게이트에 적용할 향후/정본 래스터 요구사항이며, 고정 오라클 PDF/PNG 픽스처와 비교 하네스가
+준비된 뒤에만 활성화한다.
 
 ## 5. 글꼴 게이트 (F1)
 
@@ -109,16 +121,20 @@ IR에 파싱돼 있다. 렌더러는 이 비트를 1급 페이지/단 경계 신
 
 ## 7. 데이터 정책
 
-- **공개 코퍼스**(`fixtures/pdf-parity/public/`): 소유자 자작·가명화 문서만. 기본 텍스트,
+- **공개 코퍼스**(`fixtures/pdf-parity/public/`): 소유자 자작·가명화 원본 문서만. 기본 텍스트,
   문단, 목록, 표, 다단, 머리말·꼬리말·쪽번호, 각주·미주, 이미지, 도형, 수식, 복합 보고서를
-  HWP/HWPX 쌍으로 커버한다. `.gitignore`는 이 디렉터리만 명시적으로 허용한다. 매니페스트는
-  정확한 Hancom 빌드, Windows 버전, PDF 설정, 글꼴 SHA-256, source/oracle SHA-256, Poppler
-  버전, 150 DPI를 고정한다.
+  HWP/HWPX 쌍으로 커버한다. `.gitignore`는 `fixtures/pdf-parity/` 전체를 기본 무시하고,
+  `public/source/` 아래 HWP/HWPX 파일, `public/recipes/` 아래 Markdown/JSON 레시피 파일,
+  `public/manifest.json`, `public/scoreboard/` 아래 숫자 JSON/CSV 스코어보드만 다시 허용한다
+  (루트의 `scoreboard.json`과 `scoreboard.csv`도 허용). 공개 오라클 PDF/PNG와 모든 비공개
+  코퍼스 경로는 계속 무시한다. 매니페스트는 정확한 Hancom 빌드, Windows 버전, PDF 설정,
+  글꼴 SHA-256, source/oracle SHA-256, Poppler 버전, 150 DPI를 고정한다.
 - **비공개 코퍼스**(`HWP_PDF_PARITY_CORPUS_DIR`): 실제 복합 문서. 보고서는 해시와 집계
   지표만 담고 원문·PDF·절대 경로는 기록하지 않는다.
-- **Hancom 유래 아티팩트는 커밋하지 않는다** — 로컬 베이스라인, 커밋된 레시피, 커밋된 수치.
-  베이스라인은 파일 → PDF로 저장하기 → `pdftoppm -png -r 150`로 수동 생성(3–5건)하고 로컬에
-  둔다.
+- **한컴 유래 아티팩트는 커밋하지 않는다** — 내보낸 오라클 PDF/PNG와 비공개 원본 문서는
+  로컬에 둔다. 커밋하는 레시피·매니페스트·숫자 스코어보드는 절차, 핀, 해시, 집계 수치만
+  담으며 오라클 아티팩트가 아니다. 베이스라인은 파일 → PDF로 저장하기 →
+  `pdftoppm -png -r 150`로 수동 생성(3–5건)하고 로컬에 둔다.
 - 제3자 실제 문서, 한컴 명세 사본, 비공개 오라클 PDF는 커밋하지 않는다.
 
 ## 8. 안티패턴 가드

--- a/docs/design/21-pdf-parity.ko.md
+++ b/docs/design/21-pdf-parity.ko.md
@@ -1,0 +1,138 @@
+[한국어](21-pdf-parity.ko.md) · [English](21-pdf-parity.md)
+
+# PDF 동등성 계약 (한컴오피스 2024)
+
+> **상태:** 활성 계약. [issue #79](https://github.com/STAIxBWLB/hwp-cli/issues/79)에서 추적한다.
+> 이 문서는 parity 하네스가 읽는 지속 계약이다 — 지표 집합, 임계값, 데이터 정책, 비목표를
+> 정의한다. 작업 순서(PR 1–9)는 이슈 본문이 정하고, 이 문서는 "동등"의 뜻을 정의한다.
+
+목표: `hwp convert --to pdf`와 `hwp render --format pdf`가 일반 문서(공문, 보고서, 표, 양식,
+이미지, 도형, 수식)에 대해 한국 사무실 사용자가 한컴오피스 2024 한글의 **파일 → PDF로
+저장하기** 출력과 상호 교환 가능하다고 받아들이는 PDF를 낸다 — 시각적으로 충실하고 텍스트
+선택·검색·복사가 가능해야 한다.
+
+## 1. 범위
+
+**Regime A — 한글이 저장한 문서 → PDF.** HWP 파일은 자체 줄 배치를 PARA_LINE_SEG에 캐시하고
+렌더러는 그 캐시를 재생한다(Regime A). 줄 위치는 한글 자신의 것이고, 차이는 잉크와 한정된
+구조적 간극뿐이다. 이 계약은 Regime A만 다룬다.
+
+**Regime B — hwp-cli가 생성한 문서 → PDF**(합성 lineseg, 금칙처리, Latin 단어 유지,
+widow/orphan, 어울림 텍스트 감싸기)는 별개 이슈로 여기서는 제외한다.
+
+### 1.1 비목표
+
+[release-readiness](../release-readiness.ko.md)와 issue #79에서 인용:
+
+- 릴리스는 스모크 픽스처가 모든 실제 문서 형태를 커버한다거나, 한컴 픽셀 동등성을
+  제공한다거나, 플랫폼 간 동일 래스터 바이트를 증명한다고 주장하지 않는다.
+- 책갈피(`/Outlines`)와 클릭 가능한 링크(`/Annots`): 한컴 PDF는 둘 다 내지 않으므로 동등성을
+  **넘어서는** 기능이다.
+- PDF/A-2b와 tagged PDF: 제외. tagged PDF는 의도적으로 도메인 없는 DisplayList 때문에
+  구조적으로 막혀 있다.
+- 릴리스 카피에 "한컴 픽셀 동등성" 주장 금지. README의 "No Hancom parity claim" 문구는
+  일반문서 프로파일 전체가 §4의 모든 게이트를 통과한 후에만 제한적인 "validated Hancom
+  Office 2024 PDF profile"로 바꿀 수 있다.
+- 차트, OLE, 동영상, 글맵시, 메모, 마스터 페이지, 세로쓰기, 고급 수식 구조는 명시적 누락으로
+  보고하며 조용히 누락하지 않는다.
+
+## 2. 오라클
+
+정답지는 **최신 패치를 적용한 Windows용 한컴오피스 2024 한글**이 파일 → PDF로 저장하기로
+만든 PDF다. 정품 Producer `Hancom PDF 1.3.0.550` 파일 검사로 문서 수준 동등성 표면 — 6개
+catalog/Info 기능 — 을 확정했다:
+
+- `/Lang (ko-KR)`, `/PageLayout /SinglePage`, XMP `/Metadata`,
+  `/OutputIntents` (GTS_PDFA1 + sRGB IEC61966-2.1, 임베디드 ICC), `/MarkInfo <</Marked false>>`
+- `/Info`는 Author, Creator, Producer, CreationDate, ModDate, PDFVersion뿐
+- 글꼴: Type0 + CIDFontType2 + FontFile2 + Identity-H + ToUnicode (hwp-render가 이미 구현한
+  방식)
+- 없음: `/Outlines`, `/Annots`, `/PageLabels`, `/AcroForm`, `/Encrypt`, `/Shading`,
+  `/Pattern`, `/ExtGState`, `/SMask` (한컴도 그라데이션을 평면화 — 우리의 밴드 근사는
+  결함이 아니다)
+- PDF 1.4; tagged PDF 아님
+
+## 3. 다섯 지표 집합 (우선순위 순)
+
+양쪽 모두 벡터 텍스트이므로 픽셀 차이 지표는 글꼴 대체와 안티앨리어싱에 지배된다 — 엔진
+아티팩트이지 충실도가 아니다. 결정적 지표는 픽셀이 필요 없다:
+
+| # | 지표 | 도구 | 잡아내는 것 |
+|---|---|---|---|
+| 1 | 임베디드 글꼴 목록 | `pdffonts` | 글꼴 대체 (§5) |
+| 2 | 페이지 수 차이 | `pdfinfo` | 표 분할, 넘침, 장식 회귀 |
+| 3 | 페이지별 추출 텍스트 일치 | `pdftotext -layout`, 정규화 | 누락 콘텐츠, 잘못된 페이지네이션, 깨진 ToUnicode |
+| 4 | 잉크 bbox 차이 (`dx`, `dy`) | 150 DPI에서 한 번 래스터 | 체계적 여백/베이스라인 오프셋 |
+| 5 | `bad_pixel_pct` / `MAE` | `hwp diff` | 타이브레이커 전용 |
+
+지표 4–5의 래스터화는 Hancom PDF와 자체 PDF 모두 같은 고정 Poppler(`pdftoppm -png -r 150`)를
+쓴다.
+
+## 4. 게이트
+
+### 4.1 블로킹 게이트 — 공개 코퍼스 모든 페이지
+
+- 페이지 수: 완전 일치
+- MediaBox 차이 0.5 pt 이하
+- `dx`, `dy` 각각 2 px 이하(150 DPI); `ink_ratio` 0.97–1.03
+- `bad_pixel_pct` 5 % 이하, MAE 5 이하
+- 기능 ROI 잉크 precision/recall 각각 0.95 이상
+- 글꼴 대체, 미지원 누락, fatal 렌더 이슈: **0건**
+- `pdffonts`: 모든 글꼴 embedded/subset + Unicode 지원
+- `pdftotext -layout` 정규화 결과가 기대 가시 텍스트·순서와 일치
+- 동일 입력·글꼴로 두 번 생성한 PDF가 byte-identical
+
+### 4.2 자체 백엔드 게이트
+
+같은 DisplayList의 PDF 래스터와 PNG 백엔드 비교: `dx`/`dy` 1 px 이하, ink ratio
+0.99–1.01, bad pixels 2 % 이하. structured corpus run(`scripts/check-structured-corpus.sh`)이
+고정 Noto Sans KR 아래 "세 백엔드 일치" 불변식을 강제한다.
+
+## 5. 글꼴 게이트 (F1)
+
+한컴은 함초롬바탕/함초롬돋움을 임베드하고, 우리는 fontdb로 해석해 일반 산세리프로 폴백할 수
+있다. 대체 한 번이 모든 advance, 모든 줄바꿈 결정, 모든 글리프 형태를 바꾸므로 **대체 글꼴
+아래 잰 parity 수치는 무의미하다**.
+
+- `RenderIssueReport::font_coverage()`가 FontMatched / FontSubstituted / FontMissing /
+  FontSubsetFallback 횟수를 집계하고, CLI 렌더 리포트가 커버리지 줄을 출력한다.
+- `FontCoverage::substitution_free()`가 하드 게이트다: 대체 없이 렌더되지 않은 케이스의
+  parity 수치는 발행할 수 없다.
+
+## 6. 페이지네이션 정본 (F3)
+
+한글은 이미 페이지 경계를 알려준다: `LineSeg.flags` bit0(페이지 첫 줄)과 bit1(단 첫 줄)이
+IR에 파싱돼 있다. 렌더러는 이 비트를 1급 페이지/단 경계 신호로 읽고, 합성 lineseg(flags
+`0x0006_0000`)에서만 `v_pos` 리셋 휴리스틱으로 폴백한다. 표가 페이지를 걸쳐 잘리는 동안은
+페이지 인덱스 비교가 무의미하므로, 페이지네이션 정확성(표 분할 포함, PR 2)은 측정의
+**전제조건**이지 소비자가 아니다.
+
+## 7. 데이터 정책
+
+- **공개 코퍼스**(`fixtures/pdf-parity/public/`): 소유자 자작·가명화 문서만. 기본 텍스트,
+  문단, 목록, 표, 다단, 머리말·꼬리말·쪽번호, 각주·미주, 이미지, 도형, 수식, 복합 보고서를
+  HWP/HWPX 쌍으로 커버한다. `.gitignore`는 이 디렉터리만 명시적으로 허용한다. 매니페스트는
+  정확한 Hancom 빌드, Windows 버전, PDF 설정, 글꼴 SHA-256, source/oracle SHA-256, Poppler
+  버전, 150 DPI를 고정한다.
+- **비공개 코퍼스**(`HWP_PDF_PARITY_CORPUS_DIR`): 실제 복합 문서. 보고서는 해시와 집계
+  지표만 담고 원문·PDF·절대 경로는 기록하지 않는다.
+- **Hancom 유래 아티팩트는 커밋하지 않는다** — 로컬 베이스라인, 커밋된 레시피, 커밋된 수치.
+  베이스라인은 파일 → PDF로 저장하기 → `pdftoppm -png -r 150`로 수동 생성(3–5건)하고 로컬에
+  둔다.
+- 제3자 실제 문서, 한컴 명세 사본, 비공개 오라클 PDF는 커밋하지 않는다.
+
+## 8. 안티패턴 가드
+
+- Hancom Office/COM을 runtime dependency로 추가하지 않는다.
+- PDF를 페이지 이미지로 평면화하지 않는다 — 벡터 텍스트와 ToUnicode를 유지한다.
+- PDF 백엔드에 별도 레이아웃 계산을 복제하지 않는다; DisplayList 직렬화 차이만 수정한다.
+- 미지원 개체를 조용히 누락하지 않는다; placeholder를 정상 출력으로 인정하지 않는다.
+- 일반문서 프로파일 밖의 기능까지 보편적 동등성으로 홍보하지 않는다.
+
+## 9. 완료 조건
+
+- 커밋된 스코어보드가 첫 베이스라인(PR 4)부터 PR 9까지 단조 개선된다.
+- 모든 채점 케이스에서 글꼴 대체가 0건이다.
+- `MAX_BAD_PIXEL_PCT`는 advance 영향 배치의 단일 리베이스라인 PR(PR 7)에서 정확히 한 번만
+  조여지고 placeholder로 남지 않는다.
+- `scripts/check.sh`, PDF 단위/통합 테스트, 공개 parity 게이트가 모두 통과한다.

--- a/docs/design/21-pdf-parity.md
+++ b/docs/design/21-pdf-parity.md
@@ -70,7 +70,10 @@ Hancom PDF and our PDF.
 
 ## 4. Gates
 
-### 4.1 Blocking gate — every public corpus page
+### 4.1 Normative Hancom-oracle gate — future public corpus
+
+This is the normative target for future public Hancom-oracle scoring. It is not the current
+structured-corpus gate; the current self-consistency checks are listed separately in §4.2.
 
 - Page count: exact match
 - MediaBox delta ≤ 0.5 pt
@@ -82,11 +85,20 @@ Hancom PDF and our PDF.
 - `pdftotext -layout` normalized output matches the expected visible text and order
 - Byte-identical PDF on two runs with identical input and fonts
 
-### 4.2 Self-backend gate
+### 4.2 Current structured-corpus self-consistency gate
 
-Same DisplayList, PDF raster vs PNG backend: `dx`/`dy` ≤ 1 px, ink ratio 0.99–1.01,
-bad pixels ≤ 2 %. The structured corpus run (`scripts/check-structured-corpus.sh`) enforces the
-"three backends agree" invariant under the pinned Noto Sans KR.
+The structured-corpus run (`scripts/check-structured-corpus.sh`) currently enforces backend
+self-consistency under the pinned Noto Sans KR:
+
+- PDF page count equals the PNG backend page count.
+- Every displayed PDF glyph round-trips through its ToUnicode mapping to the complete expected
+  logical text; this is a full mapping check, not only a required-text substring check.
+- Two PDF renders with identical input and fonts are byte-identical.
+
+It does not currently rasterize PDF and PNG output against each other. Therefore `dx`, `dy`,
+`ink_ratio`, `bad_pixel_pct`, and MAE are not current structured-corpus thresholds. Those are
+future/normative raster requirements for the Hancom-oracle gate in §4.1, activated only when the
+pinned oracle PDF/PNG fixtures and comparison harness are available.
 
 ## 5. The font gate (F1)
 
@@ -110,16 +122,21 @@ not a consumer of it.
 
 ## 7. Data policy
 
-- **Public corpus** (`fixtures/pdf-parity/public/`): owner-authored / anonymized documents only,
-  as HWP/HWPX pairs covering basic text, paragraphs, lists, tables, columns, headers/footers/page
+- **Public corpus** (`fixtures/pdf-parity/public/`): owner-authored / anonymized source documents
+  only, as HWP/HWPX pairs covering basic text, paragraphs, lists, tables, columns, headers/footers/page
   numbers, footnotes/endnotes, images, shapes, equations and composite reports. `.gitignore`
-  explicitly allows only this directory. The manifest pins the exact Hancom build, Windows
-  version, PDF settings, font SHA-256, source/oracle SHA-256, Poppler version and 150 DPI.
+  ignores the entire `fixtures/pdf-parity/` tree by default and re-allows only HWP/HWPX files under
+  `public/source/`, Markdown/JSON recipe files under `public/recipes/`, `public/manifest.json`,
+  and numeric JSON/CSV scoreboards under `public/scoreboard/` (with the root `scoreboard.json` and
+  `scoreboard.csv` names also allowed). Public oracle PDFs/PNGs and every private-corpus path stay
+  ignored. The manifest pins the exact Hancom build, Windows version, PDF settings, font SHA-256,
+  source/oracle SHA-256, Poppler version and 150 DPI.
 - **Private corpus** (`HWP_PDF_PARITY_CORPUS_DIR`): real composite documents. Reports contain
   hashes and aggregate metrics only — never originals, PDFs or absolute paths.
-- **Hancom-derived artifacts are never committed** — local baselines, committed recipe, committed
-  numbers. Baselines are produced manually (3–5 cases) via 파일 → PDF로 저장하기 →
-  `pdftoppm -png -r 150` and kept local.
+- **Hancom-derived artifacts are never committed** — exported oracle PDFs/PNGs and private source
+  documents stay local. The checked-in recipe, manifest and numeric scoreboard contain only the
+  procedure, pins, hashes and aggregate numbers; they are not oracle artifacts. Baselines are
+  produced manually (3–5 cases) via 파일 → PDF로 저장하기 → `pdftoppm -png -r 150` and kept local.
 - Third-party real documents, Hancom spec copies and private oracle PDFs are never committed.
 
 ## 8. Anti-pattern guards

--- a/docs/design/21-pdf-parity.md
+++ b/docs/design/21-pdf-parity.md
@@ -1,0 +1,139 @@
+[한국어](21-pdf-parity.ko.md) · [English](21-pdf-parity.md)
+
+# PDF parity contract (Hancom Office 2024)
+
+> **Status:** active contract. Tracked by
+> [issue #79](https://github.com/STAIxBWLB/hwp-cli/issues/79). This document is the durable
+> definition the parity harness reads: metric set, thresholds, data policy and non-goals. The
+> issue body sequences the work (PR 1–9); this document defines what "par" means.
+
+The goal: `hwp convert --to pdf` and `hwp render --format pdf` emit a PDF that a Korean office
+worker accepts as interchangeable with Hancom Office 2024 한글's own **파일 → PDF로 저장하기**
+for general documents (공문, 보고서, 표, 양식, 이미지, 도형, 수식) — visually faithful and with
+selectable, searchable, copyable text.
+
+## 1. Scope
+
+**Regime A — 한글이 저장한 문서 → PDF.** HWP files cache their own line layout in PARA_LINE_SEG,
+and the renderer replays that cache (Regime A). Line positions are Hangul's own; the delta is ink
+plus a bounded set of structural gaps. This contract covers Regime A only.
+
+**Regime B — hwp-cli가 생성한 문서 → PDF** (synthesized linesegs, 금칙처리, Latin word keeping,
+widow/orphan, 어울림 text wrapping) is a separate issue and out of scope here.
+
+### 1.1 Non-goals
+
+Quoted from [release-readiness](../release-readiness.md) and issue #79:
+
+- The release must not claim that the smoke fixtures cover every real document form, provide
+  Hancom pixel parity, or prove cross-platform-identical raster bytes.
+- Bookmarks (`/Outlines`) and clickable links (`/Annots`): Hancom's PDF emits neither, so these
+  **exceed** parity.
+- PDF/A-2b and tagged PDF: excluded; tagged PDF is additionally blocked by the deliberately
+  domain-free DisplayList.
+- No "Hancom pixel parity" claim in release copy. The README "No Hancom parity claim" wording may
+  change to a limited "validated Hancom Office 2024 PDF profile" only after the full
+  general-document profile passes every gate in §4.
+- Charts, OLE, video, word art, memos, master pages, vertical writing and advanced equation
+  constructs are reported as explicit omissions, never silently dropped.
+
+## 2. The oracle
+
+Ground truth is a PDF produced by **최신 패치를 적용한 Windows용 한컴오피스 2024 한글** via
+파일 → PDF로 저장하기. Inspection of genuine Producer `Hancom PDF 1.3.0.550` files established
+the document-level parity surface — six catalog/Info features:
+
+- `/Lang (ko-KR)`, `/PageLayout /SinglePage`, XMP `/Metadata`,
+  `/OutputIntents` (GTS_PDFA1 + sRGB IEC61966-2.1, embedded ICC), `/MarkInfo <</Marked false>>`
+- `/Info` limited to Author, Creator, Producer, CreationDate, ModDate, PDFVersion
+- Fonts: Type0 + CIDFontType2 + FontFile2 + Identity-H + ToUnicode (the scheme hwp-render already
+  implements)
+- Absent: `/Outlines`, `/Annots`, `/PageLabels`, `/AcroForm`, `/Encrypt`, `/Shading`, `/Pattern`,
+  `/ExtGState`, `/SMask` (Hancom flattens gradients — our banded approximation is not a defect)
+- PDF 1.4; not a tagged PDF
+
+## 3. The five-metric set (priority order)
+
+Both sides are vector text, so pixel diff metrics are dominated by font substitution and
+antialiasing — engine artifacts, not fidelity. The decisive metrics need no pixels:
+
+| # | Metric | Tool | Catches |
+|---|---|---|---|
+| 1 | Embedded font list | `pdffonts` | Font substitution (§5) |
+| 2 | Page count delta | `pdfinfo` | Table splitting, overflow, furniture regressions |
+| 3 | Per-page extracted text equality | `pdftotext -layout`, normalized | Missing content, wrong pagination, broken ToUnicode |
+| 4 | Ink bbox delta (`dx`, `dy`) | Rasterize once at 150 DPI | Systematic margin/baseline offset |
+| 5 | `bad_pixel_pct` / `MAE` | `hwp diff` | Tiebreaker only |
+
+Rasterization for metrics 4–5 uses the same pinned Poppler (`pdftoppm -png -r 150`) for both the
+Hancom PDF and our PDF.
+
+## 4. Gates
+
+### 4.1 Blocking gate — every public corpus page
+
+- Page count: exact match
+- MediaBox delta ≤ 0.5 pt
+- `dx`, `dy` ≤ 2 px each at 150 DPI; `ink_ratio` in 0.97–1.03
+- `bad_pixel_pct` ≤ 5 %, MAE ≤ 5
+- Feature ROI ink precision/recall ≥ 0.95 each
+- Font substitution, unsupported omission, fatal render issue: **0**
+- `pdffonts`: every font embedded/subset with Unicode support
+- `pdftotext -layout` normalized output matches the expected visible text and order
+- Byte-identical PDF on two runs with identical input and fonts
+
+### 4.2 Self-backend gate
+
+Same DisplayList, PDF raster vs PNG backend: `dx`/`dy` ≤ 1 px, ink ratio 0.99–1.01,
+bad pixels ≤ 2 %. The structured corpus run (`scripts/check-structured-corpus.sh`) enforces the
+"three backends agree" invariant under the pinned Noto Sans KR.
+
+## 5. The font gate (F1)
+
+Hancom embeds 함초롬바탕/함초롬돋움; we resolve through fontdb and can fall back to a generic
+sans-serif. Every substitution changes every advance, every wrap decision and every glyph shape,
+so **a parity number measured under substituted fonts is meaningless**.
+
+- `RenderIssueReport::font_coverage()` aggregates FontMatched / FontSubstituted / FontMissing /
+  FontSubsetFallback counts; the CLI render report prints the coverage line.
+- `FontCoverage::substitution_free()` is the hard gate: no parity figure may be published for a
+  case whose render was not substitution-free.
+
+## 6. Pagination truth (F3)
+
+Hancom already tells us where its page breaks are: `LineSeg.flags` bit0 (페이지 첫 줄) and bit1
+(단 첫 줄) are parsed into the IR. The renderer reads these bits as the first-class page/column
+break signal and falls back to the `v_pos` reset heuristic only for synthesized linesegs (flags
+`0x0006_0000`). Page-indexed comparison is meaningless while a table clips across pages, so
+pagination correctness (including table splitting, PR 2) is a **precondition** for measurement,
+not a consumer of it.
+
+## 7. Data policy
+
+- **Public corpus** (`fixtures/pdf-parity/public/`): owner-authored / anonymized documents only,
+  as HWP/HWPX pairs covering basic text, paragraphs, lists, tables, columns, headers/footers/page
+  numbers, footnotes/endnotes, images, shapes, equations and composite reports. `.gitignore`
+  explicitly allows only this directory. The manifest pins the exact Hancom build, Windows
+  version, PDF settings, font SHA-256, source/oracle SHA-256, Poppler version and 150 DPI.
+- **Private corpus** (`HWP_PDF_PARITY_CORPUS_DIR`): real composite documents. Reports contain
+  hashes and aggregate metrics only — never originals, PDFs or absolute paths.
+- **Hancom-derived artifacts are never committed** — local baselines, committed recipe, committed
+  numbers. Baselines are produced manually (3–5 cases) via 파일 → PDF로 저장하기 →
+  `pdftoppm -png -r 150` and kept local.
+- Third-party real documents, Hancom spec copies and private oracle PDFs are never committed.
+
+## 8. Anti-pattern guards
+
+- No Hancom Office/COM runtime dependency.
+- No PDF page flattening to images — vector text and ToUnicode stay.
+- No layout computation duplicated in the PDF backend; DisplayList serialization differences only.
+- No silent omission of unsupported objects; placeholders are never counted as correct output.
+- No universal-parity claims beyond the general-document profile.
+
+## 9. Done means
+
+- The committed scoreboard improves monotonically from the first baseline (PR 4) through PR 9.
+- Font substitution is zero on every scored case.
+- `MAX_BAD_PIXEL_PCT` is tightened exactly once, in the advance-affecting re-baseline PR (PR 7),
+  rather than left at its placeholder.
+- `scripts/check.sh`, the PDF unit/integration tests and the public parity gate all pass.

--- a/schemas/structured-corpus-artifacts-v1.schema.json
+++ b/schemas/structured-corpus-artifacts-v1.schema.json
@@ -23,7 +23,7 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 512,
-            "pattern": "^(?:certification|documents)/[a-z0-9][a-z0-9/-]*\\.(?:json|png|hwp|hwpx)$|^summary\\.json$"
+            "pattern": "^(?:certification|documents)/[a-z0-9][a-z0-9/-]*\\.(?:json|png|hwp|hwpx|pdf)$|^summary\\.json$"
           },
           "bytes": { "type": "integer", "minimum": 1, "maximum": 134217728 },
           "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }

--- a/schemas/structured-corpus-run-v1.schema.json
+++ b/schemas/structured-corpus-run-v1.schema.json
@@ -165,7 +165,11 @@
         "certification_failed",
         "certification_assertion_failed",
         "certification_execution_failed",
-        "two_run_render_mismatch"
+        "two_run_render_mismatch",
+        "pdf_render_failed",
+        "two_run_pdf_mismatch",
+        "pdf_page_count_mismatch",
+        "pdf_tounicode_roundtrip_failed"
       ]
     },
     "category": {
@@ -228,6 +232,8 @@
         "output_sha256",
         "output_bytes",
         "two_run_render_identical",
+        "two_run_pdf_identical",
+        "pdf",
         "semantic",
         "certification"
       ],
@@ -243,6 +249,8 @@
         "output_sha256": { "oneOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }] },
         "output_bytes": { "type": ["integer", "null"], "minimum": 0, "maximum": 134217728 },
         "two_run_render_identical": { "type": "boolean" },
+        "two_run_pdf_identical": { "type": "boolean" },
+        "pdf": { "oneOf": [{ "$ref": "#/$defs/pdf" }, { "type": "null" }] },
         "semantic": { "oneOf": [{ "$ref": "#/$defs/semantic" }, { "type": "null" }] },
         "certification": { "oneOf": [{ "$ref": "#/$defs/certification" }, { "type": "null" }] }
       },
@@ -256,6 +264,8 @@
               "output_sha256": { "$ref": "#/$defs/sha256" },
               "output_bytes": { "type": "integer", "minimum": 1 },
               "two_run_render_identical": { "const": true },
+              "two_run_pdf_identical": { "const": true },
+              "pdf": { "$ref": "#/$defs/pdf" },
               "semantic": { "$ref": "#/$defs/semantic" },
               "certification": { "$ref": "#/$defs/certification" }
             }
@@ -263,6 +273,17 @@
           "else": { "properties": { "reason_codes": { "type": "array", "minItems": 1 } } }
         }
       ]
+    },
+    "pdf": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sha256", "bytes", "page_count", "tounicode_roundtrip_ok"],
+      "properties": {
+        "sha256": { "$ref": "#/$defs/sha256" },
+        "bytes": { "type": "integer", "minimum": 1, "maximum": 134217728 },
+        "page_count": { "const": 1 },
+        "tounicode_roundtrip_ok": { "const": true }
+      }
     },
     "semantic": {
       "type": "object",

--- a/schemas/structured-corpus-run-v1.schema.json
+++ b/schemas/structured-corpus-run-v1.schema.json
@@ -265,7 +265,18 @@
               "output_bytes": { "type": "integer", "minimum": 1 },
               "two_run_render_identical": { "const": true },
               "two_run_pdf_identical": { "const": true },
-              "pdf": { "$ref": "#/$defs/pdf" },
+              "pdf": {
+                "allOf": [
+                  { "$ref": "#/$defs/pdf" },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "page_count": { "const": 1 },
+                      "tounicode_roundtrip_ok": { "const": true }
+                    }
+                  }
+                ]
+              },
               "semantic": { "$ref": "#/$defs/semantic" },
               "certification": { "$ref": "#/$defs/certification" }
             }
@@ -281,8 +292,8 @@
       "properties": {
         "sha256": { "$ref": "#/$defs/sha256" },
         "bytes": { "type": "integer", "minimum": 1, "maximum": 134217728 },
-        "page_count": { "const": 1 },
-        "tounicode_roundtrip_ok": { "const": true }
+        "page_count": { "type": "integer", "minimum": 1, "maximum": 4096 },
+        "tounicode_roundtrip_ok": { "type": "boolean" }
       }
     },
     "semantic": {


### PR DESCRIPTION
## Summary

PR 1 of #79 establishes the durable Hancom Office 2024 PDF-parity contract and the first enforceable backend invariants.

- **Pagination truth (F3).** `LineSeg.flags` bit0 and bit1 are authoritative page and column boundaries for Hancom-saved documents. The `v_pos` heuristic remains only for synthesized linesegs. Flow consumption is tracked independently of display items, so explicit empty pages and columns survive without creating a leading blank page.
- **Font gate (F1).** `FontCoverage` aggregates matched, substituted, missing, and subset-fallback outcomes. Parity figures are publishable only for substitution-free renders.
- **PDF corpus gate.** Every structured-corpus case is rendered with the pinned Noto Sans KR. The gate enforces PDF/PNG page-count agreement, complete pre-serialization text-show trace round-trip through the emitted ToUnicode CMap, and same-platform two-run PDF byte determinism.
- **Durable contract and data policy.** The EN/KO design docs define the future Hancom-oracle metrics separately from the current structured-corpus self-consistency gate. `fixtures/pdf-parity/**` is ignored by default; only narrow public source, recipe, manifest, and numeric scoreboard paths are re-allowed. Oracle PDF/PNG and private corpus data remain ignored.

## Adversarial review remediation

- Replaced required-text substring checks with exact full text-show trace comparison, preserving whitespace cardinality.
- Made failed PDF diagnostics schema-valid while keeping passed summaries strict (`page_count = 1`, successful ToUnicode round-trip).
- Fixed `TJ` array parsing so strings survive the closing bracket until the operator is processed.
- Added regressions for full-text mismatch, failed-report schema states, `Tj`/`TJ`, empty pages, and empty first columns.
- Translated all comments introduced by this PR to English per repository policy.
- Corrected the design docs so raster thresholds are described as future Hancom-oracle gates, not as current CI behavior.

## Verification

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `bash scripts/check-structured-corpus.sh`

All pass locally on the updated head.

Refs #79