### PR TITLE
ci: upgrade checkout to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # MSRV pin (Cargo.toml rust-version): keeps rustfmt/clippy results deterministic
       # (floating stable lets previously-passing code suddenly fail on version drift) and
       # proves the declared minimum supported version actually builds.
@@ -80,7 +80,7 @@ jobs:
           - { os: windows-latest }
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Render smoke tests need a system Korean font. fonts-nanum ships glyf-outline TTFs;
       # the CFF-based fonts-noto-cjk made debug-build outline extraction ~100x slower
       # (that alone was a 15-minute ubuntu test step).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
   verify-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Tag matches Cargo.toml version
         run: |
           tag="${GITHUB_REF_NAME#v}"
@@ -67,7 +67,7 @@ jobs:
     needs: [verify-ci, verify-version]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -98,7 +98,7 @@ jobs:
             os: windows-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Release binaries build on stable (latest optimizations); MSRV compatibility is
       # already guaranteed by CI, which builds and tests on the pinned MSRV toolchain.
       - uses: dtolnay/rust-toolchain@stable
@@ -117,7 +117,7 @@ jobs:
     needs: upload-assets
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Assemble and upload hwp-skill-claude-web.zip
         env:
           GH_TOKEN: ${{ github.token }}
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Check out main, not the tag — the formula change targets main.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: main
       - name: Update formula and open a PR


### PR DESCRIPTION
## Summary

- upgrade all CI and release workflow checkout steps from actions/checkout v4 to v7
- move checkout execution from the deprecated Node.js 20 runtime to the current Node.js runtime
- retain existing checkout inputs and workflow behavior

## Root cause

GitHub-hosted runners now emit a deprecation annotation because actions/checkout v4 targets Node.js 20. Checkout v7 is the current supported major and uses the newer runtime while adding safer fork pull request defaults. This repository does not use the privileged pull_request_target or workflow_run checkout patterns affected by that safety change.

## Validation

- scripts/check.sh
- git diff --check
- verified all seven workflow references use actions/checkout v7 and no v4 references remain under .github

GitHub Actions on this PR is the final YAML and hosted-runner compatibility gate.