### PR TITLE
feat(cli): Hancom baseline parity scoreboard runner (#79 PR 4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Clippy
         if: ${{ !cancelled() }}
         run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: PDF parity runner tests
+        if: ${{ !cancelled() }}
+        run: python3 -m unittest tools/test_pdf_parity.py
       # Fonts are not committed; the script fetches them from upstream and verifies
       # manifest hashes.
       - name: Structured document corpus (pinned OFL fonts, offline cargo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 **Added**
 
+- Hancom baseline parity scoreboard, the fourth step of the PDF parity roadmap
+  ([#79](https://github.com/STAIxBWLB/hwp-cli/issues/79)). `scripts/pdf-parity.sh run` scores
+  every manifest case against a local Hancom-exported oracle PDF with the five-metric set of
+  docs/design/21-pdf-parity.md §3 — `pdffonts` embedded/subset/unicode flags, `pdfinfo` page
+  count, per-page normalized `pdftotext -layout` equality, and `dx`/`dy`/`ink_ratio` +
+  `bad_pixel_pct`/`MAE` from rasterizing both PDFs with the same `pdftoppm -png -r 150` — and
+  writes schema-validated numeric scoreboards (names, SHA-256 and numbers only, no local
+  paths) under `fixtures/pdf-parity/public/scoreboard/`. Cases with a page-count delta or any
+  font substitution are recorded but marked unscored (F1 gate). `scripts/pdf-parity.sh
+  selftest` verifies the harness without an oracle, and `hwp diff` gained `--format json`
+  (contract `hwp-diff-report-v1`) plus `--ours-png` for raster-vs-raster comparison. The
+  Hancom baseline exports and the first committed numbers are owner actions;
+  `fixtures/golden/README.md` documents the per-case procedure.
+
 - PDF parity groundwork for Hancom Office 2024 equivalence
   ([#79](https://github.com/STAIxBWLB/hwp-cli/issues/79)). The renderer now reads
   `LineSeg.flags` bit0/bit1 (page-first / column-first line) as the first-class page/column

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,15 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 - Hancom baseline parity scoreboard, the fourth step of the PDF parity roadmap
   ([#79](https://github.com/STAIxBWLB/hwp-cli/issues/79)). `scripts/pdf-parity.sh run` scores
   every manifest case against a local Hancom-exported oracle PDF with the five-metric set of
-  docs/design/21-pdf-parity.md §3 — `pdffonts` embedded/subset/unicode flags, `pdfinfo` page
+  docs/design/21-pdf-parity.md §3: `pdffonts` embedded/subset/unicode flags, `pdfinfo` page
   count, per-page normalized `pdftotext -layout` equality, and `dx`/`dy`/`ink_ratio` +
-  `bad_pixel_pct`/`MAE` from rasterizing both PDFs with the same `pdftoppm -png -r 150` — and
+  `bad_pixel_pct`/`MAE` from rasterizing both PDFs with the same `pdftoppm -png -r 150`, and
   writes schema-validated numeric scoreboards (names, SHA-256 and numbers only, no local
-  paths) under `fixtures/pdf-parity/public/scoreboard/`. Cases with a page-count delta or any
-  font substitution are recorded but marked unscored (F1 gate). `scripts/pdf-parity.sh
-  selftest` verifies the harness without an oracle, and `hwp diff` gained `--format json`
+  paths) under `fixtures/pdf-parity/public/scoreboard/`. Manifest, Poppler, font-file, and
+  source/oracle pins are verified before rendering. Cases with a page-count delta, missing
+  coverage, any font substitution, or a PDF font contract violation are recorded but marked
+  unscored (F1 gate). `scripts/pdf-parity.sh selftest` verifies the harness without an oracle,
+  and `hwp diff` gained `--format json`
   (contract `hwp-diff-report-v1`) plus `--ours-png` for raster-vs-raster comparison. The
   Hancom baseline exports and the first committed numbers are owner actions;
   `fixtures/golden/README.md` documents the per-case procedure.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "sha2",
+ "tiny-skia",
  "windows-sys",
  "zip",
 ]

--- a/crates/hwp-cli/Cargo.toml
+++ b/crates/hwp-cli/Cargo.toml
@@ -27,6 +27,7 @@ getrandom = { workspace = true }
 # hwp-render가 이미 끌어오는 의존성이라 의존성 그래프는 커지지 않는다.
 flate2 = { workspace = true }
 regex = { workspace = true }
+tiny-skia = { workspace = true }
 image = { workspace = true }
 quick-xml = { workspace = true }
 libc = { workspace = true }

--- a/crates/hwp-cli/examples/validate_structured_corpus.rs
+++ b/crates/hwp-cli/examples/validate_structured_corpus.rs
@@ -25,8 +25,8 @@ fn read_json(path: &Path) -> anyhow::Result<serde_json::Value> {
 
 fn main() -> anyhow::Result<()> {
     let arguments = std::env::args_os().skip(1).collect::<Vec<_>>();
-    if arguments.len() != 6 {
-        anyhow::bail!("expected exactly three schema/document path pairs")
+    if arguments.len() < 2 || arguments.len() % 2 != 0 {
+        anyhow::bail!("expected one or more schema/document path pairs")
     }
     for pair in arguments.chunks_exact(2) {
         let schema = read_json(Path::new(&pair[0]))?;
@@ -35,9 +35,12 @@ fn main() -> anyhow::Result<()> {
             .with_draft(jsonschema::Draft::Draft202012)
             .build(&schema)?;
         if !validator.is_valid(&document) {
-            anyhow::bail!("structured corpus JSON does not satisfy its closed schema")
+            anyhow::bail!(
+                "JSON does not satisfy its closed schema: {}",
+                Path::new(&pair[1]).display()
+            )
         }
     }
-    println!("structured corpus schemas: valid");
+    println!("JSON schemas: valid ({} pair(s))", arguments.len() / 2);
     Ok(())
 }

--- a/crates/hwp-cli/src/cli.rs
+++ b/crates/hwp-cli/src/cli.rs
@@ -241,6 +241,13 @@ pub enum Cmd {
         /// Per-channel tolerance; differences at or below this count as equal
         #[arg(long, default_value_t = 16)]
         tolerance: u8,
+        /// Report output format (json = machine-readable, for the parity batch runner)
+        #[arg(long, value_enum, default_value_t = DiffFormat::Text)]
+        format: DiffFormat,
+        /// Compare this raster (e.g. pdftoppm of our PDF) against --ref instead of
+        /// rendering the input document; the input path is only recorded in the report
+        #[arg(long)]
+        ours_png: Option<PathBuf>,
     },
 
     /// Edit an existing document (text replacement, table cells); images and formatting preserved
@@ -544,6 +551,12 @@ pub enum RenderFormat {
     Png,
     Svg,
     Pdf,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum DiffFormat {
+    Text,
+    Json,
 }
 
 #[cfg(test)]

--- a/crates/hwp-cli/src/commands/diff.rs
+++ b/crates/hwp-cli/src/commands/diff.rs
@@ -1,11 +1,10 @@
-//! `hwp diff` — 렌더 결과를 한글 기준 PNG와 비교해 오차를 측정한다.
+//! Compare one rendered page with a Hancom-produced reference PNG.
 //!
-//! 한글에서 같은 페이지를 같은 DPI로 낸 기준 이미지와 우리 렌더를 픽셀·프로파일
-//! 비교해 위치 오차(dx/dy)·픽셀 차이율을 보고하고 차이 이미지를 저장한다.
-//! `--format json`은 배치 러너(scripts/pdf-parity.sh)용 기계 판독 리포트(contract
-//! hwp-diff-report-v1)를 stdout에 출력한다. `--ours-png`는 문서 렌더 대신 주어진
-//! 래스터(우리 PDF의 pdftoppm 결과)를 기준과 비교한다 — docs/design/21 §3 규약:
-//! 지표 4~5는 양쪽 PDF를 같은 Poppler로 래스터화해 비교한다.
+//! The command measures pixel and projection-profile differences at the same DPI,
+//! reports positional offsets and pixel error, and can save a difference image.
+//! `--format json` emits the machine-readable `hwp-diff-report-v1` contract for
+//! `scripts/pdf-parity.sh`. `--ours-png` compares an already-rasterized PDF page
+//! instead of rendering the document, so both PDFs use the same Poppler path.
 
 use std::path::{Path, PathBuf};
 
@@ -25,7 +24,7 @@ pub fn run(
     ours_png: Option<&Path>,
 ) -> anyhow::Result<()> {
     let dpi = crate::commands::render::validated_dpi(dpi)?;
-    // ours 래스터: --ours-png가 있으면 문서 렌더를 건어너고 그 파일을 쓴다.
+    // Reuse a pre-rasterized page when the parity runner supplies --ours-png.
     let (ours, coverage) = if let Some(png) = ours_png {
         (hwp_render::load_png(png)?, None)
     } else {
@@ -75,7 +74,8 @@ pub fn run(
             let out_path = out
                 .map(Path::to_path_buf)
                 .unwrap_or_else(|| reference.with_extension("diff.png"));
-            write_diff_image(input, &out_path, &encode_png(&diff_img)?)?;
+            let ours_input = ours_png.unwrap_or(input);
+            write_diff_image(&[ours_input, reference], &out_path, &encode_png(&diff_img)?)?;
         }
         DiffFormat::Json => {
             let json = diff_report_json(
@@ -90,27 +90,29 @@ pub fn run(
                 coverage,
             );
             println!("{}", serde_json::to_string_pretty(&json)?);
-            // 배치 모드는 차이 이미지를 -o 지정 시에만 저장한다(기본 산출물 남발 방지).
+            // JSON mode writes an image only when the caller explicitly requests one.
             if let Some(out_path) = out {
-                write_diff_image(input, out_path, &encode_png(&diff_img)?)?;
+                let ours_input = ours_png.unwrap_or(input);
+                write_diff_image(&[ours_input, reference], out_path, &encode_png(&diff_img)?)?;
             }
         }
     }
     Ok(())
 }
 
-/// 차이 이미지 PNG 인코딩.
+/// Encode the difference image as PNG.
 fn encode_png(diff_img: &tiny_skia::Pixmap) -> anyhow::Result<Vec<u8>> {
     diff_img
         .encode_png()
         .map_err(|error| anyhow::anyhow!("차이 이미지 인코딩 실패: {error}"))
 }
 
-/// 차이 이미지를 검증 쓰기한다.
-fn write_diff_image(input: &Path, out_path: &Path, png: &[u8]) -> anyhow::Result<()> {
+/// Publish a validated difference image without overwriting either immutable input.
+fn write_diff_image(inputs: &[&Path], out_path: &Path, png: &[u8]) -> anyhow::Result<()> {
+    crate::commands::output::reject_output_aliases(out_path, inputs)?;
     crate::commands::output::write_validated(
         out_path,
-        Some(input),
+        None,
         |staged| {
             std::fs::write(staged, png)?;
             Ok(())
@@ -129,8 +131,8 @@ fn write_diff_image(input: &Path, out_path: &Path, png: &[u8]) -> anyhow::Result
     Ok(())
 }
 
-/// 기계 판독 리포트 JSON (contract `hwp-diff-report-v1`).
-/// `ours_png`·`font_coverage`는 해당 경로에서만 들어간다.
+/// Build the machine-readable `hwp-diff-report-v1` payload.
+/// `ours_png` and `font_coverage` appear only on their respective code paths.
 #[allow(clippy::too_many_arguments)]
 fn diff_report_json(
     input: &Path,
@@ -187,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn json_리포트_계약() {
+    fn json_report_contract() {
         let v = diff_report_json(
             Path::new("doc.hwp"),
             None,
@@ -203,17 +205,13 @@ mod tests {
         assert_eq!(v["page"], 2);
         assert_eq!(v["dx"], 1);
         assert_eq!(v["dy"], -1);
-        // 문서 렌더 경로가 아니면 두 필드 모두 생략.
+        // Neither optional field applies to this synthetic report.
         assert!(v.get("ours_png").is_none());
         assert!(v.get("font_coverage").is_none());
     }
 
     #[test]
-    fn json_리포트_래스터_경로() {
-        let coverage = hwp_render::FontCoverage {
-            matched: 2,
-            ..Default::default()
-        };
+    fn json_report_raster_path_has_no_font_coverage() {
         let v = diff_report_json(
             Path::new("doc.hwp"),
             Some(Path::new("ours-1.png")),
@@ -223,10 +221,27 @@ mod tests {
             1240,
             1754,
             &report(),
-            Some(coverage),
+            None,
         );
         assert_eq!(v["ours_png"], "ours-1.png");
-        assert_eq!(v["font_coverage"]["matched"], 2);
-        assert_eq!(v["font_coverage"]["substitution_free"], true);
+        assert!(v.get("font_coverage").is_none());
+    }
+
+    #[test]
+    fn difference_output_cannot_replace_a_raster_input() {
+        let directory =
+            std::env::temp_dir().join(format!("hwp-cli-diff-alias-test-{}", std::process::id()));
+        std::fs::create_dir_all(&directory).unwrap();
+        let ours = directory.join("ours.png");
+        let reference = directory.join("reference.png");
+        std::fs::write(&ours, b"ours").unwrap();
+        std::fs::write(&reference, b"reference").unwrap();
+
+        assert!(write_diff_image(&[&ours, &reference], &ours, b"replacement").is_err());
+        assert_eq!(std::fs::read(&ours).unwrap(), b"ours");
+        assert!(write_diff_image(&[&ours, &reference], &reference, b"replacement").is_err());
+        assert_eq!(std::fs::read(&reference).unwrap(), b"reference");
+
+        std::fs::remove_dir_all(directory).unwrap();
     }
 }

--- a/crates/hwp-cli/src/commands/diff.rs
+++ b/crates/hwp-cli/src/commands/diff.rs
@@ -1,11 +1,16 @@
 //! `hwp diff` — 렌더 결과를 한글 기준 PNG와 비교해 오차를 측정한다.
 //!
-//! 한글에서 같은 페이지를 같은 DPI로 내보낸 기준 이미지와 우리 렌더를 픽셀·
-//! 프로파일 비교해 위치 오차(dx/dy)·픽셀 차이율을 보고하고 차이 이미지를 저장한다.
+//! 한글에서 같은 페이지를 같은 DPI로 낸 기준 이미지와 우리 렌더를 픽셀·프로파일
+//! 비교해 위치 오차(dx/dy)·픽셀 차이율을 보고하고 차이 이미지를 저장한다.
+//! `--format json`은 배치 러너(scripts/pdf-parity.sh)용 기계 판독 리포트(contract
+//! hwp-diff-report-v1)를 stdout에 출력한다. `--ours-png`는 문서 렌더 대신 주어진
+//! 래스터(우리 PDF의 pdftoppm 결과)를 기준과 비교한다 — docs/design/21 §3 규약:
+//! 지표 4~5는 양쪽 PDF를 같은 Poppler로 래스터화해 비교한다.
 
 use std::path::{Path, PathBuf};
 
 use crate::commands::cat::load_document;
+use hwp_cli::cli::DiffFormat;
 
 #[allow(clippy::too_many_arguments)]
 pub fn run(
@@ -16,53 +21,98 @@ pub fn run(
     out: Option<&Path>,
     font_dirs: Vec<PathBuf>,
     tolerance: u8,
+    format: DiffFormat,
+    ours_png: Option<&Path>,
 ) -> anyhow::Result<()> {
     let dpi = crate::commands::render::validated_dpi(dpi)?;
-    let doc = load_document(input)?;
-    let result = hwp_render::render_document_pages(
-        &doc,
-        &hwp_render::RenderOptions {
-            dpi,
-            font_dirs: crate::commands::convert::resolve_font_dirs(font_dirs),
-        },
-        Some(&[page]),
-    )?;
-    for issue in result.report.info.iter().chain(&result.report.issues) {
-        eprintln!("렌더: {issue}");
-    }
-    let ours = &result.pages[0];
+    // ours 래스터: --ours-png가 있으면 문서 렌더를 건어너고 그 파일을 쓴다.
+    let (ours, coverage) = if let Some(png) = ours_png {
+        (hwp_render::load_png(png)?, None)
+    } else {
+        let doc = load_document(input)?;
+        let result = hwp_render::render_document_pages(
+            &doc,
+            &hwp_render::RenderOptions {
+                dpi,
+                font_dirs: crate::commands::convert::resolve_font_dirs(font_dirs),
+            },
+            Some(&[page]),
+        )?;
+        for issue in result.report.info.iter().chain(&result.report.issues) {
+            eprintln!("렌더: {issue}");
+        }
+        let coverage = result.report.font_coverage();
+        let page_px = result
+            .pages
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("페이지 {page} 렌더 결과 없음"))?;
+        (page_px, Some(coverage))
+    };
 
     let reference_px = hwp_render::load_png(reference)?;
 
     let (report, diff_img) =
-        hwp_render::compare(ours, &reference_px, tolerance).map_err(|e| anyhow::anyhow!(e))?;
+        hwp_render::compare(&ours, &reference_px, tolerance).map_err(|e| anyhow::anyhow!(e))?;
 
-    println!("페이지 {page} ({}×{}px)", ours.width(), ours.height());
-    println!(
-        "  잉크 적용률(완전성): {:.1}% (우리 잉크 / 한글 잉크 — 100%면 같은 양)",
-        report.ink_ratio * 100.0
-    );
-    println!(
-        "  위치 오프셋: dx={}px, dy={}px (작을수록 정합)",
-        report.dx, report.dy
-    );
-    println!(
-        "  픽셀 차이율: {:.2}% (대부분 글리프 모양·AA 차이 — 폰트/엔진 의존)",
-        report.bad_pixel_pct * 100.0
-    );
-    println!("  평균 절대 오차(MAE): {:.2}/255", report.mae);
+    match format {
+        DiffFormat::Text => {
+            println!("페이지 {page} ({}×{}px)", ours.width(), ours.height());
+            println!(
+                "  잉크 적용률(완전성): {:.1}% (우리 잉크 / 한글 잉크 — 100%면 같은 양)",
+                report.ink_ratio * 100.0
+            );
+            println!(
+                "  위치 오프셋: dx={}px, dy={}px (작을수록 정합)",
+                report.dx, report.dy
+            );
+            println!(
+                "  픽셀 차이율: {:.2}% (대부분 글리프 모양·AA 차이 — 폰트/엔진 의존)",
+                report.bad_pixel_pct * 100.0
+            );
+            println!("  평균 절대 오차(MAE): {:.2}/255", report.mae);
 
-    let out_path = out
-        .map(Path::to_path_buf)
-        .unwrap_or_else(|| reference.with_extension("diff.png"));
-    let png = diff_img
+            let out_path = out
+                .map(Path::to_path_buf)
+                .unwrap_or_else(|| reference.with_extension("diff.png"));
+            write_diff_image(input, &out_path, &encode_png(&diff_img)?)?;
+        }
+        DiffFormat::Json => {
+            let json = diff_report_json(
+                input,
+                ours_png,
+                reference,
+                page,
+                dpi,
+                ours.width(),
+                ours.height(),
+                &report,
+                coverage,
+            );
+            println!("{}", serde_json::to_string_pretty(&json)?);
+            // 배치 모드는 차이 이미지를 -o 지정 시에만 저장한다(기본 산출물 남발 방지).
+            if let Some(out_path) = out {
+                write_diff_image(input, out_path, &encode_png(&diff_img)?)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// 차이 이미지 PNG 인코딩.
+fn encode_png(diff_img: &tiny_skia::Pixmap) -> anyhow::Result<Vec<u8>> {
+    diff_img
         .encode_png()
-        .map_err(|error| anyhow::anyhow!("차이 이미지 인코딩 실패: {error}"))?;
+        .map_err(|error| anyhow::anyhow!("차이 이미지 인코딩 실패: {error}"))
+}
+
+/// 차이 이미지를 검증 쓰기한다.
+fn write_diff_image(input: &Path, out_path: &Path, png: &[u8]) -> anyhow::Result<()> {
     crate::commands::output::write_validated(
-        &out_path,
+        out_path,
         Some(input),
         |staged| {
-            std::fs::write(staged, &png)?;
+            std::fs::write(staged, png)?;
             Ok(())
         },
         |staged, _| {
@@ -77,4 +127,106 @@ pub fn run(
     )?;
     eprintln!("차이 이미지: {}", out_path.display());
     Ok(())
+}
+
+/// 기계 판독 리포트 JSON (contract `hwp-diff-report-v1`).
+/// `ours_png`·`font_coverage`는 해당 경로에서만 들어간다.
+#[allow(clippy::too_many_arguments)]
+fn diff_report_json(
+    input: &Path,
+    ours_png: Option<&Path>,
+    reference: &Path,
+    page: usize,
+    dpi: f32,
+    width: u32,
+    height: u32,
+    report: &hwp_render::DiffReport,
+    coverage: Option<hwp_render::FontCoverage>,
+) -> serde_json::Value {
+    let mut value = serde_json::json!({
+        "contract": "hwp-diff-report-v1",
+        "input": input.to_string_lossy(),
+        "reference": reference.to_string_lossy(),
+        "page": page,
+        "dpi": dpi,
+        "width": width,
+        "height": height,
+        "dx": report.dx,
+        "dy": report.dy,
+        "ink_ratio": report.ink_ratio,
+        "bad_pixel_pct": report.bad_pixel_pct,
+        "mae": report.mae,
+    });
+    if let Some(png) = ours_png {
+        value["ours_png"] = serde_json::json!(png.to_string_lossy());
+    }
+    if let Some(c) = coverage {
+        value["font_coverage"] = serde_json::json!({
+            "matched": c.matched,
+            "substituted": c.substituted,
+            "missing": c.missing,
+            "subset_fallback": c.subset_fallback,
+            "substitution_free": c.substitution_free(),
+        });
+    }
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report() -> hwp_render::DiffReport {
+        hwp_render::DiffReport {
+            mae: 1.5,
+            bad_pixel_pct: 0.02,
+            dx: 1,
+            dy: -1,
+            ink_ratio: 0.99,
+        }
+    }
+
+    #[test]
+    fn json_리포트_계약() {
+        let v = diff_report_json(
+            Path::new("doc.hwp"),
+            None,
+            Path::new("ref.png"),
+            2,
+            150.0,
+            1240,
+            1754,
+            &report(),
+            None,
+        );
+        assert_eq!(v["contract"], "hwp-diff-report-v1");
+        assert_eq!(v["page"], 2);
+        assert_eq!(v["dx"], 1);
+        assert_eq!(v["dy"], -1);
+        // 문서 렌더 경로가 아니면 두 필드 모두 생략.
+        assert!(v.get("ours_png").is_none());
+        assert!(v.get("font_coverage").is_none());
+    }
+
+    #[test]
+    fn json_리포트_래스터_경로() {
+        let coverage = hwp_render::FontCoverage {
+            matched: 2,
+            ..Default::default()
+        };
+        let v = diff_report_json(
+            Path::new("doc.hwp"),
+            Some(Path::new("ours-1.png")),
+            Path::new("ref.png"),
+            1,
+            150.0,
+            1240,
+            1754,
+            &report(),
+            Some(coverage),
+        );
+        assert_eq!(v["ours_png"], "ours-1.png");
+        assert_eq!(v["font_coverage"]["matched"], 2);
+        assert_eq!(v["font_coverage"]["substitution_free"], true);
+    }
 }

--- a/crates/hwp-cli/src/i18n.rs
+++ b/crates/hwp-cli/src/i18n.rs
@@ -315,6 +315,16 @@ pub const KO: &[(&str, &str, &str)] = &[
         "tolerance",
         "채널 차이 허용 오차 (이하면 동일 취급)",
     ),
+    (
+        "diff",
+        "format",
+        "리포트 출력 형식 (json = 기계 판독, parity 배치 러너용)",
+    ),
+    (
+        "diff",
+        "ours_png",
+        "문서 렌더 대신 이 래스터(우리 PDF의 pdftoppm 결과)를 --ref와 비교; 입력 경로는 리포트 기록용",
+    ),
     // edit
     (
         "edit",

--- a/crates/hwp-cli/src/main.rs
+++ b/crates/hwp-cli/src/main.rs
@@ -93,6 +93,8 @@ fn main() -> anyhow::Result<()> {
             out,
             font_dir,
             tolerance,
+            format,
+            ours_png,
         } => commands::diff::run(
             &input,
             &r#ref,
@@ -101,6 +103,8 @@ fn main() -> anyhow::Result<()> {
             out.as_deref(),
             font_dir,
             tolerance,
+            format,
+            ours_png.as_deref(),
         ),
         Cmd::Mcp { font_dir, root } => commands::mcp::run(font_dir, root),
         Cmd::Update {

--- a/docs/design/21-pdf-parity.ko.md
+++ b/docs/design/21-pdf-parity.ko.md
@@ -82,8 +82,10 @@ FILETIME 메타데이터 변환(현재 시각 사용 금지 — 2회 실행 바�
 **구현 상태 2026-08-13 (PR 4):** 배치 러너가 있다 — `scripts/pdf-parity.sh run`이 manifest의
 모든 케이스를 채점해 커밋 가능한 수치 점수판(`fixtures/pdf-parity/public/scoreboard/`,
 스키마 검증, 이름+SHA-256+수치뿐)을 만들고, `selftest`는 기준 없이 하네스를 검증하며,
-`hwp diff --format json` / `--ours-png`가 쪽별 래스터 지표 원천이다. 3~5건의 한글 기준
-내기와 첫 커밋 수치는 남은 소유자 액션.
+`hwp diff --format json` / `--ours-png`가 쪽별 래스터 지표 원천이다. manifest, Poppler
+버전, 폰트 파일, source/oracle digest가 pin과 일치해야 채점하며, 검증된 산출물 집합만
+rollback 보호 방식으로 게시한다. 3~5건의 한글 기준 내기와 첫 커밋 수치는 남은 소유자
+액션.
 
 ## 4. 게이트
 
@@ -127,6 +129,8 @@ structured-corpus run(`scripts/check-structured-corpus.sh`)은 고정 Noto Sans 
   FontSubsetFallback 횟수를 집계하고, CLI 렌더 리포트가 커버리지 줄을 출력한다.
 - `FontCoverage::substitution_free()`가 하드 게이트다: 대체 없이 렌더되지 않은 케이스의
   parity 수치는 발행할 수 없다.
+- 커버리지 자체를 확인할 수 없는 경우도 게이트 실패로 처리한다. 두 PDF 중 하나라도
+  `pdffonts` 기준 임베드·서브셋·Unicode 지원을 모두 충족하지 못하면 역시 채점하지 않는다.
 
 ## 6. 페이지네이션 정본 (F3)
 

--- a/docs/design/21-pdf-parity.ko.md
+++ b/docs/design/21-pdf-parity.ko.md
@@ -79,6 +79,12 @@ FILETIME 메타데이터 변환(현재 시각 사용 금지 — 2회 실행 바�
 지표 4–5의 래스터화는 Hancom PDF와 자체 PDF 모두 같은 고정 Poppler(`pdftoppm -png -r 150`)를
 쓴다.
 
+**구현 상태 2026-08-13 (PR 4):** 배치 러너가 있다 — `scripts/pdf-parity.sh run`이 manifest의
+모든 케이스를 채점해 커밋 가능한 수치 점수판(`fixtures/pdf-parity/public/scoreboard/`,
+스키마 검증, 이름+SHA-256+수치뿐)을 만들고, `selftest`는 기준 없이 하네스를 검증하며,
+`hwp diff --format json` / `--ours-png`가 쪽별 래스터 지표 원천이다. 3~5건의 한글 기준
+내기와 첫 커밋 수치는 남은 소유자 액션.
+
 ## 4. 게이트
 
 ### 4.1 정본 한컴 오라클 게이트 — 향후 공개 코퍼스

--- a/docs/design/21-pdf-parity.md
+++ b/docs/design/21-pdf-parity.md
@@ -84,8 +84,10 @@ Hancom PDF and our PDF.
 `scripts/pdf-parity.sh run` scores every manifest case into the committable numeric scoreboard
 under `fixtures/pdf-parity/public/scoreboard/` (schema-validated, names + SHA-256 + numbers
 only), `selftest` verifies the harness without an oracle, and `hwp diff --format json` /
-`--ours-png` is the per-page raster metric source. The 3–5 Hancom baseline exports and the
-first committed numbers are the remaining owner action.
+`--ours-png` is the per-page raster metric source. Scoring fails closed unless the manifest,
+Poppler version, font files, and source/oracle digests match their pins; validated outputs are
+published as one rollback-protected set. The 3–5 Hancom baseline exports and the first committed
+numbers are the remaining owner action.
 
 ## 4. Gates
 
@@ -129,6 +131,8 @@ so **a parity number measured under substituted fonts is meaningless**.
   FontSubsetFallback counts; the CLI render report prints the coverage line.
 - `FontCoverage::substitution_free()` is the hard gate: no parity figure may be published for a
   case whose render was not substitution-free.
+- Missing coverage is a gate failure, as is any font in either PDF that `pdffonts` does not report
+  as embedded, subset, and Unicode-capable.
 
 ## 6. Pagination truth (F3)
 

--- a/docs/design/21-pdf-parity.md
+++ b/docs/design/21-pdf-parity.md
@@ -80,6 +80,13 @@ antialiasing — engine artifacts, not fidelity. The decisive metrics need no pi
 Rasterization for metrics 4–5 uses the same pinned Poppler (`pdftoppm -png -r 150`) for both the
 Hancom PDF and our PDF.
 
+**Implementation status 2026-08-13 (PR 4):** the batch runner exists —
+`scripts/pdf-parity.sh run` scores every manifest case into the committable numeric scoreboard
+under `fixtures/pdf-parity/public/scoreboard/` (schema-validated, names + SHA-256 + numbers
+only), `selftest` verifies the harness without an oracle, and `hwp diff --format json` /
+`--ours-png` is the per-page raster metric source. The 3–5 Hancom baseline exports and the
+first committed numbers are the remaining owner action.
+
 ## 4. Gates
 
 ### 4.1 Normative Hancom-oracle gate — future public corpus

--- a/docs/manual/cli-reference.ko.md
+++ b/docs/manual/cli-reference.ko.md
@@ -164,6 +164,8 @@ TemplateSpec/Data v1에서 typed native HWP/HWPX 생성
 | `-o, --out` | `<OUT>` |  | 차이 이미지 출력 경로 (생략 시 <ref>.diff.png) |
 | `--font-dir` | `<FONT_DIR>` |  | 추가 폰트 디렉터리 (반복 가능) |
 | `--tolerance` | `<TOLERANCE>` | `16` | 채널 차이 허용 오차 (이하면 동일 취급) |
+| `--format` | `text` \| `json` | `text` | 리포트 출력 형식 (json = 기계 판독, parity 배치 러너용) |
+| `--ours-png` | `<OURS_PNG>` |  | 문서 렌더 대신 이 래스터(우리 PDF의 pdftoppm 결과)를 --ref와 비교; 입력 경로는 리포트 기록용 |
 
 ## `hwp edit`
 

--- a/docs/manual/cli-reference.md
+++ b/docs/manual/cli-reference.md
@@ -164,6 +164,8 @@ Compare a render against a Hancom reference PNG (offset and pixel difference)
 | `-o, --out` | `<OUT>` |  | Difference image output path (defaults to <ref>.diff.png) |
 | `--font-dir` | `<FONT_DIR>` |  | Additional font directory (repeatable) |
 | `--tolerance` | `<TOLERANCE>` | `16` | Per-channel tolerance; differences at or below this count as equal |
+| `--format` | `text` \| `json` | `text` | Report output format (json = machine-readable, for the parity batch runner) |
+| `--ours-png` | `<OURS_PNG>` |  | Compare this raster (e.g. pdftoppm of our PDF) against --ref instead of rendering the input document; the input path is only recorded in the report |
 
 ## `hwp edit`
 

--- a/fixtures/golden/README.ko.md
+++ b/fixtures/golden/README.ko.md
@@ -54,10 +54,12 @@ HWP_FONT_DIR=$PWD/fonts \
    (HWP/HWPX만 — 커밋 가능한 유일한 산출물).
 2. 한글에서 **파일 → PDF로 저장하기**(기본 설정)로 낸 뒤, 정확한 한글 빌드·Windows
    버전·PDF 설정을 `fixtures/pdf-parity/public/manifest.json`(`pins`)에 적고, 고정 폰트
-   (함초롬바탕/돋움, `fonts/`)의 SHA-256도 함께 기록한다.
+   (함초롬바탕/돋움, `fonts/`)의 SHA-256도 함께 기록한다. 고정 폰트가 저장소의 `fonts/`
+   디렉터리에 없으면 `HWP_FONT_DIR`을 지정한다.
 3. 낸 PDF는 로컬에만 둔다 — `$HWP_PDF_PARITY_ORACLE_DIR` 아래(커밋 금지, oracle 트리는
    전부 gitignore).
-4. manifest에 케이스를 추가한다: `{name, source, oracle}`.
+4. manifest에 케이스를 추가한다:
+   `{name, source, source_sha256, oracle, oracle_sha256}`.
 5. 실행:
 
    ```sh
@@ -65,9 +67,10 @@ HWP_FONT_DIR=$PWD/fonts \
    ```
 
    점수판(`public/scoreboard/<case>.json`, `scoreboard.json`, `scoreboard.csv`)은 이름·
-   SHA-256·수치뿐이며(경로·기준 바이트 없음) 커밋되는 유일한 산출물이다. 쪽수가 다르거나
-   폰트 대체가 있는 케이스는 기록하되 `"scored": false`로 표시한다(F1 게이트 — 대체 폰트
-   렌더의 parity 수치는 발행 금지).
+   SHA-256·수치뿐이며(경로·기준 바이트 없음) 커밋되는 유일한 산출물이다. 렌더 전에 닫힌
+   manifest 스키마, Poppler 버전, 고정 폰트 파일, 모든 source/oracle SHA-256을 검증한다.
+   글꼴 커버리지를 확인할 수 없거나, 폰트 대체·쪽수 차이·PDF의 임베드/서브셋/Unicode
+   계약 위반이 있으면 해당 케이스를 `"scored": false`로 표시한다.
 
 `scripts/pdf-parity.sh selftest`는 하네스 자기 검증(fixture를 자기 PDF와 비교하면 모든
 지표가 완벽해야 함)으로 한글 기준 없이 돌릴 수 있다.

--- a/fixtures/golden/README.ko.md
+++ b/fixtures/golden/README.ko.md
@@ -40,3 +40,34 @@ HWP_FONT_DIR=$PWD/fonts \
 `HWP_GOLDEN=1 cargo test -p hwp-render golden`로 이 디렉터리의 `*.ref.png`를 자동 대조한다
 (이미지가 없으면 통과/스킵). 단계별로 임계를 조여 회귀를 막는다. 폰트 없는 CI에서는
 기본적으로 건너뛴다(`tests/render.rs`의 구조 스모크는 상시 실행).
+
+## PDF 동등성 기준 (issue #79)
+
+배치 러너 `scripts/pdf-parity.sh`가 우리 PDF와 한글 기준 PDF를
+[docs/design/21-pdf-parity.md](../../docs/design/21-pdf-parity.md) §3의 다섯 지표
+(`pdffonts`, `pdfinfo`, 쪽별 `pdftotext -layout`, 같은 `pdftoppm -png -r 150` 래스터의
+`dx/dy`·`bad_pixel_pct`/`MAE`)로 채점한다.
+
+케이스별 기준 만드는 순서 (소유자, Windows 한컴오피스 2024):
+
+1. 소스 문서를 직접 작성·비식별화해 `fixtures/pdf-parity/public/source/`에 커밋한다
+   (HWP/HWPX만 — 커밋 가능한 유일한 산출물).
+2. 한글에서 **파일 → PDF로 저장하기**(기본 설정)로 낸 뒤, 정확한 한글 빌드·Windows
+   버전·PDF 설정을 `fixtures/pdf-parity/public/manifest.json`(`pins`)에 적고, 고정 폰트
+   (함초롬바탕/돋움, `fonts/`)의 SHA-256도 함께 기록한다.
+3. 낸 PDF는 로컬에만 둔다 — `$HWP_PDF_PARITY_ORACLE_DIR` 아래(커밋 금지, oracle 트리는
+   전부 gitignore).
+4. manifest에 케이스를 추가한다: `{name, source, oracle}`.
+5. 실행:
+
+   ```sh
+   scripts/pdf-parity.sh run --oracle-dir "$HWP_PDF_PARITY_ORACLE_DIR"
+   ```
+
+   점수판(`public/scoreboard/<case>.json`, `scoreboard.json`, `scoreboard.csv`)은 이름·
+   SHA-256·수치뿐이며(경로·기준 바이트 없음) 커밋되는 유일한 산출물이다. 쪽수가 다르거나
+   폰트 대체가 있는 케이스는 기록하되 `"scored": false`로 표시한다(F1 게이트 — 대체 폰트
+   렌더의 parity 수치는 발행 금지).
+
+`scripts/pdf-parity.sh selftest`는 하네스 자기 검증(fixture를 자기 PDF와 비교하면 모든
+지표가 완벽해야 함)으로 한글 기준 없이 돌릴 수 있다.

--- a/fixtures/golden/README.md
+++ b/fixtures/golden/README.md
@@ -60,10 +60,11 @@ Per-case baseline procedure (owner, on Windows Hancom Office 2024):
    `fixtures/pdf-parity/public/source/` (HWP/HWPX only — the only committable artifacts).
 2. In Hancom: **File → Save as PDF** with default settings; record the exact Hancom build,
    Windows version and PDF settings in `fixtures/pdf-parity/public/manifest.json` (`pins`),
-   plus the SHA-256 of the pinned fonts (HCR Batang/Dotum in `fonts/`).
+   plus the SHA-256 of the pinned fonts (HCR Batang/Dotum in `fonts/`). Set `HWP_FONT_DIR` when
+   the pinned font directory is not the repository's `fonts/` directory.
 3. Keep the exported PDF local — put it in `$HWP_PDF_PARITY_ORACLE_DIR` (never committed;
    the whole oracle tree is gitignored).
-4. Add the case to the manifest: `{name, source, oracle}`.
+4. Add the case to the manifest: `{name, source, source_sha256, oracle, oracle_sha256}`.
 5. Run:
 
    ```sh
@@ -72,9 +73,10 @@ Per-case baseline procedure (owner, on Windows Hancom Office 2024):
 
    The scoreboard (`public/scoreboard/<case>.json`, `scoreboard.json`, `scoreboard.csv`)
    contains names, SHA-256 hashes and numbers only — no paths, no oracle bytes — and is the
-   only output that gets committed. Cases with a page-count delta or any font substitution
-   are recorded but marked `"scored": false` (the F1 gate: no parity figure may be published
-   from a substituted-font render).
+   only output that gets committed. Before rendering, the runner validates the closed manifest
+   schema and verifies the Poppler version, pinned font files, and every source/oracle digest.
+   Missing font coverage, any substitution, a page-count delta, or a PDF font that is not
+   embedded/subset/Unicode-capable records the case as `"scored": false`.
 
 `scripts/pdf-parity.sh selftest` checks the harness itself (a fixture against its own PDF
 must produce perfect metrics) and needs no Hancom baseline.

--- a/fixtures/golden/README.md
+++ b/fixtures/golden/README.md
@@ -46,3 +46,35 @@ glyph shape error grows, which is separate from position error and is measured b
 automatically (passing or skipping when an image is absent). Tighten the thresholds step by step to
 prevent regressions. It is skipped by default in CI, which has no fonts (the structural smoke test in
 `tests/render.rs` always runs).
+
+## PDF parity baselines (issue #79)
+
+The batch runner `scripts/pdf-parity.sh` scores our PDF against Hancom's own PDF with the
+five-metric set of [docs/design/21-pdf-parity.md](../../docs/design/21-pdf-parity.md) §3
+(`pdffonts`, `pdfinfo`, per-page `pdftotext -layout`, and `dx/dy` + `bad_pixel_pct`/`MAE`
+after rasterizing both PDFs with the same `pdftoppm -png -r 150`).
+
+Per-case baseline procedure (owner, on Windows Hancom Office 2024):
+
+1. Author or anonymize the source document and commit it under
+   `fixtures/pdf-parity/public/source/` (HWP/HWPX only — the only committable artifacts).
+2. In Hancom: **File → Save as PDF** with default settings; record the exact Hancom build,
+   Windows version and PDF settings in `fixtures/pdf-parity/public/manifest.json` (`pins`),
+   plus the SHA-256 of the pinned fonts (HCR Batang/Dotum in `fonts/`).
+3. Keep the exported PDF local — put it in `$HWP_PDF_PARITY_ORACLE_DIR` (never committed;
+   the whole oracle tree is gitignored).
+4. Add the case to the manifest: `{name, source, oracle}`.
+5. Run:
+
+   ```sh
+   scripts/pdf-parity.sh run --oracle-dir "$HWP_PDF_PARITY_ORACLE_DIR"
+   ```
+
+   The scoreboard (`public/scoreboard/<case>.json`, `scoreboard.json`, `scoreboard.csv`)
+   contains names, SHA-256 hashes and numbers only — no paths, no oracle bytes — and is the
+   only output that gets committed. Cases with a page-count delta or any font substitution
+   are recorded but marked `"scored": false` (the F1 gate: no parity figure may be published
+   from a substituted-font render).
+
+`scripts/pdf-parity.sh selftest` checks the harness itself (a fixture against its own PDF
+must produce perfect metrics) and needs no Hancom baseline.

--- a/fixtures/pdf-parity/public/manifest.json
+++ b/fixtures/pdf-parity/public/manifest.json
@@ -1,0 +1,15 @@
+{
+  "contract": "hwp-pdf-parity-manifest-v1",
+  "pins": {
+    "hancom_build": "TODO-owner",
+    "windows_version": "TODO-owner",
+    "pdf_settings": "파일 → PDF로 저장하기 (기본 설정)",
+    "poppler_version": "TODO-owner",
+    "dpi": 150,
+    "fonts": {
+      "HCR Batang": "TODO-owner-sha256",
+      "HCR Dotum": "TODO-owner-sha256"
+    }
+  },
+  "cases": []
+}

--- a/schemas/pdf-parity-manifest-v1.schema.json
+++ b/schemas/pdf-parity-manifest-v1.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hwp-cli.local/schemas/pdf-parity-manifest-v1.schema.json",
+  "title": "hwp PDF parity manifest v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract", "pins", "cases"],
+  "properties": {
+    "contract": { "const": "hwp-pdf-parity-manifest-v1" },
+    "pins": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "hancom_build",
+        "windows_version",
+        "pdf_settings",
+        "poppler_version",
+        "dpi",
+        "fonts"
+      ],
+      "properties": {
+        "hancom_build": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "windows_version": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "pdf_settings": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "poppler_version": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "dpi": { "const": 150 },
+        "fonts": {
+          "type": "object",
+          "minProperties": 1,
+          "additionalProperties": { "type": "string", "minLength": 1, "maxLength": 128 }
+        }
+      }
+    },
+    "cases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "source", "oracle"],
+        "properties": {
+          "name": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$", "maxLength": 64 },
+          "source": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+\\.(hwp|hwpx)$" },
+          "oracle": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+\\.pdf$" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/pdf-parity-manifest-v1.schema.json
+++ b/schemas/pdf-parity-manifest-v1.schema.json
@@ -36,11 +36,13 @@
       "items": {
         "type": "object",
         "additionalProperties": false,
-        "required": ["name", "source", "oracle"],
+        "required": ["name", "source", "source_sha256", "oracle", "oracle_sha256"],
         "properties": {
           "name": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$", "maxLength": 64 },
           "source": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+\\.(hwp|hwpx)$" },
-          "oracle": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+\\.pdf$" }
+          "source_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+          "oracle": { "type": "string", "pattern": "^[A-Za-z0-9_.-]+\\.pdf$" },
+          "oracle_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
         }
       }
     }

--- a/schemas/pdf-parity-scoreboard-v1.schema.json
+++ b/schemas/pdf-parity-scoreboard-v1.schema.json
@@ -37,7 +37,14 @@
           "scored": { "type": "boolean" },
           "unscored_reasons": {
             "type": "array",
-            "items": { "enum": ["page_count_delta", "font_substitution"] },
+            "items": {
+              "enum": [
+                "page_count_delta",
+                "font_coverage_unavailable",
+                "font_substitution",
+                "pdf_font_contract"
+              ]
+            },
             "uniqueItems": true
           },
           "pages_delta": { "type": "integer" },

--- a/schemas/pdf-parity-scoreboard-v1.schema.json
+++ b/schemas/pdf-parity-scoreboard-v1.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hwp-cli.local/schemas/pdf-parity-scoreboard-v1.schema.json",
+  "title": "hwp PDF parity aggregate scoreboard v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract", "generated_by", "poppler_version", "dpi", "cases"],
+  "properties": {
+    "contract": { "const": "hwp-pdf-parity-scoreboard-v1" },
+    "generated_by": { "const": "scripts/pdf-parity.sh" },
+    "poppler_version": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "dpi": { "const": 150 },
+    "cases": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "scored",
+          "unscored_reasons",
+          "pages_delta",
+          "text_pages_equal",
+          "text_pages_compared",
+          "raster_pages",
+          "max_abs_dx",
+          "max_abs_dy",
+          "ink_ratio_min",
+          "ink_ratio_max",
+          "bad_pixel_pct_max",
+          "mae_max",
+          "fonts_all_embedded_subset_unicode",
+          "substitution_free"
+        ],
+        "properties": {
+          "name": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$", "maxLength": 64 },
+          "scored": { "type": "boolean" },
+          "unscored_reasons": {
+            "type": "array",
+            "items": { "enum": ["page_count_delta", "font_substitution"] },
+            "uniqueItems": true
+          },
+          "pages_delta": { "type": "integer" },
+          "text_pages_equal": { "type": "integer", "minimum": 0 },
+          "text_pages_compared": { "type": "integer", "minimum": 0 },
+          "raster_pages": { "type": "integer", "minimum": 0 },
+          "max_abs_dx": { "type": "integer", "minimum": 0 },
+          "max_abs_dy": { "type": "integer", "minimum": 0 },
+          "ink_ratio_min": { "type": "number", "minimum": 0 },
+          "ink_ratio_max": { "type": "number", "minimum": 0 },
+          "bad_pixel_pct_max": { "type": "number", "minimum": 0, "maximum": 1 },
+          "mae_max": { "type": "number", "minimum": 0, "maximum": 255 },
+          "fonts_all_embedded_subset_unicode": { "type": "boolean" },
+          "substitution_free": { "type": "boolean" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/pdf-parity-scorecard-v1.schema.json
+++ b/schemas/pdf-parity-scorecard-v1.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hwp-cli.local/schemas/pdf-parity-scorecard-v1.schema.json",
+  "title": "hwp PDF parity per-case scorecard v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "contract",
+    "case",
+    "source",
+    "oracle",
+    "dpi",
+    "scored",
+    "unscored_reasons",
+    "pages",
+    "fonts",
+    "font_coverage",
+    "substitution_free",
+    "text",
+    "raster"
+  ],
+  "properties": {
+    "contract": { "const": "hwp-pdf-parity-scorecard-v1" },
+    "case": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$", "maxLength": 64 },
+    "source": { "$ref": "#/$defs/artifact" },
+    "oracle": { "$ref": "#/$defs/artifact" },
+    "dpi": { "const": 150 },
+    "scored": { "type": "boolean" },
+    "unscored_reasons": {
+      "type": "array",
+      "items": { "enum": ["page_count_delta", "font_substitution"] },
+      "uniqueItems": true
+    },
+    "pages": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ours", "oracle", "delta"],
+      "properties": {
+        "ours": { "type": "integer", "minimum": 0 },
+        "oracle": { "type": "integer", "minimum": 0 },
+        "delta": { "type": "integer" }
+      }
+    },
+    "fonts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ours", "oracle", "ours_all_embedded_subset_unicode"],
+      "properties": {
+        "ours": { "type": "array", "items": { "$ref": "#/$defs/font" } },
+        "oracle": { "type": "array", "items": { "$ref": "#/$defs/font" } },
+        "ours_all_embedded_subset_unicode": { "type": "boolean" }
+      }
+    },
+    "font_coverage": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["matched", "substituted", "missing", "subset_fallback", "substitution_free"],
+      "properties": {
+        "matched": { "type": "integer", "minimum": 0 },
+        "substituted": { "type": "integer", "minimum": 0 },
+        "missing": { "type": "integer", "minimum": 0 },
+        "subset_fallback": { "type": "integer", "minimum": 0 },
+        "substitution_free": { "type": "boolean" }
+      }
+    },
+    "substitution_free": { "type": "boolean" },
+    "text": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["pages_compared", "pages_equal", "first_diff_page"],
+      "properties": {
+        "pages_compared": { "type": "integer", "minimum": 0 },
+        "pages_equal": { "type": "integer", "minimum": 0 },
+        "first_diff_page": { "type": ["integer", "null"], "minimum": 1 }
+      }
+    },
+    "raster": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["page", "dx", "dy", "ink_ratio", "bad_pixel_pct", "mae"],
+        "properties": {
+          "page": { "type": "integer", "minimum": 1 },
+          "dx": { "type": "integer" },
+          "dy": { "type": "integer" },
+          "ink_ratio": { "type": "number", "minimum": 0 },
+          "bad_pixel_pct": { "type": "number", "minimum": 0, "maximum": 1 },
+          "mae": { "type": "number", "minimum": 0, "maximum": 255 }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "artifact": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "sha256"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+      }
+    },
+    "font": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "type", "embedded", "subset", "unicode"],
+      "properties": {
+        "name": { "type": "string", "maxLength": 256 },
+        "type": { "type": "string", "maxLength": 64 },
+        "embedded": { "type": "boolean" },
+        "subset": { "type": "boolean" },
+        "unicode": { "type": "boolean" }
+      }
+    }
+  }
+}

--- a/schemas/pdf-parity-scorecard-v1.schema.json
+++ b/schemas/pdf-parity-scorecard-v1.schema.json
@@ -28,7 +28,14 @@
     "scored": { "type": "boolean" },
     "unscored_reasons": {
       "type": "array",
-      "items": { "enum": ["page_count_delta", "font_substitution"] },
+      "items": {
+        "enum": [
+          "page_count_delta",
+          "font_coverage_unavailable",
+          "font_substitution",
+          "pdf_font_contract"
+        ]
+      },
       "uniqueItems": true
     },
     "pages": {
@@ -44,11 +51,19 @@
     "fonts": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["ours", "oracle", "ours_all_embedded_subset_unicode"],
+      "required": [
+        "ours",
+        "oracle",
+        "ours_all_embedded_subset_unicode",
+        "oracle_all_embedded_subset_unicode",
+        "all_embedded_subset_unicode"
+      ],
       "properties": {
         "ours": { "type": "array", "items": { "$ref": "#/$defs/font" } },
         "oracle": { "type": "array", "items": { "$ref": "#/$defs/font" } },
-        "ours_all_embedded_subset_unicode": { "type": "boolean" }
+        "ours_all_embedded_subset_unicode": { "type": "boolean" },
+        "oracle_all_embedded_subset_unicode": { "type": "boolean" },
+        "all_embedded_subset_unicode": { "type": "boolean" }
       }
     },
     "font_coverage": {

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -23,10 +23,11 @@ run() {
 run $CARGO fmt --all --check
 run $CARGO clippy --workspace --all-targets -- -D warnings
 run $CARGO test --workspace
+run python3 -m unittest tools/test_pdf_parity.py
 run bash scripts/check-structured-corpus.sh
 
 if [ "$fail" -ne 0 ]; then
     echo "== check: FAILED (위 게이트 중 실패 있음) =="
     exit 1
 fi
-echo "== check: OK (fmt/clippy/test/structured-corpus = CI 게이트) =="
+echo "== check: OK (fmt/clippy/test/pdf-parity/structured-corpus = CI 게이트) =="

--- a/scripts/pdf-parity.sh
+++ b/scripts/pdf-parity.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# scripts/pdf-parity.sh — Hancom 기준 PDF 동등성 배치 러너 (issue #79 PR 4).
+#
+#   scripts/pdf-parity.sh selftest [--source <doc>]   하네스 자기 검증 (fixture vs 자기 PDF)
+#   scripts/pdf-parity.sh run [--oracle-dir <dir>]    manifest 케이스 집계 → 점수판
+#
+# 다섯 지표 정의와 게이트는 docs/design/21-pdf-parity.md §3/§4, 데이터 정책은 §7.
+# 기준(oracle) PDF는 로컬 전용 — 기본 위치는 $HWP_PDF_PARITY_ORACLE_DIR 이며 절대
+# 커밋하지 않는다. 커밋되는 산출물은 fixtures/pdf-parity/public/scoreboard/ 아래
+# 수치 JSON/CSV뿐이다. 구현 상세는 tools/pdf_parity.py.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+for tool in pdfinfo pdffonts pdftotext pdftoppm python3; do
+  command -v "$tool" >/dev/null 2>&1 || {
+    echo "[pdf-parity] $tool 필요 (poppler · python3 설치)" >&2
+    exit 1
+  }
+done
+
+HWP_BIN="${HWP_BIN:-$ROOT/target/debug/hwp}"
+if [ ! -x "$HWP_BIN" ]; then
+  echo "[pdf-parity] hwp 빌드"
+  cargo build -p hwp-cli --quiet
+fi
+
+MANIFEST="${PDF_PARITY_MANIFEST:-$ROOT/fixtures/pdf-parity/public/manifest.json}"
+OUT_DIR="$ROOT/fixtures/pdf-parity/public/scoreboard"
+
+cmd="${1:-}"
+case "$cmd" in
+  selftest)
+    shift
+    exec python3 tools/pdf_parity.py selftest --hwp-bin "$HWP_BIN" "$@"
+    ;;
+  run)
+    shift
+    # 산출물 스키마 검증기 (임의 개수의 schema/instance 쌍, tools/pdf_parity.py가 호출).
+    cargo build -p hwp-cli --example validate_structured_corpus --quiet
+    python3 tools/pdf_parity.py run --hwp-bin "$HWP_BIN" \
+      --manifest "$MANIFEST" --out "$OUT_DIR" "$@"
+    ;;
+  *)
+    echo "usage: $0 selftest [--source <doc>] | run [--oracle-dir <dir>]" >&2
+    exit 2
+    ;;
+esac

--- a/scripts/pdf-parity.sh
+++ b/scripts/pdf-parity.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-# scripts/pdf-parity.sh — Hancom 기준 PDF 동등성 배치 러너 (issue #79 PR 4).
+# Hancom PDF parity batch runner for issue #79 PR 4.
 #
-#   scripts/pdf-parity.sh selftest [--source <doc>]   하네스 자기 검증 (fixture vs 자기 PDF)
-#   scripts/pdf-parity.sh run [--oracle-dir <dir>]    manifest 케이스 집계 → 점수판
+#   scripts/pdf-parity.sh selftest [--source <doc>]   Verify the harness against itself.
+#   scripts/pdf-parity.sh run [--oracle-dir <dir>]    Aggregate manifest cases.
 #
-# 다섯 지표 정의와 게이트는 docs/design/21-pdf-parity.md §3/§4, 데이터 정책은 §7.
-# 기준(oracle) PDF는 로컬 전용 — 기본 위치는 $HWP_PDF_PARITY_ORACLE_DIR 이며 절대
-# 커밋하지 않는다. 커밋되는 산출물은 fixtures/pdf-parity/public/scoreboard/ 아래
-# 수치 JSON/CSV뿐이다. 구현 상세는 tools/pdf_parity.py.
+# Metric definitions and gates live in docs/design/21-pdf-parity.md sections 3-4;
+# the data policy is section 7. Oracle PDFs remain local under
+# $HWP_PDF_PARITY_ORACLE_DIR. Only numeric JSON/CSV scoreboards are committable.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
@@ -36,7 +35,7 @@ case "$cmd" in
     ;;
   run)
     shift
-    # 산출물 스키마 검증기 (임의 개수의 schema/instance 쌍, tools/pdf_parity.py가 호출).
+    # Build the closed-schema validator used before scoring and before publishing.
     cargo build -p hwp-cli --example validate_structured_corpus --quiet
     python3 tools/pdf_parity.py run --hwp-bin "$HWP_BIN" \
       --manifest "$MANIFEST" --out "$OUT_DIR" "$@"

--- a/tools/pdf_parity.py
+++ b/tools/pdf_parity.py
@@ -1,15 +1,13 @@
 #!/usr/bin/env python3
-"""PDF 동등성 배치 러너 (issue #79 PR 4) — docs/design/21-pdf-parity.md §3의 다섯 지표.
+"""Hancom PDF parity batch runner for issue #79 PR 4.
 
-케이스마다 우리 PDF(hwp render --format pdf)와 한컴 기준 PDF를 나란히 재서
-1) pdffonts 임베드/서브셋/유니코드, 2) pdfinfo 쪽수, 3) pdftotext -layout 정규화
-텍스트 등가, 4~5) 같은 Poppler(pdftoppm -r 150) 래스터의 dx/dy·ink_ratio·
-bad_pixel_pct·mae(hwp diff --format json)를 모아 점수카드 JSON을 만든다.
+The runner compares locally rendered PDFs with private Hancom oracle PDFs using
+the five metrics defined in docs/design/21-pdf-parity.md section 3. It validates
+and enforces every locally checkable manifest pin before measuring any case.
+Only names, SHA-256 digests, and numeric results are allowed in published files.
 
-데이터 정책(docs/design/21 §7): 기준 PDF는 로컬 전용, 커밋되는 산출물은 이름과
-SHA-256, 수치뿐 — 절대 경로가 새지 않도록 쓰기 전에 가드를 둔다.
-
-직접 실행보다 scripts/pdf-parity.sh 래퍼를 쓴다(도구 점검·hwp 빌드 포함).
+Use scripts/pdf-parity.sh instead of invoking this module directly. The wrapper
+checks external tools and builds the hwp binary and JSON Schema validator.
 """
 
 import argparse
@@ -28,8 +26,12 @@ CONTRACT_SCORECARD = "hwp-pdf-parity-scorecard-v1"
 CONTRACT_SCOREBOARD = "hwp-pdf-parity-scoreboard-v1"
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMAS = REPO_ROOT / "schemas"
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+PLACEHOLDER_RE = re.compile(r"(?:todo|placeholder)", re.IGNORECASE)
+FONT_EXTENSIONS = {".otc", ".otf", ".ttc", ".ttf"}
 
-# pdffonts 한 행: name type encoding emb sub uni object-ID(2토큰).
+# A pdffonts row is: name, type, encoding, emb, sub, uni, object ID (two tokens).
 FONT_ROW = re.compile(
     r"^(?P<name>.*?)\s+"
     r"(?P<type>CID Font Type 0C?|CID TrueType(?: \(OpenType\))?|CID Type 0C?(?: \(OT\))?"
@@ -61,10 +63,72 @@ def sha256_file(path: Path) -> str:
 
 
 def poppler_version() -> str:
-    # pdfinfo -v는 stderr로 버전을 내는 배포판이 있어 양쪽을 모두 본다.
+    # Some pdfinfo builds write their version to stderr.
     proc = subprocess.run(["pdfinfo", "-v"], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise die("pdfinfo 버전을 확인할 수 없음")
     out = (proc.stdout or proc.stderr).strip()
     return out.splitlines()[0] if out else "unknown"
+
+
+def validator_path() -> Path:
+    suffix = ".exe" if os.name == "nt" else ""
+    return REPO_ROOT / f"target/debug/examples/validate_structured_corpus{suffix}"
+
+
+def validate_documents(pairs: list) -> None:
+    """Validate every (schema name, document path) pair using the Rust validator."""
+    validator = validator_path()
+    if not validator.is_file():
+        raise die("JSON 스키마 검증기 없음 (scripts/pdf-parity.sh run 사용 필요)")
+    arguments = []
+    for schema, document in pairs:
+        arguments.extend([str(SCHEMAS / f"{schema}.schema.json"), str(document)])
+    proc = subprocess.run(
+        [str(validator), *arguments], capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout).strip().splitlines()
+        reason = detail[-1] if detail else "unknown validation failure"
+        raise die(f"JSON 스키마 검증 실패: {reason}")
+
+
+def require_concrete_pin(label: str, value: str) -> None:
+    if not value.strip() or PLACEHOLDER_RE.search(value):
+        raise die(f"manifest pin 미설정: {label}")
+
+
+def font_directory() -> Path:
+    return Path(os.environ.get("HWP_FONT_DIR", "fonts")).expanduser()
+
+
+def verify_manifest_pins(manifest: dict) -> str:
+    """Verify metadata, Poppler, and font file pins before any case is scored."""
+    pins = manifest["pins"]
+    for key in ("hancom_build", "windows_version", "pdf_settings", "poppler_version"):
+        require_concrete_pin(key, pins[key])
+
+    actual_poppler = poppler_version()
+    if pins["poppler_version"] != actual_poppler:
+        raise die(
+            "Poppler 버전 불일치: "
+            f"manifest={pins['poppler_version']!r}, actual={actual_poppler!r}"
+        )
+
+    directory = font_directory()
+    if not directory.is_dir():
+        raise die(f"고정 폰트 디렉터리 없음: {directory}")
+    available = {
+        sha256_file(path)
+        for path in directory.rglob("*")
+        if path.is_file() and path.suffix.lower() in FONT_EXTENSIONS
+    }
+    for family, expected in pins["fonts"].items():
+        if not SHA256_RE.fullmatch(expected):
+            raise die(f"manifest font SHA-256 미설정 또는 형식 오류: {family}")
+        if expected not in available:
+            raise die(f"고정 폰트 SHA-256 불일치 또는 파일 없음: {family}")
+    return actual_poppler
 
 
 def pdf_pages(pdf: Path) -> int:
@@ -76,10 +140,10 @@ def pdf_pages(pdf: Path) -> int:
 
 
 def pdf_fonts(pdf: Path) -> list:
-    """pdffonts → [{name, type, embedded, subset, unicode}]."""
+    """Return normalized pdffonts rows."""
     out = run(["pdffonts", str(pdf)]).stdout
     fonts = []
-    for line in out.splitlines()[2:]:  # 헤더 2행 건너뜀
+    for line in out.splitlines()[2:]:  # Skip the two header rows.
         if not line.strip():
             continue
         m = FONT_ROW.match(line)
@@ -98,7 +162,7 @@ def pdf_fonts(pdf: Path) -> list:
 
 
 def page_text(pdf: Path, page: int) -> str:
-    """pdftotext -layout 한 쪽 — 공백 런 붕괴·빈 줄 제거로 정규화."""
+    """Normalize one pdftotext -layout page by collapsing whitespace."""
     out = run(["pdftotext", "-layout", "-f", str(page), "-l", str(page), str(pdf), "-"]).stdout
     lines = [re.sub(r"\s+", " ", ln).strip() for ln in out.splitlines()]
     return "\n".join(ln for ln in lines if ln)
@@ -127,7 +191,7 @@ def raster_diff(hwp_bin: Path, source_name: str, ours_png: Path, ref_png: Path,
 
 
 def render_ours(hwp_bin: Path, source: Path, out_pdf: Path, dpi: int) -> dict:
-    """우리 PDF를 만들고 폰트 커버리지(stderr)를 파싱해 돌려준다."""
+    """Render a PDF and parse the font coverage report from stderr."""
     proc = subprocess.run(
         [str(hwp_bin), "render", str(source), "-o", str(out_pdf),
          "--format", "pdf", "--dpi", str(dpi)],
@@ -154,7 +218,7 @@ def render_ours(hwp_bin: Path, source: Path, out_pdf: Path, dpi: int) -> dict:
 
 def score_case(name: str, source: Path, oracle: Path, hwp_bin: Path, dpi: int,
                work: Path) -> dict:
-    """케이스 하나의 다섯 지표를 모아 점수카드를 만든다."""
+    """Collect the five metric groups for one case."""
     coverage = render_ours(hwp_bin, source, work / "ours.pdf", dpi)
     ours_pdf = work / "ours.pdf"
 
@@ -162,7 +226,15 @@ def score_case(name: str, source: Path, oracle: Path, hwp_bin: Path, dpi: int,
     delta = ours_pages - oracle_pages
 
     ours_fonts, oracle_fonts = pdf_fonts(ours_pdf), pdf_fonts(oracle)
-    fonts_ok = all(f["embedded"] and f["subset"] and f["unicode"] for f in ours_fonts)
+    ours_fonts_ok = all(
+        font["embedded"] and font["subset"] and font["unicode"]
+        for font in ours_fonts
+    )
+    oracle_fonts_ok = all(
+        font["embedded"] and font["subset"] and font["unicode"]
+        for font in oracle_fonts
+    )
+    fonts_ok = ours_fonts_ok and oracle_fonts_ok
 
     compared = min(ours_pages, oracle_pages)
     equal = 0
@@ -181,12 +253,16 @@ def score_case(name: str, source: Path, oracle: Path, hwp_bin: Path, dpi: int,
         entry.update(raster_diff(hwp_bin, source.name, ours_png, ref_png, n, dpi))
         raster.append(entry)
 
-    substitution_free = True if coverage is None else coverage["substitution_free"]
+    substitution_free = coverage is not None and coverage["substitution_free"]
     reasons = []
     if delta != 0:
         reasons.append("page_count_delta")
-    if not substitution_free:
+    if coverage is None:
+        reasons.append("font_coverage_unavailable")
+    elif not substitution_free:
         reasons.append("font_substitution")
+    if not fonts_ok:
+        reasons.append("pdf_font_contract")
 
     return {
         "contract": CONTRACT_SCORECARD,
@@ -200,7 +276,9 @@ def score_case(name: str, source: Path, oracle: Path, hwp_bin: Path, dpi: int,
         "fonts": {
             "ours": ours_fonts,
             "oracle": oracle_fonts,
-            "ours_all_embedded_subset_unicode": fonts_ok,
+            "ours_all_embedded_subset_unicode": ours_fonts_ok,
+            "oracle_all_embedded_subset_unicode": oracle_fonts_ok,
+            "all_embedded_subset_unicode": fonts_ok,
         },
         "font_coverage": coverage,
         "substitution_free": substitution_free,
@@ -230,13 +308,13 @@ def summarize(card: dict) -> dict:
         "bad_pixel_pct_max": max((r["bad_pixel_pct"] for r in raster), default=0.0),
         "mae_max": max((r["mae"] for r in raster), default=0.0),
         "fonts_all_embedded_subset_unicode": card["fonts"]
-        ["ours_all_embedded_subset_unicode"],
+        ["all_embedded_subset_unicode"],
         "substitution_free": card["substitution_free"],
     }
 
 
 def guard_no_paths(payload: str, forbidden: list) -> None:
-    """커밋될 산출물에 로컬 절대 경로가 새지 않았는지 검사한다."""
+    """Reject local absolute paths from committable output payloads."""
     for needle in forbidden:
         if needle and needle in payload:
             raise die(f"산출물에 로컬 경로 누출: {needle}")
@@ -249,29 +327,135 @@ def write_json(path: Path, value: dict, forbidden: list) -> None:
     path.write_text(payload, encoding="utf-8")
 
 
+def resolve_case_file(root: Path, filename: str, label: str) -> Path:
+    """Resolve a regular case file without allowing a symlink escape."""
+    try:
+        resolved_root = root.resolve(strict=True)
+    except OSError:
+        raise die(f"{label} 디렉터리 없음: {root}")
+    candidate = resolved_root / filename
+    if candidate.is_symlink() or not candidate.is_file():
+        raise die(f"{label} 파일 없음 또는 심볼릭 링크: {filename}")
+    try:
+        resolved = candidate.resolve(strict=True)
+        contained = os.path.commonpath([str(resolved_root), str(resolved)]) == str(
+            resolved_root
+        )
+    except (OSError, ValueError):
+        contained = False
+    if not contained:
+        raise die(f"{label} 파일이 허용 디렉터리를 벗어남: {filename}")
+    return candidate
+
+
+def prepare_cases(manifest: dict, manifest_path: Path, oracle_dir: Path) -> list:
+    """Reject duplicate names and verify every pinned artifact before rendering."""
+    if not manifest["cases"]:
+        raise die("manifest cases가 비어 있음")
+    source_root = manifest_path.parent / "source"
+    case_names = [case["name"] for case in manifest["cases"]]
+    if len(set(case_names)) != len(case_names):
+        duplicate = next(name for name in case_names if case_names.count(name) > 1)
+        raise die(f"중복 case 이름: {duplicate}")
+    prepared = []
+    for case in manifest["cases"]:
+        name = case["name"]
+        source = resolve_case_file(source_root, case["source"], f"케이스 {name} source")
+        oracle = resolve_case_file(oracle_dir, case["oracle"], f"케이스 {name} oracle")
+        source_hash = sha256_file(source)
+        oracle_hash = sha256_file(oracle)
+        if source_hash != case["source_sha256"]:
+            raise die(f"케이스 {name}: source SHA-256 불일치")
+        if oracle_hash != case["oracle_sha256"]:
+            raise die(f"케이스 {name}: oracle SHA-256 불일치")
+        prepared.append(
+            {
+                "name": name,
+                "source": source,
+                "oracle": oracle,
+                "source_sha256": source_hash,
+                "oracle_sha256": oracle_hash,
+            }
+        )
+    return prepared
+
+
+def validate_output_directory(out_dir: Path) -> None:
+    if out_dir.is_symlink() or (out_dir.exists() and not out_dir.is_dir()):
+        raise die(f"점수판 출력 디렉터리 경로가 안전하지 않음: {out_dir}")
+
+
+def publish_artifacts(stage: Path, out_dir: Path, filenames: list) -> None:
+    """Publish a validated file set with rollback for any mid-publish failure."""
+    validate_output_directory(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    backup_dir = stage / ".previous"
+    backup_dir.mkdir()
+    published = []
+    backups = []
+    try:
+        for filename in filenames:
+            source = stage / filename
+            destination = out_dir / filename
+            if destination.is_symlink() or (
+                destination.exists() and not destination.is_file()
+            ):
+                raise die(f"기존 점수판 산출물 경로가 안전하지 않음: {filename}")
+            if destination.exists():
+                backup = backup_dir / filename
+                os.replace(destination, backup)
+                backups.append((backup, destination))
+            os.replace(source, destination)
+            published.append(destination)
+    except BaseException:
+        for destination in reversed(published):
+            if destination.is_file() or destination.is_symlink():
+                destination.unlink()
+        for backup, destination in reversed(backups):
+            if backup.exists():
+                os.replace(backup, destination)
+        raise
+
+
 def cmd_run(args) -> int:
-    manifest = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
+    manifest_path = Path(args.manifest)
+    validate_documents([("pdf-parity-manifest-v1", manifest_path)])
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     if manifest.get("contract") != CONTRACT_MANIFEST:
         raise die(f"manifest 계약 불일치: {manifest.get('contract')!r}")
     oracle_dir = Path(args.oracle_dir).expanduser()
     if not oracle_dir.is_dir():
         raise die(f"기준 PDF 디렉터리 없음: {oracle_dir} (로컬 전용, 커밋 금지)")
     out_dir = Path(args.out)
+    validate_output_directory(out_dir)
+    hwp_bin = Path(args.hwp_bin)
+    if not hwp_bin.is_file():
+        raise die(f"hwp 실행 파일 없음: {hwp_bin}")
     dpi = int(manifest["pins"]["dpi"])
-    source_root = Path(args.manifest).parent / "source"
+    actual_poppler = verify_manifest_pins(manifest)
+    cases = prepare_cases(manifest, manifest_path, oracle_dir)
 
-    forbidden = [str(oracle_dir), str(Path.home()), str(REPO_ROOT) + os.sep]
+    forbidden = [
+        str(oracle_dir.resolve()),
+        str(Path.home()),
+        str(REPO_ROOT) + os.sep,
+    ]
     cards = []
-    for case in manifest["cases"]:
+    for case in cases:
         name = case["name"]
-        source = source_root / case["source"]
-        oracle = oracle_dir / case["oracle"]
-        for p in (source, oracle):
-            if not p.is_file():
-                raise die(f"케이스 {name}: 파일 없음 — {p.name}")
         with tempfile.TemporaryDirectory(prefix="hwp-parity-") as tmp:
-            card = score_case(name, source, oracle, Path(args.hwp_bin), dpi, Path(tmp))
-        write_json(out_dir / f"{name}.json", card, forbidden)
+            card = score_case(
+                name,
+                case["source"],
+                case["oracle"],
+                hwp_bin,
+                dpi,
+                Path(tmp),
+            )
+        if card["source"]["sha256"] != case["source_sha256"]:
+            raise die(f"케이스 {name}: 측정 중 source 파일 변경 감지")
+        if card["oracle"]["sha256"] != case["oracle_sha256"]:
+            raise die(f"케이스 {name}: 측정 중 oracle 파일 변경 감지")
         cards.append(card)
         mark = "scored" if card["scored"] else f"unscored({','.join(card['unscored_reasons'])})"
         print(f"[pdf-parity] {name}: pages Δ{card['pages']['delta']}, "
@@ -281,42 +465,46 @@ def cmd_run(args) -> int:
     board = {
         "contract": CONTRACT_SCOREBOARD,
         "generated_by": "scripts/pdf-parity.sh",
-        "poppler_version": poppler_version(),
+        "poppler_version": actual_poppler,
         "dpi": dpi,
         "cases": [summarize(c) for c in cards],
     }
-    write_json(out_dir / "scoreboard.json", board, forbidden)
 
-    csv_lines = ["case,page,dx,dy,ink_ratio,bad_pixel_pct,mae"]
-    for c in cards:
-        for r in c["raster"]:
-            csv_lines.append(
-                f"{c['case']},{r['page']},{r['dx']},{r['dy']},"
-                f"{r['ink_ratio']:.6f},{r['bad_pixel_pct']:.6f},{r['mae']:.4f}"
-            )
-    csv_payload = "\n".join(csv_lines) + "\n"
-    guard_no_paths(csv_payload, forbidden)
-    (out_dir / "scoreboard.csv").write_text(csv_payload, encoding="utf-8")
+    out_dir.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=".pdf-parity-stage-", dir=out_dir.parent) as tmp:
+        stage = Path(tmp)
+        for card in cards:
+            write_json(stage / f"{card['case']}.json", card, forbidden)
+        write_json(stage / "scoreboard.json", board, forbidden)
 
-    # 스키마 검증 (래퍼가 빌드해 둔 예제 검증기 재사용).
-    validator = REPO_ROOT / "target/debug/examples/validate_structured_corpus"
-    if validator.is_file():
-        pairs = []
-        for schema, doc in [
-            ("pdf-parity-scoreboard-v1", out_dir / "scoreboard.json"),
-            ("pdf-parity-manifest-v1", Path(args.manifest)),
-        ] + [("pdf-parity-scorecard-v1", out_dir / f"{c['case']}.json") for c in cards]:
-            pairs += [str(REPO_ROOT / f"schemas/{schema}.schema.json"), str(doc)]
-        subprocess.run([str(validator)] + pairs, check=True)
-        print("[pdf-parity] 스키마 검증 통과")
-    else:
-        print("[pdf-parity] 경고: 스키마 검증기 없음 — 검증 건너뜀", file=sys.stderr)
+        csv_lines = ["case,page,dx,dy,ink_ratio,bad_pixel_pct,mae"]
+        for card in cards:
+            for raster in card["raster"]:
+                csv_lines.append(
+                    f"{card['case']},{raster['page']},{raster['dx']},{raster['dy']},"
+                    f"{raster['ink_ratio']:.6f},{raster['bad_pixel_pct']:.6f},"
+                    f"{raster['mae']:.4f}"
+                )
+        csv_payload = "\n".join(csv_lines) + "\n"
+        guard_no_paths(csv_payload, forbidden)
+        (stage / "scoreboard.csv").write_text(csv_payload, encoding="utf-8")
+
+        pairs = [("pdf-parity-scoreboard-v1", stage / "scoreboard.json")]
+        pairs.extend(
+            ("pdf-parity-scorecard-v1", stage / f"{card['case']}.json")
+            for card in cards
+        )
+        validate_documents(pairs)
+        filenames = [f"{card['case']}.json" for card in cards]
+        filenames.extend(["scoreboard.json", "scoreboard.csv"])
+        publish_artifacts(stage, out_dir, filenames)
+    print("[pdf-parity] 스키마 검증 통과")
     print(f"[pdf-parity] 점수판: {out_dir}/scoreboard.json (+ .csv, 케이스 {len(cards)}건)")
     return 0
 
 
 def cmd_selftest(args) -> int:
-    """하네스 자기 검증: 같은 PDF를 기준으로 돌리면 모든 지표가 완벽해야 한다."""
+    """Verify that comparing one rendered PDF with itself is exact."""
     source = Path(args.source) if args.source else None
     if source is None:
         candidates = sorted((REPO_ROOT / "fixtures/hwp5").glob("*.hwp"))
@@ -328,9 +516,10 @@ def cmd_selftest(args) -> int:
     dpi = 150
     with tempfile.TemporaryDirectory(prefix="hwp-parity-selftest-") as tmp:
         work = Path(tmp)
-        render_ours(Path(args.hwp_bin), source, work / "ours.pdf", dpi)
-        # 기준 = 우리 PDF 자신.
-        card = score_case("selftest", source, work / "ours.pdf",
+        oracle = work / "oracle.pdf"
+        render_ours(Path(args.hwp_bin), source, oracle, dpi)
+        # Compare two independent renders so the oracle is never overwritten in place.
+        card = score_case("selftest", source, oracle,
                           Path(args.hwp_bin), dpi, work)
     problems = []
     if card["pages"]["delta"] != 0:
@@ -339,10 +528,17 @@ def cmd_selftest(args) -> int:
     if t["pages_equal"] != t["pages_compared"]:
         problems.append(f"텍스트 불일치 (첫 쪽 {t['first_diff_page']})")
     for r in card["raster"]:
-        if (r["dx"], r["dy"]) != (0, 0) or r["bad_pixel_pct"] != 0.0 or r["ink_ratio"] != 1.0:
+        if (
+            (r["dx"], r["dy"]) != (0, 0)
+            or r["bad_pixel_pct"] != 0.0
+            or r["ink_ratio"] != 1.0
+            or r["mae"] != 0.0
+        ):
             problems.append(f"래스터 불일치 (쪽 {r['page']})")
-    if not card["fonts"]["ours_all_embedded_subset_unicode"]:
+    if not card["fonts"]["all_embedded_subset_unicode"]:
         problems.append("임베드/서브셋/유니코드 아닌 폰트")
+    if not card["substitution_free"]:
+        problems.append("글꼴 커버리지 확인 실패 또는 대체 감지")
     if problems:
         for p in problems:
             print(f"[pdf-parity] selftest 실패: {p}", file=sys.stderr)

--- a/tools/pdf_parity.py
+++ b/tools/pdf_parity.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""PDF 동등성 배치 러너 (issue #79 PR 4) — docs/design/21-pdf-parity.md §3의 다섯 지표.
+
+케이스마다 우리 PDF(hwp render --format pdf)와 한컴 기준 PDF를 나란히 재서
+1) pdffonts 임베드/서브셋/유니코드, 2) pdfinfo 쪽수, 3) pdftotext -layout 정규화
+텍스트 등가, 4~5) 같은 Poppler(pdftoppm -r 150) 래스터의 dx/dy·ink_ratio·
+bad_pixel_pct·mae(hwp diff --format json)를 모아 점수카드 JSON을 만든다.
+
+데이터 정책(docs/design/21 §7): 기준 PDF는 로컬 전용, 커밋되는 산출물은 이름과
+SHA-256, 수치뿐 — 절대 경로가 새지 않도록 쓰기 전에 가드를 둔다.
+
+직접 실행보다 scripts/pdf-parity.sh 래퍼를 쓴다(도구 점검·hwp 빌드 포함).
+"""
+
+import argparse
+import glob
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+CONTRACT_MANIFEST = "hwp-pdf-parity-manifest-v1"
+CONTRACT_SCORECARD = "hwp-pdf-parity-scorecard-v1"
+CONTRACT_SCOREBOARD = "hwp-pdf-parity-scoreboard-v1"
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# pdffonts 한 행: name type encoding emb sub uni object-ID(2토큰).
+FONT_ROW = re.compile(
+    r"^(?P<name>.*?)\s+"
+    r"(?P<type>CID Font Type 0C?|CID TrueType(?: \(OpenType\))?|CID Type 0C?(?: \(OT\))?"
+    r"|TrueType(?: \(OpenType\))?|Type 0|Type 1C?(?: \(OT\))?|Type 3)\s+"
+    r"(?P<encoding>\S+)\s+(?P<emb>yes|no)\s+(?P<sub>yes|no)\s+(?P<uni>yes|no)\s+"
+    r"\d+\s+\d+\s*$"
+)
+
+COVERAGE_RE = re.compile(
+    r"글꼴 커버리지 matched=(\d+) substituted=(\d+) missing=(\d+) subset_fallback=(\d+)"
+)
+
+
+def die(msg: str) -> "SystemExit":
+    print(f"[pdf-parity] 오류: {msg}", file=sys.stderr)
+    return SystemExit(1)
+
+
+def run(cmd: list, **kw) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, check=True, **kw)
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def poppler_version() -> str:
+    # pdfinfo -v는 stderr로 버전을 내는 배포판이 있어 양쪽을 모두 본다.
+    proc = subprocess.run(["pdfinfo", "-v"], capture_output=True, text=True)
+    out = (proc.stdout or proc.stderr).strip()
+    return out.splitlines()[0] if out else "unknown"
+
+
+def pdf_pages(pdf: Path) -> int:
+    out = run(["pdfinfo", str(pdf)]).stdout
+    m = re.search(r"^Pages:\s+(\d+)", out, re.M)
+    if not m:
+        raise die(f"pdfinfo Pages 파싱 실패: {pdf.name}")
+    return int(m.group(1))
+
+
+def pdf_fonts(pdf: Path) -> list:
+    """pdffonts → [{name, type, embedded, subset, unicode}]."""
+    out = run(["pdffonts", str(pdf)]).stdout
+    fonts = []
+    for line in out.splitlines()[2:]:  # 헤더 2행 건너뜀
+        if not line.strip():
+            continue
+        m = FONT_ROW.match(line)
+        if not m:
+            raise die(f"pdffonts 행 파싱 실패: {line!r} ({pdf.name})")
+        fonts.append(
+            {
+                "name": m.group("name"),
+                "type": m.group("type"),
+                "embedded": m.group("emb") == "yes",
+                "subset": m.group("sub") == "yes",
+                "unicode": m.group("uni") == "yes",
+            }
+        )
+    return fonts
+
+
+def page_text(pdf: Path, page: int) -> str:
+    """pdftotext -layout 한 쪽 — 공백 런 붕괴·빈 줄 제거로 정규화."""
+    out = run(["pdftotext", "-layout", "-f", str(page), "-l", str(page), str(pdf), "-"]).stdout
+    lines = [re.sub(r"\s+", " ", ln).strip() for ln in out.splitlines()]
+    return "\n".join(ln for ln in lines if ln)
+
+
+def rasterize(pdf: Path, page: int, dpi: int, prefix: Path) -> Path:
+    run(["pdftoppm", "-png", "-r", str(dpi), "-f", str(page), "-l", str(page),
+         str(pdf), str(prefix)])
+    hits = glob.glob(f"{prefix}-*.png")
+    if len(hits) != 1:
+        raise die(f"pdftoppm 산출물 해석 실패: {prefix}-*.png → {hits}")
+    return Path(hits[0])
+
+
+def raster_diff(hwp_bin: Path, source_name: str, ours_png: Path, ref_png: Path,
+                page: int, dpi: int) -> dict:
+    out = run([
+        str(hwp_bin), "diff", source_name,
+        "--ours-png", str(ours_png), "--ref", str(ref_png),
+        "--page", str(page), "--dpi", str(dpi), "--format", "json",
+    ]).stdout
+    rep = json.loads(out)
+    if rep.get("contract") != "hwp-diff-report-v1":
+        raise die(f"hwp diff 계약 불일치: {rep.get('contract')!r}")
+    return {k: rep[k] for k in ("dx", "dy", "ink_ratio", "bad_pixel_pct", "mae")}
+
+
+def render_ours(hwp_bin: Path, source: Path, out_pdf: Path, dpi: int) -> dict:
+    """우리 PDF를 만들고 폰트 커버리지(stderr)를 파싱해 돌려준다."""
+    proc = subprocess.run(
+        [str(hwp_bin), "render", str(source), "-o", str(out_pdf),
+         "--format", "pdf", "--dpi", str(dpi)],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        raise die(f"hwp render 실패: {source.name}\n{proc.stderr.strip()}")
+    m = COVERAGE_RE.search(proc.stderr)
+    coverage = None
+    if m:
+        coverage = {
+            "matched": int(m.group(1)),
+            "substituted": int(m.group(2)),
+            "missing": int(m.group(3)),
+            "subset_fallback": int(m.group(4)),
+        }
+        coverage["substitution_free"] = (
+            coverage["substituted"] == 0
+            and coverage["missing"] == 0
+            and coverage["subset_fallback"] == 0
+        )
+    return coverage
+
+
+def score_case(name: str, source: Path, oracle: Path, hwp_bin: Path, dpi: int,
+               work: Path) -> dict:
+    """케이스 하나의 다섯 지표를 모아 점수카드를 만든다."""
+    coverage = render_ours(hwp_bin, source, work / "ours.pdf", dpi)
+    ours_pdf = work / "ours.pdf"
+
+    ours_pages, oracle_pages = pdf_pages(ours_pdf), pdf_pages(oracle)
+    delta = ours_pages - oracle_pages
+
+    ours_fonts, oracle_fonts = pdf_fonts(ours_pdf), pdf_fonts(oracle)
+    fonts_ok = all(f["embedded"] and f["subset"] and f["unicode"] for f in ours_fonts)
+
+    compared = min(ours_pages, oracle_pages)
+    equal = 0
+    first_diff = None
+    for n in range(1, compared + 1):
+        if page_text(ours_pdf, n) == page_text(oracle, n):
+            equal += 1
+        elif first_diff is None:
+            first_diff = n
+
+    raster = []
+    for n in range(1, compared + 1):
+        ours_png = rasterize(ours_pdf, n, dpi, work / f"ours-{n}")
+        ref_png = rasterize(oracle, n, dpi, work / f"ref-{n}")
+        entry = {"page": n}
+        entry.update(raster_diff(hwp_bin, source.name, ours_png, ref_png, n, dpi))
+        raster.append(entry)
+
+    substitution_free = True if coverage is None else coverage["substitution_free"]
+    reasons = []
+    if delta != 0:
+        reasons.append("page_count_delta")
+    if not substitution_free:
+        reasons.append("font_substitution")
+
+    return {
+        "contract": CONTRACT_SCORECARD,
+        "case": name,
+        "source": {"name": source.name, "sha256": sha256_file(source)},
+        "oracle": {"name": oracle.name, "sha256": sha256_file(oracle)},
+        "dpi": dpi,
+        "scored": not reasons,
+        "unscored_reasons": reasons,
+        "pages": {"ours": ours_pages, "oracle": oracle_pages, "delta": delta},
+        "fonts": {
+            "ours": ours_fonts,
+            "oracle": oracle_fonts,
+            "ours_all_embedded_subset_unicode": fonts_ok,
+        },
+        "font_coverage": coverage,
+        "substitution_free": substitution_free,
+        "text": {
+            "pages_compared": compared,
+            "pages_equal": equal,
+            "first_diff_page": first_diff,
+        },
+        "raster": raster,
+    }
+
+
+def summarize(card: dict) -> dict:
+    raster = card["raster"]
+    return {
+        "name": card["case"],
+        "scored": card["scored"],
+        "unscored_reasons": card["unscored_reasons"],
+        "pages_delta": card["pages"]["delta"],
+        "text_pages_equal": card["text"]["pages_equal"],
+        "text_pages_compared": card["text"]["pages_compared"],
+        "raster_pages": len(raster),
+        "max_abs_dx": max((abs(r["dx"]) for r in raster), default=0),
+        "max_abs_dy": max((abs(r["dy"]) for r in raster), default=0),
+        "ink_ratio_min": min((r["ink_ratio"] for r in raster), default=1.0),
+        "ink_ratio_max": max((r["ink_ratio"] for r in raster), default=1.0),
+        "bad_pixel_pct_max": max((r["bad_pixel_pct"] for r in raster), default=0.0),
+        "mae_max": max((r["mae"] for r in raster), default=0.0),
+        "fonts_all_embedded_subset_unicode": card["fonts"]
+        ["ours_all_embedded_subset_unicode"],
+        "substitution_free": card["substitution_free"],
+    }
+
+
+def guard_no_paths(payload: str, forbidden: list) -> None:
+    """커밋될 산출물에 로컬 절대 경로가 새지 않았는지 검사한다."""
+    for needle in forbidden:
+        if needle and needle in payload:
+            raise die(f"산출물에 로컬 경로 누출: {needle}")
+
+
+def write_json(path: Path, value: dict, forbidden: list) -> None:
+    payload = json.dumps(value, ensure_ascii=False, indent=2) + "\n"
+    guard_no_paths(payload, forbidden)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(payload, encoding="utf-8")
+
+
+def cmd_run(args) -> int:
+    manifest = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
+    if manifest.get("contract") != CONTRACT_MANIFEST:
+        raise die(f"manifest 계약 불일치: {manifest.get('contract')!r}")
+    oracle_dir = Path(args.oracle_dir).expanduser()
+    if not oracle_dir.is_dir():
+        raise die(f"기준 PDF 디렉터리 없음: {oracle_dir} (로컬 전용, 커밋 금지)")
+    out_dir = Path(args.out)
+    dpi = int(manifest["pins"]["dpi"])
+    source_root = Path(args.manifest).parent / "source"
+
+    forbidden = [str(oracle_dir), str(Path.home()), str(REPO_ROOT) + os.sep]
+    cards = []
+    for case in manifest["cases"]:
+        name = case["name"]
+        source = source_root / case["source"]
+        oracle = oracle_dir / case["oracle"]
+        for p in (source, oracle):
+            if not p.is_file():
+                raise die(f"케이스 {name}: 파일 없음 — {p.name}")
+        with tempfile.TemporaryDirectory(prefix="hwp-parity-") as tmp:
+            card = score_case(name, source, oracle, Path(args.hwp_bin), dpi, Path(tmp))
+        write_json(out_dir / f"{name}.json", card, forbidden)
+        cards.append(card)
+        mark = "scored" if card["scored"] else f"unscored({','.join(card['unscored_reasons'])})"
+        print(f"[pdf-parity] {name}: pages Δ{card['pages']['delta']}, "
+              f"text {card['text']['pages_equal']}/{card['text']['pages_compared']}, "
+              f"raster {len(card['raster'])}쪽 — {mark}")
+
+    board = {
+        "contract": CONTRACT_SCOREBOARD,
+        "generated_by": "scripts/pdf-parity.sh",
+        "poppler_version": poppler_version(),
+        "dpi": dpi,
+        "cases": [summarize(c) for c in cards],
+    }
+    write_json(out_dir / "scoreboard.json", board, forbidden)
+
+    csv_lines = ["case,page,dx,dy,ink_ratio,bad_pixel_pct,mae"]
+    for c in cards:
+        for r in c["raster"]:
+            csv_lines.append(
+                f"{c['case']},{r['page']},{r['dx']},{r['dy']},"
+                f"{r['ink_ratio']:.6f},{r['bad_pixel_pct']:.6f},{r['mae']:.4f}"
+            )
+    csv_payload = "\n".join(csv_lines) + "\n"
+    guard_no_paths(csv_payload, forbidden)
+    (out_dir / "scoreboard.csv").write_text(csv_payload, encoding="utf-8")
+
+    # 스키마 검증 (래퍼가 빌드해 둔 예제 검증기 재사용).
+    validator = REPO_ROOT / "target/debug/examples/validate_structured_corpus"
+    if validator.is_file():
+        pairs = []
+        for schema, doc in [
+            ("pdf-parity-scoreboard-v1", out_dir / "scoreboard.json"),
+            ("pdf-parity-manifest-v1", Path(args.manifest)),
+        ] + [("pdf-parity-scorecard-v1", out_dir / f"{c['case']}.json") for c in cards]:
+            pairs += [str(REPO_ROOT / f"schemas/{schema}.schema.json"), str(doc)]
+        subprocess.run([str(validator)] + pairs, check=True)
+        print("[pdf-parity] 스키마 검증 통과")
+    else:
+        print("[pdf-parity] 경고: 스키마 검증기 없음 — 검증 건너뜀", file=sys.stderr)
+    print(f"[pdf-parity] 점수판: {out_dir}/scoreboard.json (+ .csv, 케이스 {len(cards)}건)")
+    return 0
+
+
+def cmd_selftest(args) -> int:
+    """하네스 자기 검증: 같은 PDF를 기준으로 돌리면 모든 지표가 완벽해야 한다."""
+    source = Path(args.source) if args.source else None
+    if source is None:
+        candidates = sorted((REPO_ROOT / "fixtures/hwp5").glob("*.hwp"))
+        if not candidates:
+            raise die("selftest용 fixture 없음 (fixtures/hwp5/*.hwp)")
+        source = candidates[0]
+    if not source.is_file():
+        raise die(f"fixture 없음: {source}")
+    dpi = 150
+    with tempfile.TemporaryDirectory(prefix="hwp-parity-selftest-") as tmp:
+        work = Path(tmp)
+        render_ours(Path(args.hwp_bin), source, work / "ours.pdf", dpi)
+        # 기준 = 우리 PDF 자신.
+        card = score_case("selftest", source, work / "ours.pdf",
+                          Path(args.hwp_bin), dpi, work)
+    problems = []
+    if card["pages"]["delta"] != 0:
+        problems.append("쪽수 불일치")
+    t = card["text"]
+    if t["pages_equal"] != t["pages_compared"]:
+        problems.append(f"텍스트 불일치 (첫 쪽 {t['first_diff_page']})")
+    for r in card["raster"]:
+        if (r["dx"], r["dy"]) != (0, 0) or r["bad_pixel_pct"] != 0.0 or r["ink_ratio"] != 1.0:
+            problems.append(f"래스터 불일치 (쪽 {r['page']})")
+    if not card["fonts"]["ours_all_embedded_subset_unicode"]:
+        problems.append("임베드/서브셋/유니코드 아닌 폰트")
+    if problems:
+        for p in problems:
+            print(f"[pdf-parity] selftest 실패: {p}", file=sys.stderr)
+        return 1
+    print(f"[pdf-parity] selftest 통과: {source.name} — "
+          f"{card['pages']['ours']}쪽, 텍스트 {t['pages_equal']}/{t['pages_compared']}, "
+          f"래스터 {len(card['raster'])}쪽 전부 일치")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Hancom 기준 PDF 동등성 배치 러너")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_run = sub.add_parser("run", help="manifest의 케이스를 점수판으로 집계")
+    p_run.add_argument("--manifest", required=True)
+    p_run.add_argument("--oracle-dir",
+                       default=os.environ.get("HWP_PDF_PARITY_ORACLE_DIR", ""))
+    p_run.add_argument("--out", required=True)
+    p_run.add_argument("--hwp-bin", required=True)
+
+    p_self = sub.add_parser("selftest", help="하네스 자기 검증 (fixture vs 자기 자신)")
+    p_self.add_argument("--hwp-bin", required=True)
+    p_self.add_argument("--source", default=None)
+
+    args = ap.parse_args()
+    if args.cmd == "run":
+        if not args.oracle_dir:
+            raise die("--oracle-dir 또는 HWP_PDF_PARITY_ORACLE_DIR 필요")
+        return cmd_run(args)
+    return cmd_selftest(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/test_pdf_parity.py
+++ b/tools/test_pdf_parity.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Regression tests for the Hancom PDF parity runner."""
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tools import pdf_parity as parity
+
+
+def digest(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def concrete_manifest() -> dict:
+    return {
+        "pins": {
+            "hancom_build": "Hancom Office 2024 13.0.0.1",
+            "windows_version": "Windows 11 24H2",
+            "pdf_settings": "File > Save as PDF, defaults",
+            "poppler_version": "pdfinfo version 26.0.0",
+            "dpi": 150,
+            "fonts": {},
+        },
+        "cases": [],
+    }
+
+
+class ManifestPinTests(unittest.TestCase):
+    def test_poppler_and_font_hashes_are_enforced(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            font_dir = Path(temporary)
+            font = font_dir / "Pinned.ttf"
+            font.write_bytes(b"pinned font")
+            manifest = concrete_manifest()
+            manifest["pins"]["fonts"] = {"Pinned": digest(b"pinned font")}
+            with mock.patch.dict("os.environ", {"HWP_FONT_DIR": str(font_dir)}), mock.patch.object(
+                parity, "poppler_version", return_value="pdfinfo version 26.0.0"
+            ):
+                self.assertEqual(
+                    parity.verify_manifest_pins(manifest),
+                    "pdfinfo version 26.0.0",
+                )
+
+            manifest["pins"]["fonts"]["Pinned"] = "0" * 64
+            with mock.patch.dict("os.environ", {"HWP_FONT_DIR": str(font_dir)}), mock.patch.object(
+                parity, "poppler_version", return_value="pdfinfo version 26.0.0"
+            ), self.assertRaises(SystemExit):
+                parity.verify_manifest_pins(manifest)
+
+    def test_placeholder_metadata_is_rejected(self) -> None:
+        manifest = concrete_manifest()
+        manifest["pins"]["hancom_build"] = "TODO-owner"
+        with self.assertRaises(SystemExit):
+            parity.verify_manifest_pins(manifest)
+
+
+class CasePreflightTests(unittest.TestCase):
+    def test_case_hashes_are_verified_and_duplicate_names_are_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            manifest_path = root / "public" / "manifest.json"
+            source_dir = manifest_path.parent / "source"
+            oracle_dir = root / "oracle"
+            source_dir.mkdir(parents=True)
+            oracle_dir.mkdir()
+            (source_dir / "case.hwp").write_bytes(b"source")
+            (oracle_dir / "case.pdf").write_bytes(b"oracle")
+            case = {
+                "name": "case",
+                "source": "case.hwp",
+                "source_sha256": digest(b"source"),
+                "oracle": "case.pdf",
+                "oracle_sha256": digest(b"oracle"),
+            }
+            manifest = {"cases": [case]}
+            prepared = parity.prepare_cases(manifest, manifest_path, oracle_dir)
+            self.assertEqual(prepared[0]["source_sha256"], digest(b"source"))
+
+            manifest["cases"] = [case, case.copy()]
+            with self.assertRaises(SystemExit):
+                parity.prepare_cases(manifest, manifest_path, oracle_dir)
+
+    def test_case_file_cannot_escape_its_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            allowed = root / "allowed"
+            allowed.mkdir()
+            (root / "secret.hwp").write_bytes(b"secret")
+            with self.assertRaises(SystemExit):
+                parity.resolve_case_file(allowed, "../secret.hwp", "source")
+
+
+class ScoreGateTests(unittest.TestCase):
+    def score_with(self, coverage, font_rows) -> dict:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "case.hwp"
+            oracle = root / "case.pdf"
+            source.write_bytes(b"source")
+            oracle.write_bytes(b"oracle")
+            metrics = {
+                "dx": 0,
+                "dy": 0,
+                "ink_ratio": 1.0,
+                "bad_pixel_pct": 0.0,
+                "mae": 0.0,
+            }
+            with mock.patch.object(parity, "render_ours", return_value=coverage), mock.patch.object(
+                parity, "pdf_pages", return_value=1
+            ), mock.patch.object(parity, "pdf_fonts", side_effect=font_rows), mock.patch.object(
+                parity, "page_text", return_value="same"
+            ), mock.patch.object(parity, "rasterize", return_value=root / "page.png"), mock.patch.object(
+                parity, "raster_diff", return_value=metrics
+            ):
+                return parity.score_case(
+                    "case", source, oracle, root / "hwp", 150, root
+                )
+
+    def test_missing_font_coverage_fails_closed(self) -> None:
+        valid_font = {
+            "name": "Pinned",
+            "type": "TrueType",
+            "embedded": True,
+            "subset": True,
+            "unicode": True,
+        }
+        card = self.score_with(None, [[valid_font], [valid_font]])
+        self.assertFalse(card["scored"])
+        self.assertFalse(card["substitution_free"])
+        self.assertIn("font_coverage_unavailable", card["unscored_reasons"])
+
+    def test_pdf_font_contract_applies_to_both_pdfs(self) -> None:
+        valid_font = {
+            "name": "Pinned",
+            "type": "TrueType",
+            "embedded": True,
+            "subset": True,
+            "unicode": True,
+        }
+        invalid_font = {**valid_font, "unicode": False}
+        coverage = {
+            "matched": 1,
+            "substituted": 0,
+            "missing": 0,
+            "subset_fallback": 0,
+            "substitution_free": True,
+        }
+        card = self.score_with(coverage, [[valid_font], [invalid_font]])
+        self.assertFalse(card["scored"])
+        self.assertFalse(card["fonts"]["all_embedded_subset_unicode"])
+        self.assertIn("pdf_font_contract", card["unscored_reasons"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fourth step of the PDF parity roadmap (#79): a Hancom baseline scoreboard runner using the five-metric contract in `docs/design/21-pdf-parity.md`, plus a machine-readable report mode for `hwp diff`.

- `hwp diff --format json` emits the `hwp-diff-report-v1` contract with `dx`, `dy`, `ink_ratio`, `bad_pixel_pct`, `mae`, dimensions, and render font coverage when available.
- `hwp diff --ours-png <path>` compares two pre-rasterized PDF pages, so metrics 4-5 use the same pinned Poppler rasterizer on both sides.
- `scripts/pdf-parity.sh` and `tools/pdf_parity.py` collect `pdffonts`, `pdfinfo`, per-page normalized `pdftotext -layout`, and raster metrics into per-case scorecards plus aggregate JSON/CSV scoreboards.
- Closed Draft 2020-12 schemas define the manifest, scorecard, and scoreboard contracts.

## Adversarial hardening

- The manifest is schema-validated before any case field or path is used.
- Placeholder metadata is rejected; the exact Poppler version and every pinned font SHA-256 are verified before rendering.
- Every case requires pinned source and oracle SHA-256 values. Digests are checked before rendering and again before publication.
- Duplicate case names, path escapes, symlinked case inputs, and unsafe output paths are rejected.
- Missing render font coverage fails closed. The `pdffonts` embedded/subset/Unicode contract applies to both our PDF and the oracle PDF.
- All case files are computed first, staged, path-leak checked, schema-validated, and then published with rollback protection.
- Difference image output cannot overwrite either raster input.
- The selftest keeps two independent PDF renders instead of overwriting its oracle.

## Verification

- `scripts/check.sh`: fmt, clippy with `-D warnings`, full workspace tests, PDF parity Python tests, and the structured corpus gate all pass.
- `python3 -m unittest tools/test_pdf_parity.py`: 6 regression tests pass.
- `scripts/pdf-parity.sh selftest`: `annual_report.hwp`, 9 pages, text 9/9 equal, raster 9/9 exact.
- The checked-in placeholder manifest is schema-valid but exits before creating output because required owner pins are still unset.
- GitHub review threads for pin enforcement, preflight validation, duplicate names, PDF font gating, and the typo were answered and resolved.

## Data policy

Committed artifacts contain names, SHA-256 digests, and numeric results only. Oracle PDFs, private documents, and absolute local paths remain uncommitted.

## Out of scope: owner action

- Export 3-5 baselines with Windows Hancom Office 2024 and record the exact Hancom build, Windows version, PDF settings, Poppler version, font hashes, and source/oracle hashes.
- Commit the first numeric scoreboard after those pins and local oracle files are available.
- Keep `MAX_BAD_PIXEL_PCT` at its 0.60 placeholder until PR 7, per issue #79.
