### PR TITLE
fix: add typed preservation gate for native writes

### DIFF
--- a/crates/hwp-cli/src/commands/compose.rs
+++ b/crates/hwp-cli/src/commands/compose.rs
@@ -185,7 +185,7 @@ fn execute_spec_v2_with_source(
         return Ok(report);
     }
     let document = compiled.document;
-    let warnings = crate::commands::output::write_validated(
+    let writer_report = crate::commands::output::write_validated(
         output,
         source_path,
         |staged| {
@@ -198,11 +198,11 @@ fn execute_spec_v2_with_source(
                     crate::commands::convert::write_hwp_structural(&document, staged)
                 }
             } else {
-                Ok(hwpx::write_document(&document, staged)?)
+                Ok(hwpx::write_document_with_report(&document, staged)?)
             }
         },
-        |staged, writer_warnings| {
-            crate::commands::reject_drop_warnings("compose", writer_warnings)?;
+        |staged, writer_report| {
+            crate::commands::reject_preservation_loss("compose", &writer_report.preservation)?;
             if font_files.is_some() {
                 crate::commands::edit::verify_document_quiet(staged, &document)
             } else {
@@ -211,7 +211,7 @@ fn execute_spec_v2_with_source(
             .context("합성 문서 의미 검증 실패")
         },
     )?;
-    report.warnings = warnings;
+    report.warnings = writer_report.warnings;
     Ok(report)
 }
 
@@ -242,7 +242,7 @@ pub(crate) fn execute_spec_with_source_and_fonts(
     }
 
     let document = compiled.document;
-    let warnings = crate::commands::output::write_validated(
+    let writer_report = crate::commands::output::write_validated(
         output,
         source_path,
         |staged| {
@@ -255,11 +255,11 @@ pub(crate) fn execute_spec_with_source_and_fonts(
                     crate::commands::convert::write_hwp_structural(&document, staged)
                 }
             } else {
-                Ok(hwpx::write_document(&document, staged)?)
+                Ok(hwpx::write_document_with_report(&document, staged)?)
             }
         },
-        |staged, writer_warnings| {
-            crate::commands::reject_drop_warnings("compose", writer_warnings)?;
+        |staged, writer_report| {
+            crate::commands::reject_preservation_loss("compose", &writer_report.preservation)?;
             if font_files.is_some() {
                 crate::commands::edit::verify_document_quiet(staged, &document)
             } else {
@@ -268,7 +268,7 @@ pub(crate) fn execute_spec_with_source_and_fonts(
             .context("합성 문서 의미 검증 실패")
         },
     )?;
-    report.warnings = warnings;
+    report.warnings = writer_report.warnings;
     Ok(report)
 }
 

--- a/crates/hwp-cli/src/commands/convert.rs
+++ b/crates/hwp-cli/src/commands/convert.rs
@@ -24,6 +24,7 @@ pub struct MdOpts<'a> {
 #[derive(Debug, Default)]
 pub struct ConvertReport {
     pub warnings: Vec<String>,
+    pub preservation: hwp_model::PreservationReport,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -48,6 +49,7 @@ pub fn run(
         font_dirs,
     )?;
     print_warnings(&report.warnings);
+    crate::commands::preservation::print_report(&report.preservation);
     eprintln!("변환 완료: {} → {}", input.display(), output.display());
     Ok(())
 }
@@ -294,64 +296,103 @@ pub fn execute(
             },
             |_, _, _| Ok(()),
         )?;
-        return Ok(ConvertReport { warnings });
+        return Ok(ConvertReport {
+            warnings,
+            preservation: hwp_model::PreservationReport::new(),
+        });
     }
 
-    let warnings = crate::commands::output::write_validated(
+    let source_format = crate::format::detect(input)?;
+    let same_native_format = matches!(
+        (source_format, target),
+        (crate::format::FileFormat::Hwp5, ConvertFormat::Hwp)
+            | (crate::format::FileFormat::Hwpx, ConvertFormat::Hwpx)
+    );
+    let write_report = crate::commands::output::write_validated(
         output,
         Some(input),
-        |staged| match target {
-            ConvertFormat::Md => unreachable!("Markdown은 sidecar 트랜잭션 경로에서 처리"),
-            ConvertFormat::Html => {
-                std::fs::write(staged, hwp_convert::to_html(&doc))?;
-                Ok(Vec::new())
-            }
-            ConvertFormat::Txt => {
-                std::fs::write(staged, doc.plain_text())?;
-                Ok(Vec::new())
-            }
-            ConvertFormat::Csv => {
-                std::fs::write(staged, hwp_convert::to_csv(&doc))?;
-                Ok(Vec::new())
-            }
-            ConvertFormat::Docx => {
-                std::fs::write(staged, hwp_convert::to_docx(&doc)?)?;
-                Ok(Vec::new())
-            }
-            ConvertFormat::Odt => {
-                std::fs::write(staged, hwp_convert::to_odt(&doc)?)?;
-                Ok(Vec::new())
-            }
-            ConvertFormat::Pdf => {
-                let result =
-                    hwp_render::render_document_pdf(&doc, &pdf_render_opts(font_dirs), None)?;
-                std::fs::write(staged, &result.data)?;
-                Ok(render_issue_messages(&result.report))
-            }
-            ConvertFormat::Json => {
-                std::fs::write(staged, hwp_convert::to_json(&doc, true, embed_bin)?)?;
-                Ok(Vec::new())
-            }
-            ConvertFormat::Hwpx => Ok(hwpx::write::write_document_with(
-                &doc,
-                staged,
-                &hwpx::write::HwpxWriteOptions {
-                    preserve_linesegs: preserve_layout,
-                },
-            )?),
-            ConvertFormat::Hwp => write_hwp(&doc, staged, preserve_layout),
-        },
-        |staged, warnings| {
-            // DROP 여부를 게시 전에 판정한다. strict 실패 시 기존 destination은 그대로다.
+        |staged| {
+            let mut report = match target {
+                ConvertFormat::Md => {
+                    unreachable!("Markdown은 sidecar 트랜잭션 경로에서 처리")
+                }
+                ConvertFormat::Html => {
+                    std::fs::write(staged, hwp_convert::to_html(&doc))?;
+                    hwp_model::WriteReport::new()
+                }
+                ConvertFormat::Txt => {
+                    std::fs::write(staged, doc.plain_text())?;
+                    hwp_model::WriteReport::new()
+                }
+                ConvertFormat::Csv => {
+                    std::fs::write(staged, hwp_convert::to_csv(&doc))?;
+                    hwp_model::WriteReport::new()
+                }
+                ConvertFormat::Docx => {
+                    std::fs::write(staged, hwp_convert::to_docx(&doc)?)?;
+                    hwp_model::WriteReport::new()
+                }
+                ConvertFormat::Odt => {
+                    std::fs::write(staged, hwp_convert::to_odt(&doc)?)?;
+                    hwp_model::WriteReport::new()
+                }
+                ConvertFormat::Pdf => {
+                    let result =
+                        hwp_render::render_document_pdf(&doc, &pdf_render_opts(font_dirs), None)?;
+                    std::fs::write(staged, &result.data)?;
+                    hwp_model::WriteReport {
+                        warnings: render_issue_messages(&result.report),
+                        preservation: hwp_model::PreservationReport::new(),
+                    }
+                }
+                ConvertFormat::Json => {
+                    std::fs::write(staged, hwp_convert::to_json(&doc, true, embed_bin)?)?;
+                    hwp_model::WriteReport::new()
+                }
+                ConvertFormat::Hwpx => hwpx::write::write_document_with_report_with(
+                    &doc,
+                    staged,
+                    &hwpx::write::HwpxWriteOptions {
+                        preserve_linesegs: preserve_layout,
+                    },
+                )?,
+                ConvertFormat::Hwp => write_hwp(&doc, staged, preserve_layout)?,
+            };
+
             if matches!(target, ConvertFormat::Hwp | ConvertFormat::Hwpx) {
-                bail_on_strict(strict, warnings)?;
+                if same_native_format {
+                    report.preservation.extend(
+                        crate::commands::preservation::inspect_same_format_container(
+                            input, staged,
+                        )?,
+                    );
+                }
+                let output_document = load_document(staged)
+                    .with_context(|| format!("변환 문서 재읽기 실패: {}", staged.display()))?;
+                report.preservation.extend(
+                    crate::commands::preservation::inspect_conversion_semantics(
+                        &doc,
+                        &output_document,
+                    ),
+                );
+            }
+            Ok(report)
+        },
+        |staged, report| {
+            if matches!(target, ConvertFormat::Hwp | ConvertFormat::Hwpx) {
+                if same_native_format || strict {
+                    crate::commands::reject_preservation_loss("convert", &report.preservation)?;
+                }
                 load_document(staged)
                     .with_context(|| format!("변환 문서 재읽기 실패: {}", staged.display()))?;
             }
             Ok(())
         },
     )?;
-    Ok(ConvertReport { warnings })
+    Ok(ConvertReport {
+        warnings: write_report.warnings,
+        preservation: write_report.preservation,
+    })
 }
 
 fn markdown_media_paths(
@@ -398,31 +439,6 @@ pub(crate) fn print_warnings(warnings: &[String]) {
     for w in warnings {
         eprintln!("경고: {w}");
     }
-}
-
-/// `--strict`이고 보존 불가(`DROP:`) 경고가 있으면 비정상 종료한다.
-/// 구조 보존 대상(hwp/hwpx)에만 의미가 있다 (md/html/pdf는 본디 손실 변환).
-fn bail_on_strict(strict: bool, warnings: &[String]) -> anyhow::Result<()> {
-    if !strict {
-        return Ok(());
-    }
-    let drops: Vec<&str> = warnings
-        .iter()
-        .filter(|w| w.starts_with("DROP: "))
-        .map(|w| w.as_str())
-        .collect();
-    if drops.is_empty() {
-        return Ok(());
-    }
-    anyhow::bail!(
-        "--strict: 보존 불가 데이터 {}건 드롭\n{}",
-        drops.len(),
-        drops
-            .iter()
-            .map(|w| format!("  - {}", w.trim_start_matches("DROP: ")))
-            .collect::<Vec<_>>()
-            .join("\n")
-    );
 }
 
 /// `--font-dir`가 비었으면 `HWP_FONT_DIR`(없으면 `fonts/`)로 기본 폰트 디렉터리를 정한다.
@@ -479,7 +495,7 @@ pub fn write_hwp(
     doc: &hwp_model::Document,
     output: &std::path::Path,
     preserve_layout: bool,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<hwp_model::WriteReport> {
     write_hwp_impl(doc, output, preserve_layout, false, None)
 }
 
@@ -496,7 +512,7 @@ pub fn write_hwp(
 pub fn write_hwp_edited(
     doc: &hwp_model::Document,
     output: &std::path::Path,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<hwp_model::WriteReport> {
     if doc.meta.source_format == "hwp5" {
         // 원본 줄 배치 보존(preserve), 합성 정규화 없음 — 편집 문단만 count=0.
         write_hwp_impl(doc, output, true, false, None)
@@ -513,7 +529,7 @@ pub fn write_hwp_edited(
 pub fn write_hwp_structural(
     doc: &hwp_model::Document,
     output: &std::path::Path,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<hwp_model::WriteReport> {
     write_hwp_impl(doc, output, false, true, None)
 }
 
@@ -526,7 +542,7 @@ pub fn write_hwp_structural_isolated(
     doc: &hwp_model::Document,
     output: &std::path::Path,
     font_files: &[std::path::PathBuf],
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<hwp_model::WriteReport> {
     if font_files.is_empty() {
         anyhow::bail!("isolated HWP writer requires at least one explicit font file");
     }
@@ -539,7 +555,7 @@ fn write_hwp_impl(
     preserve_layout: bool,
     edited: bool,
     isolated_font_files: Option<&[std::path::PathBuf]>,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<hwp_model::WriteReport> {
     let font_dir =
         std::path::PathBuf::from(std::env::var("HWP_FONT_DIR").unwrap_or_else(|_| "fonts".into()));
     let synthesize = doc.meta.source_format != "hwp5" || edited;
@@ -549,7 +565,7 @@ fn write_hwp_impl(
         .flat_map(|s| &s.paragraphs)
         .any(|p| !p.line_segs.is_empty());
 
-    let mut report: Vec<String> = Vec::new();
+    let mut report = hwp_model::WriteReport::new();
     let owned;
     let doc = if !synthesize || preserve_layout {
         // hwp5 무수정/preserve-layout: 원본 줄 배치 그대로.
@@ -585,7 +601,9 @@ fn write_hwp_impl(
         let mut warns = hwp_render::RenderIssueAccumulator::new();
         hwp_render::lineseg::synthesize_linesegs(&mut d, &mut store, &mut warns);
         warns.absorb(store.issues.finish());
-        report.append(&mut render_issue_messages(&warns.finish()));
+        report
+            .warnings
+            .append(&mut render_issue_messages(&warns.finish()));
         owned = d;
         &owned
     };
@@ -616,7 +634,7 @@ fn write_hwp_impl(
             .and_then(|out| out.pages.first().and_then(|p| p.encode_png().ok()))
     };
 
-    let warnings = hwp5::write_document(
+    let writer_report = hwp5::write_document_with_report(
         doc,
         output,
         &hwp5::WriteOptions {
@@ -625,7 +643,8 @@ fn write_hwp_impl(
             edited,
         },
     )?;
-    report.extend(warnings);
+    report.warnings.extend(writer_report.warnings);
+    report.preservation.extend(writer_report.preservation);
     Ok(report)
 }
 
@@ -676,6 +695,7 @@ fn clear_linesegs(doc: &mut hwp_model::Document) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::{Read as _, Write as _};
     use std::sync::atomic::{AtomicU64, Ordering};
 
     static TEST_SEQUENCE: AtomicU64 = AtomicU64::new(0);
@@ -710,13 +730,82 @@ mod tests {
             None,
             |staged| {
                 std::fs::write(staged, b"PARTIAL CONVERSION")?;
-                Ok(vec!["DROP: 지원하지 않는 테스트 컨트롤".to_string()])
+                let mut report = hwp_model::WriteReport::new();
+                report.loss(
+                    hwp_model::PreservationCode::OpaqueControlUnrepresentable,
+                    hwp_model::PreservationResourceKind::Control,
+                    hwp_model::PreservationDisposition::Unrepresentable,
+                    1,
+                );
+                Ok(report)
             },
-            |_, warnings| bail_on_strict(true, warnings),
+            |_, report| crate::commands::reject_preservation_loss("convert", &report.preservation),
         );
         assert!(result.is_err());
         assert_eq!(std::fs::read(&destination).unwrap(), b"ORIGINAL");
         std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn same_format_container_loss_fails_closed_without_strict() {
+        let sequence = TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "hwp-convert-preservation-test-{}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let generated = dir.join("generated.hwpx");
+        let source = dir.join("source.hwpx");
+        let destination = dir.join("result.hwpx");
+        hwpx::write_document(
+            &hwp_convert::from_markdown("owner-authored fixture"),
+            &generated,
+        )
+        .unwrap();
+        append_synthetic_package_entry(&generated, &source);
+        std::fs::write(&destination, b"ORIGINAL").unwrap();
+
+        let result = execute(
+            &source,
+            &destination,
+            Some(ConvertFormat::Hwpx),
+            false,
+            false,
+            false,
+            &MdOpts::default(),
+            Vec::new(),
+        );
+
+        let error = format!("{:#}", result.unwrap_err());
+        assert!(
+            error.contains("hwpx_package_entry_removed: 1 item(s)"),
+            "{error}"
+        );
+        assert_eq!(std::fs::read(&destination).unwrap(), b"ORIGINAL");
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    fn append_synthetic_package_entry(source: &Path, output: &Path) {
+        let mut archive = zip::ZipArchive::new(std::fs::File::open(source).unwrap()).unwrap();
+        let mut writer = zip::ZipWriter::new(std::fs::File::create(output).unwrap());
+        for index in 0..archive.len() {
+            let mut entry = archive.by_index(index).unwrap();
+            let options =
+                zip::write::SimpleFileOptions::default().compression_method(entry.compression());
+            writer.start_file(entry.name(), options).unwrap();
+            let mut bytes = Vec::new();
+            entry.read_to_end(&mut bytes).unwrap();
+            writer.write_all(&bytes).unwrap();
+        }
+        writer
+            .start_file(
+                "SyntheticOpaque/entry.bin",
+                zip::write::SimpleFileOptions::default()
+                    .compression_method(zip::CompressionMethod::Deflated),
+            )
+            .unwrap();
+        writer.write_all(b"owner-authored opaque payload").unwrap();
+        writer.finish().unwrap();
     }
 
     #[test]

--- a/crates/hwp-cli/src/commands/corpus.rs
+++ b/crates/hwp-cli/src/commands/corpus.rs
@@ -1062,12 +1062,12 @@ fn generate(
             if !read.warnings.is_empty() {
                 anyhow::bail!("intermediate HWPX emitted warnings")
             }
-            let warnings = crate::commands::convert::write_hwp_structural_isolated(
+            let writer_report = crate::commands::convert::write_hwp_structural_isolated(
                 &read.document,
                 output,
                 font_files,
             )?;
-            crate::commands::reject_drop_warnings("corpus", &warnings)
+            crate::commands::reject_preservation_loss("corpus", &writer_report.preservation)
         })();
         let cleanup = if intermediate.is_file() {
             fs::remove_file(&intermediate).context("corpus intermediate cleanup failed")

--- a/crates/hwp-cli/src/commands/edit.rs
+++ b/crates/hwp-cli/src/commands/edit.rs
@@ -240,6 +240,7 @@ pub struct EditReport {
     pub output: String,
     pub applied: usize,
     pub warnings: Vec<String>,
+    pub preservation: hwp_model::PreservationReport,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -407,6 +408,7 @@ impl EditPlan {
 pub fn run(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<()> {
     let report = execute(input, output, plan)?;
     crate::commands::convert::print_warnings(&report.warnings);
+    crate::commands::preservation::print_report(&report.preservation);
     eprintln!("편집 완료: {} → {}", input.display(), output.display());
     Ok(())
 }
@@ -448,6 +450,7 @@ pub fn execute(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<E
             output: output.display().to_string(),
             applied: report.applied_requests,
             warnings: report.warnings,
+            preservation: hwp_model::PreservationReport::new(),
         });
     }
 
@@ -954,13 +957,30 @@ pub fn execute(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<E
         .iter()
         .map(|request| format!("미적용 편집 요청: {request}"))
         .collect::<Vec<_>>();
-    let writer_warnings = crate::commands::output::write_validated(
+    let writer_report = crate::commands::output::write_validated(
         output,
         Some(input),
-        |staged| write_output(&doc, staged, structural, output_format),
-        |staged, writer_warnings| {
+        |staged| {
+            let mut report = write_output(&doc, staged, structural, output_format)?;
             if output_format.supports_verify() {
-                crate::commands::reject_drop_warnings("edit", writer_warnings)?;
+                let removed_binary_allowance =
+                    crate::commands::preservation::intentional_removed_binary_assets(
+                        &original_doc,
+                        &doc,
+                    );
+                report.preservation.extend(
+                    crate::commands::preservation::inspect_same_format_container_with_binary_allowance(
+                        input,
+                        staged,
+                        removed_binary_allowance,
+                    )?,
+                );
+            }
+            Ok(report)
+        },
+        |staged, writer_report| {
+            if output_format.supports_verify() {
+                crate::commands::reject_preservation_loss("edit", &writer_report.preservation)?;
             }
             if plan.verify {
                 verify_output(staged, Some(&doc))?;
@@ -968,11 +988,12 @@ pub fn execute(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<E
             Ok(())
         },
     )?;
-    warnings.extend(writer_warnings);
+    warnings.extend(writer_report.warnings);
     Ok(EditReport {
         output: output.display().to_string(),
         applied: edits,
         warnings,
+        preservation: writer_report.preservation,
     })
 }
 
@@ -1389,21 +1410,21 @@ fn write_output(
     output: &Path,
     structural: bool,
     output_format: OutputFormat,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<hwp_model::WriteReport> {
     match output_format {
         // 구조 편집은 삽입 문단/행에 불변식을 세우려 합성 경로를 강제한다.
         OutputFormat::Hwp if structural => {
             crate::commands::convert::write_hwp_structural(doc, output)
         }
         OutputFormat::Hwp => crate::commands::convert::write_hwp_edited(doc, output),
-        OutputFormat::Hwpx => Ok(hwpx::write_document(doc, output)?),
+        OutputFormat::Hwpx => Ok(hwpx::write_document_with_report(doc, output)?),
         OutputFormat::Json => {
             fs::write(output, hwp_convert::to_json(doc, true, true)?)?;
-            Ok(Vec::new())
+            Ok(hwp_model::WriteReport::new())
         }
         OutputFormat::Markdown => {
             fs::write(output, hwp_convert::to_markdown(doc))?;
-            Ok(Vec::new())
+            Ok(hwp_model::WriteReport::new())
         }
     }
 }

--- a/crates/hwp-cli/src/commands/fill.rs
+++ b/crates/hwp-cli/src/commands/fill.rs
@@ -24,6 +24,7 @@ pub struct FillReport {
     pub filled: usize,
     pub rows_added: usize,
     pub warnings: Vec<String>,
+    pub preservation: hwp_model::PreservationReport,
 }
 
 pub fn run(
@@ -58,6 +59,7 @@ pub fn run(
     };
 
     let report = execute(input, output, set, data_value.as_ref(), allow_partial, &[])?;
+    crate::commands::preservation::print_report(&report.preservation);
 
     if json {
         println!("{}", serde_json::to_string_pretty(&report_json(&report))?);
@@ -254,6 +256,7 @@ pub fn execute_values(
         filled: total,
         rows_added: 0,
         warnings: report_warnings,
+        preservation: hwp_model::PreservationReport::new(),
     })
 }
 
@@ -381,18 +384,24 @@ fn fill_tables_ir(
         ));
     }
 
-    let writer_warnings = crate::commands::output::write_validated(
+    let writer_report = crate::commands::output::write_validated(
         output,
         Some(input),
-        |staged| write_table_fill(&doc, staged, added > 0),
-        |staged, writer_warnings| {
-            crate::commands::reject_drop_warnings("fill", writer_warnings)?;
+        |staged| {
+            let mut report = write_table_fill(&doc, staged, added > 0)?;
+            report.preservation.extend(
+                crate::commands::preservation::inspect_same_format_container(input, staged)?,
+            );
+            Ok(report)
+        },
+        |staged, writer_report| {
+            crate::commands::reject_preservation_loss("fill", &writer_report.preservation)?;
             ensure_valid_document(staged)?;
             crate::commands::edit::verify_document(staged, &doc)?;
             Ok(())
         },
     )?;
-    warnings.extend(writer_warnings);
+    warnings.extend(writer_report.warnings);
 
     Ok(FillReport {
         output: output.display().to_string(),
@@ -410,6 +419,7 @@ fn fill_tables_ir(
         filled,
         rows_added: added,
         warnings,
+        preservation: writer_report.preservation,
     })
 }
 
@@ -540,18 +550,24 @@ fn fill_parts_ir(
         warnings.push(format!("미치환 자리표시자: {}", unmatched.join(", ")));
     }
 
-    let writer_warnings = crate::commands::output::write_validated(
+    let writer_report = crate::commands::output::write_validated(
         output,
         Some(input),
-        |staged| write_table_fill(&doc, staged, true),
-        |staged, writer_warnings| {
-            crate::commands::reject_drop_warnings("fill", writer_warnings)?;
+        |staged| {
+            let mut report = write_table_fill(&doc, staged, true)?;
+            report.preservation.extend(
+                crate::commands::preservation::inspect_same_format_container(input, staged)?,
+            );
+            Ok(report)
+        },
+        |staged, writer_report| {
+            crate::commands::reject_preservation_loss("fill", &writer_report.preservation)?;
             ensure_valid_document(staged)?;
             crate::commands::edit::verify_document(staged, &doc)?;
             Ok(())
         },
     )?;
-    warnings.extend(writer_warnings);
+    warnings.extend(writer_report.warnings);
 
     Ok(FillReport {
         output: output.display().to_string(),
@@ -561,6 +577,7 @@ fn fill_parts_ir(
         filled,
         rows_added: 0,
         warnings,
+        preservation: writer_report.preservation,
     })
 }
 
@@ -649,7 +666,7 @@ fn write_table_fill(
     doc: &hwp_model::Document,
     output: &Path,
     structural: bool,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<hwp_model::WriteReport> {
     match output
         .extension()
         .and_then(|extension| extension.to_str())
@@ -658,7 +675,7 @@ fn write_table_fill(
     {
         Some("hwp") if structural => crate::commands::convert::write_hwp_structural(doc, output),
         Some("hwp") => crate::commands::convert::write_hwp_edited(doc, output),
-        Some("hwpx") => Ok(hwpx::write_document(doc, output)?),
+        Some("hwpx") => Ok(hwpx::write_document_with_report(doc, output)?),
         other => anyhow::bail!("fill 출력은 .hwp 또는 .hwpx만 지원합니다 (확장자: {other:?})"),
     }
 }

--- a/crates/hwp-cli/src/commands/mcp.rs
+++ b/crates/hwp-cli/src/commands/mcp.rs
@@ -1346,6 +1346,7 @@ fn tool_edit(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
             "output": report.output,
             "applied": report.applied,
             "warnings": report.warnings,
+            "preservation": report.preservation,
         }))
         .unwrap_or_default(),
     )])
@@ -1433,6 +1434,7 @@ fn tool_convert(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
             "output": request.output,
             "strict": request.strict,
             "warnings": report.warnings,
+            "preservation": report.preservation,
         }))
         .unwrap_or_default(),
     )])
@@ -1467,6 +1469,7 @@ fn tool_new(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
         &serde_json::to_string_pretty(&json!({
             "output": report.output,
             "warnings": report.warnings,
+            "preservation": report.preservation,
         }))
         .unwrap_or_default(),
     )])
@@ -2784,9 +2787,11 @@ mod tests {
             &ctx(),
         );
         assert!(
-            result
-                .as_ref()
-                .is_err_and(|error| error.contains("보존 불가") && error.contains("zzzz")),
+            result.as_ref().is_err_and(|error| {
+                error.contains("보존 불가")
+                    && error.contains("opaque_control_unrepresentable")
+                    && !error.contains("zzzz")
+            }),
             "DROP은 hard failure여야: {result:?}"
         );
         assert_eq!(std::fs::read(&destination).unwrap(), b"ORIGINAL");

--- a/crates/hwp-cli/src/commands/mod.rs
+++ b/crates/hwp-cli/src/commands/mod.rs
@@ -14,6 +14,7 @@ pub mod info;
 pub mod mcp;
 pub mod new;
 pub(crate) mod output;
+pub(crate) mod preservation;
 pub mod render;
 pub mod skill;
 pub mod slots;
@@ -21,27 +22,4 @@ pub mod template;
 pub mod update;
 pub mod validate;
 
-/// 구조 문서 writer의 보존 불가 경고를 게시 전에 거부한다.
-///
-/// `DROP:`은 단순 진단이 아니라 요청한 문서 내용이 산출물에서 사라졌다는 뜻이다.
-/// `new`/`edit`처럼 작성 결과가 정본이 되는 명령은 parseable한 파일이라도 게시하지
-/// 않는다. 손실 변환이 본래 목적일 수 있는 markdown/pdf 등은 이 함수를 호출하지 않는다.
-pub(crate) fn reject_drop_warnings(context: &str, warnings: &[String]) -> anyhow::Result<()> {
-    let drops: Vec<&str> = warnings
-        .iter()
-        .filter(|warning| warning.starts_with("DROP: "))
-        .map(String::as_str)
-        .collect();
-    if drops.is_empty() {
-        return Ok(());
-    }
-    anyhow::bail!(
-        "{context}: 보존 불가 데이터 {}건을 드롭할 수 없어 출력을 게시하지 않습니다\n{}",
-        drops.len(),
-        drops
-            .iter()
-            .map(|warning| format!("  - {}", warning.trim_start_matches("DROP: ")))
-            .collect::<Vec<_>>()
-            .join("\n")
-    )
-}
+pub(crate) use preservation::reject_loss as reject_preservation_loss;

--- a/crates/hwp-cli/src/commands/new.rs
+++ b/crates/hwp-cli/src/commands/new.rs
@@ -20,6 +20,7 @@ pub enum NewInput<'a> {
 pub struct NewReport {
     pub output: String,
     pub warnings: Vec<String>,
+    pub preservation: hwp_model::PreservationReport,
 }
 
 pub fn run(
@@ -51,6 +52,7 @@ pub fn run(
     };
     let report = execute(output, input, set_meta, preset, strict)?;
     crate::commands::convert::print_warnings(&report.warnings);
+    crate::commands::preservation::print_report(&report.preservation);
     eprintln!("생성 완료: {}", output.display());
     Ok(())
 }
@@ -137,27 +139,28 @@ pub fn execute(
         hwp_convert::apply_meta(&mut doc, spec).map_err(|e| anyhow::anyhow!(e))?;
     }
 
-    let mut warnings = crate::commands::output::write_validated(
+    let mut writer_report = crate::commands::output::write_validated(
         output,
         None,
         |staged| {
             if write_hwp {
                 crate::commands::convert::write_hwp(&doc, staged, false)
             } else {
-                Ok(hwpx::write_document(&doc, staged)?)
+                Ok(hwpx::write_document_with_report(&doc, staged)?)
             }
         },
-        |staged, writer_warnings| {
-            crate::commands::reject_drop_warnings("new", writer_warnings)?;
+        |staged, writer_report| {
+            crate::commands::reject_preservation_loss("new", &writer_report.preservation)?;
             crate::commands::cat::load_document(staged)
                 .map_err(|e| anyhow::anyhow!("생성 문서 재읽기 실패: {e:#}"))?;
             Ok(())
         },
     )?;
     // markdown import 경고(계약 위반 드롭 등)를 리포트에 실어 CLI/MCP에서 프로그램적으로 보이게 한다.
-    warnings.extend(import_warnings);
+    writer_report.warnings.extend(import_warnings);
     Ok(NewReport {
         output: output.display().to_string(),
-        warnings,
+        warnings: writer_report.warnings,
+        preservation: writer_report.preservation,
     })
 }

--- a/crates/hwp-cli/src/commands/preservation.rs
+++ b/crates/hwp-cli/src/commands/preservation.rs
@@ -1,0 +1,521 @@
+//! Content-free preservation accounting for native document publication.
+//!
+//! Paths, package entry names, document text, and payload hashes are used only
+//! inside the comparison. Public reports contain stable codes and aggregate
+//! counts.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use hwp_model::{
+    Control, Document, Paragraph, PreservationCode, PreservationDisposition, PreservationEvent,
+    PreservationReport, PreservationResourceKind,
+};
+use sha2::{Digest as _, Sha256};
+
+use crate::format::FileFormat;
+
+/// Compare native containers after a same-format write.
+pub(crate) fn inspect_same_format_container(
+    source: &Path,
+    output: &Path,
+) -> anyhow::Result<PreservationReport> {
+    inspect_same_format_container_with_binary_allowance(source, output, 0)
+}
+
+/// Compare native containers while allowing only the exact number of binary
+/// entries deliberately removed by the requested edit.
+pub(crate) fn inspect_same_format_container_with_binary_allowance(
+    source: &Path,
+    output: &Path,
+    removed_binary_allowance: usize,
+) -> anyhow::Result<PreservationReport> {
+    let source_format = crate::format::detect(source)?;
+    let output_format = crate::format::detect(output)?;
+    if source_format != output_format {
+        return Ok(PreservationReport::new());
+    }
+    match source_format {
+        FileFormat::Hwp5 => inspect_hwp_container(source, output, removed_binary_allowance),
+        FileFormat::Hwpx => inspect_hwpx_package(source, output, removed_binary_allowance),
+    }
+}
+
+pub(crate) fn intentional_removed_binary_assets(source: &Document, edited: &Document) -> usize {
+    removed_multiset_count(
+        resolved_picture_asset_multiset(source),
+        resolved_picture_asset_multiset(edited),
+    )
+}
+
+/// Compare semantic resources for conversion, irrespective of container format.
+pub(crate) fn inspect_conversion_semantics(
+    source: &Document,
+    output: &Document,
+) -> PreservationReport {
+    let mut report = PreservationReport::new();
+
+    let removed_assets = removed_multiset_count(binary_multiset(source), binary_multiset(output));
+    record_removed(
+        &mut report,
+        PreservationCode::BinaryAssetRemoved,
+        PreservationResourceKind::BinaryAsset,
+        removed_assets,
+    );
+
+    let source_controls = control_multiset(source);
+    let output_controls = control_multiset(output);
+    let removed_controls = removed_multiset_count(source_controls, output_controls);
+    record_removed(
+        &mut report,
+        PreservationCode::ControlRemoved,
+        PreservationResourceKind::Control,
+        removed_controls,
+    );
+
+    let removed_relationships = resolved_picture_relationships(source)
+        .saturating_sub(resolved_picture_relationships(output));
+    record_removed(
+        &mut report,
+        PreservationCode::BinaryRelationshipRemoved,
+        PreservationResourceKind::Relationship,
+        removed_relationships,
+    );
+
+    let removed_metadata = metadata_values(source)
+        .into_iter()
+        .zip(metadata_values(output))
+        .filter(|(source, output)| source.is_some() && source != output)
+        .count()
+        + usize::from(
+            source.metadata.create_time.is_some()
+                && source.metadata.create_time != output.metadata.create_time,
+        )
+        + usize::from(
+            source.metadata.modify_time.is_some()
+                && source.metadata.modify_time != output.metadata.modify_time,
+        );
+    record_removed(
+        &mut report,
+        PreservationCode::MetadataValueRemoved,
+        PreservationResourceKind::Metadata,
+        removed_metadata,
+    );
+
+    report
+}
+
+pub(crate) fn reject_loss(context: &str, report: &PreservationReport) -> anyhow::Result<()> {
+    if report.is_lossless() {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "{context}: 보존 불가 데이터 {}건을 제거하거나 변경할 수 없어 출력을 게시하지 않습니다\n{}",
+        report.events.iter().map(|event| event.count).sum::<usize>(),
+        report
+            .events
+            .iter()
+            .map(|event| format!("  - {}: {} item(s)", event.code, event.count))
+            .collect::<Vec<_>>()
+            .join("\n")
+    )
+}
+
+pub(crate) fn print_report(report: &PreservationReport) {
+    for event in &report.events {
+        eprintln!(
+            "보존 경고: {} ({:?}, {:?}, {} item(s))",
+            event.code, event.resource, event.disposition, event.count
+        );
+    }
+}
+
+fn inspect_hwp_container(
+    source: &Path,
+    output: &Path,
+    removed_binary_allowance: usize,
+) -> anyhow::Result<PreservationReport> {
+    let mut source_container = hwp5::Hwp5Container::open(source)?;
+    let mut output_container = hwp5::Hwp5Container::open(output)?;
+    let source_streams = source_container
+        .list_streams()
+        .into_iter()
+        .map(|entry| entry.path)
+        .collect::<BTreeSet<_>>();
+    let output_streams = output_container
+        .list_streams()
+        .into_iter()
+        .map(|entry| entry.path)
+        .collect::<BTreeSet<_>>();
+    let source_storages = source_container
+        .list_storages()
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let output_storages = output_container
+        .list_storages()
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+
+    let mut report = PreservationReport::new();
+    let removed_streams = source_streams.difference(&output_streams);
+    let (removed_binary_streams, removed_other_streams): (Vec<_>, Vec<_>) =
+        removed_streams.partition(|path| path.starts_with("/BinData/"));
+    record_removed(
+        &mut report,
+        PreservationCode::HwpContainerStreamRemoved,
+        PreservationResourceKind::ContainerStream,
+        removed_other_streams.len()
+            + removed_binary_streams
+                .len()
+                .saturating_sub(removed_binary_allowance),
+    );
+    record_removed(
+        &mut report,
+        PreservationCode::HwpContainerStorageRemoved,
+        PreservationResourceKind::ContainerStorage,
+        source_storages.difference(&output_storages).count(),
+    );
+
+    let changed = source_streams
+        .intersection(&output_streams)
+        .filter(|path| is_hwp_opaque_stream(path))
+        .try_fold(0usize, |count, path| {
+            let source_bytes = source_container.read_stream_raw(path)?;
+            let output_bytes = output_container.read_stream_raw(path)?;
+            Ok::<_, hwp5::Hwp5Error>(count + usize::from(source_bytes != output_bytes))
+        })?;
+    record_changed(
+        &mut report,
+        PreservationCode::HwpOpaqueStreamChanged,
+        PreservationResourceKind::ContainerStream,
+        changed,
+    );
+    Ok(report)
+}
+
+fn inspect_hwpx_package(
+    source: &Path,
+    output: &Path,
+    removed_binary_allowance: usize,
+) -> anyhow::Result<PreservationReport> {
+    let mut source_package = hwpx::HwpxPackage::open(source)?;
+    let mut output_package = hwpx::HwpxPackage::open(output)?;
+    let source_entries = source_package
+        .entries()?
+        .into_iter()
+        .map(|entry| entry.name)
+        .filter(|name| !name.ends_with('/'))
+        .collect::<BTreeSet<_>>();
+    let output_entries = output_package
+        .entries()?
+        .into_iter()
+        .map(|entry| entry.name)
+        .filter(|name| !name.ends_with('/'))
+        .collect::<BTreeSet<_>>();
+
+    let mut report = PreservationReport::new();
+    let removed_entries = source_entries.difference(&output_entries);
+    let (removed_binary_entries, removed_other_entries): (Vec<_>, Vec<_>) =
+        removed_entries.partition(|name| name.starts_with("BinData/"));
+    record_removed(
+        &mut report,
+        PreservationCode::HwpxPackageEntryRemoved,
+        PreservationResourceKind::PackageEntry,
+        removed_other_entries.len()
+            + removed_binary_entries
+                .len()
+                .saturating_sub(removed_binary_allowance),
+    );
+
+    let changed = source_entries
+        .intersection(&output_entries)
+        .filter(|name| is_hwpx_opaque_entry(name))
+        .try_fold(0usize, |count, name| {
+            let source_bytes = source_package.read_entry(name)?;
+            let output_bytes = output_package.read_entry(name)?;
+            Ok::<_, hwpx::HwpxError>(count + usize::from(source_bytes != output_bytes))
+        })?;
+    record_changed(
+        &mut report,
+        PreservationCode::HwpxOpaqueEntryChanged,
+        PreservationResourceKind::PackageEntry,
+        changed,
+    );
+    Ok(report)
+}
+
+fn is_hwp_opaque_stream(path: &str) -> bool {
+    path != "/FileHeader"
+        && path != "/DocInfo"
+        && !path.starts_with("/BodyText/")
+        && !path.starts_with("/BinData/")
+        && path != "/\u{5}HwpSummaryInformation"
+        && path != "/PrvText"
+        && path != "/PrvImage"
+}
+
+fn is_hwpx_opaque_entry(name: &str) -> bool {
+    name != "mimetype"
+        && name != "version.xml"
+        && name != "settings.xml"
+        && name != "META-INF/container.xml"
+        && name != "META-INF/manifest.xml"
+        && name != "Contents/header.xml"
+        && name != "Contents/content.hpf"
+        && !name.starts_with("Contents/section")
+        && !name.starts_with("BinData/")
+        && !name.starts_with("Preview/")
+}
+
+fn record_removed(
+    report: &mut PreservationReport,
+    code: PreservationCode,
+    resource: PreservationResourceKind,
+    count: usize,
+) {
+    if count > 0 {
+        report.record(PreservationEvent::new(
+            code,
+            resource,
+            PreservationDisposition::Removed,
+            count,
+        ));
+    }
+}
+
+fn record_changed(
+    report: &mut PreservationReport,
+    code: PreservationCode,
+    resource: PreservationResourceKind,
+    count: usize,
+) {
+    if count > 0 {
+        report.record(PreservationEvent::new(
+            code,
+            resource,
+            PreservationDisposition::ChangedNonTarget,
+            count,
+        ));
+    }
+}
+
+fn binary_multiset(document: &Document) -> BTreeMap<[u8; 32], usize> {
+    let mut values = BTreeMap::new();
+    for stream in &document.bin_streams {
+        let digest: [u8; 32] = Sha256::digest(&stream.data).into();
+        *values.entry(digest).or_default() += 1;
+    }
+    values
+}
+
+fn control_multiset(document: &Document) -> BTreeMap<[u8; 4], usize> {
+    let mut values = BTreeMap::new();
+    for paragraph in document
+        .sections
+        .iter()
+        .flat_map(|section| section.paragraphs.iter())
+    {
+        collect_paragraph_controls(paragraph, &mut values, None);
+    }
+    values
+}
+
+fn resolved_picture_relationships(document: &Document) -> usize {
+    let mut count = 0usize;
+    for paragraph in document
+        .sections
+        .iter()
+        .flat_map(|section| section.paragraphs.iter())
+    {
+        let mut ignored = BTreeMap::new();
+        collect_paragraph_controls(paragraph, &mut ignored, Some((document, &mut count)));
+    }
+    count
+}
+
+fn resolved_picture_asset_multiset(document: &Document) -> BTreeMap<[u8; 32], usize> {
+    fn visit(document: &Document, paragraph: &Paragraph, values: &mut BTreeMap<[u8; 32], usize>) {
+        for control in &paragraph.controls {
+            if let Control::Picture(picture) = control
+                && let Some(bytes) = document.resolve_bin(&picture.bin_ref)
+            {
+                let digest: [u8; 32] = Sha256::digest(bytes).into();
+                *values.entry(digest).or_default() += 1;
+            }
+            let mut visit_nested = |paragraph: &Paragraph| visit(document, paragraph, values);
+            match control {
+                Control::Table(table) => {
+                    for cell in &table.cells {
+                        for paragraph in &cell.paragraphs {
+                            visit_nested(paragraph);
+                        }
+                    }
+                    if let Some(caption) = &table.caption {
+                        for paragraph in &caption.paragraphs {
+                            visit_nested(paragraph);
+                        }
+                    }
+                }
+                Control::Picture(picture) => {
+                    if let Some(caption) = &picture.caption {
+                        for paragraph in &caption.paragraphs {
+                            visit_nested(paragraph);
+                        }
+                    }
+                }
+                Control::Generic(generic) => {
+                    for list in &generic.paragraph_lists {
+                        for paragraph in &list.paragraphs {
+                            visit_nested(paragraph);
+                        }
+                    }
+                    if let Some(caption) = &generic.caption {
+                        for paragraph in &caption.paragraphs {
+                            visit_nested(paragraph);
+                        }
+                    }
+                }
+                Control::SectionDef(_) => {}
+            }
+        }
+    }
+
+    let mut values = BTreeMap::new();
+    for paragraph in document
+        .sections
+        .iter()
+        .flat_map(|section| section.paragraphs.iter())
+    {
+        visit(document, paragraph, &mut values);
+    }
+    values
+}
+
+fn collect_paragraph_controls(
+    paragraph: &Paragraph,
+    values: &mut BTreeMap<[u8; 4], usize>,
+    mut relationships: Option<(&Document, &mut usize)>,
+) {
+    for control in &paragraph.controls {
+        *values.entry(control.ctrl_id()).or_default() += 1;
+        if let Control::Picture(picture) = control
+            && let Some((document, count)) = relationships.as_mut()
+            && document.resolve_bin(&picture.bin_ref).is_some()
+        {
+            **count += 1;
+        }
+        let mut visit = |nested: &Paragraph| {
+            collect_paragraph_controls(
+                nested,
+                values,
+                relationships
+                    .as_mut()
+                    .map(|(document, count)| (*document, &mut **count)),
+            );
+        };
+        match control {
+            Control::Table(table) => {
+                for cell in &table.cells {
+                    for nested in &cell.paragraphs {
+                        visit(nested);
+                    }
+                }
+                if let Some(caption) = &table.caption {
+                    for nested in &caption.paragraphs {
+                        visit(nested);
+                    }
+                }
+            }
+            Control::Picture(picture) => {
+                if let Some(caption) = &picture.caption {
+                    for nested in &caption.paragraphs {
+                        visit(nested);
+                    }
+                }
+            }
+            Control::Generic(generic) => {
+                for list in &generic.paragraph_lists {
+                    for nested in &list.paragraphs {
+                        visit(nested);
+                    }
+                }
+                if let Some(caption) = &generic.caption {
+                    for nested in &caption.paragraphs {
+                        visit(nested);
+                    }
+                }
+            }
+            Control::SectionDef(_) => {}
+        }
+    }
+}
+
+fn metadata_values(document: &Document) -> [Option<&str>; 6] {
+    [
+        document.metadata.title.as_deref(),
+        document.metadata.author.as_deref(),
+        document.metadata.subject.as_deref(),
+        document.metadata.keywords.as_deref(),
+        document.metadata.description.as_deref(),
+        document.metadata.last_saved_by.as_deref(),
+    ]
+}
+
+fn removed_multiset_count<K: Ord>(source: BTreeMap<K, usize>, output: BTreeMap<K, usize>) -> usize {
+    source
+        .into_iter()
+        .map(|(key, count)| count.saturating_sub(output.get(&key).copied().unwrap_or(0)))
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hwp_model::{BinStream, Metadata};
+
+    #[test]
+    fn semantic_report_is_content_free_and_counts_removed_resources() {
+        let source = Document {
+            metadata: Metadata {
+                title: Some("private title".to_string()),
+                create_time: Some(123),
+                ..Metadata::default()
+            },
+            bin_streams: vec![BinStream {
+                name: "private/name.png".to_string(),
+                data: b"private bytes".to_vec(),
+            }],
+            ..Document::default()
+        };
+        let output = Document::default();
+        let report = inspect_conversion_semantics(&source, &output);
+
+        assert_eq!(report.events.len(), 2);
+        assert!(report.events.iter().any(|event| {
+            event.code == PreservationCode::BinaryAssetRemoved
+                && event.resource == PreservationResourceKind::BinaryAsset
+                && event.count == 1
+        }));
+        assert!(report.events.iter().any(|event| {
+            event.code == PreservationCode::MetadataValueRemoved
+                && event.resource == PreservationResourceKind::Metadata
+                && event.count == 2
+        }));
+        assert!(report.events.iter().all(|event| {
+            !event.code.as_str().contains("private") && !event.code.as_str().contains('/')
+        }));
+    }
+
+    #[test]
+    fn reject_loss_uses_only_bounded_event_codes() {
+        let mut report = PreservationReport::new();
+        record_removed(
+            &mut report,
+            PreservationCode::ControlRemoved,
+            PreservationResourceKind::Control,
+            3,
+        );
+        let error = reject_loss("convert", &report).unwrap_err().to_string();
+        assert!(error.contains("control_removed: 3 item(s)"));
+    }
+}

--- a/crates/hwp-cli/src/commands/template.rs
+++ b/crates/hwp-cli/src/commands/template.rs
@@ -323,7 +323,7 @@ fn ensure_report_budget(plan: &template_spec::ExpansionPlan) -> anyhow::Result<(
 
 fn verify_reference_output(path: &Path) -> anyhow::Result<()> {
     let read = hwpx::read_document(path).context("reference output semantic read failed")?;
-    crate::commands::reject_drop_warnings("template", &read.warnings)?;
+    reject_read_warnings("template", &read.warnings)?;
     let validation = crate::commands::validate::validate_json(path);
     if validation.get("valid").and_then(serde_json::Value::as_bool) != Some(true) {
         anyhow::bail!("reference output package validation failed");
@@ -369,18 +369,37 @@ fn validate_reference_counts(
 
 fn strict_reference_gate(input: &Path, output: &Path) -> anyhow::Result<()> {
     let read = hwpx::read_document(input).context("reference read failed")?;
-    crate::commands::reject_drop_warnings("template reference read", &read.warnings)?;
+    reject_read_warnings("template reference read", &read.warnings)?;
     crate::commands::output::validate_without_publish(
         output,
         Some(input),
-        |staged| Ok(hwpx::write_document(&read.document, staged)?),
-        |staged, warnings| {
-            crate::commands::reject_drop_warnings("template reference regeneration", warnings)?;
+        |staged| {
+            let mut report = hwpx::write_document_with_report(&read.document, staged)?;
+            report.preservation.extend(
+                crate::commands::preservation::inspect_same_format_container(input, staged)?,
+            );
+            Ok(report)
+        },
+        |staged, report| {
+            crate::commands::reject_preservation_loss(
+                "template reference regeneration",
+                &report.preservation,
+            )?;
             crate::commands::edit::verify_document(staged, &read.document)
                 .context("reference strict semantic gate failed")
         },
     )?;
     Ok(())
+}
+
+fn reject_read_warnings(context: &str, warnings: &[String]) -> anyhow::Result<()> {
+    if warnings.is_empty() {
+        return Ok(());
+    }
+    anyhow::bail!(
+        "{context}: strict reference read emitted {} diagnostic(s)",
+        warnings.len()
+    )
 }
 
 fn recheck_reference(path: &Path, base_dir: &Path, roots: &[PathBuf]) -> anyhow::Result<()> {

--- a/crates/hwp-convert/src/from_html.rs
+++ b/crates/hwp-convert/src/from_html.rs
@@ -125,6 +125,7 @@ pub fn from_html_with(html: &str, opts: &HtmlImportOptions) -> Result<Document, 
         bin_streams: blocks.bin_streams,
         hwpx_settings_xml: None,
         hwpx_version_xml: None,
+        hwpx_preview_image: None,
         hwp5_xml_template: Vec::new(),
         hwp5_doc_history: Vec::new(),
     })

--- a/crates/hwp-convert/src/from_markdown.rs
+++ b/crates/hwp-convert/src/from_markdown.rs
@@ -520,6 +520,7 @@ fn from_markdown_inner(
             bin_streams: b.bin_streams,
             hwpx_settings_xml: None,
             hwpx_version_xml: None,
+            hwpx_preview_image: None,
             hwp5_xml_template: Vec::new(),
             hwp5_doc_history: Vec::new(),
         },

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -27,6 +27,10 @@ pub struct Document {
     /// 통과시키기 위한 슬롯. hwp5 출신 문서는 `None`(쓰기 시 기본 상수).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hwpx_version_xml: Option<String>,
+    /// Raw HWPX preview image bytes. The payload is intentionally excluded from
+    /// JSON, like [`BinStream::data`], and exists only for same-format pass-through.
+    #[serde(skip)]
+    pub hwpx_preview_image: Option<Vec<u8>>,
     /// hwp5 `/XMLTemplate` 스토리지의 스트림 원문(스트림 CFB 경로 + 압축 미해제
     /// 바이트). XML 스키마 바인딩 문서(전자정부 서식 등, §3.2.10)의 부속 파트를 IR
     /// 경유 되쓰기에서 그대로 통과시키는 슬롯. 내용은 해석하지 않는다. hwpx 출신·해당

--- a/crates/hwp-model/src/lib.rs
+++ b/crates/hwp-model/src/lib.rs
@@ -21,6 +21,7 @@ pub mod ids;
 pub mod list;
 pub mod opaque;
 pub mod paragraph;
+pub mod preservation;
 pub mod text;
 pub mod units;
 
@@ -37,6 +38,10 @@ pub use header::{
 pub use ids::{BinDataId, BorderFillId, CharShapeId, FaceNameId, ParaShapeId, StyleId};
 pub use opaque::OpaqueRecord;
 pub use paragraph::{CharKind, HwpChar, LineSeg, ParaHeaderInfo, Paragraph, char_kind, ctrl_char};
+pub use preservation::{
+    PRESERVATION_REPORT_CONTRACT, PreservationCode, PreservationDisposition, PreservationEvent,
+    PreservationReport, PreservationResourceKind, WriteReport,
+};
 pub use text::TextOptions;
 pub use units::{
     HwpUnit, filetime_to_iso8601_utc, filetime_to_korean_kst, iso8601_utc_to_filetime,

--- a/crates/hwp-model/src/preservation.rs
+++ b/crates/hwp-model/src/preservation.rs
@@ -1,0 +1,257 @@
+//! Typed preservation diagnostics shared by the HWP and HWPX writers.
+//!
+//! These types deliberately carry only bounded, content-free identifiers. Format
+//! readers and writers may keep private hashes and entry names while comparing
+//! containers, but public reports must expose only stable codes, resource classes,
+//! dispositions, and aggregate counts.
+
+use serde::{Deserialize, Serialize};
+
+pub const PRESERVATION_REPORT_CONTRACT: &str = "hwp-preservation-report-v1";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PreservationCode {
+    BinaryAssetRemoved,
+    BinaryRelationshipRemoved,
+    ControlMetadataUnrepresentable,
+    ControlRemoved,
+    GsoHeaderUnrepresentable,
+    GsoShapeUnrepresentable,
+    HwpContainerStorageRemoved,
+    HwpContainerStreamRemoved,
+    HwpOpaqueStreamChanged,
+    HwpxOpaqueEntryChanged,
+    HwpxPackageEntryRemoved,
+    MetadataValueRemoved,
+    OpaqueControlUnrepresentable,
+    PictureControlRemoved,
+}
+
+impl PreservationCode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::BinaryAssetRemoved => "binary_asset_removed",
+            Self::BinaryRelationshipRemoved => "binary_relationship_removed",
+            Self::ControlMetadataUnrepresentable => "control_metadata_unrepresentable",
+            Self::ControlRemoved => "control_removed",
+            Self::GsoHeaderUnrepresentable => "gso_header_unrepresentable",
+            Self::GsoShapeUnrepresentable => "gso_shape_unrepresentable",
+            Self::HwpContainerStorageRemoved => "hwp_container_storage_removed",
+            Self::HwpContainerStreamRemoved => "hwp_container_stream_removed",
+            Self::HwpOpaqueStreamChanged => "hwp_opaque_stream_changed",
+            Self::HwpxOpaqueEntryChanged => "hwpx_opaque_entry_changed",
+            Self::HwpxPackageEntryRemoved => "hwpx_package_entry_removed",
+            Self::MetadataValueRemoved => "metadata_value_removed",
+            Self::OpaqueControlUnrepresentable => "opaque_control_unrepresentable",
+            Self::PictureControlRemoved => "picture_control_removed",
+        }
+    }
+}
+
+impl std::fmt::Display for PreservationCode {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PreservationResourceKind {
+    ContainerStream,
+    ContainerStorage,
+    PackageEntry,
+    Control,
+    BinaryAsset,
+    Relationship,
+    Metadata,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PreservationDisposition {
+    Removed,
+    ChangedNonTarget,
+    Unrepresentable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PreservationEvent {
+    pub code: PreservationCode,
+    pub resource: PreservationResourceKind,
+    pub disposition: PreservationDisposition,
+    pub count: usize,
+}
+
+impl PreservationEvent {
+    pub fn new(
+        code: PreservationCode,
+        resource: PreservationResourceKind,
+        disposition: PreservationDisposition,
+        count: usize,
+    ) -> Self {
+        Self {
+            code,
+            resource,
+            disposition,
+            count: count.max(1),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PreservationReport {
+    #[serde(default = "contract")]
+    pub contract: String,
+    #[serde(default)]
+    pub events: Vec<PreservationEvent>,
+}
+
+fn contract() -> String {
+    PRESERVATION_REPORT_CONTRACT.to_string()
+}
+
+impl PreservationReport {
+    pub fn new() -> Self {
+        Self {
+            contract: contract(),
+            events: Vec::new(),
+        }
+    }
+
+    pub fn record(&mut self, event: PreservationEvent) {
+        if let Some(existing) = self.events.iter_mut().find(|existing| {
+            existing.code == event.code
+                && existing.resource == event.resource
+                && existing.disposition == event.disposition
+        }) {
+            existing.count = existing.count.saturating_add(event.count);
+        } else {
+            self.events.push(event);
+        }
+        self.events.sort_by(|left, right| {
+            (&left.code, left.resource, left.disposition).cmp(&(
+                &right.code,
+                right.resource,
+                right.disposition,
+            ))
+        });
+    }
+
+    pub fn extend(&mut self, other: Self) {
+        for event in other.events {
+            self.record(event);
+        }
+    }
+
+    pub fn is_lossless(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    pub fn status(&self) -> &'static str {
+        if self.is_lossless() {
+            "clean"
+        } else {
+            "loss_detected"
+        }
+    }
+}
+
+impl Default for PreservationReport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct WriteReport {
+    pub warnings: Vec<String>,
+    pub preservation: PreservationReport,
+}
+
+impl WriteReport {
+    pub fn new() -> Self {
+        Self {
+            warnings: Vec::new(),
+            preservation: PreservationReport::new(),
+        }
+    }
+
+    pub fn warning(&mut self, message: impl Into<String>) {
+        self.warnings.push(message.into());
+    }
+
+    pub fn loss(
+        &mut self,
+        code: PreservationCode,
+        resource: PreservationResourceKind,
+        disposition: PreservationDisposition,
+        count: usize,
+    ) {
+        self.preservation
+            .record(PreservationEvent::new(code, resource, disposition, count));
+    }
+
+    /// Compatibility rendering for callers that still consume the legacy list.
+    pub fn into_legacy_warnings(mut self) -> Vec<String> {
+        self.warnings
+            .extend(self.preservation.events.iter().map(|event| {
+                format!(
+                    "DROP: {} ({:?}, {} item(s))",
+                    event.code, event.resource, event.count
+                )
+            }));
+        self.warnings
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn events_are_aggregated_and_sorted_without_payloads() {
+        let mut report = PreservationReport::new();
+        report.record(PreservationEvent::new(
+            PreservationCode::OpaqueControlUnrepresentable,
+            PreservationResourceKind::Control,
+            PreservationDisposition::Unrepresentable,
+            1,
+        ));
+        report.record(PreservationEvent::new(
+            PreservationCode::BinaryAssetRemoved,
+            PreservationResourceKind::BinaryAsset,
+            PreservationDisposition::Removed,
+            2,
+        ));
+        report.record(PreservationEvent::new(
+            PreservationCode::BinaryAssetRemoved,
+            PreservationResourceKind::BinaryAsset,
+            PreservationDisposition::Removed,
+            3,
+        ));
+
+        assert_eq!(report.status(), "loss_detected");
+        assert_eq!(report.events.len(), 2);
+        assert_eq!(report.events[0].code, PreservationCode::BinaryAssetRemoved);
+        assert_eq!(report.events[0].count, 5);
+        assert!(
+            report
+                .events
+                .iter()
+                .all(|event| !event.code.as_str().contains('/'))
+        );
+        assert!(
+            report
+                .events
+                .iter()
+                .all(|event| !event.code.as_str().contains("sha256"))
+        );
+        assert_eq!(
+            PreservationReport::default().contract,
+            PRESERVATION_REPORT_CONTRACT
+        );
+    }
+}

--- a/crates/hwp5/src/container.rs
+++ b/crates/hwp5/src/container.rs
@@ -61,6 +61,23 @@ impl Hwp5Container {
         v
     }
 
+    /// Lists every storage in path order, excluding the root storage (`/`).
+    ///
+    /// Preservation checks must detect removal of empty opaque storages as well
+    /// as streams. Paths are used only for private aggregation and never appear
+    /// in the public report.
+    pub fn list_storages(&self) -> Vec<String> {
+        let mut storages: Vec<String> = self
+            .cfb
+            .walk()
+            .filter(|entry| entry.is_storage())
+            .map(|entry| entry.path().to_string_lossy().replace('\\', "/"))
+            .filter(|path| path != "/")
+            .collect();
+        storages.sort();
+        storages
+    }
+
     /// Certification-oriented stream enumeration. The entry and normalized
     /// name budgets are enforced while walking the CFB directory, before a
     /// caller can clone all paths into a stream cache.

--- a/crates/hwp5/src/lib.rs
+++ b/crates/hwp5/src/lib.rs
@@ -33,4 +33,4 @@ pub use error::Hwp5Error;
 pub use file_header::FileHeader;
 pub use read::{BoundedReadLimits, BoundedReadSnapshot, ReadResult, ScriptPresence, read_document};
 pub use summary::parse_summary;
-pub use write::{WriteOptions, write_document};
+pub use write::{WriteOptions, write_document, write_document_with_report};

--- a/crates/hwp5/src/read.rs
+++ b/crates/hwp5/src/read.rs
@@ -302,6 +302,7 @@ fn read_document_from_streams(
         bin_streams,
         hwpx_settings_xml: None,
         hwpx_version_xml: None,
+        hwpx_preview_image: None,
         hwp5_xml_template,
         hwp5_doc_history,
     };
@@ -386,6 +387,7 @@ pub fn read_document(path: &Path) -> Result<ReadResult> {
         // hwp5 출신 문서는 hwpx 부속 파트가 없다 → None(쓰기 시 기본 상수).
         hwpx_settings_xml: None,
         hwpx_version_xml: None,
+        hwpx_preview_image: None,
         hwp5_xml_template,
         hwp5_doc_history,
     };

--- a/crates/hwp5/src/write.rs
+++ b/crates/hwp5/src/write.rs
@@ -11,8 +11,9 @@ use std::path::Path;
 
 use hwp_model::{
     BorderLine, Caption, CaptionDirection, CaptionSide, Cell, CharShape, Control, Document,
-    FaceName, HwpChar, LANG_COUNT, Metadata, OpaqueRecord, ParaShape, Paragraph, Picture, RawEntry,
-    Section, SectionDef, Style, Table,
+    FaceName, HwpChar, LANG_COUNT, Metadata, OpaqueRecord, ParaShape, Paragraph, Picture,
+    PreservationCode, PreservationDisposition, PreservationResourceKind, RawEntry, Section,
+    SectionDef, Style, Table, WriteReport,
 };
 
 use crate::codec::{ByteWriter, compress};
@@ -40,8 +41,21 @@ pub struct WriteOptions {
 }
 
 /// 문서를 HWP 5.0 파일로 저장한다. 경고(평탄화/드롭) 목록을 반환한다.
+///
+/// This is the legacy compatibility surface. New callers should use
+/// [`write_document_with_report`] so preservation events remain typed rather
+/// than being reconstructed from warning strings.
 pub fn write_document(doc: &Document, path: &Path, opts: &WriteOptions) -> Result<Vec<String>> {
-    let mut warnings = Vec::new();
+    write_document_with_report(doc, path, opts).map(WriteReport::into_legacy_warnings)
+}
+
+/// Writes an HWP 5.0 document and returns typed warnings and preservation events.
+pub fn write_document_with_report(
+    doc: &Document,
+    path: &Path,
+    opts: &WriteOptions,
+) -> Result<WriteReport> {
+    let mut report = WriteReport::new();
 
     // hwpx 출신 문서 정규화: hwp5 레코드(SHAPE_COMPONENT)가 없는 그림은
     // 쓸 수 없으므로 컨트롤과 확장 문자를 동기 제거한다
@@ -62,14 +76,14 @@ pub fn write_document(doc: &Document, path: &Path, opts: &WriteOptions) -> Resul
         // hwpx/md 출신 이미지에 hwp5 도형 레코드(SHAPE_COMPONENT + 그림)를 먼저
         // 합성한다 — 합성되면 extras가 채워져 아래 strip이 드롭하지 않는다.
         if synth_pictures {
-            synthesize_pictures(&mut d, &mut warnings);
+            synthesize_pictures(&mut d, &mut report);
         }
         if synth_gso {
-            degrade_hwpx_gso(&mut d, &mut warnings);
+            degrade_hwpx_gso(&mut d, &mut report);
         }
         for section in &mut d.sections {
             for para in &mut section.paragraphs {
-                strip_unwritable_pictures(para, &mut warnings);
+                strip_unwritable_pictures(para, &mut report);
             }
         }
         // 합성 5.1.x 문서: 줄 배치(PARA_LINE_SEG)를 합성한다. 5.1.x는 줄 배치
@@ -104,7 +118,7 @@ pub fn write_document(doc: &Document, path: &Path, opts: &WriteOptions) -> Resul
     };
 
     // 레코드 스트림 구성
-    let doc_info_nodes = emit_doc_info(doc, &mut warnings);
+    let doc_info_nodes = emit_doc_info(doc, &mut report);
     let doc_info = RecordNode::serialize_forest(&doc_info_nodes);
     // PARA_HEADER 꼬리 게이트: 5.0.3.2 이상은 '변경추적 병합 문단여부' UINT16이
     // 필수다(스펙 표 58, 전체 길이 24B). 합성 문단(tail 비어 있음)에만 적용해
@@ -125,7 +139,7 @@ pub fn write_document(doc: &Document, path: &Path, opts: &WriteOptions) -> Resul
                 synthesize,
                 opts.preserve_linesegs,
                 add_tracking_tail,
-                &mut warnings,
+                &mut report,
             );
             if synthesize {
                 assign_instance_ids(&mut roots, &mut inst_counter);
@@ -199,7 +213,7 @@ pub fn write_document(doc: &Document, path: &Path, opts: &WriteOptions) -> Resul
         }
     }
     if bin_written < doc.bin_streams.len() {
-        warnings.push(format!(
+        report.warning(format!(
             "BinData {}개 중 {}개만 동봉 (hwp5 BIN_DATA 테이블이 참조하는 항목만)",
             doc.bin_streams.len(),
             bin_written
@@ -262,7 +276,7 @@ pub fn write_document(doc: &Document, path: &Path, opts: &WriteOptions) -> Resul
         cfb.set_modified_time(&entry_path, cfb_epoch)?;
     }
     cfb.flush()?;
-    Ok(warnings)
+    Ok(report)
 }
 
 /// PARA_HEADER instance_id(offset 18~22)가 0이면 유니크 non-zero 값을 부여.
@@ -620,13 +634,13 @@ pub fn is_materialized_generated_picture(picture: &hwp_model::Picture, media: &[
 
 /// hwpx-출신 글상자의 문단을 본문으로 hoist해 텍스트를 보존한다(도형 래퍼는 생략).
 /// 순수 장식 도형은 건드리지 않아 strip이 드롭한다. 본문·표 셀·중첩 리스트 재귀.
-fn degrade_hwpx_gso(doc: &mut Document, warnings: &mut Vec<String>) {
+fn degrade_hwpx_gso(doc: &mut Document, warnings: &mut WriteReport) {
     for section in &mut doc.sections {
         degrade_hwpx_gso_list(&mut section.paragraphs, warnings);
     }
 }
 
-fn degrade_hwpx_gso_list(paras: &mut Vec<Paragraph>, warnings: &mut Vec<String>) {
+fn degrade_hwpx_gso_list(paras: &mut Vec<Paragraph>, warnings: &mut WriteReport) {
     // 중첩 컨테이너(표 셀·모든 Generic 문단 리스트)를 먼저 재귀 처리한다.
     for p in paras.iter_mut() {
         for c in &mut p.controls {
@@ -662,7 +676,7 @@ fn degrade_hwpx_gso_list(paras: &mut Vec<Paragraph>, warnings: &mut Vec<String>)
                     hoisted.extend(l.paragraphs.iter().cloned());
                 }
                 removed.push(i as u32);
-                warnings.push(
+                warnings.warning(
                     "hwpx 출신 글상자를 본문 텍스트로 저하(도형 래퍼 생략 — 한글 수용)".to_string(),
                 );
             }
@@ -743,7 +757,7 @@ fn has_synthesizable_picture(doc: &Document) -> bool {
 }
 
 /// 합성 문서의 hwpx 출신 이미지에 도형 레코드 + BIN_DATA 항목을 채운다.
-fn synthesize_pictures(doc: &mut Document, warnings: &mut Vec<String>) {
+fn synthesize_pictures(doc: &mut Document, warnings: &mut WriteReport) {
     let bin_names: Vec<String> = doc.bin_streams.iter().map(|b| b.name.clone()).collect();
     if bin_names.is_empty() {
         return;
@@ -863,7 +877,7 @@ fn synth_pictures_para(
     inst: &mut u32,
     new_items: &mut Vec<hwp_model::BinDataItem>,
     renames: &mut Vec<(usize, String)>,
-    warnings: &mut Vec<String>,
+    warnings: &mut WriteReport,
 ) {
     for control in &mut para.controls {
         match control {
@@ -879,7 +893,12 @@ fn synth_pictures_para(
                     .position(|n| !item_ref.is_empty() && n.contains(&item_ref))
                     .or(if bin_names.is_empty() { None } else { Some(0) });
                 let Some(idx) = pick else {
-                    warnings.push("DROP: 이미지 바이너리 스트림을 찾지 못해 생략".to_string());
+                    warnings.loss(
+                        PreservationCode::BinaryAssetRemoved,
+                        PreservationResourceKind::BinaryAsset,
+                        PreservationDisposition::Removed,
+                        1,
+                    );
                     continue;
                 };
                 // 같은 스트림에 이미 storage_id가 있으면 재사용(공유 이미지).
@@ -1028,7 +1047,7 @@ fn synth_pictures_para(
 fn append_gso_description(
     common: &mut Vec<u8>,
     description: Option<&str>,
-    warnings: &mut Vec<String>,
+    warnings: &mut WriteReport,
 ) {
     let Some(description) = description.filter(|value| !value.is_empty()) else {
         common.extend_from_slice(&0u16.to_le_bytes());
@@ -1036,7 +1055,12 @@ fn append_gso_description(
     };
     let encoded = description.encode_utf16().collect::<Vec<_>>();
     let Ok(len) = u16::try_from(encoded.len()) else {
-        warnings.push("DROP: 그림 개체 설명이 HWP5 u16 길이 한계를 초과해 생략".to_string());
+        warnings.loss(
+            PreservationCode::ControlMetadataUnrepresentable,
+            PreservationResourceKind::Metadata,
+            PreservationDisposition::Unrepresentable,
+            1,
+        );
         common.extend_from_slice(&0u16.to_le_bytes());
         return;
     };
@@ -1048,14 +1072,18 @@ fn append_gso_description(
 
 /// hwp5 레코드가 없는 그림 컨트롤을 확장 문자와 동기 제거하고
 /// 남은 ExtCtrl의 ctrl_index를 재조정한다 (중첩 구조 재귀).
-fn strip_unwritable_pictures(para: &mut Paragraph, warnings: &mut Vec<String>) {
+fn strip_unwritable_pictures(para: &mut Paragraph, warnings: &mut WriteReport) {
     let mut removed: Vec<u32> = Vec::new();
     let mut kept = Vec::with_capacity(para.controls.len());
     for (i, mut control) in std::mem::take(&mut para.controls).into_iter().enumerate() {
         match &mut control {
             Control::Picture(p) if p.extras.is_empty() => {
-                warnings
-                    .push("DROP: hwp5 그림 레코드가 없는 이미지를 생략 (hwpx 출신)".to_string());
+                warnings.loss(
+                    PreservationCode::PictureControlRemoved,
+                    PreservationResourceKind::Control,
+                    PreservationDisposition::Removed,
+                    1,
+                );
                 removed.push(i as u32);
                 continue;
             }
@@ -1070,10 +1098,12 @@ fn strip_unwritable_pictures(para: &mut Paragraph, warnings: &mut Vec<String>) {
                     && !((g.ctrl_id == *b"fn  " || g.ctrl_id == *b"en  ")
                         && !g.paragraph_lists.is_empty()) =>
             {
-                warnings.push(format!(
-                    "DROP: hwp5 페이로드가 없는 {:?} 컨트롤을 생략 (hwpx 출신)",
-                    String::from_utf8_lossy(&g.ctrl_id)
-                ));
+                warnings.loss(
+                    PreservationCode::OpaqueControlUnrepresentable,
+                    PreservationResourceKind::Control,
+                    PreservationDisposition::Unrepresentable,
+                    1,
+                );
                 removed.push(i as u32);
                 continue;
             }
@@ -1511,7 +1541,7 @@ fn hwp_string(w: &mut ByteWriter, s: &str) {
 
 // ─────────────────────────── DocInfo ───────────────────────────
 
-fn emit_doc_info(doc: &Document, _warnings: &mut Vec<String>) -> Vec<RecordNode> {
+fn emit_doc_info(doc: &Document, _warnings: &mut WriteReport) -> Vec<RecordNode> {
     let h = &doc.header;
     let mut roots = Vec::new();
 
@@ -1925,7 +1955,7 @@ fn emit_section(
     synthesize: bool,
     preserve_linesegs: bool,
     add_tracking_tail: bool,
-    warnings: &mut Vec<String>,
+    warnings: &mut WriteReport,
 ) -> Vec<RecordNode> {
     let mut roots: Vec<RecordNode> = section
         .paragraphs
@@ -1949,7 +1979,7 @@ fn emit_paragraph(
     synthesize: bool,
     preserve_linesegs: bool,
     add_tracking_tail: bool,
-    warnings: &mut Vec<String>,
+    warnings: &mut WriteReport,
 ) -> RecordNode {
     // 합성 경로(md/hwpx 출신)는 한글 문단 불변식을 직렬화 시 보정한다. 모든
     // 합성 문단(본문·표 셀·글상자)이 이 단일 지점을 거치므로 누락이 없다.
@@ -2149,13 +2179,17 @@ fn emit_control(
     synthesize: bool,
     preserve_linesegs: bool,
     add_tracking_tail: bool,
-    warnings: &mut Vec<String>,
+    warnings: &mut WriteReport,
 ) -> RecordNode {
     match control {
         Control::SectionDef(def) => emit_section_def(def),
-        Control::Table(table) => {
-            emit_table(table, synthesize, preserve_linesegs, add_tracking_tail)
-        }
+        Control::Table(table) => emit_table(
+            table,
+            synthesize,
+            preserve_linesegs,
+            add_tracking_tail,
+            warnings,
+        ),
         Control::Picture(pic) => emit_picture(
             pic,
             synthesize,
@@ -2207,7 +2241,7 @@ fn emit_control(
                 }
             }
             if !g.extras.is_empty() && !g.paragraph_lists.is_empty() {
-                warnings.push(format!(
+                warnings.warning(format!(
                     "{:?} 컨트롤 내부 구조가 평탄화되어 저장됨 — 한글에서 확인 필요",
                     String::from_utf8_lossy(&g.ctrl_id)
                 ));
@@ -2283,6 +2317,7 @@ fn emit_table(
     synthesize: bool,
     preserve_linesegs: bool,
     add_tracking_tail: bool,
+    report: &mut WriteReport,
 ) -> RecordNode {
     let mut w = ByteWriter::new();
     w.write_bytes(b" lbt");
@@ -2358,7 +2393,6 @@ fn emit_table(
         tw.write_bytes(&table.table_tail);
     }
 
-    let mut cell_warnings = Vec::new();
     // Table 71 caption records precede the TABLE record.
     let mut children = match &table.caption {
         Some(caption) => emit_caption_records(
@@ -2366,7 +2400,7 @@ fn emit_table(
             synthesize,
             preserve_linesegs,
             add_tracking_tail,
-            &mut cell_warnings,
+            report,
         ),
         None => Vec::new(),
     };
@@ -2383,7 +2417,7 @@ fn emit_table(
                 synthesize,
                 preserve_linesegs,
                 add_tracking_tail,
-                &mut cell_warnings,
+                report,
             ));
         }
     }
@@ -2432,7 +2466,7 @@ fn emit_caption_records(
     synthesize: bool,
     preserve_linesegs: bool,
     add_tracking_tail: bool,
-    warnings: &mut Vec<String>,
+    warnings: &mut WriteReport,
 ) -> Vec<RecordNode> {
     let mut out = vec![emit_caption_header(caption)];
     for p in &caption.paragraphs {
@@ -2480,13 +2514,13 @@ fn emit_picture(
     synthesize: bool,
     preserve_linesegs: bool,
     add_tracking_tail: bool,
-    warnings: &mut Vec<String>,
+    warnings: &mut WriteReport,
 ) -> RecordNode {
     let mut w = ByteWriter::new();
     w.write_bytes(b" osg");
     if pic.common_data.is_empty() {
         // hwpx/md 출신: 개체 공통 속성 최소 구성 (글자처럼 취급)
-        warnings.push("그림 개체 공통 속성을 기본값으로 생성 — 한글에서 확인 필요".to_string());
+        warnings.warning("그림 개체 공통 속성을 기본값으로 생성 — 한글에서 확인 필요");
         w.write_u32(u32::from(pic.treat_as_char)); // 속성
         w.write_u32(0); // 세로 오프셋
         w.write_u32(0); // 가로 오프셋
@@ -2577,7 +2611,7 @@ mod tests {
             true,
             false,
             false,
-            &mut Vec::new(),
+            &mut WriteReport::new(),
         );
         assert_eq!(node.children[0].tag, tag::LIST_HEADER);
         assert_eq!(node.children[1].tag, tag::PARA_HEADER);
@@ -2661,15 +2695,15 @@ mod tests {
 
     #[test]
     fn gso_설명_utf16_u16_경계() {
-        let mut warnings = Vec::new();
+        let mut report = WriteReport::new();
         let mut common = Vec::new();
-        append_gso_description(&mut common, Some("😀"), &mut warnings);
+        append_gso_description(&mut common, Some("😀"), &mut report);
         assert_eq!(u16::from_le_bytes(common[0..2].try_into().unwrap()), 2);
         assert_eq!(common.len(), 6);
-        assert!(warnings.is_empty());
+        assert!(report.warnings.is_empty());
 
         let mut max_common = Vec::new();
-        append_gso_description(&mut max_common, Some(&"가".repeat(65_535)), &mut warnings);
+        append_gso_description(&mut max_common, Some(&"가".repeat(65_535)), &mut report);
         assert_eq!(
             u16::from_le_bytes(max_common[0..2].try_into().unwrap()),
             u16::MAX
@@ -2677,12 +2711,105 @@ mod tests {
         assert_eq!(max_common.len(), 2 + 65_535 * 2);
 
         let mut overflow = Vec::new();
-        append_gso_description(&mut overflow, Some(&"가".repeat(65_536)), &mut warnings);
+        append_gso_description(&mut overflow, Some(&"가".repeat(65_536)), &mut report);
         assert_eq!(overflow, 0u16.to_le_bytes());
         assert_eq!(
-            warnings.last().map(String::as_str),
-            Some("DROP: 그림 개체 설명이 HWP5 u16 길이 한계를 초과해 생략")
+            report.preservation.events.as_slice(),
+            &[hwp_model::PreservationEvent::new(
+                PreservationCode::ControlMetadataUnrepresentable,
+                PreservationResourceKind::Metadata,
+                PreservationDisposition::Unrepresentable,
+                1,
+            )]
         );
+    }
+
+    #[test]
+    fn typed_write_report_keeps_loss_events_out_of_ordinary_warnings() {
+        let mut doc = hwp_convert::from_markdown("typed report");
+        doc.sections[0].paragraphs[0]
+            .controls
+            .push(Control::Generic(hwp_model::GenericControl {
+                ctrl_id: *b"head",
+                data: Vec::new(),
+                paragraph_lists: Vec::new(),
+                extras: Vec::new(),
+                raw_children: Vec::new(),
+                gso_shapes: Vec::new(),
+                equation: None,
+                column_def: None,
+                caption: None,
+            }));
+        let output =
+            std::env::temp_dir().join(format!("hwp5-typed-report-{}.hwp", std::process::id()));
+
+        let report = write_document_with_report(&doc, &output, &WriteOptions::default()).unwrap();
+        assert!(
+            report
+                .warnings
+                .iter()
+                .all(|warning| !warning.starts_with("DROP:"))
+        );
+        assert_eq!(report.preservation.events.len(), 1);
+        let event = &report.preservation.events[0];
+        assert_eq!(event.code, PreservationCode::OpaqueControlUnrepresentable);
+        assert_eq!(event.resource, PreservationResourceKind::Control);
+        assert_eq!(event.disposition, PreservationDisposition::Unrepresentable);
+        assert_eq!(event.count, 1);
+
+        let legacy = write_document(&doc, &output, &WriteOptions::default()).unwrap();
+        assert!(
+            legacy
+                .iter()
+                .any(|warning| { warning.starts_with("DROP: opaque_control_unrepresentable") })
+        );
+        std::fs::remove_file(output).unwrap();
+    }
+
+    #[test]
+    fn typed_write_report_accounts_for_missing_picture_payload() {
+        let mut doc = hwp_convert::from_markdown("picture report");
+        doc.sections[0].paragraphs[0]
+            .controls
+            .push(Control::Picture(Picture {
+                common_data: Vec::new(),
+                width: hwp_model::HwpUnit(1000),
+                height: hwp_model::HwpUnit(500),
+                treat_as_char: true,
+                z_order: 0,
+                vert_offset: 0,
+                horz_offset: 0,
+                description: None,
+                crop: None,
+                flip: 0,
+                rotation: None,
+                brightness: 0,
+                contrast: 0,
+                effect_flags: 0,
+                effects_raw: Vec::new(),
+                caption: None,
+                bin_ref: hwp_model::BinRef::ItemRef("missing-image".to_string()),
+                extras: Vec::new(),
+            }));
+        let output = std::env::temp_dir().join(format!(
+            "hwp5-typed-picture-report-{}.hwp",
+            std::process::id()
+        ));
+
+        let report = write_document_with_report(&doc, &output, &WriteOptions::default()).unwrap();
+        assert!(
+            report
+                .warnings
+                .iter()
+                .all(|warning| !warning.starts_with("DROP:"))
+        );
+        assert!(report.preservation.events.iter().any(|event| {
+            event.code == PreservationCode::PictureControlRemoved
+                && event.resource == PreservationResourceKind::Control
+                && event.disposition == PreservationDisposition::Removed
+                && event.count == 1
+        }));
+        std::fs::remove_file(output).unwrap();
     }
 
     fn synth_table(placement: Option<hwp_model::GsoPlacement>) -> Table {
@@ -2716,7 +2843,13 @@ mod tests {
             z_order: 3,
             ..Default::default()
         };
-        let node = emit_table(&synth_table(Some(pl)), true, false, false);
+        let node = emit_table(
+            &synth_table(Some(pl)),
+            true,
+            false,
+            false,
+            &mut WriteReport::new(),
+        );
         assert_eq!(&node.data[0..4], b" lbt", "표 ctrl ID");
         assert_eq!(
             node.data.len(),
@@ -2735,7 +2868,13 @@ mod tests {
         );
 
         // 2) md 출신 경로(placement=None, common_data 비어 있음).
-        let node = emit_table(&synth_table(None), true, false, false);
+        let node = emit_table(
+            &synth_table(None),
+            true,
+            false,
+            false,
+            &mut WriteReport::new(),
+        );
         assert_eq!(node.data.len(), 46, "md 경로: 46B (스펙 표 69 최소)");
         assert_eq!(
             i32::from_le_bytes(node.data[40..44].try_into().unwrap()),

--- a/crates/hwpx/src/lib.rs
+++ b/crates/hwpx/src/lib.rs
@@ -24,4 +24,8 @@ pub use package::{
     PackageLimitsProfile,
 };
 pub use read::{ReadResult, parse_content_meta, read_document, read_structure};
-pub use write::{DEFAULT_SETTINGS_XML, DEFAULT_VERSION_XML, write_document};
+pub use write::{
+    DEFAULT_SETTINGS_XML, DEFAULT_VERSION_XML, HwpxWriteOptions, write_document,
+    write_document_with, write_document_with_limits, write_document_with_report,
+    write_document_with_report_with, write_document_with_report_with_limits,
+};

--- a/crates/hwpx/src/read/mod.rs
+++ b/crates/hwpx/src/read/mod.rs
@@ -92,6 +92,15 @@ fn read_document_impl(path: &Path, load_binary_data: bool) -> Result<ReadResult>
     // 버리지 않는다".
     let hwpx_settings_xml = pkg.read_entry_string("settings.xml").ok();
     let hwpx_version_xml = pkg.read_entry_string("version.xml").ok();
+    let has_preview_image = pkg
+        .entries()?
+        .iter()
+        .any(|entry| entry.name == "Preview/PrvImage.png");
+    let hwpx_preview_image = if load_binary_data && has_preview_image {
+        Some(pkg.read_entry("Preview/PrvImage.png")?)
+    } else {
+        None
+    };
 
     Ok(ReadResult {
         document: Document {
@@ -105,6 +114,7 @@ fn read_document_impl(path: &Path, load_binary_data: bool) -> Result<ReadResult>
             bin_streams,
             hwpx_settings_xml,
             hwpx_version_xml,
+            hwpx_preview_image,
             // hwpx 출신은 hwp5 전용 스토리지가 없다(GE-β7/β8 경로 무관).
             hwp5_xml_template: Vec::new(),
             hwp5_doc_history: Vec::new(),

--- a/crates/hwpx/src/write/mod.rs
+++ b/crates/hwpx/src/write/mod.rs
@@ -11,7 +11,7 @@ use std::fs::File;
 use std::io::Write as _;
 use std::path::Path;
 
-use hwp_model::Document;
+use hwp_model::{Document, WriteReport};
 use zip::CompressionMethod;
 use zip::write::SimpleFileOptions;
 
@@ -38,7 +38,7 @@ pub struct HwpxWriteOptions {
 
 /// 문서를 HWPX 파일로 저장한다 (줄 배치 제거 — 한글이 재계산).
 pub fn write_document(doc: &Document, path: &Path) -> Result<Vec<String>> {
-    write_document_with(doc, path, &HwpxWriteOptions::default())
+    write_document_with_report(doc, path).map(WriteReport::into_legacy_warnings)
 }
 
 /// 옵션 지정 저장.
@@ -47,7 +47,7 @@ pub fn write_document_with(
     path: &Path,
     opts: &HwpxWriteOptions,
 ) -> Result<Vec<String>> {
-    write_document_with_limits(doc, path, opts, &PackageLimits::default())
+    write_document_with_report_with(doc, path, opts).map(WriteReport::into_legacy_warnings)
 }
 
 /// 옵션과 패키지 자원 제한을 지정해 저장한다.
@@ -57,14 +57,47 @@ pub fn write_document_with_limits(
     opts: &HwpxWriteOptions,
     limits: &PackageLimits,
 ) -> Result<Vec<String>> {
-    let mut warnings = Vec::new();
+    write_document_with_report_with_limits(doc, path, opts, limits)
+        .map(WriteReport::into_legacy_warnings)
+}
+
+/// Writes an HWPX document and returns typed preservation diagnostics.
+pub fn write_document_with_report(doc: &Document, path: &Path) -> Result<WriteReport> {
+    write_document_with_report_with(doc, path, &HwpxWriteOptions::default())
+}
+
+/// Writes with options and returns typed preservation diagnostics.
+pub fn write_document_with_report_with(
+    doc: &Document,
+    path: &Path,
+    opts: &HwpxWriteOptions,
+) -> Result<WriteReport> {
+    write_document_with_report_with_limits(doc, path, opts, &PackageLimits::default())
+}
+
+/// Writes with options and package limits, returning typed preservation diagnostics.
+pub fn write_document_with_report_with_limits(
+    doc: &Document,
+    path: &Path,
+    opts: &HwpxWriteOptions,
+    limits: &PackageLimits,
+) -> Result<WriteReport> {
+    let mut report = WriteReport::new();
 
     // 본문 먼저 직렬화 (BinData 수집 포함)
     let mut bins = BinCollector::default();
     let sections: Vec<String> = doc
         .sections
         .iter()
-        .map(|s| section::write_section(doc, s, opts.preserve_linesegs, &mut bins, &mut warnings))
+        .map(|s| {
+            section::write_section_with_report(
+                doc,
+                s,
+                opts.preserve_linesegs,
+                &mut bins,
+                &mut report,
+            )
+        })
         .collect();
     let header_xml = header::write_header(&doc.header, doc.sections.len().max(1));
 
@@ -125,6 +158,12 @@ pub fn write_document_with_limits(
             .map(|(_, href, _, bytes)| (href.clone(), bytes.len() as u64)),
     );
     output_entries.push(("Preview/PrvText.txt".to_string(), preview.len() as u64));
+    if let Some(preview_image) = &doc.hwpx_preview_image {
+        output_entries.push((
+            "Preview/PrvImage.png".to_string(),
+            preview_image.len() as u64,
+        ));
+    }
     output_entries.push(("settings.xml".to_string(), settings_xml.len() as u64));
     validate_output_entries(output_entries, limits)?;
 
@@ -182,9 +221,12 @@ pub fn write_document_with_limits(
         put(&mut zip, href, bytes)?;
     }
     put(&mut zip, "Preview/PrvText.txt", preview.as_bytes())?;
+    if let Some(preview_image) = &doc.hwpx_preview_image {
+        put(&mut zip, "Preview/PrvImage.png", preview_image)?;
+    }
     // settings.xml — 슬롯이 있으면 원문 pass-through, 없으면 기본 상수(바이트 동일).
     put(&mut zip, "settings.xml", settings_xml.as_bytes())?;
 
     zip.finish()?;
-    Ok(warnings)
+    Ok(report)
 }

--- a/crates/hwpx/src/write/section.rs
+++ b/crates/hwpx/src/write/section.rs
@@ -2,14 +2,16 @@
 //!
 //! 런 상태 기계: 문자 모양 경계에서 `<hp:run>`을 전환하며 텍스트를
 //! 흘려보내고, 확장 컨트롤 위치에서 표/그림/머리말 등을 직렬화한다.
-//! 미지원 컨트롤(글상자 등)은 드롭하되 경고로 집계한다.
+//! Unsupported controls are omitted only with a typed preservation event.
 
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
 use hwp_model::{
     BinRef, Caption, CaptionDirection, CaptionSide, Cell, Control, Document, Equation,
-    GenericControl, HwpChar, PageDef, Paragraph, Picture, Section, SectionDef, ShapeKind, Table,
+    GenericControl, HwpChar, PageDef, Paragraph, Picture, PreservationCode,
+    PreservationDisposition, PreservationResourceKind, Section, SectionDef, ShapeKind, Table,
+    WriteReport,
 };
 
 use crate::write::templates::{color_attr, esc};
@@ -54,6 +56,20 @@ pub fn write_section(
     bins: &mut BinCollector,
     warnings: &mut Vec<String>,
 ) -> String {
+    let mut report = WriteReport::new();
+    let output = write_section_with_report(doc, section, preserve_linesegs, bins, &mut report);
+    warnings.extend(report.into_legacy_warnings());
+    output
+}
+
+/// Serializes one section while retaining typed preservation events.
+pub fn write_section_with_report(
+    doc: &Document,
+    section: &Section,
+    preserve_linesegs: bool,
+    bins: &mut BinCollector,
+    report: &mut WriteReport,
+) -> String {
     let mut out = String::with_capacity(16 * 1024);
     out.push_str(
         r##"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">"##,
@@ -74,7 +90,7 @@ pub fn write_section(
             bins,
             inject,
             preserve_linesegs,
-            warnings,
+            report,
         );
     }
     out.push_str("</hs:sec>");
@@ -129,7 +145,7 @@ fn write_paragraph(
     bins: &mut BinCollector,
     inject_secpr: bool,
     preserve_linesegs: bool,
-    warnings: &mut Vec<String>,
+    report: &mut WriteReport,
 ) {
     let _ = write!(
         out,
@@ -256,19 +272,19 @@ fn write_paragraph(
                     Control::Generic(g) if g.ctrl_id == *b"head" || g.ctrl_id == *b"foot" => {
                         open_run!(cur_shape);
                         flush_text(out, &mut text_buf, &mut pending_tabs);
-                        write_header_footer(out, doc, g, ids, bins, preserve_linesegs, warnings);
+                        write_header_footer(out, doc, g, ids, bins, preserve_linesegs, report);
                     }
                     Control::Table(table) => {
                         open_run!(cur_shape);
                         flush_text(out, &mut text_buf, &mut pending_tabs);
-                        write_table(out, doc, table, ids, bins, preserve_linesegs, warnings);
+                        write_table(out, doc, table, ids, bins, preserve_linesegs, report);
                     }
                     Control::Picture(pic) => {
                         open_run!(cur_shape);
                         flush_text(out, &mut text_buf, &mut pending_tabs);
                         shape_break!();
                         let before = out.len();
-                        write_picture(out, doc, pic, ids, bins, warnings);
+                        write_picture(out, doc, pic, ids, bins, report);
                         run_shapes += count_shape_tags(&out[before..]);
                     }
                     Control::Generic(g) if hwp_convert::field::is_field_ctrl_id(&g.ctrl_id) => {
@@ -366,7 +382,7 @@ fn write_paragraph(
                         flush_text(out, &mut text_buf, &mut pending_tabs);
                         shape_break!();
                         let before = out.len();
-                        write_ir_shapes(out, doc, g, ids, bins, preserve_linesegs, warnings);
+                        write_ir_shapes(out, doc, g, ids, bins, preserve_linesegs, report);
                         run_shapes += count_shape_tags(&out[before..]);
                     }
                     Control::Generic(g) if g.ctrl_id == *b"gso " => {
@@ -376,7 +392,7 @@ fn write_paragraph(
                         flush_text(out, &mut text_buf, &mut pending_tabs);
                         shape_break!();
                         let before = out.len();
-                        write_gso(out, doc, g, ids, bins, preserve_linesegs, warnings);
+                        write_gso(out, doc, g, ids, bins, preserve_linesegs, report);
                         run_shapes += count_shape_tags(&out[before..]);
                     }
                     Control::Generic(g) if g.ctrl_id == *b"fn  " || g.ctrl_id == *b"en  " => {
@@ -384,7 +400,7 @@ fn write_paragraph(
                         // 속성을 무시하고 subList 문단만 수집하므로 표준 속성으로 방출한다.
                         open_run!(cur_shape);
                         flush_text(out, &mut text_buf, &mut pending_tabs);
-                        write_foot_end_note(out, doc, g, ids, bins, preserve_linesegs, warnings);
+                        write_foot_end_note(out, doc, g, ids, bins, preserve_linesegs, report);
                     }
                     Control::Generic(g) if g.equation.is_some() => {
                         // 수식 — hp:ctrl이 아닌 run 직속 개체(리더 parse_equation의 역).
@@ -398,11 +414,13 @@ fn write_paragraph(
                         write_equation(out, g, eq, ids);
                         run_shapes += count_shape_tags(&out[before..]);
                     }
-                    Control::Generic(g) => {
-                        warnings.push(format!(
-                            "DROP: hwpx 쓰기 미지원 컨트롤 드롭: {:?}",
-                            String::from_utf8_lossy(&g.ctrl_id)
-                        ));
+                    Control::Generic(_) => {
+                        report.loss(
+                            PreservationCode::OpaqueControlUnrepresentable,
+                            PreservationResourceKind::Control,
+                            PreservationDisposition::Unrepresentable,
+                            1,
+                        );
                     }
                 }
             }
@@ -925,7 +943,7 @@ fn write_header_footer(
     ids: &mut IdSeq,
     bins: &mut BinCollector,
     preserve_linesegs: bool,
-    warnings: &mut Vec<String>,
+    report: &mut WriteReport,
 ) {
     let el = if g.ctrl_id == *b"head" {
         "header"
@@ -943,16 +961,7 @@ fn write_header_footer(
             r##"<hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0">"##,
         );
         for para in &list.paragraphs {
-            write_paragraph(
-                out,
-                doc,
-                para,
-                ids,
-                bins,
-                false,
-                preserve_linesegs,
-                warnings,
-            );
+            write_paragraph(out, doc, para, ids, bins, false, preserve_linesegs, report);
         }
         out.push_str("</hp:subList>");
     }
@@ -970,7 +979,7 @@ fn write_foot_end_note(
     ids: &mut IdSeq,
     bins: &mut BinCollector,
     preserve_linesegs: bool,
-    warnings: &mut Vec<String>,
+    report: &mut WriteReport,
 ) {
     // 한글 저장본 실측 형태(정답지=커밋 픽스처): number는 종류별 1-기반 수열,
     // suffixChar="41", instId는 문서 고유값(정품도 임의 u32 — 큰 베이스로 합성).
@@ -1004,7 +1013,7 @@ fn write_foot_end_note(
                 bins,
                 false,
                 preserve_linesegs,
-                warnings,
+                report,
             );
             const PAGE_SNIP: &str = r##"<hp:ctrl><hp:autoNum numType="PAGE"/></hp:ctrl>"##;
             if buf.contains(PAGE_SNIP) {
@@ -1230,7 +1239,7 @@ fn write_draw_text(
     bins: &mut BinCollector,
     width: i32,
     _preserve_linesegs: bool,
-    warnings: &mut Vec<String>,
+    report: &mut WriteReport,
 ) {
     if g.paragraph_lists.is_empty() {
         return;
@@ -1245,7 +1254,7 @@ fn write_draw_text(
             // 도형 텍스트는 항상 linesegarray를 방출한다(정품 실측 — 한글은 글상자 문단에
             // 줄배치를 항상 담는다). line_segs가 없으면 no-op이라 안전. 본문(전역
             // preserve_linesegs)과 무관하게 강제.
-            write_paragraph(out, doc, para, ids, bins, false, true, warnings);
+            write_paragraph(out, doc, para, ids, bins, false, true, report);
         }
     }
     out.push_str(
@@ -1304,7 +1313,7 @@ fn write_shape_element(
     text: Option<&GenericControl>,
     caption: Option<&Caption>,
     preserve_linesegs: bool,
-    warnings: &mut Vec<String>,
+    report: &mut WriteReport,
 ) {
     let el = match s.kind {
         ShapeKind::Rect => "rect",
@@ -1384,7 +1393,7 @@ fn write_shape_element(
     // shadow(type=NONE)도 정품 실측 필수 요소.
     out.push_str(r##"<hp:shadow type="NONE" color="#B2B2B2" offsetX="0" offsetY="0" alpha="0"/>"##);
     if let Some(g) = text {
-        write_draw_text(out, doc, g, ids, bins, sz.0, preserve_linesegs, warnings);
+        write_draw_text(out, doc, g, ids, bins, sz.0, preserve_linesegs, report);
     }
     // 기하 좌표점은 drawText 뒤(정품 순서). Rect/Ellipse는 bbox 4모서리 pt0~3 —
     // 이 점이 없으면 한글이 도형 외곽을 몰라 렌더하지 않는다(빈 화면 원인).
@@ -1447,7 +1456,7 @@ fn write_shape_element(
         sz.0, sz.1,
     );
     if let Some(caption) = caption {
-        write_caption(out, doc, caption, i64::from(sz.0), ids, bins, warnings);
+        write_caption(out, doc, caption, i64::from(sz.0), ids, bins, report);
     }
     if let Some(description) = s.description.as_deref().filter(|value| !value.is_empty()) {
         let _ = write!(
@@ -1470,10 +1479,15 @@ fn write_gso(
     ids: &mut IdSeq,
     bins: &mut BinCollector,
     preserve_linesegs: bool,
-    warnings: &mut Vec<String>,
+    report: &mut WriteReport,
 ) {
     let Some((attr, voff, hoff, w, h, zorder)) = parse_gso_header(&g.data) else {
-        warnings.push("DROP: gso 공통 헤더 파싱 실패 — 드롭".to_string());
+        report.loss(
+            PreservationCode::GsoHeaderUnrepresentable,
+            PreservationResourceKind::Control,
+            PreservationDisposition::Unrepresentable,
+            1,
+        );
         return;
     };
     let shapes = hwp_convert::gso::shapes_from_raw(&g.raw_children);
@@ -1512,10 +1526,15 @@ fn write_gso(
             Some(g),
             g.caption.as_ref(),
             preserve_linesegs,
-            warnings,
+            report,
         );
     } else if shapes.is_empty() {
-        warnings.push("DROP: gso 도형 해석 실패(ARC/이미지채움 등) — 드롭".to_string());
+        report.loss(
+            PreservationCode::GsoShapeUnrepresentable,
+            PreservationResourceKind::Control,
+            PreservationDisposition::Unrepresentable,
+            1,
+        );
     } else {
         // 장식 도형: 도형별 요소. 배치 = gso 오프셋 + 박스 내 도형 오프셋.
         // ★그룹 도형(도넛=회색+흰 구멍 등, 한 gso 다중 도형)은 gso z-order를 공유하면
@@ -1544,7 +1563,7 @@ fn write_gso(
                 None,
                 (i == 0).then_some(g.caption.as_ref()).flatten(),
                 preserve_linesegs,
-                warnings,
+                report,
             );
         }
     }
@@ -1565,7 +1584,7 @@ fn write_ir_shapes(
     ids: &mut IdSeq,
     bins: &mut BinCollector,
     preserve_linesegs: bool,
-    warnings: &mut Vec<String>,
+    report: &mut WriteReport,
 ) {
     for (i, s) in g.gso_shapes.iter().enumerate() {
         // 글자처럼(anchored)이면 정품 인라인 관례(PARA/COLUMN), 아니면 PAPER 절대 좌표.
@@ -1592,7 +1611,7 @@ fn write_ir_shapes(
             text,
             (i == 0).then_some(g.caption.as_ref()).flatten(),
             preserve_linesegs,
-            warnings,
+            report,
         );
     }
 }
@@ -1610,7 +1629,7 @@ fn write_caption(
     obj_width: i64,
     ids: &mut IdSeq,
     bins: &mut BinCollector,
-    warnings: &mut Vec<String>,
+    report: &mut WriteReport,
 ) {
     let side = match caption.side {
         CaptionSide::Left => "LEFT",
@@ -1635,7 +1654,7 @@ fn write_caption(
         caption.gap,
     );
     for para in &caption.paragraphs {
-        write_paragraph(out, doc, para, ids, bins, false, true, warnings);
+        write_paragraph(out, doc, para, ids, bins, false, true, report);
     }
     out.push_str("</hp:subList></hp:caption>");
 }
@@ -1650,7 +1669,7 @@ fn write_table(
     // 표 셀 줄 배치는 전역 옵션과 무관하게 항상 방출한다(아래 참조). 시그니처는
     // 다른 write_* 와 대칭 유지를 위해 남긴다.
     _preserve_linesegs: bool,
-    warnings: &mut Vec<String>,
+    report: &mut WriteReport,
 ) {
     let cols = table.cols.max(1) as usize;
     let rows = table.rows.max(1) as usize;
@@ -1728,7 +1747,7 @@ fn write_table(
     );
     // hwpxlib TableWriter orders caption after outMargin and before inMargin.
     if let Some(caption) = &table.caption {
-        write_caption(out, doc, caption, sz_w, ids, bins, warnings);
+        write_caption(out, doc, caption, sz_w, ids, bins, report);
     }
     let _ = write!(
         out,
@@ -1766,7 +1785,7 @@ fn write_table(
                 // 잘린다(GE-8 실기 결함). write_paragraph 내부 가드가 line_segs가 있을
                 // 때만 방출하므로, 편집으로 줄 배치를 지운 문단(edit.rs가 clear)·md
                 // 출신(줄 배치 없음)은 자동으로 비게 돼 "변조" 경고 위험이 없다.
-                write_paragraph(out, doc, para, ids, bins, false, true, warnings);
+                write_paragraph(out, doc, para, ids, bins, false, true, report);
             }
             let cm = cell.margins;
             let _ = write!(
@@ -1795,13 +1814,15 @@ fn write_picture(
     pic: &Picture,
     ids: &mut IdSeq,
     bins: &mut BinCollector,
-    warnings: &mut Vec<String>,
+    report: &mut WriteReport,
 ) {
     let Some(item) = bins.register(doc, &pic.bin_ref) else {
-        warnings.push(format!(
-            "DROP: 그림 데이터를 찾지 못해 드롭: {:?}",
-            pic.bin_ref
-        ));
+        report.loss(
+            PreservationCode::BinaryAssetRemoved,
+            PreservationResourceKind::BinaryAsset,
+            PreservationDisposition::Removed,
+            1,
+        );
         return;
     };
     let (w, h) = (pic.width.0.max(1), pic.height.0.max(1));
@@ -1825,7 +1846,7 @@ fn write_picture(
         .as_ref()
         .map(|c| {
             let mut s = String::new();
-            write_caption(&mut s, doc, c, i64::from(w), ids, bins, warnings);
+            write_caption(&mut s, doc, c, i64::from(w), ids, bins, report);
             s
         })
         .unwrap_or_default();

--- a/crates/hwpx/tests/write.rs
+++ b/crates/hwpx/tests/write.rs
@@ -33,6 +33,154 @@ const VALID_PNG_1X1: &[u8] = &[
     0x42, 0x60, 0x82,
 ];
 
+fn append_control(doc: &mut hwp_model::Document, control: hwp_model::Control) {
+    let para = &mut doc.sections[0].paragraphs[0];
+    let index = para.controls.len() as u32;
+    para.chars.push(hwp_model::HwpChar::ExtCtrl {
+        code: 11,
+        ctrl_id: control.ctrl_id(),
+        payload: Vec::new(),
+        ctrl_index: Some(index),
+    });
+    para.controls.push(control);
+}
+
+#[test]
+fn typed_report_records_unsupported_control_without_warning_parsing() {
+    let mut doc = hwp_convert::from_markdown("본문\n");
+    append_control(
+        &mut doc,
+        hwp_model::Control::Generic(hwp_model::GenericControl {
+            ctrl_id: *b"ole ",
+            data: Vec::new(),
+            paragraph_lists: Vec::new(),
+            extras: Vec::new(),
+            raw_children: Vec::new(),
+            gso_shapes: Vec::new(),
+            equation: None,
+            column_def: None,
+            caption: None,
+        }),
+    );
+
+    let out = tmp("typed-report-unsupported-control.hwpx");
+    let report = hwpx::write_document_with_report(&doc, &out).unwrap();
+
+    assert!(
+        report.warnings.is_empty(),
+        "ordinary warnings: {:?}",
+        report.warnings
+    );
+    assert_eq!(report.preservation.events.len(), 1);
+    let event = &report.preservation.events[0];
+    assert_eq!(
+        event.code,
+        hwp_model::PreservationCode::OpaqueControlUnrepresentable
+    );
+    assert_eq!(event.resource, hwp_model::PreservationResourceKind::Control);
+    assert_eq!(
+        event.disposition,
+        hwp_model::PreservationDisposition::Unrepresentable
+    );
+    assert_eq!(event.count, 1);
+}
+
+#[test]
+fn typed_report_records_missing_picture_binary_as_asset_loss() {
+    let mut doc = hwp_convert::from_markdown("본문\n");
+    append_control(
+        &mut doc,
+        hwp_model::Control::Picture(hwp_model::Picture {
+            common_data: Vec::new(),
+            width: hwp_model::HwpUnit(1000),
+            height: hwp_model::HwpUnit(500),
+            treat_as_char: true,
+            z_order: 0,
+            vert_offset: 0,
+            horz_offset: 0,
+            description: None,
+            crop: None,
+            flip: 0,
+            rotation: None,
+            brightness: 0,
+            contrast: 0,
+            effect_flags: 0,
+            effects_raw: Vec::new(),
+            caption: None,
+            bin_ref: hwp_model::BinRef::ItemRef("missing-image".to_string()),
+            extras: Vec::new(),
+        }),
+    );
+
+    let out = tmp("typed-report-missing-image.hwpx");
+    let report = hwpx::write_document_with_report(&doc, &out).unwrap();
+
+    assert!(
+        report.warnings.is_empty(),
+        "ordinary warnings: {:?}",
+        report.warnings
+    );
+    assert_eq!(report.preservation.events.len(), 1);
+    let event = &report.preservation.events[0];
+    assert_eq!(event.code, hwp_model::PreservationCode::BinaryAssetRemoved);
+    assert_eq!(
+        event.resource,
+        hwp_model::PreservationResourceKind::BinaryAsset
+    );
+    assert_eq!(
+        event.disposition,
+        hwp_model::PreservationDisposition::Removed
+    );
+    assert_eq!(event.count, 1);
+
+    let legacy =
+        hwpx::write_document(&doc, &tmp("typed-report-missing-image-legacy.hwpx")).unwrap();
+    assert_eq!(legacy.len(), 1);
+    assert!(
+        legacy[0].starts_with("DROP: binary_asset_removed"),
+        "{legacy:?}"
+    );
+}
+
+#[test]
+fn typed_report_records_both_gso_drop_paths() {
+    let generic_gso = |data: Vec<u8>| {
+        hwp_model::Control::Generic(hwp_model::GenericControl {
+            ctrl_id: *b"gso ",
+            data,
+            paragraph_lists: Vec::new(),
+            extras: Vec::new(),
+            raw_children: Vec::new(),
+            gso_shapes: Vec::new(),
+            equation: None,
+            column_def: None,
+            caption: None,
+        })
+    };
+
+    let mut invalid_header = hwp_convert::from_markdown("본문\n");
+    append_control(&mut invalid_header, generic_gso(Vec::new()));
+    let header_report =
+        hwpx::write_document_with_report(&invalid_header, &tmp("typed-report-gso-header.hwpx"))
+            .unwrap();
+    assert_eq!(header_report.preservation.events.len(), 1);
+    assert_eq!(
+        header_report.preservation.events[0].code,
+        hwp_model::PreservationCode::GsoHeaderUnrepresentable
+    );
+
+    let mut invalid_shapes = hwp_convert::from_markdown("본문\n");
+    append_control(&mut invalid_shapes, generic_gso(vec![0; 24]));
+    let shape_report =
+        hwpx::write_document_with_report(&invalid_shapes, &tmp("typed-report-gso-shape.hwpx"))
+            .unwrap();
+    assert_eq!(shape_report.preservation.events.len(), 1);
+    assert_eq!(
+        shape_report.preservation.events[0].code,
+        hwp_model::PreservationCode::GsoShapeUnrepresentable
+    );
+}
+
 /// hwpx → IR → hwpx → IR 왕복: 의미 동등성.
 #[test]
 fn 왕복_의미_동등() {
@@ -1126,6 +1274,28 @@ fn ge_b5_settings_version_원문_passthrough_왕복() {
     let back = hwp_convert::from_json(&json).unwrap();
     assert_eq!(back.hwpx_settings_xml.as_deref(), Some(settings));
     assert_eq!(back.hwpx_version_xml.as_deref(), Some(version));
+}
+
+#[test]
+fn preview_image_bytes_are_preserved_on_same_format_rewrite() {
+    let mut doc = hwp_convert::from_markdown("preview pass-through\n");
+    doc.hwpx_preview_image = Some(VALID_PNG_1X1.to_vec());
+
+    let out = tmp("preview-image-passthrough.hwpx");
+    let report = hwpx::write_document_with_report(&doc, &out).unwrap();
+    assert!(report.preservation.is_lossless());
+
+    let bytes = std::fs::read(&out).unwrap();
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+    let mut preview = Vec::new();
+    zip.by_name("Preview/PrvImage.png")
+        .unwrap()
+        .read_to_end(&mut preview)
+        .unwrap();
+    assert_eq!(preview, VALID_PNG_1X1);
+
+    let reread = hwpx::read_document(&out).unwrap().document;
+    assert_eq!(reread.hwpx_preview_image.as_deref(), Some(VALID_PNG_1X1));
 }
 
 /// GE-β5 보강: 슬롯이 None이면 두 파트가 기존 기본 상수와 바이트 동일하게 방출된다

--- a/docs/design/07-hangul-compat-rules.ko.md
+++ b/docs/design/07-hangul-compat-rules.ko.md
@@ -28,6 +28,26 @@ hwp-cli는 pyhwp·자체 리더/렌더로는 100% 통과하지만 **한컴오피
 
 ---
 
+## 타입드 보존 게이트
+
+네이티브 writer는 `hwp-preservation-report-v1` 형식의 content-free ledger를 제공한다. event
+code, resource class, disposition은 닫힌 enum이며 개수만 집계한다. 문서 텍스트, 패키지 이름,
+컨테이너 경로, payload 일부, hash는 공개 보고서에 포함하지 않는다.
+
+- writer omission과 표현 불가 payload는 typed loss event로 기록한다. 기존 `Vec<String>` API는
+  호환 wrapper로 유지하지만, 발행 정책은 `DROP:` prefix를 파싱하지 않는다.
+- 원본 없는 HWP/HWPX 작성은 typed loss event가 하나라도 있으면 atomic publication 전에 거부한다.
+- 같은 포맷 변환·편집은 HWP stream/storage 또는 HWPX entry inventory도 대조한다. 예상하지 않은
+  제거 또는 opaque non-target 항목 변경은 `--strict` 없이도 발행을 차단한다.
+- 포맷 간 `--strict` 변환은 asset, control, relationship, metadata의 의미 손실을 거부한다.
+  non-strict 변환은 typed ledger를 명시적으로 반환하는 경우에만 발행할 수 있다.
+
+이 게이트는 알려진 silent loss를 막지만 한컴 호환성을 인증하지 않는다. 현재 HWP full rewriter에는
+이슈 #90의 source-preserving repair와 독립 한컴 열기 검증이 여전히 필요하다. package-surgical HWPX
+편집도 #90의 후속 단계로 남아 있다.
+
+---
+
 ## A. 파일 "손상/변조" 게이트 (열기 자체가 거부되는 규칙)
 
 가장 치명적인 계층. 한글이 파일을 열 때 `"파일이 손상되었습니다"` / `"문서가 변조되었을 가능성 — 보안 수준을 낮춤"` 팝업을 띄우면 내용이 아예 안 보인다. 5.1.x 버전 선언과 레코드 레이아웃의 정합성을 한글이 검사한다.

--- a/docs/design/07-hangul-compat-rules.md
+++ b/docs/design/07-hangul-compat-rules.md
@@ -37,6 +37,27 @@ than static analysis**.
 
 ---
 
+## Typed preservation gate
+
+Native writers expose `hwp-preservation-report-v1`, a content-free ledger whose event code, resource
+class and disposition are closed enums. Counts are aggregate only. Document text, package names,
+container paths, payload fragments and hashes are never part of the public report.
+
+- Writer omissions and unrepresentable payloads are typed loss events. The old `Vec<String>` APIs
+  remain compatibility wrappers, but publication policy never parses a `DROP:` prefix.
+- Source-free HWP/HWPX authoring rejects every typed loss event before atomic publication.
+- Same-format conversion and editing additionally inventory HWP streams/storages or HWPX entries.
+  Any unexpected removal or change to an opaque non-target item blocks publication even without
+  `--strict`.
+- Cross-format `--strict` rejects semantic asset, control, relationship or metadata loss. Non-strict
+  conversion may publish only while returning the explicit typed ledger.
+
+This gate prevents known silent loss; it does not certify Hancom compatibility. The current full HWP
+rewriter still requires the source-preserving repair and independent Hancom-open checks tracked by
+issue #90. Package-surgical HWPX editing remains a later #90 step.
+
+---
+
 ## A. The file "corrupt/tampered" gate (rules that block opening at all)
 
 The most fatal layer. When Hancom shows `"파일이 손상되었습니다"` (the file is corrupt) or

--- a/docs/design/11-hwpx-structure-map.ko.md
+++ b/docs/design/11-hwpx-structure-map.ko.md
@@ -69,16 +69,17 @@ HWPX는 OPC(Open Packaging Conventions) ZIP 아카이브다. 아래는 한글이
 | `Contents/section{i}.xml` | 본문(문단·표·도형) | `read/section.rs:52` `parse_section` | `write/section.rs:50` `write_section` | §3.1/§4 참조 |
 | `BinData/imageN.*` | 임베드 이미지 원본 | `read/mod.rs:47` → `BinStream` | `write/mod.rs:110` ← `BinCollector`(`section.rs:24`) | 바이트 보존(중복 제거) |
 | `Preview/PrvText.txt` | 미리보기 텍스트 | **없음** | `write/mod.rs:113` `doc.plain_text()` 선두 1000자 | 본문에서 재생성 |
-| `Preview/PrvImage.png` | 미리보기 썸네일 | **없음** | **없음(IR 경로 손실)** | `patch.rs`만 raw 복사로 보존 |
+| `Preview/PrvImage.png` | 미리보기 썸네일 | raw pass-through(`Document.hwpx_preview_image`, JSON 제외) | 존재하면 원본 재방출 | ✅ 네이티브 IR 경로 바이트 보존(2026-08-14), `patch.rs`는 계속 전체 entry raw 복사 |
 
 **쓰기 엔트리 순서**(`write/mod.rs:72‑114`, 왼쪽이 먼저): `mimetype`(STORED) → `version.xml` →
 `META-INF/container.rdf` → `container.xml` → `manifest.xml` → `Contents/content.hpf` → `header.xml` →
-`section{0..}.xml` → `BinData/*` → `Preview/PrvText.txt` → `settings.xml`. `mimetype`은 반드시 첫
+`section{0..}.xml` → `BinData/*` → `Preview/PrvText.txt` → 선택적 `Preview/PrvImage.png` →
+`settings.xml`. `mimetype`은 반드시 첫
 로컬 헤더 + 무압축이어야 한다(OPC 규약; 위반 시 한글이 손상 파일로 판단).
 
 **읽기 진입**(`read/mod.rs:24` `read_document`): header → section(수치 정렬 `section0<…<section10`,
-`package.rs:105`) → BinData → version → content.hpf 순. `settings.xml`·`Preview/*`·`META-INF/*`는
-읽기 경로가 없어 IR로 들어오지 않는다 — IR 왕복 시 write가 상수/재생성으로 채운다.
+`package.rs:105`) → BinData → version → content.hpf → settings와 preview-image pass-through 순.
+Preview text는 재생성한다. `META-INF/*`는 여전히 IR 읽기 경로가 없으며 full rewrite에서 상수로 채운다.
 
 ---
 

--- a/docs/design/11-hwpx-structure-map.md
+++ b/docs/design/11-hwpx-structure-map.md
@@ -71,17 +71,18 @@ The read/write path for each part:
 | `Contents/section{i}.xml` | body (paragraphs, tables, shapes) | `read/section.rs:52` `parse_section` | `write/section.rs:50` `write_section` | see §3.1 and §4 |
 | `BinData/imageN.*` | embedded image originals | `read/mod.rs:47` → `BinStream` | `write/mod.rs:110` ← `BinCollector` (`section.rs:24`) | bytes preserved (deduplicated) |
 | `Preview/PrvText.txt` | preview text | **none** | `write/mod.rs:113`, the first 1000 characters of `doc.plain_text()` | regenerated from the body |
-| `Preview/PrvImage.png` | preview thumbnail | **none** | **none (lost on the IR path)** | preserved only by `patch.rs` through a raw copy |
+| `Preview/PrvImage.png` | preview thumbnail | raw pass-through (`Document.hwpx_preview_image`, excluded from JSON) | re-emits the original when present | ✅ bytes preserved on the native IR path (2026-08-14); `patch.rs` still raw-copies the entire entry |
 
 **Write entry order** (`write/mod.rs:72-114`, leftmost first): `mimetype` (STORED) → `version.xml` →
 `META-INF/container.rdf` → `container.xml` → `manifest.xml` → `Contents/content.hpf` → `header.xml` →
-`section{0..}.xml` → `BinData/*` → `Preview/PrvText.txt` → `settings.xml`. `mimetype` must be the
+`section{0..}.xml` → `BinData/*` → `Preview/PrvText.txt` → optional `Preview/PrvImage.png` →
+`settings.xml`. `mimetype` must be the
 first local header and uncompressed (an OPC rule; violating it makes Hancom judge the file corrupt).
 
 **Read entry** (`read/mod.rs:24` `read_document`): header → sections (sorted numerically so that
-`section0 < ... < section10`, `package.rs:105`) → BinData → version → content.hpf. `settings.xml`,
-`Preview/*` and `META-INF/*` have no read path and never enter the IR; on an IR round-trip, write
-fills them with constants or regenerates them.
+`section0 < ... < section10`, `package.rs:105`) → BinData → version → content.hpf → settings and
+preview-image pass-through. Preview text is regenerated. `META-INF/*` still has no IR read path and
+is filled with constants on a full rewrite.
 
 ---
 

--- a/docs/design/12-feature-gaps.ko.md
+++ b/docs/design/12-feature-gaps.ko.md
@@ -39,7 +39,10 @@
 > **Opaque 보존은 왕복에서는 갭이 아니다. 합성(포맷 간 변환)과 렌더에서만 갭이다.**
 
 - hwp5의 `OpaqueRecord`(서브트리째 보존, [10](10-hwp5-structure-map.ko.md) §0 상태표)는
-  `hwp5→hwp5` 왕복에서 **바이트를 잃지 않는다** → 그 경로에선 갭 아님.
+  `hwp5→hwp5` 왕복에서 **바이트를 잃지 않는다** → 레코드 수준에서는 그 경로의 갭이 아니다.
+  다만 IR 기반 full container rewrite가 부속 CFB stream이나 storage metadata까지 보존한다는 뜻은
+  아니다. 2026-08-14부터 typed preservation gate가 이 넓은 범위의 손실을 감지해 발행을 거부하며,
+  source-preserving HWP container repair는 이슈 #90에 남아 있다.
 - 같은 레코드를 `hwp5→hwpx`로 **합성**하려면 의미를 해석해 OWPML로 다시 써야 하는데, 그 지식이
   없으므로 **드롭**된다 → 합성 경로에선 갭.
 - 렌더러가 그 개체(차트·OLE 등)를 그리려면 페이로드 해석이 필요한데 안 되므로 **빈자리** →
@@ -72,6 +75,13 @@
 ### 0.5 해소 이력
 
 해소된 항목은 카탈로그에서 지우지 않고 해당 행에 ✅와 날짜를 남긴다(무엇이 갭이었는지가 곧 지식이므로).
+
+- **2026-08-14 (이슈 #90 보존 게이트)**: 네이티브 writer에 closed-enum, content-free
+  `hwp-preservation-report-v1` ledger를 추가했다. 원본 없는 작성과 같은 포맷 write는 writer omission
+  또는 예상하지 않은 container/package loss가 있으면 atomic하게 실패하고, 포맷 간 strict 변환은
+  semantic asset, control, relationship, metadata도 비교한다. 이는 silent publication을 해소한 것이며
+  writer 자체의 갭을 해소한 것은 아니다. source-preserving HWP repair와 package-surgical HWPX 편집은
+  이슈 #90에 남아 있다.
 
 - **2026-07-15**: GA-5(버전 게이트), GE-α1~α5·α7(글자효과·밑줄모양·번호형식 hwpx 왕복),
   GE-β4(요약정보 필드), GH-1·GH-2(md/html 링크·이미지), GL-1(추출 옵션 CLI 노출) —
@@ -327,7 +337,7 @@ stale 갭이 아니다 — 갭은 아래 항목들이다.
 
 | ID | 대상 | 근거 코드 | 현 동작 | 영향 경로 | 난이도 |
 |---|---|---|---|---|---|
-| GE-β1 | **미리보기 이미지(PrvImage / Preview/PrvImage.png)** — read가 IR로 미포착, 재생성기(썸네일 렌더러)도 없음 | hwp5 `write.rs:226-228`(opts 제공 시만), hwpx `write/mod.rs:113`(PrvText만), `patch.rs:3` | 드롭(되쓰기) | 되쓰기 | S(렌더러 재활용 시) |
+| GE-β1 | **미리보기 이미지(PrvImage / Preview/PrvImage.png)** — ✅ HWPX raw pass-through는 2026-08-14 해소. HWP read는 아직 원본 preview를 IR로 포착하지 않고 writer는 명시적으로 렌더한 option만 사용 | hwp5 `write.rs`(opts 제공 시만), hwpx `read/mod.rs` + `write/mod.rs`, `patch.rs` | HWPX 보존, HWP 재생성 또는 생략 | HWP 되쓰기 | S(렌더러 재활용 시) |
 | GE-β2 | **Scripts(매크로)** — 원본 JScript를 버리고 한글 빈 문서 표본 상수로 대체 | hwp5 `write.rs:213-221`(표본 바이트 상수), hwpx `patch.rs:4` | 드롭→상수 | 되쓰기 | S |
 | GE-β3 | **DocOptions 부속 스트림** — `_LinkDoc`은 524B 0 상수, DRM·서명 6스트림은 미방출 | `write.rs:208-210`, [10](10-hwp5-structure-map.ko.md) §1 | 드롭/상수 | 되쓰기 | M |
 | GE-β4 | **요약정보 필드 소실** — 작성/수정일시·마지막저장자·설명 | `summary.rs`·`write.rs`·`hwp-model/src/document.rs`·hwpx `templates.rs` | ✅ **해소(2026-07-15)** — Metadata에 description/last_saved_by/create_time/modify_time(raw FILETIME u64) 추가, read/write 왕복. 인쇄일시·통계는 잔존(기본값 방출) | 되쓰기 | S |

--- a/docs/design/12-feature-gaps.md
+++ b/docs/design/12-feature-gaps.md
@@ -45,7 +45,10 @@ The same record can be a gap or not **depending on which path you look from**. T
 
 - An hwp5 `OpaqueRecord` (the whole subtree preserved; see the status table in
   [10](10-hwp5-structure-map.md) §0) **loses no bytes** in an `hwp5 → hwp5` round-trip, so it is
-  not a gap on that path.
+  not a record-level gap on that path. This does not imply that an IR-based full container rewrite
+  preserves ancillary CFB streams or storage metadata. Since 2026-08-14, the typed preservation gate
+  detects that wider loss and refuses publication; source-preserving HWP container repair remains
+  tracked by issue #90.
 - To **synthesize** that same record as `hwp5 → hwpx`, its meaning would have to be interpreted and
   rewritten as OWPML; that knowledge is missing, so it is **dropped**, making it a gap on the
   synthesis path.
@@ -83,6 +86,13 @@ The `crates/` prefix is omitted (`hwp5/src/write.rs` means `crates/hwp5/src/writ
 
 Resolved items are not deleted from the catalog; the row keeps a ✅ and a date (what used to be a gap
 is itself knowledge).
+
+- **2026-08-14 (issue #90 preservation gate)**: native writers gained the closed-enum,
+  content-free `hwp-preservation-report-v1` ledger. Source-free authoring and same-format writes now
+  fail atomically on writer omissions or unexpected container/package loss; cross-format strict
+  conversion also compares semantic assets, controls, relationships and metadata. This resolves
+  silent publication, not the underlying writer gaps: source-preserving HWP repair and
+  package-surgical HWPX editing remain open in #90.
 
 - **2026-07-15**: GA-5 (version gate), GE-α1 to α5 and α7 (character effects, underline shape and
   numbering format in the hwpx round-trip), GE-β4 (summary information fields), GH-1 and GH-2
@@ -383,7 +393,7 @@ time and is therefore not a stale gap; the gaps are the items below.
 
 | ID | Target | Code evidence | Current behavior | Paths | Difficulty |
 |---|---|---|---|---|---|
-| GE-β1 | **The preview image (PrvImage / Preview/PrvImage.png)**: read does not capture it into the IR and there is no regenerator (thumbnail renderer) | hwp5 `write.rs:226-228` (only when opts provide it), hwpx `write/mod.rs:113` (PrvText only), `patch.rs:3` | dropped (rewrite) | rewrite | S (if the renderer is reused) |
+| GE-β1 | **The preview image (PrvImage / Preview/PrvImage.png)**: ✅ HWPX raw pass-through resolved 2026-08-14; HWP read still does not capture the source preview and its writer uses only an explicitly rendered option | hwp5 `write.rs` (only when opts provide it), hwpx `read/mod.rs` + `write/mod.rs`, `patch.rs` | HWPX preserved; HWP regenerated or omitted | HWP rewrite | S (if the renderer is reused) |
 | GE-β2 | **Scripts (macros)**: the original JScript is discarded and replaced with the constant from an empty Hancom document | hwp5 `write.rs:213-221` (sample byte constants), hwpx `patch.rs:4` | dropped → constant | rewrite | S |
 | GE-β3 | **DocOptions ancillary streams**: `_LinkDoc` is a 524B zero constant and the six DRM and signature streams are not emitted | `write.rs:208-210`, [10](10-hwp5-structure-map.md) §1 | dropped/constant | rewrite | M |
 | GE-β4 | **Summary information fields lost**: creation and modification time, last saved by, description | `summary.rs`, `write.rs`, `hwp-model/src/document.rs`, hwpx `templates.rs` | ✅ **resolved (2026-07-15)**: Metadata gained description, last_saved_by, create_time and modify_time (raw FILETIME u64) with a read/write round-trip. Print time and statistics remain (defaults emitted) | rewrite | S |


### PR DESCRIPTION
## Summary

- add the closed-enum `hwp-preservation-report-v1` contract to HWP and HWPX writers while keeping legacy warning wrappers
- fail native publication atomically on writer omissions, same-format container/package loss, or strict cross-format semantic loss
- expose content-free preservation reports through CLI/MCP results and preserve HWPX preview-image bytes on IR rewrites
- document the fail-closed boundary and the remaining source-preserving writer work

This is PR 1 of issue #90. It intentionally does not close the epic.

## Verification

- `scripts/check.sh`
- synthetic atomic regression for same-format package loss
- private complex-proposal aggregate: HWP same-format fail-closed, HWPX same-format fail-closed, and strict HWP-to-HWPX fail-closed all passed

## Privacy

No private source, filename, path, payload, hash, PDF, or raster is included. Public preservation events contain only enum codes, resource classes, dispositions, and aggregate counts.