### PR TITLE
fix(hwp): preserve source container during native edits

### DIFF
--- a/crates/hwp-cli/src/commands/convert.rs
+++ b/crates/hwp-cli/src/commands/convert.rs
@@ -308,87 +308,101 @@ pub fn execute(
         (crate::format::FileFormat::Hwp5, ConvertFormat::Hwp)
             | (crate::format::FileFormat::Hwpx, ConvertFormat::Hwpx)
     );
-    let write_report = crate::commands::output::write_validated(
-        output,
-        Some(input),
-        |staged| {
-            let mut report = match target {
-                ConvertFormat::Md => {
-                    unreachable!("Markdown은 sidecar 트랜잭션 경로에서 처리")
+    let write_staged = |source: &std::path::Path, staged: &std::path::Path| {
+        let mut report = match target {
+            ConvertFormat::Md => {
+                unreachable!("Markdown은 sidecar 트랜잭션 경로에서 처리")
+            }
+            ConvertFormat::Html => {
+                std::fs::write(staged, hwp_convert::to_html(&doc))?;
+                hwp_model::WriteReport::new()
+            }
+            ConvertFormat::Txt => {
+                std::fs::write(staged, doc.plain_text())?;
+                hwp_model::WriteReport::new()
+            }
+            ConvertFormat::Csv => {
+                std::fs::write(staged, hwp_convert::to_csv(&doc))?;
+                hwp_model::WriteReport::new()
+            }
+            ConvertFormat::Docx => {
+                std::fs::write(staged, hwp_convert::to_docx(&doc)?)?;
+                hwp_model::WriteReport::new()
+            }
+            ConvertFormat::Odt => {
+                std::fs::write(staged, hwp_convert::to_odt(&doc)?)?;
+                hwp_model::WriteReport::new()
+            }
+            ConvertFormat::Pdf => {
+                let result =
+                    hwp_render::render_document_pdf(&doc, &pdf_render_opts(font_dirs), None)?;
+                std::fs::write(staged, &result.data)?;
+                hwp_model::WriteReport {
+                    warnings: render_issue_messages(&result.report),
+                    preservation: hwp_model::PreservationReport::new(),
                 }
-                ConvertFormat::Html => {
-                    std::fs::write(staged, hwp_convert::to_html(&doc))?;
-                    hwp_model::WriteReport::new()
-                }
-                ConvertFormat::Txt => {
-                    std::fs::write(staged, doc.plain_text())?;
-                    hwp_model::WriteReport::new()
-                }
-                ConvertFormat::Csv => {
-                    std::fs::write(staged, hwp_convert::to_csv(&doc))?;
-                    hwp_model::WriteReport::new()
-                }
-                ConvertFormat::Docx => {
-                    std::fs::write(staged, hwp_convert::to_docx(&doc)?)?;
-                    hwp_model::WriteReport::new()
-                }
-                ConvertFormat::Odt => {
-                    std::fs::write(staged, hwp_convert::to_odt(&doc)?)?;
-                    hwp_model::WriteReport::new()
-                }
-                ConvertFormat::Pdf => {
-                    let result =
-                        hwp_render::render_document_pdf(&doc, &pdf_render_opts(font_dirs), None)?;
-                    std::fs::write(staged, &result.data)?;
-                    hwp_model::WriteReport {
-                        warnings: render_issue_messages(&result.report),
-                        preservation: hwp_model::PreservationReport::new(),
-                    }
-                }
-                ConvertFormat::Json => {
-                    std::fs::write(staged, hwp_convert::to_json(&doc, true, embed_bin)?)?;
-                    hwp_model::WriteReport::new()
-                }
-                ConvertFormat::Hwpx => hwpx::write::write_document_with_report_with(
-                    &doc,
-                    staged,
-                    &hwpx::write::HwpxWriteOptions {
-                        preserve_linesegs: preserve_layout,
-                    },
-                )?,
-                ConvertFormat::Hwp => write_hwp(&doc, staged, preserve_layout)?,
-            };
+            }
+            ConvertFormat::Json => {
+                std::fs::write(staged, hwp_convert::to_json(&doc, true, embed_bin)?)?;
+                hwp_model::WriteReport::new()
+            }
+            ConvertFormat::Hwpx => hwpx::write::write_document_with_report_with(
+                &doc,
+                staged,
+                &hwpx::write::HwpxWriteOptions {
+                    preserve_linesegs: preserve_layout,
+                },
+            )?,
+            ConvertFormat::Hwp if source_format == crate::format::FileFormat::Hwp5 => {
+                write_hwp_preserving_source(source, &doc, &doc, staged, preserve_layout, false)?
+            }
+            ConvertFormat::Hwp => write_hwp(&doc, staged, preserve_layout)?,
+        };
 
-            if matches!(target, ConvertFormat::Hwp | ConvertFormat::Hwpx) {
-                if same_native_format {
-                    report.preservation.extend(
-                        crate::commands::preservation::inspect_same_format_container(
-                            input, staged,
-                        )?,
-                    );
-                }
-                let output_document = load_document(staged)
-                    .with_context(|| format!("변환 문서 재읽기 실패: {}", staged.display()))?;
+        if matches!(target, ConvertFormat::Hwp | ConvertFormat::Hwpx) {
+            if same_native_format {
                 report.preservation.extend(
-                    crate::commands::preservation::inspect_conversion_semantics(
-                        &doc,
-                        &output_document,
-                    ),
+                    crate::commands::preservation::inspect_same_format_container(source, staged)?,
                 );
             }
-            Ok(report)
-        },
-        |staged, report| {
-            if matches!(target, ConvertFormat::Hwp | ConvertFormat::Hwpx) {
-                if same_native_format || strict {
-                    crate::commands::reject_preservation_loss("convert", &report.preservation)?;
-                }
-                load_document(staged)
-                    .with_context(|| format!("변환 문서 재읽기 실패: {}", staged.display()))?;
+            let output_document = load_document(staged)
+                .with_context(|| format!("변환 문서 재읽기 실패: {}", staged.display()))?;
+            report.preservation.extend(
+                crate::commands::preservation::inspect_conversion_semantics(&doc, &output_document),
+            );
+        }
+        Ok(report)
+    };
+    let verify_staged = |staged: &std::path::Path, report: &hwp_model::WriteReport| {
+        if matches!(target, ConvertFormat::Hwp | ConvertFormat::Hwpx) {
+            if same_native_format || strict {
+                crate::commands::reject_preservation_loss("convert", &report.preservation)?;
             }
-            Ok(())
-        },
-    )?;
+            load_document(staged)
+                .with_context(|| format!("변환 문서 재읽기 실패: {}", staged.display()))?;
+        }
+        Ok(())
+    };
+    let write_report = if source_format == crate::format::FileFormat::Hwp5
+        && matches!(target, ConvertFormat::Hwp)
+    {
+        let (_, report) = crate::commands::output::write_with_private_input_snapshot(
+            output,
+            input,
+            hwp_cli::certification::MAX_INPUT_BYTES,
+            crate::commands::output::SnapshotOutputMode::Publish,
+            |snapshot, staged, _| write_staged(snapshot, staged),
+            verify_staged,
+        )?;
+        report
+    } else {
+        crate::commands::output::write_validated(
+            output,
+            Some(input),
+            |staged| write_staged(input, staged),
+            verify_staged,
+        )?
+    };
     Ok(ConvertReport {
         warnings: write_report.warnings,
         preservation: write_report.preservation,
@@ -496,7 +510,28 @@ pub fn write_hwp(
     output: &std::path::Path,
     preserve_layout: bool,
 ) -> anyhow::Result<hwp_model::WriteReport> {
-    write_hwp_impl(doc, output, preserve_layout, false, None)
+    write_hwp_impl(doc, output, preserve_layout, false, None, None)
+}
+
+/// Writes an HWP edit against an immutable source snapshot. The low-level
+/// writer derives its target stream set from `original` versus `doc` and keeps
+/// every unrelated CFB entry owned by `source`.
+pub fn write_hwp_preserving_source(
+    source: &std::path::Path,
+    original: &hwp_model::Document,
+    doc: &hwp_model::Document,
+    output: &std::path::Path,
+    preserve_layout: bool,
+    structural: bool,
+) -> anyhow::Result<hwp_model::WriteReport> {
+    write_hwp_impl(
+        doc,
+        output,
+        preserve_layout,
+        structural,
+        None,
+        Some((source, original)),
+    )
 }
 
 /// 편집된 문서를 hwp로 다시 쓴다.
@@ -515,9 +550,9 @@ pub fn write_hwp_edited(
 ) -> anyhow::Result<hwp_model::WriteReport> {
     if doc.meta.source_format == "hwp5" {
         // 원본 줄 배치 보존(preserve), 합성 정규화 없음 — 편집 문단만 count=0.
-        write_hwp_impl(doc, output, true, false, None)
+        write_hwp_impl(doc, output, true, false, None, None)
     } else {
-        write_hwp_impl(doc, output, false, true, None)
+        write_hwp_impl(doc, output, false, true, None, None)
     }
 }
 
@@ -530,7 +565,7 @@ pub fn write_hwp_structural(
     doc: &hwp_model::Document,
     output: &std::path::Path,
 ) -> anyhow::Result<hwp_model::WriteReport> {
-    write_hwp_impl(doc, output, false, true, None)
+    write_hwp_impl(doc, output, false, true, None, None)
 }
 
 /// 구조 문서를 시스템 글꼴 없이 명시된 파일만으로 HWP로 쓴다.
@@ -546,7 +581,7 @@ pub fn write_hwp_structural_isolated(
     if font_files.is_empty() {
         anyhow::bail!("isolated HWP writer requires at least one explicit font file");
     }
-    write_hwp_impl(doc, output, false, true, Some(font_files))
+    write_hwp_impl(doc, output, false, true, Some(font_files), None)
 }
 
 fn write_hwp_impl(
@@ -555,6 +590,7 @@ fn write_hwp_impl(
     preserve_layout: bool,
     edited: bool,
     isolated_font_files: Option<&[std::path::PathBuf]>,
+    source: Option<(&std::path::Path, &hwp_model::Document)>,
 ) -> anyhow::Result<hwp_model::WriteReport> {
     let font_dir =
         std::path::PathBuf::from(std::env::var("HWP_FONT_DIR").unwrap_or_else(|_| "fonts".into()));
@@ -564,10 +600,43 @@ fn write_hwp_impl(
         .iter()
         .flat_map(|s| &s.paragraphs)
         .any(|p| !p.line_segs.is_empty());
+    let source_has_edits = source.is_some_and(|(_, original)| original != doc);
 
     let mut report = hwp_model::WriteReport::new();
     let owned;
-    let doc = if !synthesize || preserve_layout {
+    let doc = if source_has_edits {
+        // Native HWP edits keep every unchanged paragraph as an immutable source
+        // subtree. Missing line layout therefore identifies changed/new paragraphs;
+        // synthesize them before stream materialization. The source-aware writer
+        // replaces the renderer's output for every unchanged paragraph with the
+        // original record tree, so originally cache-less paragraphs stay untouched.
+        let mut d = doc.clone();
+        let mut store = if isolated_font_files.is_some() {
+            hwp_render::FontStore::new_isolated()
+        } else {
+            hwp_render::FontStore::new()
+        };
+        if let Some(files) = isolated_font_files {
+            for file in files {
+                store.load_file(file).with_context(|| {
+                    format!("isolated font file could not be loaded: {}", file.display())
+                })?;
+            }
+        } else {
+            store.load_dir(&font_dir);
+        }
+        let mut warns = hwp_render::RenderIssueAccumulator::new();
+        hwp_render::lineseg::synthesize_linesegs(&mut d, &mut store, &mut warns);
+        if let Some((_, original)) = source {
+            restore_unchanged_native_paragraphs(original, doc, &mut d);
+        }
+        warns.absorb(store.issues.finish());
+        report
+            .warnings
+            .append(&mut render_issue_messages(&warns.finish()));
+        owned = d;
+        &owned
+    } else if source.is_some() || !synthesize || preserve_layout {
         // hwp5 무수정/preserve-layout: 원본 줄 배치 그대로.
         doc
     } else if has_source_linesegs {
@@ -634,18 +703,160 @@ fn write_hwp_impl(
             .and_then(|out| out.pages.first().and_then(|p| p.encode_png().ok()))
     };
 
-    let writer_report = hwp5::write_document_with_report(
-        doc,
-        output,
-        &hwp5::WriteOptions {
-            prv_image,
-            preserve_linesegs: preserve_layout,
-            edited,
-        },
-    )?;
+    let options = hwp5::WriteOptions {
+        prv_image,
+        preserve_linesegs: preserve_layout,
+        edited,
+    };
+    let writer_report = if let Some((source, original)) = source {
+        hwp5::rewrite_document_with_report(source, original, doc, output, &options)?
+    } else {
+        hwp5::write_document_with_report(doc, output, &options)?
+    };
     report.warnings.extend(writer_report.warnings);
     report.preservation.extend(writer_report.preservation);
     Ok(report)
+}
+
+/// After renderer layout synthesis, put every semantically unchanged native
+/// paragraph back exactly as it appeared in the immutable input snapshot.
+/// This limits new PARA_LINE_SEG records to edited and inserted paragraphs,
+/// including paragraphs nested in table cells and generic controls.
+fn restore_unchanged_native_paragraphs(
+    original: &hwp_model::Document,
+    edited: &hwp_model::Document,
+    synthesized: &mut hwp_model::Document,
+) {
+    for (section_index, synthesized_section) in synthesized.sections.iter_mut().enumerate() {
+        let (Some(original_section), Some(edited_section)) = (
+            original.sections.get(section_index),
+            edited.sections.get(section_index),
+        ) else {
+            continue;
+        };
+        restore_unchanged_paragraph_list(
+            &original_section.paragraphs,
+            &edited_section.paragraphs,
+            &mut synthesized_section.paragraphs,
+        );
+    }
+}
+
+fn restore_unchanged_paragraph_list(
+    original: &[hwp_model::Paragraph],
+    edited: &[hwp_model::Paragraph],
+    synthesized: &mut [hwp_model::Paragraph],
+) {
+    if edited.len() != synthesized.len() {
+        return;
+    }
+    let mut used = vec![false; original.len()];
+    for edited_index in 0..edited.len() {
+        let instance_id = edited[edited_index].header.instance_id;
+        let original_index = if instance_id != 0
+            && edited
+                .iter()
+                .filter(|paragraph| paragraph.header.instance_id == instance_id)
+                .count()
+                == 1
+        {
+            let matches = original
+                .iter()
+                .enumerate()
+                .filter(|(index, paragraph)| {
+                    !used[*index] && paragraph.header.instance_id == instance_id
+                })
+                .map(|(index, _)| index)
+                .collect::<Vec<_>>();
+            if matches.len() == 1 {
+                Some(matches[0])
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+        .or_else(|| {
+            original
+                .iter()
+                .enumerate()
+                .find(|(index, paragraph)| !used[*index] && *paragraph == &edited[edited_index])
+                .map(|(index, _)| index)
+        })
+        .or_else(|| {
+            (original.len() == edited.len() && !used[edited_index]).then_some(edited_index)
+        });
+
+        if let Some(original_index) = original_index {
+            used[original_index] = true;
+            restore_unchanged_paragraph(
+                &original[original_index],
+                &edited[edited_index],
+                &mut synthesized[edited_index],
+            );
+        }
+    }
+}
+
+fn restore_unchanged_paragraph(
+    original: &hwp_model::Paragraph,
+    edited: &hwp_model::Paragraph,
+    synthesized: &mut hwp_model::Paragraph,
+) {
+    if original == edited {
+        *synthesized = original.clone();
+        return;
+    }
+    for ((original_control, edited_control), synthesized_control) in original
+        .controls
+        .iter()
+        .zip(&edited.controls)
+        .zip(&mut synthesized.controls)
+    {
+        if original_control == edited_control {
+            *synthesized_control = original_control.clone();
+            continue;
+        }
+        match (original_control, edited_control, synthesized_control) {
+            (
+                hwp_model::Control::Table(original_table),
+                hwp_model::Control::Table(edited_table),
+                hwp_model::Control::Table(synthesized_table),
+            ) => {
+                for ((original_cell, edited_cell), synthesized_cell) in original_table
+                    .cells
+                    .iter()
+                    .zip(&edited_table.cells)
+                    .zip(&mut synthesized_table.cells)
+                {
+                    restore_unchanged_paragraph_list(
+                        &original_cell.paragraphs,
+                        &edited_cell.paragraphs,
+                        &mut synthesized_cell.paragraphs,
+                    );
+                }
+            }
+            (
+                hwp_model::Control::Generic(original_generic),
+                hwp_model::Control::Generic(edited_generic),
+                hwp_model::Control::Generic(synthesized_generic),
+            ) => {
+                for ((original_list, edited_list), synthesized_list) in original_generic
+                    .paragraph_lists
+                    .iter()
+                    .zip(&edited_generic.paragraph_lists)
+                    .zip(&mut synthesized_generic.paragraph_lists)
+                {
+                    restore_unchanged_paragraph_list(
+                        &original_list.paragraphs,
+                        &edited_list.paragraphs,
+                        &mut synthesized_list.paragraphs,
+                    );
+                }
+            }
+            _ => {}
+        }
+    }
 }
 
 fn render_issue_messages(report: &hwp_render::RenderIssueReport) -> Vec<String> {
@@ -814,5 +1025,55 @@ mod tests {
         issues.push(hwp_render::RenderIssueCode::FontMatched, b"font");
         let report = issues.finish();
         assert!(render_issue_messages(&report).is_empty());
+    }
+
+    #[test]
+    fn native_layout_restore_limits_synthesis_to_changed_paragraphs() {
+        let mut original = hwp_convert::from_markdown("first\n\nsecond");
+        assert_eq!(original.sections[0].paragraphs.len(), 2);
+        for (index, paragraph) in original.sections[0].paragraphs.iter_mut().enumerate() {
+            paragraph.header.instance_id = index as u32 + 1;
+            paragraph.line_segs = vec![hwp_model::LineSeg {
+                text_start: 0,
+                v_pos: index as i32 * 100,
+                line_height: 1000,
+                text_height: 1000,
+                baseline_gap: 800,
+                line_spacing: 600,
+                col_start: 0,
+                seg_width: 5000,
+                flags: 0x60000,
+            }];
+        }
+        let mut edited = original.clone();
+        edited.sections[0].paragraphs[0]
+            .chars
+            .insert(0, hwp_model::HwpChar::Text('X'));
+        edited.sections[0].paragraphs[0].line_segs.clear();
+        let mut synthesized = edited.clone();
+        for paragraph in &mut synthesized.sections[0].paragraphs {
+            paragraph.line_segs = vec![hwp_model::LineSeg {
+                text_start: 0,
+                v_pos: 999,
+                line_height: 999,
+                text_height: 999,
+                baseline_gap: 999,
+                line_spacing: 999,
+                col_start: 0,
+                seg_width: 999,
+                flags: 0,
+            }];
+        }
+
+        restore_unchanged_native_paragraphs(&original, &edited, &mut synthesized);
+
+        assert_eq!(
+            synthesized.sections[0].paragraphs[0].line_segs[0].v_pos,
+            999
+        );
+        assert_eq!(
+            synthesized.sections[0].paragraphs[1].line_segs,
+            original.sections[0].paragraphs[1].line_segs
+        );
     }
 }

--- a/crates/hwp-cli/src/commands/edit.rs
+++ b/crates/hwp-cli/src/commands/edit.rs
@@ -957,37 +957,58 @@ pub fn execute(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<E
         .iter()
         .map(|request| format!("미적용 편집 요청: {request}"))
         .collect::<Vec<_>>();
-    let writer_report = crate::commands::output::write_validated(
-        output,
-        Some(input),
-        |staged| {
-            let mut report = write_output(&doc, staged, structural, output_format)?;
-            if output_format.supports_verify() {
-                let removed_binary_allowance =
-                    crate::commands::preservation::intentional_removed_binary_assets(
-                        &original_doc,
-                        &doc,
-                    );
-                report.preservation.extend(
-                    crate::commands::preservation::inspect_same_format_container_with_binary_allowance(
-                        input,
-                        staged,
-                        removed_binary_allowance,
-                    )?,
+    let write_staged = |source: &Path, staged: &Path| {
+        let mut report = write_output(
+            &doc,
+            staged,
+            structural,
+            output_format,
+            Some((source, &original_doc)),
+        )?;
+        if output_format.supports_verify() {
+            let removed_binary_allowance =
+                crate::commands::preservation::intentional_removed_binary_assets(
+                    &original_doc,
+                    &doc,
                 );
-            }
-            Ok(report)
-        },
-        |staged, writer_report| {
-            if output_format.supports_verify() {
-                crate::commands::reject_preservation_loss("edit", &writer_report.preservation)?;
-            }
-            if plan.verify {
-                verify_output(staged, Some(&doc))?;
-            }
-            Ok(())
-        },
-    )?;
+            report.preservation.extend(
+                crate::commands::preservation::inspect_same_format_container_with_binary_allowance(
+                    source,
+                    staged,
+                    removed_binary_allowance,
+                )?,
+            );
+        }
+        Ok(report)
+    };
+    let verify_staged = |staged: &Path, writer_report: &hwp_model::WriteReport| {
+        if output_format.supports_verify() {
+            crate::commands::reject_preservation_loss("edit", &writer_report.preservation)?;
+        }
+        if plan.verify {
+            verify_output(staged, Some(&doc))?;
+        }
+        Ok(())
+    };
+    let writer_report =
+        if output_format == OutputFormat::Hwp && original_doc.meta.source_format == "hwp5" {
+            let (_, report) = crate::commands::output::write_with_private_input_snapshot(
+                output,
+                input,
+                hwp_cli::certification::MAX_INPUT_BYTES,
+                crate::commands::output::SnapshotOutputMode::Publish,
+                |snapshot, staged, _| write_staged(snapshot, staged),
+                verify_staged,
+            )?;
+            report
+        } else {
+            crate::commands::output::write_validated(
+                output,
+                Some(input),
+                |staged| write_staged(input, staged),
+                verify_staged,
+            )?
+        };
     warnings.extend(writer_report.warnings);
     Ok(EditReport {
         output: output.display().to_string(),
@@ -1410,8 +1431,22 @@ fn write_output(
     output: &Path,
     structural: bool,
     output_format: OutputFormat,
+    source: Option<(&Path, &hwp_model::Document)>,
 ) -> anyhow::Result<hwp_model::WriteReport> {
     match output_format {
+        OutputFormat::Hwp
+            if source.is_some_and(|(_, original)| original.meta.source_format == "hwp5") =>
+        {
+            let (source, original) = source.expect("guarded source");
+            crate::commands::convert::write_hwp_preserving_source(
+                source,
+                original,
+                doc,
+                output,
+                !structural,
+                structural,
+            )
+        }
         // 구조 편집은 삽입 문단/행에 불변식을 세우려 합성 경로를 강제한다.
         OutputFormat::Hwp if structural => {
             crate::commands::convert::write_hwp_structural(doc, output)
@@ -1698,6 +1733,7 @@ fn canonical_document(
         paragraph.header.ctrl_mask = 0;
         paragraph.header.instance_id = 0;
         paragraph.header.tail.clear();
+        paragraph.header.hwp5_child_order.clear();
         // HWP5 writer는 모든 문단을 PARA_BREAK로 닫지만 HWPX는 문단 경계 자체가
         // 같은 의미를 표현하고 reader가 이 문자를 만들지 않는다. 포맷 간 검증에서
         // 이 writer 정규화만 의미 차이로 보지 않는다.

--- a/crates/hwp-cli/src/commands/fill.rs
+++ b/crates/hwp-cli/src/commands/fill.rs
@@ -384,23 +384,7 @@ fn fill_tables_ir(
         ));
     }
 
-    let writer_report = crate::commands::output::write_validated(
-        output,
-        Some(input),
-        |staged| {
-            let mut report = write_table_fill(&doc, staged, added > 0)?;
-            report.preservation.extend(
-                crate::commands::preservation::inspect_same_format_container(input, staged)?,
-            );
-            Ok(report)
-        },
-        |staged, writer_report| {
-            crate::commands::reject_preservation_loss("fill", &writer_report.preservation)?;
-            ensure_valid_document(staged)?;
-            crate::commands::edit::verify_document(staged, &doc)?;
-            Ok(())
-        },
-    )?;
+    let writer_report = write_ir_fill(input, output, &original, &doc, added > 0)?;
     warnings.extend(writer_report.warnings);
 
     Ok(FillReport {
@@ -550,23 +534,7 @@ fn fill_parts_ir(
         warnings.push(format!("미치환 자리표시자: {}", unmatched.join(", ")));
     }
 
-    let writer_report = crate::commands::output::write_validated(
-        output,
-        Some(input),
-        |staged| {
-            let mut report = write_table_fill(&doc, staged, true)?;
-            report.preservation.extend(
-                crate::commands::preservation::inspect_same_format_container(input, staged)?,
-            );
-            Ok(report)
-        },
-        |staged, writer_report| {
-            crate::commands::reject_preservation_loss("fill", &writer_report.preservation)?;
-            ensure_valid_document(staged)?;
-            crate::commands::edit::verify_document(staged, &doc)?;
-            Ok(())
-        },
-    )?;
+    let writer_report = write_ir_fill(input, output, &original, &doc, true)?;
     warnings.extend(writer_report.warnings);
 
     Ok(FillReport {
@@ -663,6 +631,7 @@ fn strip_section_controls(para: &mut hwp_model::Paragraph) {
 }
 
 fn write_table_fill(
+    source: Option<(&Path, &hwp_model::Document)>,
     doc: &hwp_model::Document,
     output: &Path,
     structural: bool,
@@ -673,10 +642,68 @@ fn write_table_fill(
         .map(str::to_ascii_lowercase)
         .as_deref()
     {
+        Some("hwp")
+            if source.is_some_and(|(_, original)| original.meta.source_format == "hwp5") =>
+        {
+            let (source, original) = source.expect("guarded source");
+            crate::commands::convert::write_hwp_preserving_source(
+                source,
+                original,
+                doc,
+                output,
+                !structural,
+                structural,
+            )
+        }
         Some("hwp") if structural => crate::commands::convert::write_hwp_structural(doc, output),
         Some("hwp") => crate::commands::convert::write_hwp_edited(doc, output),
         Some("hwpx") => Ok(hwpx::write_document_with_report(doc, output)?),
         other => anyhow::bail!("fill 출력은 .hwp 또는 .hwpx만 지원합니다 (확장자: {other:?})"),
+    }
+}
+
+fn write_ir_fill(
+    input: &Path,
+    output: &Path,
+    original: &hwp_model::Document,
+    edited: &hwp_model::Document,
+    structural: bool,
+) -> anyhow::Result<hwp_model::WriteReport> {
+    let write_staged = |source: &Path, staged: &Path| {
+        let mut report = write_table_fill(Some((source, original)), edited, staged, structural)?;
+        report
+            .preservation
+            .extend(crate::commands::preservation::inspect_same_format_container(source, staged)?);
+        Ok(report)
+    };
+    let verify_staged = |staged: &Path, writer_report: &hwp_model::WriteReport| {
+        crate::commands::reject_preservation_loss("fill", &writer_report.preservation)?;
+        ensure_valid_document(staged)?;
+        crate::commands::edit::verify_document(staged, edited)?;
+        Ok(())
+    };
+    let hwp_source_and_output = original.meta.source_format == "hwp5"
+        && output
+            .extension()
+            .and_then(|extension| extension.to_str())
+            .is_some_and(|extension| extension.eq_ignore_ascii_case("hwp"));
+    if hwp_source_and_output {
+        let (_, report) = crate::commands::output::write_with_private_input_snapshot(
+            output,
+            input,
+            hwp_cli::certification::MAX_INPUT_BYTES,
+            crate::commands::output::SnapshotOutputMode::Publish,
+            |snapshot, staged, _| write_staged(snapshot, staged),
+            verify_staged,
+        )?;
+        Ok(report)
+    } else {
+        crate::commands::output::write_validated(
+            output,
+            Some(input),
+            |staged| write_staged(input, staged),
+            verify_staged,
+        )
     }
 }
 

--- a/crates/hwp-cli/tests/cli_surface.rs
+++ b/crates/hwp-cli/tests/cli_surface.rs
@@ -318,11 +318,9 @@ fn mcp_stdio_session() {
 /// hwp5 합성 왕복 게이트: hwpx 픽스처 → a.hwp → `convert a.hwp -o b.hwp --preserve-layout`
 /// 후 **스트림 단위 바이트 동일** 단언.
 ///
-/// 주의: 이 테스트는 로컬 전용 정품 identity 게이트(crates/hwp5/tests/identity.rs,
-/// 로컬 픽스처 필요)를 대체하지 않고 **보완**한다 — 커밋 픽스처로 CI에서 도는 합성 경로
-/// 왕복이다. 전체 파일 비교는 불가: cfb 크레이트가 디렉터리 엔트리에 Timestamp::now()
-/// (18바이트)를 찍어 파일 단위 해시는 매번 달라진다(실측). `--preserve-layout`은
-/// 줄 배치 캐시 보존 전제 — 무수정 왕복 경로를 타게 하는 필수 플래그.
+/// This CI-safe synthetic case complements the local genuine-file identity
+/// gate. A same-format no-op now copies the immutable HWP source snapshot, so
+/// the whole file, including CFB directory metadata, must be byte-identical.
 #[test]
 fn hwp5_synthetic_identity_gate() {
     let dir = tmp_dir("hwp5_identity");
@@ -352,6 +350,12 @@ fn hwp5_synthetic_identity_gate() {
         r2.status.success(),
         "hwp→hwp(preserve-layout): {}",
         String::from_utf8_lossy(&r2.stderr)
+    );
+
+    assert_eq!(
+        std::fs::read(&a).unwrap(),
+        std::fs::read(&b).unwrap(),
+        "same-format no-op is an exact source snapshot copy"
     );
 
     let mut ca = hwp5::Hwp5Container::open(&a).unwrap();

--- a/crates/hwp-model/src/lib.rs
+++ b/crates/hwp-model/src/lib.rs
@@ -37,7 +37,9 @@ pub use header::{
 };
 pub use ids::{BinDataId, BorderFillId, CharShapeId, FaceNameId, ParaShapeId, StyleId};
 pub use opaque::OpaqueRecord;
-pub use paragraph::{CharKind, HwpChar, LineSeg, ParaHeaderInfo, Paragraph, char_kind, ctrl_char};
+pub use paragraph::{
+    CharKind, Hwp5ParagraphChild, HwpChar, LineSeg, ParaHeaderInfo, Paragraph, char_kind, ctrl_char,
+};
 pub use preservation::{
     PRESERVATION_REPORT_CONTRACT, PreservationCode, PreservationDisposition, PreservationEvent,
     PreservationReport, PreservationResourceKind, WriteReport,

--- a/crates/hwp-model/src/paragraph.rs
+++ b/crates/hwp-model/src/paragraph.rs
@@ -156,6 +156,22 @@ pub struct ParaHeaderInfo {
     /// 버전에 따라 붙는 꼬리 (변경 추적 병합 등) — 왕복 보존
     #[serde(with = "hex_bytes")]
     pub tail: Vec<u8>,
+    /// HWP5 PARA_HEADER 아래에서 opaque 레코드와 CTRL_HEADER가 나타난 순서.
+    ///
+    /// CTRL_DATA처럼 컨트롤과 같은 레벨에 저장되는 레코드는 이 순서를 잃으면
+    /// 한글이 문서를 손상된 것으로 판정할 수 있다. 다른 포맷에는 의미가 없는
+    /// HWP5 왕복 캐시이며, 합성 문서는 비어 있다.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hwp5_child_order: Vec<Hwp5ParagraphChild>,
+}
+
+/// HWP5 문단의 비표준 자식 레코드 순서.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Hwp5ParagraphChild {
+    /// [`Paragraph::extras`]의 다음 레코드.
+    Extra,
+    /// [`Paragraph::controls`]의 다음 컨트롤.
+    Control,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]

--- a/crates/hwp5/src/body_text.rs
+++ b/crates/hwp5/src/body_text.rs
@@ -10,8 +10,9 @@
 
 use hwp_model::{
     Caption, CaptionDirection, CaptionSide, Cell, CharKind, CharShapeId, ColumnDef, Control,
-    Equation, GenericControl, HwpChar, HwpUnit, LineSeg, PageDef, ParaHeaderInfo, ParaShapeId,
-    Paragraph, ParagraphList, Section, SectionDef, StyleId, Table, char_kind,
+    Equation, GenericControl, Hwp5ParagraphChild, HwpChar, HwpUnit, LineSeg, PageDef,
+    ParaHeaderInfo, ParaShapeId, Paragraph, ParagraphList, Section, SectionDef, StyleId, Table,
+    char_kind,
 };
 
 use crate::codec::ByteReader;
@@ -69,8 +70,16 @@ fn parse_paragraph(node: &RecordNode, warnings: &mut Vec<String>) -> Paragraph {
                 Ok(segs) => para.line_segs = segs,
                 Err(e) => warnings.push(format!("PARA_LINE_SEG 파싱 실패: {e}")),
             },
-            tag::CTRL_HEADER => para.controls.push(parse_control(child, warnings)),
-            _ => para.extras.push(to_opaque(child)),
+            tag::CTRL_HEADER => {
+                para.header
+                    .hwp5_child_order
+                    .push(Hwp5ParagraphChild::Control);
+                para.controls.push(parse_control(child, warnings));
+            }
+            _ => {
+                para.header.hwp5_child_order.push(Hwp5ParagraphChild::Extra);
+                para.extras.push(to_opaque(child));
+            }
         }
     }
 
@@ -106,6 +115,7 @@ fn parse_para_header(data: &[u8]) -> Result<(ParaShapeId, StyleId, ParaHeaderInf
         break_type,
         instance_id,
         tail: r.take_rest().to_vec(),
+        hwp5_child_order: Vec::new(),
     };
     Ok((para_shape, style, info, nchars_raw & 0x7FFF_FFFF))
 }

--- a/crates/hwp5/src/error.rs
+++ b/crates/hwp5/src/error.rs
@@ -51,6 +51,12 @@ pub enum Hwp5Error {
 
     #[error("배포용 문서(ViewText)는 지원하지 않습니다")]
     DistributionDoc,
+
+    #[error("HWP 원본 snapshot이 편집 기준 문서와 일치하지 않습니다")]
+    SourceSnapshotMismatch,
+
+    #[error("HWP 원본 보존 재작성 실패: {0}")]
+    SourceRewrite(String),
 }
 
 pub type Result<T> = std::result::Result<T, Hwp5Error>;

--- a/crates/hwp5/src/lib.rs
+++ b/crates/hwp5/src/lib.rs
@@ -33,4 +33,6 @@ pub use error::Hwp5Error;
 pub use file_header::FileHeader;
 pub use read::{BoundedReadLimits, BoundedReadSnapshot, ReadResult, ScriptPresence, read_document};
 pub use summary::parse_summary;
-pub use write::{WriteOptions, write_document, write_document_with_report};
+pub use write::{
+    WriteOptions, rewrite_document_with_report, write_document, write_document_with_report,
+};

--- a/crates/hwp5/src/write.rs
+++ b/crates/hwp5/src/write.rs
@@ -6,6 +6,7 @@
 //! 수준). ID_MAPPINGS 카운트는 테이블 길이에서 유도한다(수동 동기화
 //! 금지) — 원본에 버전별 추가 카운트가 있으면 꼬리만 보존.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::Write as _;
 use std::path::Path;
 
@@ -16,10 +17,10 @@ use hwp_model::{
     SectionDef, Style, Table, WriteReport,
 };
 
-use crate::codec::{ByteWriter, compress};
+use crate::codec::{ByteWriter, compress, decompress};
 use crate::error::Result;
 use crate::file_header::{FILE_HEADER_SIZE, FileHeader, HwpVersion};
-use crate::record::{RecordNode, tag};
+use crate::record::{RecordNode, ScanMode, scan_stream, tag};
 
 #[derive(Default)]
 pub struct WriteOptions {
@@ -40,6 +41,24 @@ pub struct WriteOptions {
     pub edited: bool,
 }
 
+#[derive(Debug)]
+struct HwpStreamMaterialization {
+    storages: BTreeSet<String>,
+    streams: BTreeMap<String, Vec<u8>>,
+    bin_stream_paths: BTreeMap<String, String>,
+    report: WriteReport,
+}
+
+#[derive(Debug)]
+struct HwpMutationPlan {
+    metadata_changed: bool,
+    header_changed: bool,
+    changed_sections: BTreeSet<usize>,
+    removed_sections: BTreeSet<usize>,
+    changed_bins: BTreeSet<String>,
+    removed_bins: BTreeSet<String>,
+}
+
 /// 문서를 HWP 5.0 파일로 저장한다. 경고(평탄화/드롭) 목록을 반환한다.
 ///
 /// This is the legacy compatibility surface. New callers should use
@@ -55,7 +74,448 @@ pub fn write_document_with_report(
     path: &Path,
     opts: &WriteOptions,
 ) -> Result<WriteReport> {
+    let materialization = materialize_document(doc, opts, true, false)?;
+    write_materialized_document(path, &materialization)?;
+    Ok(materialization.report)
+}
+
+/// Rewrites an HWP document by copying its immutable source container and
+/// replacing only streams selected by a mutation plan derived from the
+/// original and edited IR values.
+///
+/// A no-op is an exact file copy. Opaque streams, storages, directory metadata,
+/// FileHeader, scripts, document options, history, and every unrelated binary
+/// stream remain owned by the source container rather than being regenerated.
+pub fn rewrite_document_with_report(
+    source: &Path,
+    original: &Document,
+    edited: &Document,
+    path: &Path,
+    opts: &WriteOptions,
+) -> Result<WriteReport> {
+    if source_output_alias(source, path)? {
+        return Err(crate::error::Hwp5Error::SourceRewrite(
+            "source and output paths must be different".to_string(),
+        ));
+    }
+    let source_document = crate::read_document(source)?.document;
+    if source_document != *original {
+        return Err(crate::error::Hwp5Error::SourceSnapshotMismatch);
+    }
+    validate_source_rewrite_contract(original, edited)?;
+
+    if original == edited {
+        std::fs::copy(source, path)?;
+        return Ok(WriteReport::new());
+    }
+
+    let plan = HwpMutationPlan::derive(original, edited);
+    let mut source_container = crate::Hwp5Container::open(source)?;
+    let compressed = source_container.file_header().is_compressed();
+    let source_bin_paths = source_container
+        .list_streams()
+        .into_iter()
+        .filter_map(|entry| {
+            let normalized = entry
+                .path
+                .strip_prefix("/BinData/")
+                .map(normalized_bin_name);
+            normalized.map(|name| (name, entry.path))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let source_section_roots = plan
+        .changed_sections
+        .iter()
+        .filter(|index| **index < original.sections.len())
+        .map(|index| {
+            let stream_path = format!("/BodyText/Section{index}");
+            let bytes = source_container.read_record_stream(&stream_path)?;
+            let scan = scan_stream(&bytes, ScanMode::Strict)?;
+            Ok((*index, scan.roots))
+        })
+        .collect::<Result<BTreeMap<_, _>>>()?;
+    drop(source_container);
+
+    let mut materialization = materialize_document(edited, opts, compressed, true)?;
+    preserve_unchanged_body_subtrees(
+        original,
+        edited,
+        compressed,
+        &source_section_roots,
+        &mut materialization,
+    )?;
+    std::fs::copy(source, path)?;
+    patch_source_container(path, &plan, &source_bin_paths, &materialization)?;
+    Ok(materialization.report)
+}
+
+fn source_output_alias(source: &Path, output: &Path) -> Result<bool> {
+    if source == output {
+        return Ok(true);
+    }
+    let source_metadata = std::fs::metadata(source)?;
+    let output_metadata = match std::fs::metadata(output) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => return Err(error.into()),
+    };
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt as _;
+        Ok(source_metadata.dev() == output_metadata.dev()
+            && source_metadata.ino() == output_metadata.ino())
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = (source_metadata, output_metadata);
+        Ok(std::fs::canonicalize(source)? == std::fs::canonicalize(output)?)
+    }
+}
+
+/// Replaces regenerated, unchanged typed controls with their immutable source
+/// subtrees. This keeps level-sensitive records such as a section definition's
+/// CTRL_DATA/PAGE_DEF sequence byte-identical while still allowing the edited
+/// paragraph records around them to change.
+fn preserve_unchanged_body_subtrees(
+    original: &Document,
+    edited: &Document,
+    compressed: bool,
+    source_sections: &BTreeMap<usize, Vec<RecordNode>>,
+    materialization: &mut HwpStreamMaterialization,
+) -> Result<()> {
+    for (index, source_roots) in source_sections {
+        let stream_path = format!("/BodyText/Section{index}");
+        let materialized = required_materialized_stream(materialization, &stream_path)?;
+        let decoded = if compressed {
+            decompress(materialized, &stream_path)?
+        } else {
+            materialized.to_vec()
+        };
+        let emitted_roots = scan_stream(&decoded, ScanMode::Strict)?.roots;
+        let original_section = original.sections.get(*index).ok_or_else(|| {
+            crate::error::Hwp5Error::SourceRewrite(format!(
+                "source section {index} is missing from the original IR"
+            ))
+        })?;
+        let edited_section = edited.sections.get(*index).ok_or_else(|| {
+            crate::error::Hwp5Error::SourceRewrite(format!(
+                "changed section {index} is missing from the edited IR"
+            ))
+        })?;
+        let merged = merge_section_roots(
+            source_roots,
+            &emitted_roots,
+            original_section,
+            edited_section,
+        )?;
+        materialization.streams.insert(
+            stream_path,
+            encode_compressed_stream(RecordNode::serialize_forest(&merged), compressed),
+        );
+    }
+    Ok(())
+}
+
+fn merge_section_roots(
+    source_roots: &[RecordNode],
+    emitted_roots: &[RecordNode],
+    original: &Section,
+    edited: &Section,
+) -> Result<Vec<RecordNode>> {
+    let source_paragraphs = source_roots
+        .iter()
+        .filter(|node| node.tag == tag::PARA_HEADER)
+        .collect::<Vec<_>>();
+    let emitted_paragraphs = emitted_roots
+        .iter()
+        .filter(|node| node.tag == tag::PARA_HEADER)
+        .collect::<Vec<_>>();
+    if source_paragraphs.len() != original.paragraphs.len()
+        || emitted_paragraphs.len() != edited.paragraphs.len()
+    {
+        return Err(crate::error::Hwp5Error::SourceRewrite(
+            "paragraph records cannot be matched to the source and edited IR".to_string(),
+        ));
+    }
+
+    let matches = match_paragraphs(&original.paragraphs, &edited.paragraphs);
+    if original.extras == edited.extras
+        && source_paragraphs.len() == emitted_paragraphs.len()
+        && matches
+            .iter()
+            .enumerate()
+            .all(|(edited_index, matched)| *matched == Some(edited_index))
+    {
+        let mut paragraph_index = 0usize;
+        return Ok(source_roots
+            .iter()
+            .map(|source_node| {
+                if source_node.tag != tag::PARA_HEADER {
+                    return source_node.clone();
+                }
+                let merged = merge_paragraph_node(
+                    source_node,
+                    emitted_paragraphs[paragraph_index],
+                    &original.paragraphs[paragraph_index],
+                    &edited.paragraphs[paragraph_index],
+                );
+                paragraph_index += 1;
+                merged
+            })
+            .collect());
+    }
+
+    let mut roots = Vec::with_capacity(emitted_roots.len());
+    for (edited_index, emitted_node) in emitted_paragraphs.iter().enumerate() {
+        if let Some(original_index) = matches[edited_index] {
+            roots.push(merge_paragraph_node(
+                source_paragraphs[original_index],
+                emitted_node,
+                &original.paragraphs[original_index],
+                &edited.paragraphs[edited_index],
+            ));
+        } else {
+            roots.push((*emitted_node).clone());
+        }
+    }
+
+    if original.extras == edited.extras {
+        roots.extend(
+            source_roots
+                .iter()
+                .filter(|node| node.tag != tag::PARA_HEADER)
+                .cloned(),
+        );
+    } else {
+        roots.extend(
+            emitted_roots
+                .iter()
+                .filter(|node| node.tag != tag::PARA_HEADER)
+                .cloned(),
+        );
+    }
+    Ok(roots)
+}
+
+fn match_paragraphs(original: &[Paragraph], edited: &[Paragraph]) -> Vec<Option<usize>> {
+    let mut used = vec![false; original.len()];
+    let mut matches = vec![None; edited.len()];
+    for (edited_index, paragraph) in edited.iter().enumerate() {
+        let instance_id = paragraph.header.instance_id;
+        if instance_id == 0
+            || edited
+                .iter()
+                .filter(|candidate| candidate.header.instance_id == instance_id)
+                .count()
+                != 1
+        {
+            continue;
+        }
+        let candidates = original
+            .iter()
+            .enumerate()
+            .filter(|(index, candidate)| {
+                !used[*index] && candidate.header.instance_id == instance_id
+            })
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        if candidates.len() == 1 {
+            used[candidates[0]] = true;
+            matches[edited_index] = Some(candidates[0]);
+        }
+    }
+    for (edited_index, paragraph) in edited.iter().enumerate() {
+        if matches[edited_index].is_some() {
+            continue;
+        }
+        if let Some((original_index, _)) = original
+            .iter()
+            .enumerate()
+            .find(|(index, candidate)| !used[*index] && *candidate == paragraph)
+        {
+            used[original_index] = true;
+            matches[edited_index] = Some(original_index);
+        }
+    }
+    if original.len() == edited.len() {
+        for edited_index in 0..edited.len() {
+            if matches[edited_index].is_none() && !used[edited_index] {
+                used[edited_index] = true;
+                matches[edited_index] = Some(edited_index);
+            }
+        }
+    }
+    matches
+}
+
+fn merge_paragraph_node(
+    source: &RecordNode,
+    emitted: &RecordNode,
+    original: &Paragraph,
+    edited: &Paragraph,
+) -> RecordNode {
+    if original == edited {
+        return source.clone();
+    }
+    let source_controls = source
+        .children
+        .iter()
+        .filter(|node| node.tag == tag::CTRL_HEADER)
+        .collect::<Vec<_>>();
+    let control_matches = match_controls(&original.controls, &edited.controls);
+    let mut merged = emitted.clone();
+    let mut edited_control_index = 0usize;
+    for child in &mut merged.children {
+        if child.tag != tag::CTRL_HEADER {
+            continue;
+        }
+        if let Some(Some(original_control_index)) = control_matches.get(edited_control_index)
+            && let (Some(source_control), Some(original_control), Some(edited_control)) = (
+                source_controls.get(*original_control_index),
+                original.controls.get(*original_control_index),
+                edited.controls.get(edited_control_index),
+            )
+        {
+            *child = merge_control_node(source_control, child, original_control, edited_control);
+        }
+        edited_control_index += 1;
+    }
+    merged
+}
+
+fn match_controls(original: &[Control], edited: &[Control]) -> Vec<Option<usize>> {
+    let mut used = vec![false; original.len()];
+    let mut matches = vec![None; edited.len()];
+    for (edited_index, control) in edited.iter().enumerate() {
+        if edited
+            .iter()
+            .filter(|candidate| *candidate == control)
+            .count()
+            != 1
+        {
+            continue;
+        }
+        let candidates = original
+            .iter()
+            .enumerate()
+            .filter(|(index, candidate)| !used[*index] && *candidate == control)
+            .map(|(index, _)| index)
+            .collect::<Vec<_>>();
+        if candidates.len() == 1 {
+            used[candidates[0]] = true;
+            matches[edited_index] = Some(candidates[0]);
+        }
+    }
+    if original.len() == edited.len() {
+        for edited_index in 0..edited.len() {
+            if matches[edited_index].is_none() && !used[edited_index] {
+                used[edited_index] = true;
+                matches[edited_index] = Some(edited_index);
+            }
+        }
+    }
+    matches
+}
+
+fn merge_control_node(
+    source: &RecordNode,
+    emitted: &RecordNode,
+    original: &Control,
+    edited: &Control,
+) -> RecordNode {
+    if original == edited {
+        return source.clone();
+    }
+    match (original, edited) {
+        (Control::Table(original), Control::Table(edited)) => {
+            merge_table_control(source, emitted, original, edited)
+        }
+        _ => emitted.clone(),
+    }
+}
+
+fn merge_table_control(
+    source: &RecordNode,
+    emitted: &RecordNode,
+    original: &Table,
+    edited: &Table,
+) -> RecordNode {
+    let mut original_structure = original.clone();
+    let mut edited_structure = edited.clone();
+    clear_table_paragraphs(&mut original_structure);
+    clear_table_paragraphs(&mut edited_structure);
+    let original_paragraphs = table_paragraphs(original);
+    let edited_paragraphs = table_paragraphs(edited);
+    if original_structure != edited_structure
+        || original_paragraphs.len() != edited_paragraphs.len()
+    {
+        return emitted.clone();
+    }
+
+    let source_indices = source
+        .children
+        .iter()
+        .enumerate()
+        .filter(|(_, node)| node.tag == tag::PARA_HEADER)
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    let emitted_paragraphs_nodes = emitted
+        .children
+        .iter()
+        .filter(|node| node.tag == tag::PARA_HEADER)
+        .collect::<Vec<_>>();
+    if source_indices.len() != original_paragraphs.len()
+        || emitted_paragraphs_nodes.len() != edited_paragraphs.len()
+    {
+        return emitted.clone();
+    }
+
+    let mut merged = source.clone();
+    for index in 0..original_paragraphs.len() {
+        if original_paragraphs[index] != edited_paragraphs[index] {
+            let child_index = source_indices[index];
+            merged.children[child_index] = merge_paragraph_node(
+                &source.children[child_index],
+                emitted_paragraphs_nodes[index],
+                original_paragraphs[index],
+                edited_paragraphs[index],
+            );
+        }
+    }
+    merged
+}
+
+fn clear_table_paragraphs(table: &mut Table) {
+    if let Some(caption) = &mut table.caption {
+        caption.paragraphs.clear();
+    }
+    for cell in &mut table.cells {
+        cell.paragraphs.clear();
+    }
+}
+
+fn table_paragraphs(table: &Table) -> Vec<&Paragraph> {
+    let mut paragraphs = table
+        .caption
+        .iter()
+        .flat_map(|caption| caption.paragraphs.iter())
+        .collect::<Vec<_>>();
+    paragraphs.extend(table.cells.iter().flat_map(|cell| cell.paragraphs.iter()));
+    paragraphs
+}
+
+fn materialize_document(
+    doc: &Document,
+    opts: &WriteOptions,
+    compressed: bool,
+    source_preserving: bool,
+) -> Result<HwpStreamMaterialization> {
     let mut report = WriteReport::new();
+    let input_bin_names = doc
+        .bin_streams
+        .iter()
+        .map(|stream| normalized_bin_name(&stream.name))
+        .collect::<Vec<_>>();
 
     // hwpx 출신 문서 정규화: hwp5 레코드(SHAPE_COMPONENT)가 없는 그림은
     // 쓸 수 없으므로 컨트롤과 확장 문자를 동기 제거한다
@@ -104,7 +564,9 @@ pub fn write_document_with_report(
             // 왕복에서 잃는다(hwpx writer/reader가 직렬화/복원하지 않음). 합성
             // 경로에서만 정상 표본 기준값을 보정 주입한다 — hwp5 무수정 왕복
             // (synthesize=false)은 거치지 않으므로 바이트 동일 게이트 무영향.
-            ensure_para_shape_defaults(&mut d.header);
+            if !source_preserving {
+                ensure_para_shape_defaults(&mut d.header);
+            }
             for section in &mut d.sections {
                 if let Some(p) = section.paragraphs.first_mut() {
                     p.header.break_type |= 0x03;
@@ -171,23 +633,18 @@ pub fn write_document_with_report(
     );
     let prv_text: Vec<u8> = preview.encode_utf16().flat_map(u16::to_le_bytes).collect();
 
-    // CFB 조립 — 반드시 버전 3 (512B 섹터): 한글은 V4(4096B)를
-    // "손상된 파일"로 판정한다 (실기 게이트 실측)
-    let file = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open(path)?;
-    let mut cfb = cfb::CompoundFile::create_with_version(cfb::Version::V3, file)?;
-    cfb.create_new_stream("/FileHeader")?
-        .write_all(&header.serialize())?;
-    cfb.create_new_stream("/DocInfo")?
-        .write_all(&compress(&doc_info))?;
-    cfb.create_storage("/BodyText")?;
+    let mut storages = BTreeSet::from(["/BodyText".to_string()]);
+    let mut streams = BTreeMap::new();
+    streams.insert("/FileHeader".to_string(), header.serialize());
+    streams.insert(
+        "/DocInfo".to_string(),
+        encode_compressed_stream(doc_info, compressed),
+    );
     for (i, body) in sections.iter().enumerate() {
-        cfb.create_new_stream(format!("/BodyText/Section{i}"))?
-            .write_all(&compress(body))?;
+        streams.insert(
+            format!("/BodyText/Section{i}"),
+            encode_compressed_stream(body.clone(), compressed),
+        );
     }
     // BIN_DATA 테이블이 참조하는 스트림만 동봉 (hwp5 명명 규칙)
     let referenced: Vec<String> = doc
@@ -201,13 +658,21 @@ pub fn write_document_with_report(
         })
         .collect();
     let mut bin_written = 0usize;
+    let mut bin_stream_paths = BTreeMap::new();
     if !referenced.is_empty() && !doc.bin_streams.is_empty() {
-        cfb.create_storage("/BinData")?;
-        for bin in &doc.bin_streams {
+        storages.insert("/BinData".to_string());
+        for (index, bin) in doc.bin_streams.iter().enumerate() {
             let base = bin.name.rsplit('/').next().unwrap_or(&bin.name);
             if referenced.iter().any(|r| r.eq_ignore_ascii_case(base)) {
-                cfb.create_new_stream(format!("/BinData/{base}"))?
-                    .write_all(&compress(&bin.data))?;
+                let stream_path = format!("/BinData/{base}");
+                streams.insert(
+                    stream_path.clone(),
+                    encode_compressed_stream(bin.data.clone(), compressed),
+                );
+                bin_stream_paths.insert(normalized_bin_name(base), stream_path.clone());
+                if let Some(input_name) = input_bin_names.get(index) {
+                    bin_stream_paths.insert(input_name.clone(), stream_path);
+                }
                 bin_written += 1;
             }
         }
@@ -219,31 +684,30 @@ pub fn write_document_with_report(
             bin_written
         ));
     }
-    // 보조 스트림: 한글 저장 파일에 항상 존재 (부재 시 손상 판정 위험)
-    cfb.create_storage("/DocOptions")?;
-    cfb.create_new_stream("/DocOptions/_LinkDoc")?
-        .write_all(&[0u8; 524])?;
-    cfb.create_storage("/Scripts")?;
-    // 표본(한글 빈 문서) 원시 바이트 그대로 — 해제 시 버전 마커/빈 스크립트
-    cfb.create_new_stream("/Scripts/JScriptVersion")?
-        .write_all(&[
+    storages.insert("/DocOptions".to_string());
+    streams.insert("/DocOptions/_LinkDoc".to_string(), vec![0u8; 524]);
+    storages.insert("/Scripts".to_string());
+    streams.insert(
+        "/Scripts/JScriptVersion".to_string(),
+        vec![
             0x63, 0x64, 0x80, 0x00, 0x00, 0xF7, 0xDF, 0x88, 0xA9, 0x08, 0x00, 0x00, 0x00,
-        ])?;
-    cfb.create_new_stream("/Scripts/DefaultJScript")?
-        .write_all(&[
+        ],
+    );
+    streams.insert(
+        "/Scripts/DefaultJScript".to_string(),
+        vec![
             0x63, 0x60, 0x40, 0x05, 0xFF, 0x81, 0x00, 0x00, 0x6E, 0xBB, 0x6E, 0xD1, 0x14, 0x00,
             0x00, 0x00,
-        ])?;
-    // 요약 정보 (표본과 동일한 14개 속성 구조, 메타데이터 채움)
-    cfb.create_new_stream("/\u{5}HwpSummaryInformation")?
-        .write_all(&hwp_summary_information(&doc.metadata))?;
-    cfb.create_new_stream("/PrvText")?.write_all(&prv_text)?;
+        ],
+    );
+    streams.insert(
+        "/\u{5}HwpSummaryInformation".to_string(),
+        hwp_summary_information(&doc.metadata),
+    );
+    streams.insert("/PrvText".to_string(), prv_text);
     if let Some(img) = &opts.prv_image {
-        cfb.create_new_stream("/PrvImage")?.write_all(img)?;
+        streams.insert("/PrvImage".to_string(), img.clone());
     }
-    // XMLTemplate·DocHistory 스토리지 원문 재방출(§3.2.10·§3.2.11 — 내용 미해석
-    // pass-through). read가 압축 미해제로 포착했으므로 그대로 쓴다(compress 금지 —
-    // 바이트 동일 보존). 스트림의 상위 스토리지는 mkdir -p로 확보한다.
     for (path, bytes) in doc
         .hwp5_xml_template
         .iter()
@@ -252,15 +716,42 @@ pub fn write_document_with_report(
         if let Some((parent, _)) = path.rsplit_once('/')
             && !parent.is_empty()
         {
+            storages.insert(parent.to_string());
+        }
+        streams.insert(path.clone(), bytes.clone());
+    }
+
+    Ok(HwpStreamMaterialization {
+        storages,
+        streams,
+        bin_stream_paths,
+        report,
+    })
+}
+
+fn write_materialized_document(
+    path: &Path,
+    materialization: &HwpStreamMaterialization,
+) -> Result<()> {
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)?;
+    let mut cfb = cfb::CompoundFile::create_with_version(cfb::Version::V3, file)?;
+    for storage in &materialization.storages {
+        cfb.create_storage_all(storage)?;
+    }
+    for (stream_path, bytes) in &materialization.streams {
+        if let Some((parent, _)) = stream_path.rsplit_once('/')
+            && !parent.is_empty()
+        {
             cfb.create_storage_all(parent)?;
         }
-        cfb.create_new_stream(path.as_str())?.write_all(bytes)?;
+        cfb.create_new_stream(stream_path)?.write_all(bytes)?;
     }
-    // 신규 합성 CFB의 directory timestamp는 내용과 무관한 현재 시각을 사용하면
-    // 동일 문서도 매번 다른 바이트가 된다. CFB epoch(1601-01-01)로 root/storage를
-    // 고정한다. stream timestamp는 CFB 규격상 이미 0이며 cfb API도 변경하지 않는다.
-    // 이 함수는 언제나 새 파일을 조립하는 경로라 기존 파일의 원본 timestamp 보존
-    // 계약에는 영향을 주지 않는다.
+
     const SECONDS_FROM_CFB_TO_UNIX_EPOCH: u64 = 11_644_473_600;
     let cfb_epoch = std::time::UNIX_EPOCH
         .checked_sub(std::time::Duration::from_secs(
@@ -276,7 +767,198 @@ pub fn write_document_with_report(
         cfb.set_modified_time(&entry_path, cfb_epoch)?;
     }
     cfb.flush()?;
-    Ok(report)
+    Ok(())
+}
+
+fn encode_compressed_stream(bytes: Vec<u8>, compressed: bool) -> Vec<u8> {
+    if compressed { compress(&bytes) } else { bytes }
+}
+
+fn validate_source_rewrite_contract(original: &Document, edited: &Document) -> Result<()> {
+    if original.meta.source_format != "hwp5" || edited.meta.source_format != "hwp5" {
+        return Err(crate::error::Hwp5Error::SourceRewrite(
+            "source-preserving rewrite requires HWP5 IR".to_string(),
+        ));
+    }
+    if original.meta != edited.meta {
+        return Err(crate::error::Hwp5Error::SourceRewrite(
+            "source format and version cannot be changed by a native rewrite".to_string(),
+        ));
+    }
+    if original.hwpx_settings_xml != edited.hwpx_settings_xml
+        || original.hwpx_version_xml != edited.hwpx_version_xml
+        || original.hwpx_preview_image != edited.hwpx_preview_image
+        || original.hwp5_xml_template != edited.hwp5_xml_template
+        || original.hwp5_doc_history != edited.hwp5_doc_history
+    {
+        return Err(crate::error::Hwp5Error::SourceRewrite(
+            "opaque ancillary payloads are not editable through the HWP IR writer".to_string(),
+        ));
+    }
+    ensure_unique_bin_names(original)?;
+    ensure_unique_bin_names(edited)?;
+    Ok(())
+}
+
+fn ensure_unique_bin_names(document: &Document) -> Result<()> {
+    let mut names = BTreeSet::new();
+    for stream in &document.bin_streams {
+        let name = normalized_bin_name(&stream.name);
+        if !names.insert(name) {
+            return Err(crate::error::Hwp5Error::SourceRewrite(
+                "duplicate case-insensitive BinData names cannot be rewritten safely".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+impl HwpMutationPlan {
+    fn derive(original: &Document, edited: &Document) -> Self {
+        let changed_sections = edited
+            .sections
+            .iter()
+            .enumerate()
+            .filter(|(index, section)| original.sections.get(*index) != Some(*section))
+            .map(|(index, _)| index)
+            .collect();
+        let removed_sections = (edited.sections.len()..original.sections.len()).collect();
+
+        let original_bins = document_bins(original);
+        let edited_bins = document_bins(edited);
+        let changed_bins: BTreeSet<String> = edited_bins
+            .iter()
+            .filter(|(name, stream)| original_bins.get(*name) != Some(stream))
+            .map(|(name, _)| name.clone())
+            .collect();
+        let removed_bins: BTreeSet<String> = original_bins
+            .keys()
+            .filter(|name| !edited_bins.contains_key(*name))
+            .cloned()
+            .collect();
+        let bin_relationships_changed = original_bins.keys().ne(edited_bins.keys());
+        let header_changed = original.header != edited.header
+            || original.sections.len() != edited.sections.len()
+            || bin_relationships_changed;
+
+        Self {
+            metadata_changed: original.metadata != edited.metadata,
+            header_changed,
+            changed_sections,
+            removed_sections,
+            changed_bins,
+            removed_bins,
+        }
+    }
+}
+
+fn document_bins(document: &Document) -> BTreeMap<String, &hwp_model::BinStream> {
+    document
+        .bin_streams
+        .iter()
+        .map(|stream| (normalized_bin_name(&stream.name), stream))
+        .collect()
+}
+
+fn normalized_bin_name(name: &str) -> String {
+    name.rsplit('/').next().unwrap_or(name).to_ascii_lowercase()
+}
+
+fn patch_source_container(
+    path: &Path,
+    plan: &HwpMutationPlan,
+    source_bin_paths: &BTreeMap<String, String>,
+    materialization: &HwpStreamMaterialization,
+) -> Result<()> {
+    let mut cfb = cfb::open_rw(path)?;
+
+    if plan.metadata_changed {
+        replace_cfb_stream(
+            &mut cfb,
+            "/\u{5}HwpSummaryInformation",
+            required_materialized_stream(materialization, "/\u{5}HwpSummaryInformation")?,
+        )?;
+    }
+    if plan.header_changed {
+        replace_cfb_stream(
+            &mut cfb,
+            "/DocInfo",
+            required_materialized_stream(materialization, "/DocInfo")?,
+        )?;
+    }
+    for index in &plan.changed_sections {
+        let stream_path = format!("/BodyText/Section{index}");
+        replace_cfb_stream(
+            &mut cfb,
+            &stream_path,
+            required_materialized_stream(materialization, &stream_path)?,
+        )?;
+    }
+    for index in &plan.removed_sections {
+        let stream_path = format!("/BodyText/Section{index}");
+        if cfb.is_stream(&stream_path) {
+            cfb.remove_stream(&stream_path)?;
+        }
+    }
+
+    for normalized_name in &plan.changed_bins {
+        let stream_path = materialization
+            .bin_stream_paths
+            .get(normalized_name)
+            .ok_or_else(|| {
+                crate::error::Hwp5Error::SourceRewrite(
+                    "a changed BinData item is not representable in the materialized document"
+                        .to_string(),
+                )
+            })?;
+        let bytes = required_materialized_stream(materialization, stream_path)?;
+        replace_cfb_stream(&mut cfb, stream_path, bytes)?;
+    }
+    for normalized_name in &plan.removed_bins {
+        if let Some(stream_path) = source_bin_paths.get(normalized_name)
+            && cfb.is_stream(stream_path)
+        {
+            cfb.remove_stream(stream_path)?;
+        }
+    }
+
+    if !plan.changed_sections.is_empty() || !plan.removed_sections.is_empty() {
+        replace_cfb_stream(
+            &mut cfb,
+            "/PrvText",
+            required_materialized_stream(materialization, "/PrvText")?,
+        )?;
+        if let Some(preview) = materialization.streams.get("/PrvImage") {
+            replace_cfb_stream(&mut cfb, "/PrvImage", preview)?;
+        }
+    }
+    cfb.flush()?;
+    Ok(())
+}
+
+fn required_materialized_stream<'a>(
+    materialization: &'a HwpStreamMaterialization,
+    path: &str,
+) -> Result<&'a [u8]> {
+    materialization
+        .streams
+        .get(path)
+        .map(Vec::as_slice)
+        .ok_or_else(|| crate::error::Hwp5Error::StreamNotFound(path.to_string()))
+}
+
+fn replace_cfb_stream(
+    cfb: &mut cfb::CompoundFile<std::fs::File>,
+    path: &str,
+    bytes: &[u8],
+) -> Result<()> {
+    if let Some((parent, _)) = path.rsplit_once('/')
+        && !parent.is_empty()
+    {
+        cfb.create_storage_all(parent)?;
+    }
+    cfb.create_stream(path)?.write_all(bytes)?;
+    Ok(())
 }
 
 /// PARA_HEADER instance_id(offset 18~22)가 0이면 유니크 non-zero 값을 부여.
@@ -2117,8 +2799,32 @@ fn emit_paragraph(
             children: Vec::new(),
         });
     }
-    children.extend(para.extras.iter().map(opaque_to_node));
-    for control in &para.controls {
+    let mut next_extra = 0;
+    let mut next_control = 0;
+    for kind in &para.header.hwp5_child_order {
+        match kind {
+            hwp_model::Hwp5ParagraphChild::Extra => {
+                if let Some(extra) = para.extras.get(next_extra) {
+                    children.push(opaque_to_node(extra));
+                    next_extra += 1;
+                }
+            }
+            hwp_model::Hwp5ParagraphChild::Control => {
+                if let Some(control) = para.controls.get(next_control) {
+                    children.push(emit_control(
+                        control,
+                        synthesize,
+                        preserve_linesegs,
+                        add_tracking_tail,
+                        warnings,
+                    ));
+                    next_control += 1;
+                }
+            }
+        }
+    }
+    children.extend(para.extras[next_extra..].iter().map(opaque_to_node));
+    for control in &para.controls[next_control..] {
         children.push(emit_control(
             control,
             synthesize,
@@ -2560,6 +3266,424 @@ fn emit_picture(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn source_rewrite_path(label: &str) -> std::path::PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!(
+            "hwp5-source-rewrite-{label}-{}-{unique}.hwp",
+            std::process::id(),
+        ))
+    }
+
+    fn add_opaque_source_entries(path: &Path) {
+        let mut cfb = cfb::open_rw(path).unwrap();
+        cfb.create_stream("/MemoExtended")
+            .unwrap()
+            .write_all(b"opaque-memo-payload")
+            .unwrap();
+        cfb.create_storage_all("/OpaqueStorage").unwrap();
+        cfb.create_stream("/OpaqueStorage/Hidden")
+            .unwrap()
+            .write_all(b"opaque-hidden-payload")
+            .unwrap();
+        cfb.flush().unwrap();
+    }
+
+    fn raw_streams(path: &Path) -> BTreeMap<String, Vec<u8>> {
+        let mut container = crate::Hwp5Container::open(path).unwrap();
+        container
+            .list_streams()
+            .into_iter()
+            .map(|stream| {
+                let bytes = container.read_stream_raw(&stream.path).unwrap();
+                (stream.path, bytes)
+            })
+            .collect()
+    }
+
+    fn find_control_node(nodes: &[RecordNode], reversed_id: &[u8; 4]) -> Option<RecordNode> {
+        for node in nodes {
+            if node.tag == tag::CTRL_HEADER && node.data.get(..4) == Some(reversed_id) {
+                return Some(node.clone());
+            }
+            if let Some(found) = find_control_node(&node.children, reversed_id) {
+                return Some(found);
+            }
+        }
+        None
+    }
+
+    fn section_definition_node(path: &Path) -> RecordNode {
+        let mut container = crate::Hwp5Container::open(path).unwrap();
+        let bytes = container.read_record_stream("/BodyText/Section0").unwrap();
+        let roots = scan_stream(&bytes, ScanMode::Strict).unwrap().roots;
+        find_control_node(&roots, b"dces").expect("section definition")
+    }
+
+    fn prepend_section_ctrl_data(path: &Path) {
+        let mut container = crate::Hwp5Container::open(path).unwrap();
+        let compressed = container.file_header().is_compressed();
+        let bytes = container.read_record_stream("/BodyText/Section0").unwrap();
+        drop(container);
+        let mut roots = scan_stream(&bytes, ScanMode::Strict).unwrap().roots;
+
+        fn prepend(nodes: &mut [RecordNode]) -> bool {
+            for node in nodes {
+                if node.tag == tag::CTRL_HEADER && node.data.get(..4) == Some(b"dces") {
+                    node.children.insert(
+                        0,
+                        RecordNode {
+                            tag: tag::CTRL_DATA,
+                            data: b"source-order-sentinel".to_vec(),
+                            children: Vec::new(),
+                        },
+                    );
+                    return true;
+                }
+                if prepend(&mut node.children) {
+                    return true;
+                }
+            }
+            false
+        }
+        assert!(prepend(&mut roots));
+        let encoded = encode_compressed_stream(RecordNode::serialize_forest(&roots), compressed);
+        let mut cfb = cfb::open_rw(path).unwrap();
+        cfb.create_stream("/BodyText/Section0")
+            .unwrap()
+            .write_all(&encoded)
+            .unwrap();
+        cfb.flush().unwrap();
+    }
+
+    #[test]
+    fn source_preserving_noop_is_an_exact_file_copy() {
+        let source = source_rewrite_path("noop-source");
+        let output = source_rewrite_path("noop-output");
+        let document = hwp_convert::from_markdown("source preserving no-op");
+        write_document_with_report(&document, &source, &WriteOptions::default()).unwrap();
+        add_opaque_source_entries(&source);
+        let original = crate::read_document(&source).unwrap().document;
+
+        rewrite_document_with_report(
+            &source,
+            &original,
+            &original,
+            &output,
+            &WriteOptions::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            std::fs::read(&source).unwrap(),
+            std::fs::read(&output).unwrap()
+        );
+        std::fs::remove_file(source).unwrap();
+        std::fs::remove_file(output).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_preserving_rewrite_rejects_hardlink_output_alias() {
+        let source = source_rewrite_path("alias-source");
+        let output = source_rewrite_path("alias-output");
+        let document = hwp_convert::from_markdown("source alias guard");
+        write_document_with_report(&document, &source, &WriteOptions::default()).unwrap();
+        std::fs::hard_link(&source, &output).unwrap();
+        let original_bytes = std::fs::read(&source).unwrap();
+        let original = crate::read_document(&source).unwrap().document;
+
+        let error = rewrite_document_with_report(
+            &source,
+            &original,
+            &original,
+            &output,
+            &WriteOptions::default(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(error, crate::error::Hwp5Error::SourceRewrite(_)));
+        assert_eq!(std::fs::read(&source).unwrap(), original_bytes);
+        std::fs::remove_file(output).unwrap();
+        std::fs::remove_file(source).unwrap();
+    }
+
+    #[test]
+    fn source_mutation_plan_updates_docinfo_when_section_count_changes() {
+        let original = hwp_convert::from_markdown("first section");
+        let mut added = original.clone();
+        added.sections.push(hwp_model::Section::default());
+        let add_plan = HwpMutationPlan::derive(&original, &added);
+        assert!(add_plan.header_changed);
+        assert_eq!(add_plan.changed_sections, BTreeSet::from([1]));
+        assert!(add_plan.removed_sections.is_empty());
+
+        let remove_plan = HwpMutationPlan::derive(&added, &original);
+        assert!(remove_plan.header_changed);
+        assert_eq!(remove_plan.removed_sections, BTreeSet::from([1]));
+    }
+
+    #[test]
+    fn source_mutation_plan_does_not_rewrite_docinfo_for_bin_payload_only() {
+        let original = hwp_convert::from_markdown("binary payload");
+        let mut edited = original.clone();
+        edited.bin_streams.push(hwp_model::BinStream {
+            name: "BIN0001.png".to_string(),
+            data: vec![1, 2, 3],
+        });
+        let with_bin = edited.clone();
+        edited.bin_streams[0].data = vec![4, 5, 6];
+
+        let plan = HwpMutationPlan::derive(&with_bin, &edited);
+        assert!(!plan.header_changed);
+        assert_eq!(
+            plan.changed_bins,
+            BTreeSet::from(["bin0001.png".to_string()])
+        );
+        assert!(plan.removed_bins.is_empty());
+    }
+
+    #[test]
+    fn control_matching_preserves_shifted_unique_controls_without_guessing_duplicates() {
+        fn generic(id: [u8; 4]) -> Control {
+            Control::Generic(hwp_model::GenericControl {
+                ctrl_id: id,
+                data: Vec::new(),
+                paragraph_lists: Vec::new(),
+                extras: Vec::new(),
+                raw_children: Vec::new(),
+                gso_shapes: Vec::new(),
+                equation: None,
+                column_def: None,
+                caption: None,
+            })
+        }
+
+        let first = generic(*b"one ");
+        let second = generic(*b"two ");
+        assert_eq!(
+            match_controls(&[first, second.clone()], std::slice::from_ref(&second)),
+            vec![Some(1)]
+        );
+        assert_eq!(
+            match_controls(&[second.clone(), second.clone()], &[second]),
+            vec![None]
+        );
+    }
+
+    #[test]
+    fn source_preserving_metadata_edit_changes_only_summary_stream() {
+        let source = source_rewrite_path("metadata-source");
+        let output = source_rewrite_path("metadata-output");
+        let document = hwp_convert::from_markdown("source preserving metadata");
+        write_document_with_report(&document, &source, &WriteOptions::default()).unwrap();
+        add_opaque_source_entries(&source);
+        let original = crate::read_document(&source).unwrap().document;
+        let mut edited = original.clone();
+        edited.metadata.title = Some("edited title".to_string());
+
+        rewrite_document_with_report(
+            &source,
+            &original,
+            &edited,
+            &output,
+            &WriteOptions {
+                preserve_linesegs: true,
+                ..WriteOptions::default()
+            },
+        )
+        .unwrap();
+
+        let source_streams = raw_streams(&source);
+        let output_streams = raw_streams(&output);
+        assert_eq!(
+            source_streams.keys().collect::<Vec<_>>(),
+            output_streams.keys().collect::<Vec<_>>()
+        );
+        for (path, source_bytes) in source_streams {
+            if path == "/\u{5}HwpSummaryInformation" {
+                assert_ne!(source_bytes, output_streams[&path]);
+            } else {
+                assert_eq!(
+                    source_bytes, output_streams[&path],
+                    "unexpected stream change: {path}"
+                );
+            }
+        }
+        assert_eq!(
+            crate::read_document(&output)
+                .unwrap()
+                .document
+                .metadata
+                .title
+                .as_deref(),
+            Some("edited title")
+        );
+        std::fs::remove_file(source).unwrap();
+        std::fs::remove_file(output).unwrap();
+    }
+
+    #[test]
+    fn source_preserving_text_edit_keeps_opaque_streams_raw() {
+        let source = source_rewrite_path("text-source");
+        let output = source_rewrite_path("text-output");
+        let document = hwp_convert::from_markdown("replace this text");
+        write_document_with_report(&document, &source, &WriteOptions::default()).unwrap();
+        add_opaque_source_entries(&source);
+        let original = crate::read_document(&source).unwrap().document;
+        let mut edited = original.clone();
+        assert_eq!(
+            hwp_convert::replace_text(&mut edited, "replace", "updated", true),
+            1
+        );
+
+        rewrite_document_with_report(
+            &source,
+            &original,
+            &edited,
+            &output,
+            &WriteOptions {
+                preserve_linesegs: true,
+                ..WriteOptions::default()
+            },
+        )
+        .unwrap();
+
+        let source_streams = raw_streams(&source);
+        let output_streams = raw_streams(&output);
+        for path in [
+            "/FileHeader",
+            "/DocInfo",
+            "/MemoExtended",
+            "/OpaqueStorage/Hidden",
+        ] {
+            assert_eq!(
+                source_streams[path], output_streams[path],
+                "unexpected stream change: {path}"
+            );
+        }
+        assert_ne!(
+            source_streams["/BodyText/Section0"],
+            output_streams["/BodyText/Section0"]
+        );
+        assert_ne!(source_streams["/PrvText"], output_streams["/PrvText"]);
+        assert!(
+            crate::read_document(&output)
+                .unwrap()
+                .document
+                .plain_text()
+                .contains("updated")
+        );
+        std::fs::remove_file(source).unwrap();
+        std::fs::remove_file(output).unwrap();
+    }
+
+    #[test]
+    fn source_preserving_text_edit_keeps_unchanged_typed_control_subtrees_raw() {
+        let source = source_rewrite_path("typed-control-source");
+        let output = source_rewrite_path("typed-control-output");
+        let document = hwp_convert::from_markdown("replace this text");
+        write_document_with_report(&document, &source, &WriteOptions::default()).unwrap();
+        prepend_section_ctrl_data(&source);
+        let original = crate::read_document(&source).unwrap().document;
+        let mut edited = original.clone();
+        assert_eq!(
+            hwp_convert::replace_text(&mut edited, "replace", "updated", true),
+            1
+        );
+
+        rewrite_document_with_report(
+            &source,
+            &original,
+            &edited,
+            &output,
+            &WriteOptions {
+                preserve_linesegs: true,
+                ..WriteOptions::default()
+            },
+        )
+        .unwrap();
+
+        let source_section = section_definition_node(&source);
+        assert_eq!(source_section.children[0].tag, tag::CTRL_DATA);
+        assert_eq!(source_section, section_definition_node(&output));
+        assert!(
+            crate::read_document(&output)
+                .unwrap()
+                .document
+                .plain_text()
+                .contains("updated")
+        );
+        std::fs::remove_file(source).unwrap();
+        std::fs::remove_file(output).unwrap();
+    }
+
+    #[test]
+    fn source_preserving_image_insert_materializes_only_new_relationships() {
+        let source = source_rewrite_path("image-source");
+        let output = source_rewrite_path("image-output");
+        let asset = source_rewrite_path("image-asset").with_extension("gif");
+        let gif = vec![
+            0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x02, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0xff, 0xff, 0xff, 0x21, 0xf9, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00, 0x2c,
+            0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0x00, 0x00, 0x02, 0x02, 0x44, 0x01, 0x00,
+            0x3b,
+        ];
+        std::fs::write(&asset, gif).unwrap();
+        let document = hwp_convert::from_markdown("image anchor");
+        write_document_with_report(&document, &source, &WriteOptions::default()).unwrap();
+        add_opaque_source_entries(&source);
+        let original = crate::read_document(&source).unwrap().document;
+        let mut edited = original.clone();
+        hwp_convert::insert_image(
+            &mut edited,
+            "anchor",
+            &asset,
+            hwp_convert::ImageSize::Mm(20.0, 10.0),
+        )
+        .unwrap();
+
+        let report = rewrite_document_with_report(
+            &source,
+            &original,
+            &edited,
+            &output,
+            &WriteOptions {
+                edited: true,
+                ..WriteOptions::default()
+            },
+        )
+        .unwrap();
+        assert!(report.preservation.is_lossless());
+
+        let source_streams = raw_streams(&source);
+        let output_streams = raw_streams(&output);
+        for path in ["/FileHeader", "/MemoExtended", "/OpaqueStorage/Hidden"] {
+            assert_eq!(
+                source_streams[path], output_streams[path],
+                "unexpected stream change: {path}"
+            );
+        }
+        let reopened = crate::read_document(&output).unwrap().document;
+        assert_eq!(reopened.bin_streams.len(), original.bin_streams.len() + 1);
+        let picture = reopened.sections[0]
+            .paragraphs
+            .iter()
+            .flat_map(|paragraph| &paragraph.controls)
+            .find_map(|control| match control {
+                Control::Picture(picture) => Some(picture),
+                _ => None,
+            })
+            .expect("inserted picture");
+        assert!(reopened.resolve_bin(&picture.bin_ref).is_some());
+
+        std::fs::remove_file(source).unwrap();
+        std::fs::remove_file(output).unwrap();
+        std::fs::remove_file(asset).unwrap();
+    }
 
     #[test]
     fn caption_hwpunit_values_saturate_instead_of_wrapping() {

--- a/docs/design/03-hwp5-write.ko.md
+++ b/docs/design/03-hwp5-write.ko.md
@@ -400,3 +400,38 @@ CTRL_HEADER data = `" lbt"`(=tbl 역순) + 개체 공통 속성(`common_data` �
 10. hwp5 원본 gso는 raw_children로 무손실; hwpx 도형은 안전 저하(재합성은 손상 재발).
 
 이 모든 값은 스펙이 아니라 정품 파일 실측 + 한글 실기 게이트로 확정한 정답지다.
+
+---
+
+## 13. 원본 보존형 네이티브 HWP 되쓰기
+
+네이티브 HWP 편집은 입력 컨테이너를 새로 조립하지 않는다. `rewrite_document_with_report`는
+불변 source 경로, 그 snapshot에서 읽은 IR, 편집 IR을 함께 받는다. 쓰기 전에 source를 다시 읽어
+원본 IR과 다르면 snapshot mismatch로 거부하고, 원본과 편집본의 차이로 mutation plan을 만든다.
+
+mutation plan이 소유하는 대상은 아래뿐이다.
+
+- 메타데이터 변경: `\u0005HwpSummaryInformation`
+- header 또는 BinData 관계 변경: `DocInfo`
+- section 변경: 해당 `BodyText/SectionN`과 미리보기
+- binary 변경·삭제: 해당 `BinData/*`
+
+무수정은 `fs::copy`이므로 CFB 전체가 바이트 동일하다. 편집 시에도 source CFB를 먼저 복사한 뒤
+선택한 stream만 교체한다. `FileHeader`, `MemoExtended`, `Scripts`, `DocOptions`, XMLTemplate,
+DocHistory, 미지 stream/storage, 미변경 binary, 패치 대상과 무관한 CFB directory entry는 source가 계속 소유한다.
+
+BodyText도 외과적으로 materialize한다. 문단은 고유한 non-zero `instance_id`, 완전 동일성, 동일
+길이 위치 fallback 순으로 대응한다. 미변경 문단은 원본 record subtree를 그대로 사용한다. 변경
+문단 안에서도 미변경 typed control은 source subtree를 이식하고, 표 셀 편집은 변경 셀 문단만
+재귀적으로 교체한다. `CTRL_DATA`, `PAGE_DEF`, `PAGE_BORDER_FILL`처럼 의미 IR에서 분리해 표현해도
+실제 record level과 순서가 중요한 구조를 지키기 위함이다. `ParaHeaderInfo::hwp5_child_order`도
+opaque 문단 자식과 `CTRL_HEADER` 사이의 원본 순서를 보존한다.
+
+변경·삽입 문단은 renderer로 새 `PARA_LINE_SEG`를 계산한다. 계산 후 표 셀과 generic control 내부를
+포함한 의미상 미변경 문단은 불변 snapshot 값으로 복원한다. 이 방식으로 stale layout cache와
+문서 전체 layout churn을 함께 피한다.
+
+CLI의 `convert` 무수정, `edit`, IR `fill` 경로는 쓰기 전에 private immutable input snapshot을
+만든다. 결과 공개는 기존처럼 atomic하며 typed preservation gate를 통과해야 한다. 회귀 테스트는
+무수정 exact copy, metadata-only targeting, opaque stream 보존, 미변경 typed control subtree 보존,
+image 관계 materialization, 같은 포맷 CLI 바이트 동일을 고정한다.

--- a/docs/design/03-hwp5-write.md
+++ b/docs/design/03-hwp5-write.md
@@ -567,3 +567,41 @@ alike, and the invariant `wchar_len() == nchars` exposes a classification error 
 
 Every one of these values is ground truth confirmed by measuring genuine files and passing the Hancom
 gate, not by reading the specification.
+
+---
+
+## 13. Source-preserving native HWP rewrites
+
+Native HWP editing does not rebuild the input container. `rewrite_document_with_report` receives an
+immutable source path, the IR read from that exact snapshot, and the edited IR. It re-reads the source
+and rejects a snapshot mismatch before deriving a mutation plan.
+
+The plan owns only these targets:
+
+- metadata changes replace `\u0005HwpSummaryInformation`;
+- header or BinData relationship changes replace `DocInfo`;
+- section changes replace only the corresponding `BodyText/SectionN` stream and its previews;
+- changed or removed binaries touch only their `BinData/*` streams.
+
+A no-op is `fs::copy`, so the complete CFB file is byte-identical. For an edit, the source CFB is
+copied first and selected streams are patched in place. `FileHeader`, `MemoExtended`, `Scripts`,
+`DocOptions`, XMLTemplate, DocHistory, unknown streams, unknown storages, untouched binaries and CFB
+directory entries unrelated to patched streams remain source-owned.
+
+BodyText materialization also stays surgical. Paragraphs are matched by unique non-zero
+`instance_id`, then exact equality, with a same-length positional fallback. An unchanged paragraph is
+the original record subtree. In a changed paragraph, unchanged typed controls are transplanted from
+the source tree; a table-cell edit recursively patches only the changed cell paragraph. This matters
+because records such as `CTRL_DATA`, `PAGE_DEF` and `PAGE_BORDER_FILL` can be level-sensitive even
+when the semantic IR represents them separately. `ParaHeaderInfo::hwp5_child_order` additionally
+retains the source order between opaque paragraph children and `CTRL_HEADER` records.
+
+Changed or inserted paragraphs get fresh `PARA_LINE_SEG` values from the renderer. After synthesis,
+all semantically unchanged native paragraphs, including table-cell and generic-control paragraphs,
+are restored from the immutable snapshot. This avoids both stale layout caches and global layout
+churn.
+
+The CLI `convert` no-op, `edit`, and IR `fill` paths take a private immutable input snapshot before
+writing. The published output is still atomic and passes the typed preservation gate. The regression
+suite covers exact no-op copy, metadata-only targeting, opaque stream preservation, unchanged typed
+control subtree preservation, image relationship materialization, and same-format CLI byte identity.

--- a/docs/design/07-hangul-compat-rules.ko.md
+++ b/docs/design/07-hangul-compat-rules.ko.md
@@ -186,6 +186,20 @@ code, resource class, disposition은 닫힌 enum이며 개수만 집계한다. �
 
 ---
 
+## G. 원본 보존형 네이티브 HWP 편집
+
+| # | 현상 | 원인 | 수정 | 정답지 |
+|---|---|---|---|---|
+| G1 | 정품 복합 문서의 텍스트 하나를 편집해도 손상 경고 | section 전체 재방출 시 `CTRL_DATA`, `PAGE_DEF`, `PAGE_BORDER_FILL` 같은 level-sensitive typed-control 자식의 순서 이동 | source CFB를 복사하고 변경 section stream 안에서도 미변경 문단/control subtree를 원본에서 이식 | BodyText 이분 탐색 + 정품 복합 제안서 일부; 미변경 subtree 바이트 동일 |
+| G2 | stale line layout 제거 또는 전체 재생성 시 손상 경고·layout churn | 변경된 5.1.x 문단에는 내용과 정합한 `PARA_LINE_SEG`가 필요하고, 미변경 문단은 원본 cache를 유지해야 함 | 편집본에 layout을 합성한 뒤 의미상 미변경 네이티브 문단을 불변 snapshot 값으로 복원 | 한글에서 no-op, metadata, text, paragraph 삽입, table-cell 편집, image 삽입 모두 경고 없이 열림 |
+| G3 | 같은 포맷 no-op이 보조 stream 또는 CFB metadata 변경 | 새 container 조립으로 미지 stream/storage/directory 속성을 재현할 수 없음 | no-op은 exact file copy, 편집은 mutation plan이 지목한 stream만 교체 | exact-file 비교 + `MemoExtended`, 미변경 BinData, 미지 entry 보존 |
+
+한글 acceptance는 선택적 smoke test가 아니라 네이티브 writer 계약이다. 내부 재읽기와 typed
+preservation 검사를 먼저 통과한 뒤 [체크리스트](../hancom-verification-checklist.ko.md)의 편집 6종을
+실제 한글에서 열어야 한다.
+
+---
+
 ## 종합 교훈 — 왜 이 프로젝트는 "실기·정답지"에 목숨을 걸었나
 
 1. **관대한 도구는 거짓 통과를 준다.** pyhwp·자체 렌더가 100% 통과해도 한글은 거부한다(A1 CFB V3, D6 무채움, D8 run한계 전부 우리 도구는 통과). "재읽기 무경고"는 필요조건일 뿐 충분조건이 아니다.

--- a/docs/design/07-hangul-compat-rules.md
+++ b/docs/design/07-hangul-compat-rules.md
@@ -249,6 +249,20 @@ sufficient"; only Hancom decides.
 
 ---
 
+## G. Source-preserving native HWP edits
+
+| # | Symptom | Cause | Fix | Ground truth |
+|---|---|---|---|---|
+| G1 | A text edit corrupts an otherwise genuine complex document | Re-emitting a whole section moves level-sensitive typed-control children such as `CTRL_DATA` around `PAGE_DEF` and `PAGE_BORDER_FILL` | Copy the source CFB and merge unchanged paragraph/control subtrees into only the changed section stream | BodyText bisection plus a complex genuine proposal fragment; all unchanged subtrees are byte-identical |
+| G2 | Removing stale line layout or globally regenerating it causes a corruption warning or layout churn | A changed 5.1.x paragraph needs a content-consistent `PARA_LINE_SEG`, while unchanged paragraphs must retain their original caches | Synthesize layout for the edited document, then restore every semantically unchanged native paragraph from the immutable snapshot | Hancom opened no-op, metadata, text, paragraph insertion, table-cell edit and image insertion outputs without warnings |
+| G3 | Same-format no-op loses auxiliary streams or changes CFB metadata | A fresh container assembly cannot reproduce unknown streams, storages and directory properties | Treat no-op as an exact file copy; on edits patch only streams named by the mutation plan | Exact-file comparison plus preservation of `MemoExtended`, untouched BinData and unknown entries |
+
+The Hancom acceptance procedure is now part of the native writer contract, not an optional smoke
+test. Internal re-read and typed preservation checks must pass first, followed by real Hancom opens of
+the six edit classes in [the checklist](../hancom-verification-checklist.md).
+
+---
+
 ## Overall lessons: why this project stakes everything on Hancom testing and ground truth
 
 1. **Lenient tools give false passes.** pyhwp and our own renderer can pass 100% while Hancom refuses

--- a/docs/design/12-feature-gaps.ko.md
+++ b/docs/design/12-feature-gaps.ko.md
@@ -40,9 +40,9 @@
 
 - hwp5의 `OpaqueRecord`(서브트리째 보존, [10](10-hwp5-structure-map.ko.md) §0 상태표)는
   `hwp5→hwp5` 왕복에서 **바이트를 잃지 않는다** → 레코드 수준에서는 그 경로의 갭이 아니다.
-  다만 IR 기반 full container rewrite가 부속 CFB stream이나 storage metadata까지 보존한다는 뜻은
-  아니다. 2026-08-14부터 typed preservation gate가 이 넓은 범위의 손실을 감지해 발행을 거부하며,
-  source-preserving HWP container repair는 이슈 #90에 남아 있다.
+  2026-08-14부터 네이티브 HWP 되쓰기는 불변 source CFB를 복사한 뒤 계획된 stream만 교체하여
+  부속 stream, storage, 미변경 binary payload까지 보존한다. package-surgical HWPX 편집은 이슈
+  #90에 남아 있다.
 - 같은 레코드를 `hwp5→hwpx`로 **합성**하려면 의미를 해석해 OWPML로 다시 써야 하는데, 그 지식이
   없으므로 **드롭**된다 → 합성 경로에선 갭.
 - 렌더러가 그 개체(차트·OLE 등)를 그리려면 페이로드 해석이 필요한데 안 되므로 **빈자리** →
@@ -80,8 +80,15 @@
   `hwp-preservation-report-v1` ledger를 추가했다. 원본 없는 작성과 같은 포맷 write는 writer omission
   또는 예상하지 않은 container/package loss가 있으면 atomic하게 실패하고, 포맷 간 strict 변환은
   semantic asset, control, relationship, metadata도 비교한다. 이는 silent publication을 해소한 것이며
-  writer 자체의 갭을 해소한 것은 아니다. source-preserving HWP repair와 package-surgical HWPX 편집은
-  이슈 #90에 남아 있다.
+  writer 자체의 갭을 해소한 것은 아니며, 다음 해소 이력에 HWP repair를 별도로 기록한다.
+  package-surgical HWPX 편집은 이슈 #90에 남아 있다.
+
+- **2026-08-14 (이슈 #90 source-preserving HWP writer)**: 같은 포맷 HWP `convert`, `edit`, IR
+  `fill`이 불변 input snapshot을 기준으로 쓴다. 무수정은 exact file copy이며, 편집은 stream
+  mutation plan을 만들고 미변경 CFB entry와 BinData를 바이트 동일하게 유지한다. BodyText는
+  미변경 subtree를 보존하고 변경·삽입 문단에만 line layout을 합성한다. 비공개 복합 문서로
+  no-op, metadata, text, paragraph, table-cell, image를 검증했으며 한글 손상 경고 없이 모두
+  통과했다. #90의 잔여 작업에는 package-surgical HWPX 편집이 포함된다.
 
 - **2026-07-15**: GA-5(버전 게이트), GE-α1~α5·α7(글자효과·밑줄모양·번호형식 hwpx 왕복),
   GE-β4(요약정보 필드), GH-1·GH-2(md/html 링크·이미지), GL-1(추출 옵션 CLI 노출) —

--- a/docs/design/12-feature-gaps.md
+++ b/docs/design/12-feature-gaps.md
@@ -45,10 +45,9 @@ The same record can be a gap or not **depending on which path you look from**. T
 
 - An hwp5 `OpaqueRecord` (the whole subtree preserved; see the status table in
   [10](10-hwp5-structure-map.md) §0) **loses no bytes** in an `hwp5 → hwp5` round-trip, so it is
-  not a record-level gap on that path. This does not imply that an IR-based full container rewrite
-  preserves ancillary CFB streams or storage metadata. Since 2026-08-14, the typed preservation gate
-  detects that wider loss and refuses publication; source-preserving HWP container repair remains
-  tracked by issue #90.
+  not a record-level gap on that path. Since 2026-08-14, native HWP rewrites copy the immutable source
+  CFB and patch only planned streams, preserving ancillary streams, storages and untouched binary
+  payloads. Package-surgical HWPX editing remains tracked by issue #90.
 - To **synthesize** that same record as `hwp5 → hwpx`, its meaning would have to be interpreted and
   rewritten as OWPML; that knowledge is missing, so it is **dropped**, making it a gap on the
   synthesis path.
@@ -91,8 +90,15 @@ is itself knowledge).
   content-free `hwp-preservation-report-v1` ledger. Source-free authoring and same-format writes now
   fail atomically on writer omissions or unexpected container/package loss; cross-format strict
   conversion also compares semantic assets, controls, relationships and metadata. This resolves
-  silent publication, not the underlying writer gaps: source-preserving HWP repair and
-  package-surgical HWPX editing remain open in #90.
+  silent publication but did not itself repair either native writer; the next resolution entry
+  records the HWP repair. Package-surgical HWPX editing remains open in #90.
+
+- **2026-08-14 (issue #90 source-preserving HWP writer)**: same-format HWP `convert`, `edit` and IR
+  `fill` now write against an immutable input snapshot. A no-op is an exact file copy; edits derive a
+  stream mutation plan, retain untouched CFB entries and BinData byte-for-byte, preserve unchanged
+  BodyText subtrees, and synthesize line layout only for changed or inserted paragraphs. Private
+  complex-document acceptance passed no-op, metadata, text, paragraph, table-cell and image cases in
+  Hancom with no corruption warning. The remaining #90 work includes package-surgical HWPX editing.
 
 - **2026-07-15**: GA-5 (version gate), GE-α1 to α5 and α7 (character effects, underline shape and
   numbering format in the hwpx round-trip), GE-β4 (summary information fields), GH-1 and GH-2

--- a/docs/hancom-verification-checklist.ko.md
+++ b/docs/hancom-verification-checklist.ko.md
@@ -202,6 +202,23 @@ hwpx)를 확보하지 못해 수식 전용 속성(`version`·`baseLine`·`baseUn
 수식 편집기가 열리는지. 셋 중 무엇이냐에 따라 잘못된 속성이 갈린다(`font`/`baseUnit` vs
 `version` vs 자식 요소 순서). 정품 저장본 1개만 확보되면 그 속성으로 즉시 교체한다.
 
+## M. 원본 보존형 네이티브 HWP 편집 (이슈 #90)
+
+표·이미지·opaque 보조 stream을 포함한 비공개 정품 복합 HWP를 사용한다. source와 파생 결과는
+commit하지 않는다. 모든 케이스는 같은 불변 source snapshot에서 시작한다.
+
+| 케이스 | 필수 결과 |
+|---|---|
+| 같은 포맷 no-op convert | 파일 전체 바이트 동일, 경고 없이 열림 |
+| metadata 편집 | summary information만 변경, 경고 없이 열림 |
+| text 편집 | 미변경 control·asset 바이트 동일, 변경 텍스트 표시 |
+| paragraph 삽입 | 삽입 문단 표시, 주변 layout 안정 |
+| table-cell 편집 | 대상 셀 내용만 변경, 표 geometry 유지 |
+| image 삽입 | 기존 asset 바이트 동일, 새 relationship·payload 1개 추가 |
+
+각 결과에서 `FileHeader`, `MemoExtended`, scripts, document options, 미지 entry, 미변경 BinData를
+확인한 뒤 실제 한글로 연다. parser-only 통과는 충분하지 않다.
+
 ## 결과 회수
 각 파일에 O/X와 (실패 시) 팝업 메시지·증상을 알려주시면, 실패 항목만 정품 대조 패턴
 (가나다·다문단 실측)으로 수정합니다. 통과 항목은 미검증 → 실기 통과로 확정합니다.

--- a/docs/hancom-verification-checklist.md
+++ b/docs/hancom-verification-checklist.md
@@ -239,6 +239,23 @@ What to report on failure: whether the equation appears as **an empty box or que
 the three it is points at a different wrong attribute (`font`/`baseUnit` versus `version` versus child
 element order). Obtaining a single genuine saved file would let us replace the attributes immediately.
 
+## M. Source-preserving native HWP edits (issue #90)
+
+Use a private, genuinely complex HWP containing tables, images and opaque auxiliary streams. Do not
+commit the source or derived outputs. Run each case from the same immutable source snapshot.
+
+| Case | Required result |
+|---|---|
+| No-op same-format convert | Exact file bytes; opens without a warning |
+| Metadata edit | Only summary information changes; opens without a warning |
+| Text edit | Unchanged controls and assets remain byte-identical; edited text is visible |
+| Paragraph insertion | The inserted paragraph is visible and surrounding layout remains stable |
+| Table-cell edit | Only the target cell content changes; table geometry remains intact |
+| Image insertion | Existing assets remain byte-identical; one new relationship and payload appear |
+
+For every output, verify `FileHeader`, `MemoExtended`, scripts, document options, unknown entries and
+untouched BinData before opening it in Hancom. A parser-only pass is insufficient.
+
 ## Reporting results
 
 Tell us pass or fail per file and, on failure, the popup message and symptom; we then fix only the


### PR DESCRIPTION
## Summary

- add a source-preserving HWP rewrite API that copies an immutable CFB snapshot and patches only planned streams
- preserve unchanged paragraph, control, table-cell, opaque, auxiliary, and BinData subtrees while synthesizing layout only for changed or inserted paragraphs
- route same-format HWP convert, edit, and IR fill through private input snapshots and atomic publication
- document the native HWP contract and six-case Hancom acceptance matrix

## Root cause

Full section and container re-emission reordered level-sensitive HWP records and regenerated unrelated container state. Genuine complex documents could therefore pass internal parsing while Hancom reported corruption.

## Validation

- `scripts/check.sh` passed: fmt, clippy, workspace tests, PDF runner, and structured corpus
- public PDF parity was policy-skipped because the pinned `pdfinfo 24.02.0` runtime is unavailable
- private complex proposal fragment: baseline 39 tables, 9 pictures, and 24 binary assets
- no-op, metadata, text, paragraph, and table-cell outputs retained the baseline structure and all original assets byte-for-byte
- image insertion produced 39 tables, 10 pictures, and 25 assets while retaining all original assets byte-for-byte
- Hancom opened all six outputs (no-op, metadata, text, paragraph, table-cell, image) without a corruption warning
- no private source or derived output is included in this PR

Refs #90. This is PR2 of the native writer plan; #90 remains open for package-surgical HWPX work and later phases.