### PR TITLE
feat(hwpx): package-surgical HWPX editing + cross-format loss detection (#90 PR 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 **Added**
 
+- Cross-format loss detection and an explicit typed loss report for `hwp convert`
+  ([#90](https://github.com/STAIxBWLB/hwp-cli/issues/90)). Cross-format native conversion
+  now inventories package/container-level assets the IR cannot carry: HWPX extra package
+  entries (DocOptions, original META-INF overrides, scripts) lost on the way to HWP, and
+  the hwp5 XMLTemplate/DocHistory pass-through slots lost on the way to HWPX. These are
+  emitted as content-free typed events, so `--strict` cross-format conversion now fails
+  closed on them, and the new `--loss-report <PATH>` flag publishes the
+  `hwp-preservation-report-v1` ledger as JSON (schema-validated, empty-but-valid on a
+  lossless run) even when strict mode rejects the output.
+
 - Captions, endnotes and odd/even furniture, the ninth and final step of the PDF parity
   roadmap ([#79](https://github.com/STAIxBWLB/hwp-cli/issues/79)). Table, picture and shape
   captions are parsed end to end (GB-13): a new `Caption` IR (side, direction, gap, width,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,22 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
   `hwp-preservation-report-v1` ledger as JSON (schema-validated, empty-but-valid on a
   lossless run) even when strict mode rejects the output.
 
+- Lossless HWPX package round-trip and package-surgical same-format editing
+  ([#90](https://github.com/STAIxBWLB/hwp-cli/issues/90)). The hwpx reader retains
+  verbatim XML for run-level controls the IR does not model
+  (`GenericControl.hwpx_raw_xml`, e.g. `hp:container`) and the writer re-emits it, so an
+  opaque control survives a full rewrite. Package entries the writer does not regenerate
+  (original META-INF overrides, DocOptions, `Contents/memoExtended.xml`, extra previews)
+  ride the new `Document.hwpx_extra_entries` slot, and unreferenced BinData entries pass
+  through instead of being dropped, listed in the regenerated content.hpf manifest. Every
+  same-format HWPX→HWPX `hwp edit` operation now goes through
+  `hwpx::patch::rewrite_document_staged`: only the dirty content entries (header.xml,
+  content.hpf, section*.xml, decided by before/after IR comparison) are reserialized from
+  the IR, every other ZIP entry is raw-copied byte-for-byte, and inserted images append as
+  new BinData entries with the original OPF manifest ids preserved. Two latent writer
+  fidelity bugs fixed en route: the inline `hp:pic` zOrder and the no-border lineShape
+  color now round-trip instead of being hardcoded.
+
 - Captions, endnotes and odd/even furniture, the ninth and final step of the PDF parity
   roadmap ([#79](https://github.com/STAIxBWLB/hwp-cli/issues/79)). Table, picture and shape
   captions are parsed end to end (GB-13): a new `Caption` IR (side, direction, gap, width,

--- a/crates/hwp-cli/src/cli.rs
+++ b/crates/hwp-cli/src/cli.rs
@@ -110,7 +110,9 @@ pub enum Cmd {
         #[arg(long)]
         strict: bool,
         /// Write the typed preservation ledger (hwp-preservation-report-v1) as JSON to this
-        /// path, even when the conversion succeeds without loss (single input only)
+        /// path, even when the conversion succeeds without loss (single input only).
+        /// The preservation inspection only runs for hwp/hwpx targets — for other output
+        /// formats (docx, md, ...) the ledger is always empty
         #[arg(long)]
         loss_report: Option<PathBuf>,
         /// Preserve the line layout cache (unmodified round-trips only; Hancom treats

--- a/crates/hwp-cli/src/cli.rs
+++ b/crates/hwp-cli/src/cli.rs
@@ -109,6 +109,10 @@ pub enum Cmd {
         /// Fail when data that cannot be preserved (opaque) is found during conversion
         #[arg(long)]
         strict: bool,
+        /// Write the typed preservation ledger (hwp-preservation-report-v1) as JSON to this
+        /// path, even when the conversion succeeds without loss (single input only)
+        #[arg(long)]
+        loss_report: Option<PathBuf>,
         /// Preserve the line layout cache (unmodified round-trips only; Hancom treats
         /// a layout inconsistent with the content as tampering, so it is dropped by default)
         #[arg(long)]

--- a/crates/hwp-cli/src/commands/convert.rs
+++ b/crates/hwp-cli/src/commands/convert.rs
@@ -292,13 +292,22 @@ pub fn execute(
         Some(t) => t,
         None => infer_format(output)?,
     };
-    if let Some(report_path) = loss_report
-        && (report_path == input || report_path == output)
-    {
-        anyhow::bail!(
-            "--loss-report 경로가 입력/출력과 같을 수 없습니다: {}",
-            report_path.display()
-        );
+    if let Some(report_path) = loss_report {
+        // 경로 정규화(canonicalize 기반 — `.`/`..`/심볼릭 링크 철자 변형 해소) +
+        // output.rs의 identity 기반 별칭 탐지를 함께 쓴다. raw Path 비교만으로는
+        // `sub/../in.hwpx` 같은 철자 변형을 놓치고, 경로 비교만으로는 하드 링크
+        // 별칭을 놓친다. 리포트는 입력을 덮어쓰면 안 되고, 출력과 같으면 문서
+        // 게시가 리포트를 조용히 덮어쓰므로 둘 다 거부한다.
+        let report_normalized = normalize_for_alias_compare(report_path);
+        for other in [input, output] {
+            if report_normalized == normalize_for_alias_compare(other) {
+                anyhow::bail!(
+                    "--loss-report 경로가 입력/출력과 같을 수 없습니다: {}",
+                    report_path.display()
+                );
+            }
+        }
+        crate::commands::output::reject_output_aliases(report_path, &[input, output])?;
     }
     let doc = load_document(input)?;
     if matches!(target, ConvertFormat::Md) {
@@ -503,6 +512,22 @@ pub(crate) fn print_warnings(warnings: &[String]) {
     for w in warnings {
         eprintln!("경고: {w}");
     }
+}
+
+/// `--loss-report` 별칭 가드용 경로 정규화. 존재하는 경로는 canonicalize하고,
+/// 아직 없는 경로(새 리포트 파일)는 부모 디렉터리만 canonicalize해 파일명을
+/// 붙인다 — `.`/`..`/심볼릭 링크 철자 변형이 같은 파일을 가리키면 같아진다.
+/// 정규화가 불가능하면 절대경로로, 그마저 실패하면 원본 경로로 되돌아간다.
+fn normalize_for_alias_compare(path: &Path) -> PathBuf {
+    if let Ok(canonical) = std::fs::canonicalize(path) {
+        return canonical;
+    }
+    if let (Some(parent), Some(name)) = (path.parent(), path.file_name())
+        && let Ok(canonical_parent) = std::fs::canonicalize(parent)
+    {
+        return canonical_parent.join(name);
+    }
+    std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 /// `--loss-report` 산출물 — 다른 출력과 같은 staged/검증 트랜잭션으로 게시한다
@@ -1265,6 +1290,97 @@ mod tests {
         assert_eq!(value["contract"], "hwp-preservation-report-v1");
         assert_eq!(value["events"], serde_json::json!([]));
         assert_loss_report_schema_valid(&value);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    /// --loss-report가 입력의 lexical 변형(`./in.hwpx`, `sub/../in.hwpx`)이어도
+    /// 거부하고 입력을 보존한다. raw Path 비교는 `.`는 걸러도 `..` 철자는 놓친다
+    /// (epic #90 PR 3 후속).
+    #[test]
+    fn loss_report_lexical_alias_of_input_is_rejected() {
+        let sequence = TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "hwp-convert-loss-report-alias-test-{}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let source = dir.join("source.hwpx");
+        let destination = dir.join("result.hwpx");
+        std::fs::create_dir(dir.join("sub")).unwrap();
+        std::fs::write(&source, b"ORIGINAL").unwrap();
+
+        for alias in [
+            dir.join(".").join("source.hwpx"),
+            dir.join("sub").join("..").join("source.hwpx"),
+        ] {
+            let result = execute(
+                &source,
+                &destination,
+                Some(ConvertFormat::Hwpx),
+                false,
+                Some(&alias),
+                false,
+                false,
+                &MdOpts::default(),
+                Vec::new(),
+            );
+            let error = format!("{:#}", result.unwrap_err());
+            assert!(
+                error.contains("--loss-report"),
+                "별칭 {} 거부 사유: {error}",
+                alias.display()
+            );
+            assert_eq!(
+                std::fs::read(&source).unwrap(),
+                b"ORIGINAL",
+                "입력 파일은 그대로여야 한다"
+            );
+            assert!(
+                !destination.exists(),
+                "거부된 변환은 출력을 게시하지 않는다"
+            );
+        }
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    /// --loss-report가 출력(-o)과 같으면 거부한다 — 리포트를 게시한 뒤 문서 게시가
+    /// 조용히 덮어쓰는 순서 버그 방지.
+    #[test]
+    fn loss_report_same_as_output_is_rejected() {
+        let sequence = TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "hwp-convert-loss-report-output-test-{}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let source = dir.join("source.hwpx");
+        let destination = dir.join("result.hwpx");
+        hwpx::write_document(
+            &hwp_convert::from_markdown("owner-authored fixture"),
+            &source,
+        )
+        .unwrap();
+
+        let result = execute(
+            &source,
+            &destination,
+            Some(ConvertFormat::Hwpx),
+            false,
+            Some(&destination),
+            false,
+            false,
+            &MdOpts::default(),
+            Vec::new(),
+        );
+        let error = format!("{:#}", result.unwrap_err());
+        assert!(
+            error.contains("--loss-report"),
+            "출력 동일 거부 사유: {error}"
+        );
+        assert!(
+            !destination.exists(),
+            "거부된 변환은 출력을 게시하지 않는다"
+        );
         std::fs::remove_dir_all(dir).unwrap();
     }
 

--- a/crates/hwp-cli/src/commands/convert.rs
+++ b/crates/hwp-cli/src/commands/convert.rs
@@ -958,7 +958,10 @@ mod tests {
     }
 
     #[test]
-    fn same_format_container_loss_fails_closed_without_strict() {
+    fn same_format_opaque_package_entry_is_preserved() {
+        // 예전에는 writer 고정 목록 밖 엔트리가 silently drop돼 fail-closed로
+        // 거부됐다. 이제 같은 포맷 재작성은 잉여 엔트리를 바이트 그대로 보존하므로
+        // 변환이 성공하고 엔트리가 살아 있어야 한다(epic #90).
         let sequence = TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
         let dir = std::env::temp_dir().join(format!(
             "hwp-convert-preservation-test-{}-{sequence}",
@@ -976,7 +979,7 @@ mod tests {
         append_synthetic_package_entry(&generated, &source);
         std::fs::write(&destination, b"ORIGINAL").unwrap();
 
-        let result = execute(
+        let report = execute(
             &source,
             &destination,
             Some(ConvertFormat::Hwpx),
@@ -985,14 +988,23 @@ mod tests {
             false,
             &MdOpts::default(),
             Vec::new(),
-        );
+        )
+        .unwrap();
 
-        let error = format!("{:#}", result.unwrap_err());
         assert!(
-            error.contains("hwpx_package_entry_removed: 1 item(s)"),
-            "{error}"
+            report.preservation.is_lossless(),
+            "preservation events: {:?}",
+            report.preservation.events
         );
-        assert_eq!(std::fs::read(&destination).unwrap(), b"ORIGINAL");
+        let mut archive =
+            zip::ZipArchive::new(std::fs::File::open(&destination).unwrap()).unwrap();
+        let mut bytes = Vec::new();
+        archive
+            .by_name("SyntheticOpaque/entry.bin")
+            .expect("잉여 패키지 엔트리가 보존돼야 한다")
+            .read_to_end(&mut bytes)
+            .unwrap();
+        assert_eq!(bytes, b"owner-authored opaque payload");
         std::fs::remove_dir_all(dir).unwrap();
     }
 

--- a/crates/hwp-cli/src/commands/convert.rs
+++ b/crates/hwp-cli/src/commands/convert.rs
@@ -33,6 +33,7 @@ pub fn run(
     output: &Path,
     to: Option<ConvertFormat>,
     strict: bool,
+    loss_report: Option<&Path>,
     preserve_layout: bool,
     embed_bin: bool,
     md_opts: &MdOpts,
@@ -43,6 +44,7 @@ pub fn run(
         output,
         to,
         strict,
+        loss_report,
         preserve_layout,
         embed_bin,
         md_opts,
@@ -66,6 +68,7 @@ pub fn run_multi(
     out_dir: Option<&Path>,
     to: Option<ConvertFormat>,
     strict: bool,
+    loss_report: Option<&Path>,
     preserve_layout: bool,
     embed_bin: bool,
     md_opts: &MdOpts,
@@ -111,6 +114,7 @@ pub fn run_multi(
         out_dir,
         to,
         strict,
+        loss_report,
         preserve_layout,
         embed_bin,
         md_opts,
@@ -129,6 +133,7 @@ fn run_multi_inner(
     out_dir: Option<&Path>,
     to: Option<ConvertFormat>,
     strict: bool,
+    loss_report: Option<&Path>,
     preserve_layout: bool,
     embed_bin: bool,
     md_opts: &MdOpts,
@@ -140,6 +145,9 @@ fn run_multi_inner(
                 anyhow::bail!("여러 입력에는 --out-dir이 필요합니다 (-o는 단일 입력 전용)");
             }
             if out.as_os_str() == "-" {
+                if loss_report.is_some() {
+                    anyhow::bail!("출력이 `-`(stdout)이면 --loss-report를 지원하지 않습니다");
+                }
                 let Some(target) = to else {
                     anyhow::bail!("출력이 `-`(stdout)이면 --to가 필요합니다");
                 };
@@ -152,6 +160,7 @@ fn run_multi_inner(
                 out,
                 to,
                 strict,
+                loss_report,
                 preserve_layout,
                 embed_bin,
                 md_opts,
@@ -162,6 +171,11 @@ fn run_multi_inner(
             let Some(target) = to else {
                 anyhow::bail!("여러 입력(--out-dir)에는 --to가 필요합니다");
             };
+            if loss_report.is_some() {
+                anyhow::bail!(
+                    "--loss-report는 단일 입력 변환에서만 지원합니다 (--out-dir와 병용 불가)"
+                );
+            }
             // Pre-check: reject collisions where identical stems from different directories would overwrite one output.
             let mut seen = std::collections::BTreeMap::new();
             for input in inputs {
@@ -194,6 +208,7 @@ fn run_multi_inner(
                     &out,
                     Some(target),
                     strict,
+                    None,
                     preserve_layout,
                     embed_bin,
                     md_opts,
@@ -257,12 +272,17 @@ fn target_extension(target: ConvertFormat) -> &'static str {
 ///
 /// 출력은 검증이 끝날 때까지 destination에 게시하지 않으며, Markdown 이미지 sidecar도
 /// 본문과 같은 복구 journal에 참여한다. 사용자 메시지 출력은 호출자가 담당한다.
+///
+/// `loss_report`가 주어지면 preservation 검사 직후(strict 거부 전)에 typed ledger
+/// (`hwp-preservation-report-v1`)를 무손실이어도 항상 JSON으로 게시한다 — 자동화가
+/// 성공/실패와 무관하게 같은 경로에서 판정 근거를 읽을 수 있게 하기 위함이다.
 #[allow(clippy::too_many_arguments)]
 pub fn execute(
     input: &Path,
     output: &Path,
     to: Option<ConvertFormat>,
     strict: bool,
+    loss_report: Option<&Path>,
     preserve_layout: bool,
     embed_bin: bool,
     md_opts: &MdOpts,
@@ -272,6 +292,14 @@ pub fn execute(
         Some(t) => t,
         None => infer_format(output)?,
     };
+    if let Some(report_path) = loss_report
+        && (report_path == input || report_path == output)
+    {
+        anyhow::bail!(
+            "--loss-report 경로가 입력/출력과 같을 수 없습니다: {}",
+            report_path.display()
+        );
+    }
     let doc = load_document(input)?;
     if matches!(target, ConvertFormat::Md) {
         let (media_destination, media_prefix) = markdown_media_paths(output, md_opts.media_dir)?;
@@ -296,10 +324,14 @@ pub fn execute(
             },
             |_, _, _| Ok(()),
         )?;
-        return Ok(ConvertReport {
+        let report = ConvertReport {
             warnings,
             preservation: hwp_model::PreservationReport::new(),
-        });
+        };
+        if let Some(report_path) = loss_report {
+            write_loss_report(report_path, &report.preservation)?;
+        }
+        return Ok(report);
     }
 
     let source_format = crate::format::detect(input)?;
@@ -364,6 +396,20 @@ pub fn execute(
                 report.preservation.extend(
                     crate::commands::preservation::inspect_same_format_container(source, staged)?,
                 );
+            } else {
+                // 크로스 포맷: IR이 원본 컨테이너에서 보존한 패키지/컨테이너 수준
+                // 자산 중 대상 포맷이 표현 못 하는 것을 typed event로 계상한다.
+                let target_format = match target {
+                    ConvertFormat::Hwp => crate::format::FileFormat::Hwp5,
+                    _ => crate::format::FileFormat::Hwpx,
+                };
+                report.preservation.extend(
+                    crate::commands::preservation::inspect_cross_format_container(
+                        &doc,
+                        source_format,
+                        target_format,
+                    ),
+                );
             }
             let output_document = load_document(staged)
                 .with_context(|| format!("변환 문서 재읽기 실패: {}", staged.display()))?;
@@ -374,6 +420,10 @@ pub fn execute(
         Ok(report)
     };
     let verify_staged = |staged: &std::path::Path, report: &hwp_model::WriteReport| {
+        // strict 거부 전에 기록해야 실패한 변환의 판정 근거가 파일로 남는다.
+        if let Some(report_path) = loss_report {
+            write_loss_report(report_path, &report.preservation)?;
+        }
         if matches!(target, ConvertFormat::Hwp | ConvertFormat::Hwpx) {
             if same_native_format || strict {
                 crate::commands::reject_preservation_loss("convert", &report.preservation)?;
@@ -453,6 +503,38 @@ pub(crate) fn print_warnings(warnings: &[String]) {
     for w in warnings {
         eprintln!("경고: {w}");
     }
+}
+
+/// `--loss-report` 산출물 — 다른 출력과 같은 staged/검증 트랜잭션으로 게시한다
+/// (렌더 `--report`의 write_report와 같은 규율). 보고서는 content-free 계약이라
+/// 입력·출력 경로를 싣지 않는다.
+fn write_loss_report(
+    path: &Path,
+    report: &hwp_model::PreservationReport,
+) -> anyhow::Result<()> {
+    let bytes = serde_json::to_vec_pretty(report)?;
+    crate::commands::output::write_validated(
+        path,
+        None,
+        |staged| {
+            std::fs::write(staged, &bytes)?;
+            Ok(())
+        },
+        |staged, _| {
+            let written = std::fs::read(staged)?;
+            if written != bytes {
+                anyhow::bail!("보존 보고서 검증 중 바이트 불일치: {}", staged.display());
+            }
+            let parsed: serde_json::Value = serde_json::from_slice(&written)
+                .map_err(|error| anyhow::anyhow!("보존 보고서 JSON 검증 실패: {error}"))?;
+            if !parsed.is_object() {
+                anyhow::bail!("보존 보고서가 JSON 객체가 아닙니다");
+            }
+            Ok(())
+        },
+    )?;
+    eprintln!("보존 보고서 저장: {}", path.display());
+    Ok(())
 }
 
 /// `--font-dir`가 비었으면 `HWP_FONT_DIR`(없으면 `fonts/`)로 기본 폰트 디렉터리를 정한다.
@@ -984,6 +1066,7 @@ mod tests {
             &destination,
             Some(ConvertFormat::Hwpx),
             false,
+            None,
             false,
             false,
             &MdOpts::default(),
@@ -1029,6 +1112,179 @@ mod tests {
             .unwrap();
         writer.write_all(b"owner-authored opaque payload").unwrap();
         writer.finish().unwrap();
+    }
+
+    /// 크로스 포맷(hwpx→hwp) 변환에서 패키지 수준 잉여 엔트리(DocOptions 등)는
+    /// hwp 컨테이너에 대응 슬롯이 없어 사라진다. strict는 fail-closed로 게시를
+    /// 거부하고 기존 destination을 보존해야 하며, --loss-report는 거부 전에도
+    /// typed ledger를 남겨야 한다(epic #90 PR 3).
+    #[test]
+    fn strict_cross_format_hwpx_to_hwp_fails_closed_with_loss_report() {
+        let sequence = TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "hwp-convert-cross-strict-test-{}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let generated = dir.join("generated.hwpx");
+        let source = dir.join("source.hwpx");
+        let destination = dir.join("result.hwp");
+        let report_path = dir.join("loss.json");
+        hwpx::write_document(
+            &hwp_convert::from_markdown("owner-authored fixture"),
+            &generated,
+        )
+        .unwrap();
+        append_synthetic_package_entry(&generated, &source);
+        std::fs::write(&destination, b"ORIGINAL").unwrap();
+
+        let result = execute(
+            &source,
+            &destination,
+            Some(ConvertFormat::Hwp),
+            true,
+            Some(&report_path),
+            false,
+            false,
+            &MdOpts::default(),
+            Vec::new(),
+        );
+        let error = format!("{:#}", result.unwrap_err());
+        assert!(
+            error.contains("hwpx_package_entry_removed"),
+            "strict 거부 사유에 typed code가 있어야 한다: {error}"
+        );
+        assert_eq!(std::fs::read(&destination).unwrap(), b"ORIGINAL");
+
+        let value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&report_path).unwrap()).unwrap();
+        assert_eq!(value["contract"], "hwp-preservation-report-v1");
+        let events = value["events"].as_array().unwrap();
+        assert!(
+            events.iter().any(|event| event["code"] == "hwpx_package_entry_removed"
+                && event["resource"] == "package_entry"
+                && event["disposition"] == "removed"
+                && event["count"].as_u64().unwrap() >= 1),
+            "loss report events: {events:?}"
+        );
+        assert_loss_report_schema_valid(&value);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    /// 비-strict 크로스 포맷 변환은 손실을 ledger에 남기고 게시한다.
+    /// --loss-report는 실행 결과와 같은 이벤트를 스키마 적합 JSON으로 기록한다.
+    #[test]
+    fn non_strict_cross_format_hwpx_to_hwp_publishes_with_loss_report() {
+        let sequence = TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "hwp-convert-cross-nonstrict-test-{}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let generated = dir.join("generated.hwpx");
+        let source = dir.join("source.hwpx");
+        let destination = dir.join("result.hwp");
+        let report_path = dir.join("loss.json");
+        hwpx::write_document(
+            &hwp_convert::from_markdown("owner-authored fixture"),
+            &generated,
+        )
+        .unwrap();
+        append_synthetic_package_entry(&generated, &source);
+
+        let report = execute(
+            &source,
+            &destination,
+            Some(ConvertFormat::Hwp),
+            false,
+            Some(&report_path),
+            false,
+            false,
+            &MdOpts::default(),
+            Vec::new(),
+        )
+        .unwrap();
+
+        assert!(
+            report
+                .preservation
+                .events
+                .iter()
+                .any(|event| event.code == hwp_model::PreservationCode::HwpxPackageEntryRemoved),
+            "preservation events: {:?}",
+            report.preservation.events
+        );
+        assert_ne!(std::fs::read(&destination).unwrap(), b"ORIGINAL");
+
+        let value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&report_path).unwrap()).unwrap();
+        assert_eq!(value["contract"], "hwp-preservation-report-v1");
+        assert_eq!(
+            value["events"].as_array().unwrap().len(),
+            report.preservation.events.len(),
+            "loss report는 실행 결과 ledger와 같은 이벤트 수를 가져야 한다"
+        );
+        assert_loss_report_schema_valid(&value);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    /// --loss-report가 무손실 변환에서도 유효한(빈 events) 보고서를 쓰는지 확인.
+    #[test]
+    fn loss_report_is_written_even_when_conversion_is_lossless() {
+        let sequence = TEST_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "hwp-convert-lossless-report-test-{}-{sequence}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&dir).unwrap();
+        let generated = dir.join("generated.hwpx");
+        let source = dir.join("source.hwpx");
+        let destination = dir.join("result.hwpx");
+        let report_path = dir.join("loss.json");
+        hwpx::write_document(
+            &hwp_convert::from_markdown("owner-authored fixture"),
+            &generated,
+        )
+        .unwrap();
+        append_synthetic_package_entry(&generated, &source);
+
+        let report = execute(
+            &source,
+            &destination,
+            Some(ConvertFormat::Hwpx),
+            false,
+            Some(&report_path),
+            false,
+            false,
+            &MdOpts::default(),
+            Vec::new(),
+        )
+        .unwrap();
+        assert!(report.preservation.is_lossless());
+
+        let value: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(&report_path).unwrap()).unwrap();
+        assert_eq!(value["contract"], "hwp-preservation-report-v1");
+        assert_eq!(value["events"], serde_json::json!([]));
+        assert_loss_report_schema_valid(&value);
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    /// 생성된 loss report가 공개 스키마(`schemas/preservation-report-v1`)에
+    /// 부합하는지 검증한다 — 렌더 보고서 테스트(tests/cli.rs)와 같은 게이트.
+    fn assert_loss_report_schema_valid(value: &serde_json::Value) {
+        let schema: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../../schemas/preservation-report-v1.schema.json"
+        ))
+        .unwrap();
+        let validator = jsonschema::options()
+            .with_draft(jsonschema::Draft::Draft202012)
+            .build(&schema)
+            .unwrap();
+        assert!(
+            validator.is_valid(value),
+            "schema rejected loss report: {value}"
+        );
     }
 
     #[test]

--- a/crates/hwp-cli/src/commands/convert.rs
+++ b/crates/hwp-cli/src/commands/convert.rs
@@ -508,10 +508,7 @@ pub(crate) fn print_warnings(warnings: &[String]) {
 /// `--loss-report` 산출물 — 다른 출력과 같은 staged/검증 트랜잭션으로 게시한다
 /// (렌더 `--report`의 write_report와 같은 규율). 보고서는 content-free 계약이라
 /// 입력·출력 경로를 싣지 않는다.
-fn write_loss_report(
-    path: &Path,
-    report: &hwp_model::PreservationReport,
-) -> anyhow::Result<()> {
+fn write_loss_report(path: &Path, report: &hwp_model::PreservationReport) -> anyhow::Result<()> {
     let bytes = serde_json::to_vec_pretty(report)?;
     crate::commands::output::write_validated(
         path,
@@ -1079,8 +1076,7 @@ mod tests {
             "preservation events: {:?}",
             report.preservation.events
         );
-        let mut archive =
-            zip::ZipArchive::new(std::fs::File::open(&destination).unwrap()).unwrap();
+        let mut archive = zip::ZipArchive::new(std::fs::File::open(&destination).unwrap()).unwrap();
         let mut bytes = Vec::new();
         archive
             .by_name("SyntheticOpaque/entry.bin")
@@ -1161,10 +1157,12 @@ mod tests {
         assert_eq!(value["contract"], "hwp-preservation-report-v1");
         let events = value["events"].as_array().unwrap();
         assert!(
-            events.iter().any(|event| event["code"] == "hwpx_package_entry_removed"
-                && event["resource"] == "package_entry"
-                && event["disposition"] == "removed"
-                && event["count"].as_u64().unwrap() >= 1),
+            events
+                .iter()
+                .any(|event| event["code"] == "hwpx_package_entry_removed"
+                    && event["resource"] == "package_entry"
+                    && event["disposition"] == "removed"
+                    && event["count"].as_u64().unwrap() >= 1),
             "loss report events: {events:?}"
         );
         assert_loss_report_schema_valid(&value);

--- a/crates/hwp-cli/src/commands/corpus.rs
+++ b/crates/hwp-cli/src/commands/corpus.rs
@@ -2541,6 +2541,7 @@ mod tests {
             equation,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         })
     }
 

--- a/crates/hwp-cli/src/commands/edit.rs
+++ b/crates/hwp-cli/src/commands/edit.rs
@@ -2089,6 +2089,10 @@ fn canonical_document(
         canonical
             .hwpx_version_xml
             .get_or_insert_with(|| hwpx::DEFAULT_VERSION_XML.to_string());
+        // 매니페스트 (id, href)는 writer가 bin_streams에서 결정론적으로 재배정하는
+        // 이름 메타다(편집으로 bin이 추가/삭제되면 원본 슬롯과 달라진다). 바이트
+        // 정체성은 위의 content-hash bin_streams 비교가 담당하므로 digest에서는 제외.
+        canonical.hwpx_bin_manifest.clear();
         canonical
             .metadata
             .author

--- a/crates/hwp-cli/src/commands/edit.rs
+++ b/crates/hwp-cli/src/commands/edit.rs
@@ -2739,6 +2739,7 @@ mod tests {
                 equation: None,
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             }));
         let mut materialized = source.clone();
         materialized.header.properties.start_numbers = [1; 6];

--- a/crates/hwp-cli/src/commands/edit.rs
+++ b/crates/hwp-cli/src/commands/edit.rs
@@ -2,7 +2,9 @@
 //!
 //! 원본을 IR로 읽어(이미지·opaque 보존) 텍스트 치환·표 셀 설정을 적용한 뒤
 //! 출력 포맷으로 저장한다. hwp 출력은 합성 경로(`write_hwp_edited`)를 거쳐
-//! 편집으로 낡은 줄 배치·문단 불변식을 다시 세운다.
+//! 편집으로 낡은 줄 배치·문단 불변식을 다시 세운다. 같은 포맷 hwpx→hwpx는
+//! 패키지 외과 수술 경로(`hwpx::patch::rewrite_document_staged`)로, 편집된
+//! 콘텐츠 엔트리만 재직렬화하고 나머지 엔트리는 raw 복사로 바이트 보존한다.
 
 use std::collections::BTreeMap;
 use std::fs;
@@ -1452,7 +1454,31 @@ fn write_output(
             crate::commands::convert::write_hwp_structural(doc, output)
         }
         OutputFormat::Hwp => crate::commands::convert::write_hwp_edited(doc, output),
-        OutputFormat::Hwpx => Ok(hwpx::write_document_with_report(doc, output)?),
+        OutputFormat::Hwpx => {
+            // 같은 포맷(hwpx→hwpx)이면 패키지 외과 수술 경로: dirty 콘텐츠 엔트리만
+            // IR에서 재직렬화하고 나머지 엔트리(BinData·META-INF·미리보기·DocOptions 등)는
+            // 원본 패키지에서 raw 복사로 바이트 보존한다.
+            if let Some((source_path, original)) = source
+                && original.meta.source_format == "hwpx"
+            {
+                // dirty 판정은 편집 전후 IR 비교로 계산한다(op별 수동 매핑보다
+                // 누락 위험이 없다). 섹션 지정은 앵커/패턴/전역 표 인덱스 기반 op의
+                // 대상 섹션을 값싸게 증명할 수 없어 항상 전체 섹션을 dirty로 둔다.
+                let dirty = hwpx::patch::DirtyEntries {
+                    sections: None,
+                    header: doc.header != original.header,
+                    content_hpf: doc.metadata != original.metadata,
+                };
+                return Ok(hwpx::patch::rewrite_document_staged(
+                    source_path,
+                    output,
+                    doc,
+                    &dirty,
+                    &hwpx::PackageLimits::default(),
+                )?);
+            }
+            Ok(hwpx::write_document_with_report(doc, output)?)
+        }
         OutputFormat::Json => {
             fs::write(output, hwp_convert::to_json(doc, true, true)?)?;
             Ok(hwp_model::WriteReport::new())

--- a/crates/hwp-cli/src/commands/mcp.rs
+++ b/crates/hwp-cli/src/commands/mcp.rs
@@ -2767,6 +2767,7 @@ mod tests {
                 equation: None,
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             }));
         let insert_at = paragraph.chars.len().saturating_sub(1);
         paragraph.chars.insert(
@@ -3460,6 +3461,7 @@ mod tests {
                 equation: None,
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             }));
         let header_index = body.controls.len() as u32;
         body.controls
@@ -3476,6 +3478,7 @@ mod tests {
                 equation: None,
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             }));
         body.chars.insert(
             0,

--- a/crates/hwp-cli/src/commands/mcp.rs
+++ b/crates/hwp-cli/src/commands/mcp.rs
@@ -1418,6 +1418,7 @@ fn tool_convert(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
         &request.output,
         request.to,
         request.strict,
+        None,
         false,
         request.embed_bin,
         &crate::commands::convert::MdOpts {

--- a/crates/hwp-cli/src/commands/preservation.rs
+++ b/crates/hwp-cli/src/commands/preservation.rs
@@ -572,14 +572,16 @@ mod tests {
     fn cross_format_hwpx_extra_entries_have_no_hwp_representation() {
         let source = Document {
             hwpx_extra_entries: vec![
-                ("DocOptions/Layout.xml".to_string(), b"private layout".to_vec()),
+                (
+                    "DocOptions/Layout.xml".to_string(),
+                    b"private layout".to_vec(),
+                ),
                 ("Scripts/custom.js".to_string(), b"private script".to_vec()),
             ],
             ..Document::default()
         };
 
-        let report =
-            inspect_cross_format_container(&source, FileFormat::Hwpx, FileFormat::Hwp5);
+        let report = inspect_cross_format_container(&source, FileFormat::Hwpx, FileFormat::Hwp5);
         assert_eq!(report.events.len(), 1);
         assert_eq!(
             report.events[0].code,
@@ -617,8 +619,7 @@ mod tests {
             ..Document::default()
         };
 
-        let report =
-            inspect_cross_format_container(&source, FileFormat::Hwp5, FileFormat::Hwpx);
+        let report = inspect_cross_format_container(&source, FileFormat::Hwp5, FileFormat::Hwpx);
         assert_eq!(report.events.len(), 2);
         assert!(report.events.iter().any(|event| {
             event.code == PreservationCode::HwpContainerStreamRemoved

--- a/crates/hwp-cli/src/commands/preservation.rs
+++ b/crates/hwp-cli/src/commands/preservation.rs
@@ -105,6 +105,55 @@ pub(crate) fn inspect_conversion_semantics(
     report
 }
 
+/// Account for package/container-level assets that a cross-format conversion
+/// cannot carry, using only what the IR retained from the source container.
+///
+/// - hwpx → hwp: `Document::hwpx_extra_entries` (DocOptions, original
+///   META-INF/* overrides, extra previews, scripts, ...) have no counterpart in
+///   an HWP container and are dropped by the hwp5 writer. The hwpx reader
+///   already excludes entries the writer regenerates byte-identically
+///   (`is_writer_default_entry`), so every remaining entry is a genuine loss.
+/// - hwp → hwpx: the `hwp5_xml_template`/`hwp5_doc_history` pass-through slots
+///   have no HWPX package representation, so their streams (and owning
+///   storages) disappear. Opaque CFB streams the IR never captured
+///   (MemoExtended, Scripts, ...) stay invisible here by design — this phase
+///   deliberately does not diff the raw container.
+///
+/// Same-format pairs return an empty report; the package-level same-format
+/// inspector owns that case.
+pub(crate) fn inspect_cross_format_container(
+    source: &Document,
+    source_format: FileFormat,
+    target_format: FileFormat,
+) -> PreservationReport {
+    let mut report = PreservationReport::new();
+    match (source_format, target_format) {
+        (FileFormat::Hwpx, FileFormat::Hwp5) => record_removed(
+            &mut report,
+            PreservationCode::HwpxPackageEntryRemoved,
+            PreservationResourceKind::PackageEntry,
+            source.hwpx_extra_entries.len(),
+        ),
+        (FileFormat::Hwp5, FileFormat::Hwpx) => {
+            record_removed(
+                &mut report,
+                PreservationCode::HwpContainerStreamRemoved,
+                PreservationResourceKind::ContainerStream,
+                source.hwp5_xml_template.len() + source.hwp5_doc_history.len(),
+            );
+            record_removed(
+                &mut report,
+                PreservationCode::HwpContainerStorageRemoved,
+                PreservationResourceKind::ContainerStorage,
+                usize::from(!source.hwp5_xml_template.is_empty())
+                    + usize::from(!source.hwp5_doc_history.is_empty()),
+            );
+        }
+        _ => {}
+    }
+    report
+}
+
 pub(crate) fn reject_loss(context: &str, report: &PreservationReport) -> anyhow::Result<()> {
     if report.is_lossless() {
         return Ok(());
@@ -517,5 +566,83 @@ mod tests {
         );
         let error = reject_loss("convert", &report).unwrap_err().to_string();
         assert!(error.contains("control_removed: 3 item(s)"));
+    }
+
+    #[test]
+    fn cross_format_hwpx_extra_entries_have_no_hwp_representation() {
+        let source = Document {
+            hwpx_extra_entries: vec![
+                ("DocOptions/Layout.xml".to_string(), b"private layout".to_vec()),
+                ("Scripts/custom.js".to_string(), b"private script".to_vec()),
+            ],
+            ..Document::default()
+        };
+
+        let report =
+            inspect_cross_format_container(&source, FileFormat::Hwpx, FileFormat::Hwp5);
+        assert_eq!(report.events.len(), 1);
+        assert_eq!(
+            report.events[0].code,
+            PreservationCode::HwpxPackageEntryRemoved
+        );
+        assert_eq!(
+            report.events[0].resource,
+            PreservationResourceKind::PackageEntry
+        );
+        assert_eq!(
+            report.events[0].disposition,
+            PreservationDisposition::Removed
+        );
+        assert_eq!(report.events[0].count, 2);
+        // Entry 이름(구조 정보)도 공개 보고서에는 싣지 않는다 — 코드·건수만.
+        let serialized = serde_json::to_string(&report).unwrap();
+        assert!(!serialized.contains("DocOptions"));
+        assert!(!serialized.contains("private"));
+
+        // 같은 포맷 쌍은 패키지 수준 same-format 검사기가 담당한다.
+        assert!(
+            inspect_cross_format_container(&source, FileFormat::Hwpx, FileFormat::Hwpx)
+                .is_lossless()
+        );
+    }
+
+    #[test]
+    fn cross_format_hwp5_opaque_slots_have_no_hwpx_representation() {
+        let source = Document {
+            hwp5_xml_template: vec![
+                ("/XMLTemplate/Schema.xml".to_string(), b"x".to_vec()),
+                ("/XMLTemplate/Instance.xml".to_string(), b"y".to_vec()),
+            ],
+            hwp5_doc_history: vec![("/DocHistory/LastDoc.xml".to_string(), b"z".to_vec())],
+            ..Document::default()
+        };
+
+        let report =
+            inspect_cross_format_container(&source, FileFormat::Hwp5, FileFormat::Hwpx);
+        assert_eq!(report.events.len(), 2);
+        assert!(report.events.iter().any(|event| {
+            event.code == PreservationCode::HwpContainerStreamRemoved
+                && event.resource == PreservationResourceKind::ContainerStream
+                && event.count == 3
+        }));
+        assert!(report.events.iter().any(|event| {
+            event.code == PreservationCode::HwpContainerStorageRemoved
+                && event.resource == PreservationResourceKind::ContainerStorage
+                && event.count == 2
+        }));
+
+        assert!(
+            inspect_cross_format_container(&source, FileFormat::Hwp5, FileFormat::Hwp5)
+                .is_lossless()
+        );
+        // 슬롯이 비어 있으면 이벤트도 없다.
+        assert!(
+            inspect_cross_format_container(
+                &Document::default(),
+                FileFormat::Hwp5,
+                FileFormat::Hwpx,
+            )
+            .is_lossless()
+        );
     }
 }

--- a/crates/hwp-cli/src/document_spec.rs
+++ b/crates/hwp-cli/src/document_spec.rs
@@ -1983,6 +1983,7 @@ impl<'a> Compiler<'a> {
                     divider: None,
                 }),
                 caption: None,
+                hwpx_raw_xml: None,
             }),
         )?;
         if let Some(header) = &section.header {
@@ -2077,6 +2078,7 @@ impl<'a> Compiler<'a> {
                     equation: None,
                     column_def: None,
                     caption: None,
+                    hwpx_raw_xml: None,
                 }),
             )?;
         }
@@ -2360,6 +2362,7 @@ impl<'a> Compiler<'a> {
                 }),
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             }),
         )?;
         self.report.equations += 1;
@@ -2795,6 +2798,7 @@ fn generic_control(ctrl_id: [u8; 4], data: Vec<u8>) -> hwp_model::Control {
         equation: None,
         column_def: None,
         caption: None,
+        hwpx_raw_xml: None,
     })
 }
 
@@ -2847,6 +2851,7 @@ fn append_field(
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         }),
     )?;
     set_run_shape(paragraph, shape);

--- a/crates/hwp-cli/src/document_spec_v2.rs
+++ b/crates/hwp-cli/src/document_spec_v2.rs
@@ -1033,6 +1033,7 @@ fn attach_text_box(
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         }),
     )
 }

--- a/crates/hwp-cli/src/i18n.rs
+++ b/crates/hwp-cli/src/i18n.rs
@@ -171,7 +171,7 @@ pub const KO: &[(&str, &str, &str)] = &[
     (
         "convert",
         "loss_report",
-        "typed 보존 ledger(hwp-preservation-report-v1)를 JSON으로 기록 — 무손실 성공 시에도 작성 (단일 입력 전용)",
+        "typed 보존 ledger(hwp-preservation-report-v1)를 JSON으로 기록 — 무손실 성공 시에도 작성 (단일 입력 전용). 보존 검사는 hwp/hwpx 출력에서만 실행되므로 그 외 포맷(docx, md 등)에서는 항상 빈 ledger",
     ),
     (
         "convert",

--- a/crates/hwp-cli/src/i18n.rs
+++ b/crates/hwp-cli/src/i18n.rs
@@ -170,6 +170,11 @@ pub const KO: &[(&str, &str, &str)] = &[
     ),
     (
         "convert",
+        "loss_report",
+        "typed 보존 ledger(hwp-preservation-report-v1)를 JSON으로 기록 — 무손실 성공 시에도 작성 (단일 입력 전용)",
+    ),
+    (
+        "convert",
         "preserve_layout",
         "줄 배치 캐시 보존 (무수정 왕복 전용 — 한글은 내용과 어긋난 줄 배치를 변조로 판정하므로 기본은 제거)",
     ),

--- a/crates/hwp-cli/src/main.rs
+++ b/crates/hwp-cli/src/main.rs
@@ -51,6 +51,7 @@ fn main() -> anyhow::Result<()> {
             out_dir,
             to,
             strict,
+            loss_report,
             preserve_layout,
             embed_bin,
             media_dir,
@@ -63,6 +64,7 @@ fn main() -> anyhow::Result<()> {
             out_dir.as_deref(),
             to,
             strict,
+            loss_report.as_deref(),
             preserve_layout,
             embed_bin,
             &commands::convert::MdOpts {

--- a/crates/hwp-cli/src/main.rs
+++ b/crates/hwp-cli/src/main.rs
@@ -16,6 +16,21 @@ use hwp_cli::cli::{Cli, Cmd};
 use hwp_cli::i18n;
 
 fn main() -> anyhow::Result<()> {
+    // clap derive가 만드는 명령 트리 생성/파싱은 디버그 빌드에서 프레임이 커져
+    // Windows 기본 main 스레드 스택(1MB)을 넘는다(실기 CI 확정). 모든 작업을
+    // 큰 스택의 워커 스레드에서 실행해 플랫폼·빌드 프로파일 차이를 흡수한다.
+    let worker = std::thread::Builder::new()
+        .name("hwp-main".to_string())
+        .stack_size(32 * 1024 * 1024)
+        .spawn(real_main)?;
+    match worker.join() {
+        Ok(result) => result,
+        // 워커의 패닉을 그대로 다시 던져 패닉 메시지·동작을 보존한다.
+        Err(payload) => std::panic::resume_unwind(payload),
+    }
+}
+
+fn real_main() -> anyhow::Result<()> {
     // 도움말 언어는 clap이 help/오류를 출력하기 전에 정해야 한다.
     let command = i18n::localize(Cli::command(), i18n::Lang::detect());
     let cli = match Cli::from_arg_matches(&command.get_matches()) {

--- a/crates/hwp-cli/tests/edit_surgical.rs
+++ b/crates/hwp-cli/tests/edit_surgical.rs
@@ -79,7 +79,7 @@ fn build_container_fixture(path: &Path) {
         .unwrap();
     zip.start_file("Contents/content.hpf", deflated).unwrap();
     zip.write_all(
-        r##"<?xml version="1.0"?><opf:package xmlns:opf="http://www.idpf.org/2007/opf/"><opf:metadata><opf:title>컨테이너 문서</opf:title></opf:metadata><opf:manifest><opf:item id="header" href="Contents/header.xml" media-type="application/xml"/><opf:item id="section0" href="Contents/section0.xml" media-type="application/xml"/><opf:item id="settings" href="settings.xml" media-type="application/xml"/><opf:item id="image1" href="BinData/image1.png" media-type="image/png" isEmbeded="1"/></opf:manifest><opf:spine><opf:itemref idref="header" linear="yes"/><opf:itemref idref="section0" linear="yes"/></opf:spine></opf:package>"##
+        r##"<?xml version="1.0"?><opf:package xmlns:opf="http://www.idpf.org/2007/opf/"><opf:metadata><opf:title>컨테이너 문서</opf:title></opf:metadata><opf:manifest><opf:item id="header" href="Contents/header.xml" media-type="application/xml"/><opf:item id="section0" href="Contents/section0.xml" media-type="application/xml"/><opf:item id="settings" href="settings.xml" media-type="application/xml"/><opf:item id="layout" href="DocOptions/Layout.xml" media-type="application/xml"/><opf:item id="image1" href="BinData/image1.png" media-type="image/png" isEmbeded="1"/></opf:manifest><opf:spine><opf:itemref idref="header" linear="yes"/><opf:itemref idref="section0" linear="yes"/></opf:spine></opf:package>"##
             .as_bytes(),
     )
     .unwrap();
@@ -97,6 +97,9 @@ fn build_container_fixture(path: &Path) {
     .unwrap();
     zip.start_file("BinData/image1.png", deflated).unwrap();
     zip.write_all(&[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 1, 1, 1, 1])
+        .unwrap();
+    zip.start_file("DocOptions/Layout.xml", deflated).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><layout>DISTINCTIVE-DOCOPTIONS-MARKER</layout>"#)
         .unwrap();
     zip.start_file("Preview/PrvImage.png", deflated).unwrap();
     zip.write_all(&[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 9, 9, 9, 9])
@@ -513,4 +516,37 @@ fn table_op_inside_opaque_container_fails_closed() {
         src_bytes,
         "입력 파일은 그대로여야 한다"
     );
+}
+
+/// 확장 파트(DocOptions/Layout.xml)가 원본 OPF 매니페스트에 등재된 문서의 set-meta:
+/// content.hpf 재생성 후에도 확장 파트 항목이 매니페스트에 남아야 한다(엔트리는
+/// raw-copy되는데 등재가 사라지면 고아 파트가 된다).
+#[test]
+fn meta_edit_keeps_extension_manifest_items() {
+    let src = tmp("surgical_ext_item.hwpx");
+    build_container_fixture(&src);
+    let out = tmp("surgical_ext_item_out.hwpx");
+
+    let r = hwp()
+        .arg("edit")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .args(["--set-meta", "title=확장 파트 편집"])
+        .output()
+        .unwrap();
+    assert!(
+        r.status.success(),
+        "set-meta: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+
+    let hpf = String::from_utf8(read_zip_entry(&out, "Contents/content.hpf")).unwrap();
+    assert!(
+        hpf.contains(
+            r#"<opf:item id="layout" href="DocOptions/Layout.xml" media-type="application/xml"/>"#
+        ),
+        "재생성 매니페스트에 확장 파트 항목 유지: {hpf}"
+    );
+    assert_entries_identical(&src, &out, &["DocOptions/Layout.xml"]);
 }

--- a/crates/hwp-cli/tests/edit_surgical.rs
+++ b/crates/hwp-cli/tests/edit_surgical.rs
@@ -1,0 +1,442 @@
+//! 같은 포맷 hwpx→hwpx `hwp edit`의 패키지 외과 수술 경로 통합 테스트 (epic #90 PR 3).
+//!
+//! 편집된 콘텐츠 엔트리(section/header/content.hpf)만 재직렬화되고 나머지 엔트리
+//! (BinData·META-INF·미리보기·settings 등)는 입력과 바이트 동일해야 한다.
+
+use std::io::{Read as _, Write as _};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use zip::CompressionMethod;
+use zip::write::SimpleFileOptions;
+
+fn hwp() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_hwp"))
+}
+
+fn fixture() -> PathBuf {
+    let p =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../fixtures/samples/report-tables.hwpx");
+    assert!(p.exists(), "커밋된 픽스처가 없습니다: {}", p.display());
+    p
+}
+
+fn tmp(name: &str) -> PathBuf {
+    // PID 포함 — 같은 머신에서 cargo test가 동시에 돌면(다른 세션·CI 병렬) 고정 경로가
+    // 서로 산출물을 덮어써 플레이크가 난다(실측).
+    let dir = std::env::temp_dir().join(format!("hwp-cli-edit-surgical-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join(name)
+}
+
+fn copy_fixture(name: &str) -> PathBuf {
+    let dst = tmp(name);
+    std::fs::copy(fixture(), &dst).unwrap();
+    dst
+}
+
+fn read_zip_entry(path: &Path, name: &str) -> Vec<u8> {
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(path).unwrap()).unwrap();
+    let mut buf = Vec::new();
+    zip.by_name(name).unwrap().read_to_end(&mut buf).unwrap();
+    buf
+}
+
+fn zip_entry_names(path: &Path) -> Vec<String> {
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(path).unwrap()).unwrap();
+    (0..zip.len())
+        .map(|i| zip.by_index(i).unwrap().name().to_string())
+        .collect()
+}
+
+/// 외과 수술 계약: 비대상 엔트리가 입력과 바이트 동일해야 한다.
+fn assert_entries_identical(src: &Path, out: &Path, names: &[&str]) {
+    for name in names {
+        assert_eq!(
+            read_zip_entry(src, name),
+            read_zip_entry(out, name),
+            "{name} 바이트 보존"
+        );
+    }
+}
+
+/// hp:container(미해석 개체) + BinData + 미리보기 + META-INF 원본 바이트를 담은
+/// 합성 HWPX. 컨테이너 보존은 커밋된 표 픽스처(컨테이너 없음)로는 검증할 수 없어
+/// 직접 만든다.
+fn build_container_fixture(path: &Path) {
+    let file = std::fs::File::create(path).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("mimetype", stored).unwrap();
+    zip.write_all(b"application/hwp+zip").unwrap();
+    zip.start_file("version.xml", deflated).unwrap();
+    zip.write_all(br#"<version major="1" minor="4" micro="0" buildNumber="0"/>"#)
+        .unwrap();
+    zip.start_file("META-INF/container.rdf", deflated).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><rdf:RDF>SURGICAL-CLI-MARKER</rdf:RDF>"#)
+        .unwrap();
+    zip.start_file("Contents/content.hpf", deflated).unwrap();
+    zip.write_all(
+        r##"<?xml version="1.0"?><opf:package xmlns:opf="http://www.idpf.org/2007/opf/"><opf:metadata><opf:title>컨테이너 문서</opf:title></opf:metadata><opf:manifest><opf:item id="header" href="Contents/header.xml" media-type="application/xml"/><opf:item id="section0" href="Contents/section0.xml" media-type="application/xml"/><opf:item id="settings" href="settings.xml" media-type="application/xml"/><opf:item id="image1" href="BinData/image1.png" media-type="image/png" isEmbeded="1"/></opf:manifest><opf:spine><opf:itemref idref="header" linear="yes"/><opf:itemref idref="section0" linear="yes"/></opf:spine></opf:package>"##
+            .as_bytes(),
+    )
+    .unwrap();
+    zip.start_file("Contents/header.xml", deflated).unwrap();
+    zip.write_all(
+        r##"<?xml version="1.0" encoding="UTF-8"?><hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head"/>"##
+            .as_bytes(),
+    )
+    .unwrap();
+    zip.start_file("Contents/section0.xml", deflated).unwrap();
+    zip.write_all(
+        r##"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:t>앵커 문단</hp:t><hp:container id="77" zOrder="3"><hp:sz width="1000" height="500"/><hp:subList><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:t>컨테이너 텍스트</hp:t></hp:run></hp:p></hp:subList></hp:container><hp:pic id="5" zOrder="0"><hp:sz width="100" height="100"/><hp:pos treatAsChar="1" vertOffset="0" horzOffset="0"/><hp:img binaryItemIDRef="image1" bright="0" contrast="0"/></hp:pic></hp:run></hp:p></hs:sec>"##
+            .as_bytes(),
+    )
+    .unwrap();
+    zip.start_file("BinData/image1.png", deflated).unwrap();
+    zip.write_all(&[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 1, 1, 1, 1])
+        .unwrap();
+    zip.start_file("Preview/PrvImage.png", deflated).unwrap();
+    zip.write_all(&[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 9, 9, 9, 9])
+        .unwrap();
+    zip.start_file("settings.xml", deflated).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><setting>CLI-SETTINGS-MARKER</setting>"#)
+        .unwrap();
+    zip.finish().unwrap();
+}
+
+fn tiny_png(path: &Path) {
+    // 32x24 IHDR만 담은 최소 PNG (cli.rs의 insert-image 테스트와 같은 형태).
+    let mut png = b"\x89PNG\r\n\x1a\n".to_vec();
+    png.extend([0, 0, 0, 13]);
+    png.extend(b"IHDR");
+    png.extend(32u32.to_be_bytes());
+    png.extend(24u32.to_be_bytes());
+    png.extend([0u8; 8]);
+    std::fs::write(path, &png).unwrap();
+}
+
+/// 표 op(set-cell): 본문만 재직렬화되고 header/content.hpf/미리보기/META-INF는
+/// 입력과 바이트 동일해야 한다(전체 재작성이었다면 header.xml이 재합성된다).
+#[test]
+fn table_op_preserves_non_target_entries() {
+    let src = copy_fixture("surgical_tbl.hwpx");
+    let out = tmp("surgical_tbl_out.hwpx");
+    let r = hwp()
+        .arg("edit")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .args(["--set-cell", "9:0:0=외과수술셀"])
+        .output()
+        .unwrap();
+    assert!(
+        r.status.success(),
+        "set-cell: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+
+    assert_entries_identical(
+        &src,
+        &out,
+        &[
+            "Contents/header.xml",
+            "Contents/content.hpf",
+            "Preview/PrvImage.png",
+            "Preview/PrvText.txt",
+            "META-INF/container.rdf",
+            "META-INF/container.xml",
+            "META-INF/manifest.xml",
+            "settings.xml",
+            "version.xml",
+        ],
+    );
+    let section = String::from_utf8(read_zip_entry(&out, "Contents/section0.xml")).unwrap();
+    assert!(section.contains("외과수술셀"), "셀 편집 반영");
+    assert!(
+        hwp()
+            .arg("validate")
+            .arg(&out)
+            .output()
+            .unwrap()
+            .status
+            .success(),
+        "validate 통과"
+    );
+}
+
+/// 메타데이터 op(set-meta): content.hpf만 재생성되고 header/미리보기/META-INF는
+/// 바이트 동일. BinData가 없는 문서라 엔트리 수도 같아야 한다.
+#[test]
+fn meta_op_regenerates_only_content_hpf() {
+    let src = copy_fixture("surgical_meta.hwpx");
+    let out = tmp("surgical_meta_out.hwpx");
+    let r = hwp()
+        .arg("edit")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .args(["--set-meta", "title=외과수술 제목"])
+        .output()
+        .unwrap();
+    assert!(
+        r.status.success(),
+        "set-meta: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+
+    assert_entries_identical(
+        &src,
+        &out,
+        &[
+            "Contents/header.xml",
+            "Preview/PrvImage.png",
+            "META-INF/container.rdf",
+            "settings.xml",
+        ],
+    );
+    assert_eq!(
+        zip_entry_names(&src).len(),
+        zip_entry_names(&out).len(),
+        "엔트리 수 불변"
+    );
+    let hpf = String::from_utf8(read_zip_entry(&out, "Contents/content.hpf")).unwrap();
+    assert!(
+        hpf.contains("<opf:title>외과수술 제목</opf:title>"),
+        "메타데이터 반영: {hpf}"
+    );
+}
+
+/// 그림 삽입(insert-image): 새 BinData 엔트리가 추가되고 content.hpf 매니페스트가
+/// 갱신되며, 기존 엔트리는 바이트 보존. 제자리(in-place) 편집도 성공해야 한다.
+#[test]
+fn image_insert_appends_bindata() {
+    let md = tmp("surgical_img.md");
+    std::fs::write(&md, "이미지 앵커: 본문\n").unwrap();
+    let base = tmp("surgical_img_base.hwpx");
+    let new = hwp()
+        .args(["new", "--from"])
+        .arg(&md)
+        .arg("-o")
+        .arg(&base)
+        .output()
+        .unwrap();
+    assert!(
+        new.status.success(),
+        "합성 문서 생성: {}",
+        String::from_utf8_lossy(&new.stderr)
+    );
+    let image = tmp("surgical_img.png");
+    tiny_png(&image);
+
+    let out = tmp("surgical_img_out.hwpx");
+    let r = hwp()
+        .arg("edit")
+        .arg(&base)
+        .arg("-o")
+        .arg(&out)
+        .arg("--insert-image")
+        .arg(format!("이미지 앵커:=>{}", image.display()))
+        .output()
+        .unwrap();
+    assert!(
+        r.status.success(),
+        "insert-image: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+
+    let base_names = zip_entry_names(&base);
+    let out_names = zip_entry_names(&out);
+    assert!(
+        !base_names.iter().any(|n| n.starts_with("BinData/")),
+        "원본은 BinData 없음"
+    );
+    assert!(
+        out_names.iter().any(|n| n == "BinData/image1.png"),
+        "새 BinData 엔트리 추가: {out_names:?}"
+    );
+    assert_eq!(
+        read_zip_entry(&out, "BinData/image1.png"),
+        std::fs::read(&image).unwrap(),
+        "삽입 이미지 바이트"
+    );
+    // 신규 항목이 매니페스트에 등록됐다.
+    let hpf = String::from_utf8(read_zip_entry(&out, "Contents/content.hpf")).unwrap();
+    assert!(
+        hpf.contains(r#"id="image1" href="BinData/image1.png""#),
+        "매니페스트 갱신: {hpf}"
+    );
+    // 비대상 엔트리는 바이트 보존.
+    assert_entries_identical(&base, &out, &["Contents/header.xml", "settings.xml"]);
+    assert!(
+        hwp()
+            .arg("validate")
+            .arg(&out)
+            .output()
+            .unwrap()
+            .status
+            .success(),
+        "validate 통과"
+    );
+
+    // 제자리 편집(입력=출력 경로)도 snapshot 덕분에 안전하게 성공해야 한다.
+    let inplace = tmp("surgical_img_inplace.hwpx");
+    std::fs::copy(&base, &inplace).unwrap();
+    let r = hwp()
+        .arg("edit")
+        .arg(&inplace)
+        .arg("-o")
+        .arg(&inplace)
+        .arg("--insert-image")
+        .arg(format!("이미지 앵커:=>{}", image.display()))
+        .output()
+        .unwrap();
+    assert!(
+        r.status.success(),
+        "in-place insert-image: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+    assert!(
+        zip_entry_names(&inplace)
+            .iter()
+            .any(|n| n == "BinData/image1.png"),
+        "in-place 결과에도 새 BinData 존재"
+    );
+}
+
+/// --replace와 표 op를 섞으면 고속 경로가 아니라 IR 외과 수술 경로를 타야 하고,
+/// 그래도 비대상 엔트리는 바이트 보존이어야 한다.
+#[test]
+fn mixed_replace_and_table_op_stays_surgical() {
+    let src = copy_fixture("surgical_mixed.hwpx");
+    let out = tmp("surgical_mixed_out.hwpx");
+    let r = hwp()
+        .arg("edit")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .args([
+            "--replace",
+            "한빛대학교=>검증대학교",
+            "--set-cell",
+            "9:0:0=혼합편집",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        r.status.success(),
+        "mixed edit: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&r.stderr);
+    assert!(
+        !stderr.contains("패키지 보존"),
+        "혼합 편집은 replace 고속 경로가 아니어야: {stderr}"
+    );
+
+    assert_entries_identical(
+        &src,
+        &out,
+        &[
+            "Contents/header.xml",
+            "Preview/PrvImage.png",
+            "META-INF/container.rdf",
+            "settings.xml",
+        ],
+    );
+    let section = String::from_utf8(read_zip_entry(&out, "Contents/section0.xml")).unwrap();
+    assert!(section.contains("검증대학교"), "치환 반영");
+    assert!(section.contains("혼합편집"), "셀 편집 반영");
+}
+
+/// 미해석 개체(hp:container)를 담은 문서의 IR 외과 수술: 컨테이너 원문 XML과
+/// 기존 그림 참조가 유지되고 불투명 엔트리는 바이트 보존.
+#[test]
+fn container_and_picture_survive_surgical_edit() {
+    let src = tmp("surgical_container.hwpx");
+    build_container_fixture(&src);
+    let out = tmp("surgical_container_out.hwpx");
+
+    // IR의 컨테이너 개수를 세는 도우미 (cat JSON에서 ctrl_id "cont" = [99,111,110,116]).
+    // 모든 Generic을 세면 안 된다 — 이 합성 픽스처는 secPr가 없어 writer가 기본
+    // 구역 정의를 주입하고, 그 colPr가 Generic(cold)으로 다시 읽힌다(전체 재작성
+    // 경로도 동일한 기존 동작).
+    fn collect_generic_ids(paras: &serde_json::Value, out: &mut Vec<Vec<u8>>) {
+        for p in paras.as_array().unwrap() {
+            for c in p["controls"].as_array().unwrap() {
+                if let Some(g) = c.get("Generic") {
+                    let id: Vec<u8> = g["ctrl_id"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .map(|v| v.as_u64().unwrap() as u8)
+                        .collect();
+                    out.push(id);
+                    for l in g["paragraph_lists"].as_array().unwrap() {
+                        collect_generic_ids(&l["paragraphs"], out);
+                    }
+                } else if let Some(t) = c.get("Table") {
+                    for cell in t["cells"].as_array().unwrap() {
+                        collect_generic_ids(&cell["paragraphs"], out);
+                    }
+                }
+            }
+        }
+    }
+    let container_count = |path: &Path| {
+        let cat = hwp()
+            .arg("cat")
+            .arg(path)
+            .args(["--format", "json"])
+            .output()
+            .unwrap();
+        let j: serde_json::Value = serde_json::from_slice(&cat.stdout).unwrap();
+        let mut ids = Vec::new();
+        for section in j["sections"].as_array().unwrap() {
+            collect_generic_ids(&section["paragraphs"], &mut ids);
+        }
+        ids.iter().filter(|id| id.as_slice() == b"cont").count()
+    };
+    let before = container_count(&src);
+    assert!(before >= 1, "픽스처에 컨테이너 존재");
+
+    // set-meta는 본문과 무관하지만, 외과 수술 경로에서 본문은 항상 재직렬화된다 —
+    // 이 때 컨테이너 원문(hwpx_raw_xml)이 유지돼야 한다.
+    let r = hwp()
+        .arg("edit")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .args(["--set-meta", "title=컨테이너 편집 후"])
+        .output()
+        .unwrap();
+    assert!(
+        r.status.success(),
+        "set-meta: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+
+    assert_eq!(container_count(&out), before, "컨테이너 수 불변");
+    let section = String::from_utf8(read_zip_entry(&out, "Contents/section0.xml")).unwrap();
+    assert!(
+        section.contains(r#"<hp:container id="77" zOrder="3">"#),
+        "컨테이너 원문 유지: {section}"
+    );
+    assert!(
+        section.contains(r#"binaryItemIDRef="image1""#),
+        "기존 그림 원본 id 유지: {section}"
+    );
+    assert_entries_identical(
+        &src,
+        &out,
+        &[
+            "BinData/image1.png",
+            "Preview/PrvImage.png",
+            "META-INF/container.rdf",
+            "settings.xml",
+            "Contents/header.xml",
+        ],
+    );
+}

--- a/crates/hwp-cli/tests/edit_surgical.rs
+++ b/crates/hwp-cli/tests/edit_surgical.rs
@@ -118,6 +118,43 @@ fn tiny_png(path: &Path) {
     std::fs::write(path, &png).unwrap();
 }
 
+/// hp:container(미해석 개체)의 subList 안에 1×1 표를 담은 합성 HWPX.
+/// 표 op이 컨테이너 안 표를 바꾸면 원문 XML이 낡으므로 fail-closed로 거부돼야 한다.
+fn build_container_table_fixture(path: &Path) {
+    let file = std::fs::File::create(path).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("mimetype", stored).unwrap();
+    zip.write_all(b"application/hwp+zip").unwrap();
+    zip.start_file("version.xml", deflated).unwrap();
+    zip.write_all(br#"<version major="1" minor="4" micro="0" buildNumber="0"/>"#)
+        .unwrap();
+    zip.start_file("Contents/content.hpf", deflated).unwrap();
+    zip.write_all(
+        r##"<?xml version="1.0"?><opf:package xmlns:opf="http://www.idpf.org/2007/opf/"><opf:metadata><opf:title>컨테이너 표 문서</opf:title></opf:metadata><opf:manifest><opf:item id="header" href="Contents/header.xml" media-type="application/xml"/><opf:item id="section0" href="Contents/section0.xml" media-type="application/xml"/><opf:item id="settings" href="settings.xml" media-type="application/xml"/></opf:manifest><opf:spine><opf:itemref idref="header" linear="yes"/><opf:itemref idref="section0" linear="yes"/></opf:spine></opf:package>"##
+            .as_bytes(),
+    )
+    .unwrap();
+    zip.start_file("Contents/header.xml", deflated).unwrap();
+    zip.write_all(
+        r##"<?xml version="1.0" encoding="UTF-8"?><hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head"/>"##
+            .as_bytes(),
+    )
+    .unwrap();
+    zip.start_file("Contents/section0.xml", deflated).unwrap();
+    zip.write_all(
+        r##"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:t>앵커 문단</hp:t><hp:container id="78" zOrder="3"><hp:sz width="2000" height="1000"/><hp:subList><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:tbl id="9" zOrder="0" pageBreak="NONE" repeatHeader="0" rowCnt="1" colCnt="1" cellSpacing="0" borderFillIDRef="0" noAdjust="0"><hp:sz width="1000" height="500"/><hp:pos treatAsChar="1" affectLSpacing="0" flowWithText="0" holdAnchorAndSO="0" vertRelTo="PARA" horzRelTo="PARA" vertAlign="TOP" horzAlign="LEFT" vertOffset="0" horzOffset="0"/><hp:outMargin left="0" right="0" top="0" bottom="0"/><hp:inMargin left="0" right="0" top="0" bottom="0"/><hp:tr><hp:tc name="" header="0" hasMargin="0" protect="0" editable="0" dirty="0" borderFillIDRef="0"><hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="CENTER" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0"><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:t>컨테이너 셀</hp:t></hp:run></hp:p></hp:subList><hp:cellAddr colAddr="0" rowAddr="0"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="500"/><hp:cellMargin left="0" right="0" top="0" bottom="0"/></hp:tc></hp:tr></hp:tbl></hp:run></hp:p></hp:subList></hp:container></hp:run></hp:p></hs:sec>"##
+            .as_bytes(),
+    )
+    .unwrap();
+    zip.start_file("settings.xml", deflated).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><setting>CLI-SETTINGS-MARKER</setting>"#)
+        .unwrap();
+    zip.finish().unwrap();
+}
+
 /// 표 op(set-cell): 본문만 재직렬화되고 header/content.hpf/미리보기/META-INF는
 /// 입력과 바이트 동일해야 한다(전체 재작성이었다면 header.xml이 재합성된다).
 #[test]
@@ -438,5 +475,42 @@ fn container_and_picture_survive_surgical_edit() {
             "settings.xml",
             "Contents/header.xml",
         ],
+    );
+}
+
+/// 컨테이너(hp:container) 안의 표를 겨냥한 표 op은 컨테이너 원문 XML을 낡게 만든다.
+/// writer는 컨테이너를 재방출할 emitter가 없으므로 OpaqueControlUnrepresentable을
+/// 기록하고, fail-closed 보존 검사가 편집을 거부해야 한다(조용한 성공 = 편집 유실이
+/// 진짜 버그). 거부되면 출력은 게시되지 않고 입력도 그대로여야 한다.
+#[test]
+fn table_op_inside_opaque_container_fails_closed() {
+    let src = tmp("surgical_container_tbl.hwpx");
+    build_container_table_fixture(&src);
+    let src_bytes = std::fs::read(&src).unwrap();
+    let out = tmp("surgical_container_tbl_out.hwpx");
+
+    let r = hwp()
+        .arg("edit")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .args(["--set-cell", "0:0:0=변경시도"])
+        .output()
+        .unwrap();
+    assert!(
+        !r.status.success(),
+        "컨테이너 안 표 편집은 거부돼야 한다: {}",
+        String::from_utf8_lossy(&r.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&r.stderr);
+    assert!(
+        stderr.contains("보존 불가") && stderr.contains("opaque_control_unrepresentable"),
+        "fail-closed 보존 오류여야 한다: {stderr}"
+    );
+    assert!(!out.exists(), "거부된 편집은 출력을 게시하지 않는다");
+    assert_eq!(
+        std::fs::read(&src).unwrap(),
+        src_bytes,
+        "입력 파일은 그대로여야 한다"
     );
 }

--- a/crates/hwp-convert/src/bookmark.rs
+++ b/crates/hwp-convert/src/bookmark.rs
@@ -139,6 +139,7 @@ fn make_bokm_control(name: &str) -> Control {
         equation: None,
         column_def: None,
         caption: None,
+        hwpx_raw_xml: None,
     })
 }
 
@@ -196,6 +197,8 @@ fn create_bookmark_rec(para: &mut Paragraph, anchor: &str, name: &str) -> bool {
                 for l in &mut g.paragraph_lists {
                     for p in &mut l.paragraphs {
                         if create_bookmark_rec(p, anchor, name) {
+                            // 내용이 바뀐 개체의 원문 XML은 낡았다 — stale 방출 금지.
+                            g.hwpx_raw_xml = None;
                             return true;
                         }
                     }

--- a/crates/hwp-convert/src/docx.rs
+++ b/crates/hwp-convert/src/docx.rs
@@ -1442,6 +1442,7 @@ mod tests {
                 }),
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             }));
             para.chars.push(HwpChar::ExtCtrl {
                 code: ctrl_char::OBJECT,

--- a/crates/hwp-convert/src/edit.rs
+++ b/crates/hwp-convert/src/edit.rs
@@ -199,9 +199,9 @@ pub fn add_rows(
 }
 
 /// `table_index`번째 표(0-기반)의 (행 수, 열 수)를 반환한다. 데이터 구동 채우기가
-/// 추가할 행 수를 계산할 때 쓴다(현재 행 수 조회).
+/// 추가할 행 수를 계산할 때 쓴다(현재 행 수 조회). 읽기 전용 — `hwpx_raw_xml`을 건드리지 않는다.
 pub fn table_dims(doc: &mut Document, table_index: usize) -> Option<(u16, u16)> {
-    with_nth_table(doc, table_index, |t| (t.rows, t.cols))
+    with_nth_table_readonly(doc, table_index, |t| (t.rows, t.cols))
 }
 
 /// `table_index`번째 표(0-기반)의 `row`행을 삭제한다(이후 행 재번호, row_cell_counts
@@ -917,9 +917,30 @@ pub fn apply_meta(doc: &mut Document, spec: &str) -> Result<(), String> {
 
 /// 문서 등장 순서 `index`번째 표를 찾아 `f`를 적용한다(0-기반). 본문·표 셀·글상자
 /// 문단을 재귀로 훑는다. 표를 찾으면 `Some(f의 결과)`, 못 찾으면 `None`.
+/// `f`가 개체 원문 XML(`hwpx_raw_xml`)을 품은 Generic 안의 표를 바꾸면 그 원문은
+/// 낡으므로 지운다 — writer가 stale XML을 방출하는 것을 막는다(방출할 emitter가
+/// 없어 fail-closed 보존 오류로 이어진다).
 fn with_nth_table<R, F: FnOnce(&mut hwp_model::Table) -> R>(
     doc: &mut Document,
     index: usize,
+    f: F,
+) -> Option<R> {
+    walk_nth_table_root(doc, index, true, f)
+}
+
+/// 읽기 전용 변형([`table_dims`]) — 내용을 바꾸지 않으므로 `hwpx_raw_xml`을 지우지 않는다.
+fn with_nth_table_readonly<R, F: FnOnce(&mut hwp_model::Table) -> R>(
+    doc: &mut Document,
+    index: usize,
+    f: F,
+) -> Option<R> {
+    walk_nth_table_root(doc, index, false, f)
+}
+
+fn walk_nth_table_root<R, F: FnOnce(&mut hwp_model::Table) -> R>(
+    doc: &mut Document,
+    index: usize,
+    mutating: bool,
     f: F,
 ) -> Option<R> {
     let mut seen = 0;
@@ -927,7 +948,7 @@ fn with_nth_table<R, F: FnOnce(&mut hwp_model::Table) -> R>(
     let mut out = None;
     for section in &mut doc.sections {
         for para in &mut section.paragraphs {
-            walk_nth_table(para, index, &mut seen, &mut f, &mut out);
+            walk_nth_table(para, index, mutating, &mut seen, &mut f, &mut out);
             if out.is_some() {
                 return out;
             }
@@ -939,6 +960,7 @@ fn with_nth_table<R, F: FnOnce(&mut hwp_model::Table) -> R>(
 fn walk_nth_table<R, F: FnOnce(&mut hwp_model::Table) -> R>(
     para: &mut Paragraph,
     index: usize,
+    mutating: bool,
     seen: &mut usize,
     f: &mut Option<F>,
     out: &mut Option<R>,
@@ -959,7 +981,7 @@ fn walk_nth_table<R, F: FnOnce(&mut hwp_model::Table) -> R>(
                 *seen += 1;
                 for cell in &mut t.cells {
                     for p in &mut cell.paragraphs {
-                        walk_nth_table(p, index, seen, f, out);
+                        walk_nth_table(p, index, mutating, seen, f, out);
                         if out.is_some() {
                             return;
                         }
@@ -969,8 +991,12 @@ fn walk_nth_table<R, F: FnOnce(&mut hwp_model::Table) -> R>(
             Control::Generic(g) => {
                 for list in &mut g.paragraph_lists {
                     for p in &mut list.paragraphs {
-                        walk_nth_table(p, index, seen, f, out);
+                        walk_nth_table(p, index, mutating, seen, f, out);
                         if out.is_some() {
+                            if mutating {
+                                // 내용이 바뀐 개체의 원문 XML은 낡았다 — stale 방출 금지.
+                                g.hwpx_raw_xml = None;
+                            }
                             return;
                         }
                     }

--- a/crates/hwp-convert/src/edit.rs
+++ b/crates/hwp-convert/src/edit.rs
@@ -49,6 +49,7 @@ fn replace_in_para(para: &mut Paragraph, from: &str, to: &str, budget: &mut usiz
                 }
             }
             Control::Generic(g) => {
+                let before = n;
                 for list in &mut g.paragraph_lists {
                     for p in &mut list.paragraphs {
                         if *budget == 0 {
@@ -56,6 +57,10 @@ fn replace_in_para(para: &mut Paragraph, from: &str, to: &str, budget: &mut usiz
                         }
                         n += replace_in_para(p, from, to, budget);
                     }
+                }
+                if n > before {
+                    // 내용이 바뀐 개체의 원문 XML은 낡았다 — stale 방출 금지.
+                    g.hwpx_raw_xml = None;
                 }
             }
             _ => {}
@@ -1302,10 +1307,15 @@ fn delete_object_in_para(
                 }
             }
             Control::Generic(g) => {
+                let before = n;
                 for list in &mut g.paragraph_lists {
                     for p in &mut list.paragraphs {
                         n += delete_object_in_para(p, kind, selector, table_seen);
                     }
+                }
+                if n > before {
+                    // 내용이 바뀐 개체의 원문 XML은 낡았다 — stale 방출 금지.
+                    g.hwpx_raw_xml = None;
                 }
             }
             _ => {}

--- a/crates/hwp-convert/src/field.rs
+++ b/crates/hwp-convert/src/field.rs
@@ -365,10 +365,15 @@ fn set_field_para(para: &mut Paragraph, name: &str, value: &str) -> usize {
                 }
             }
             Control::Generic(g) => {
+                let before = nested;
                 for l in &mut g.paragraph_lists {
                     for p in &mut l.paragraphs {
                         nested += set_field_para(p, name, value);
                     }
+                }
+                if nested > before {
+                    // 내용이 바뀐 개체의 원문 XML은 낡았다 — stale 방출 금지.
+                    g.hwpx_raw_xml = None;
                 }
             }
             _ => {}
@@ -537,6 +542,7 @@ fn make_field_control(ctrl_id: [u8; 4], name: Option<&str>, command: Option<&str
         equation: None,
         column_def: None,
         caption: None,
+        hwpx_raw_xml: None,
     })
 }
 
@@ -762,6 +768,8 @@ fn create_field_rec(
                 for l in &mut g.paragraph_lists {
                     for p in &mut l.paragraphs {
                         if create_field_rec(p, anchor, ctrl_id, name, command, value, value_shape) {
+                            // 내용이 바뀐 개체의 원문 XML은 낡았다 — stale 방출 금지.
+                            g.hwpx_raw_xml = None;
                             return true;
                         }
                     }
@@ -870,6 +878,7 @@ mod tests {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         });
         let mut chars = vec![HwpChar::ExtCtrl {
             code: FIELD_START,

--- a/crates/hwp-convert/src/format.rs
+++ b/crates/hwp-convert/src/format.rs
@@ -87,10 +87,15 @@ fn restyle_para(
                 }
             }
             Control::Generic(g) => {
+                let before = n;
                 for list in &mut g.paragraph_lists {
                     for p in &mut list.paragraphs {
                         n += restyle_para(p, pattern, fmt, shapes);
                     }
+                }
+                if n > before {
+                    // 내용이 바뀐 개체의 원문 XML은 낡았다 — stale 방출 금지.
+                    g.hwpx_raw_xml = None;
                 }
             }
             _ => {}
@@ -253,10 +258,15 @@ fn align_para(
                 }
             }
             Control::Generic(g) => {
+                let before = n;
                 for list in &mut g.paragraph_lists {
                     for p in &mut list.paragraphs {
                         n += align_para(p, pattern, align, pshapes);
                     }
+                }
+                if n > before {
+                    // 내용이 바뀐 개체의 원문 XML은 낡았다 — stale 방출 금지.
+                    g.hwpx_raw_xml = None;
                 }
             }
             _ => {}
@@ -384,10 +394,15 @@ fn props_para(
                 }
             }
             Control::Generic(g) => {
+                let before = n;
                 for list in &mut g.paragraph_lists {
                     for p in &mut list.paragraphs {
                         n += props_para(p, pattern, props, pshapes);
                     }
+                }
+                if n > before {
+                    // 내용이 바뀐 개체의 원문 XML은 낡았다 — stale 방출 금지.
+                    g.hwpx_raw_xml = None;
                 }
             }
             _ => {}

--- a/crates/hwp-convert/src/from_html.rs
+++ b/crates/hwp-convert/src/from_html.rs
@@ -128,6 +128,7 @@ pub fn from_html_with(html: &str, opts: &HtmlImportOptions) -> Result<Document, 
         hwpx_preview_image: None,
         hwp5_xml_template: Vec::new(),
         hwp5_doc_history: Vec::new(),
+        hwpx_extra_entries: Vec::new(),
     })
 }
 

--- a/crates/hwp-convert/src/from_html.rs
+++ b/crates/hwp-convert/src/from_html.rs
@@ -130,6 +130,8 @@ pub fn from_html_with(html: &str, opts: &HtmlImportOptions) -> Result<Document, 
         hwp5_doc_history: Vec::new(),
         hwpx_extra_entries: Vec::new(),
         hwpx_bin_manifest: Vec::new(),
+        hwpx_opf_extra_items: Vec::new(),
+        hwpx_section_xmlns: Vec::new(),
     })
 }
 

--- a/crates/hwp-convert/src/from_html.rs
+++ b/crates/hwp-convert/src/from_html.rs
@@ -129,6 +129,7 @@ pub fn from_html_with(html: &str, opts: &HtmlImportOptions) -> Result<Document, 
         hwp5_xml_template: Vec::new(),
         hwp5_doc_history: Vec::new(),
         hwpx_extra_entries: Vec::new(),
+        hwpx_bin_manifest: Vec::new(),
     })
 }
 

--- a/crates/hwp-convert/src/from_markdown.rs
+++ b/crates/hwp-convert/src/from_markdown.rs
@@ -523,6 +523,7 @@ fn from_markdown_inner(
             hwpx_preview_image: None,
             hwp5_xml_template: Vec::new(),
             hwp5_doc_history: Vec::new(),
+            hwpx_extra_entries: Vec::new(),
         },
         b.warnings,
         b.hard_error,
@@ -632,6 +633,7 @@ pub(crate) fn footnote_anchor(
         equation: None,
         column_def: None,
         caption: None,
+        hwpx_raw_xml: None,
     });
     (ch, control)
 }
@@ -1446,6 +1448,8 @@ fn remap_para_ids(para: &mut Paragraph, ps_off: u16, cs_off: u16) {
                         remap_para_ids(p, ps_off, cs_off);
                     }
                 }
+                // ID 재매핑으로 개체 안 문단의 모양 참조가 바뀐다 — 원문 XML은 stale.
+                g.hwpx_raw_xml = None;
             }
             _ => {}
         }
@@ -1566,6 +1570,7 @@ pub(crate) fn inject_section_controls(para: &mut Paragraph, preset: Option<Offic
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         }),
     );
     let ext = |code: u16, ctrl_id: [u8; 4], idx: u32| {
@@ -1601,6 +1606,7 @@ pub(crate) fn inject_section_controls(para: &mut Paragraph, preset: Option<Offic
                 equation: None,
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             }),
         );
         para.chars.insert(2, ext(21, *b"pgnp", 2));

--- a/crates/hwp-convert/src/from_markdown.rs
+++ b/crates/hwp-convert/src/from_markdown.rs
@@ -524,6 +524,7 @@ fn from_markdown_inner(
             hwp5_xml_template: Vec::new(),
             hwp5_doc_history: Vec::new(),
             hwpx_extra_entries: Vec::new(),
+            hwpx_bin_manifest: Vec::new(),
         },
         b.warnings,
         b.hard_error,

--- a/crates/hwp-convert/src/from_markdown.rs
+++ b/crates/hwp-convert/src/from_markdown.rs
@@ -525,6 +525,8 @@ fn from_markdown_inner(
             hwp5_doc_history: Vec::new(),
             hwpx_extra_entries: Vec::new(),
             hwpx_bin_manifest: Vec::new(),
+            hwpx_opf_extra_items: Vec::new(),
+            hwpx_section_xmlns: Vec::new(),
         },
         b.warnings,
         b.hard_error,

--- a/crates/hwp-convert/src/image.rs
+++ b/crates/hwp-convert/src/image.rs
@@ -336,6 +336,8 @@ fn insert_image_rec(para: &mut Paragraph, anchor: &str, pic: &Picture) -> bool {
                 for l in &mut g.paragraph_lists {
                     for p in &mut l.paragraphs {
                         if insert_image_rec(p, anchor, pic) {
+                            // 내용이 바뀐 개체의 원문 XML은 낡았다 — stale 방출 금지.
+                            g.hwpx_raw_xml = None;
                             return true;
                         }
                     }
@@ -504,6 +506,8 @@ fn insert_seal_rec(
                 for l in &mut g.paragraph_lists {
                     for p in &mut l.paragraphs {
                         if insert_seal_rec(p, anchor, seal_w, seal_h, name) {
+                            // 내용이 바뀐 개체의 원문 XML은 낡았다 — stale 방출 금지.
+                            g.hwpx_raw_xml = None;
                             return true;
                         }
                     }

--- a/crates/hwp-convert/src/markdown.rs
+++ b/crates/hwp-convert/src/markdown.rs
@@ -1612,6 +1612,7 @@ mod tests {
                 equation: None,
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             })
         };
         let anchor = |idx: u32, id: &[u8; 4]| HwpChar::ExtCtrl {
@@ -1658,6 +1659,7 @@ mod tests {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         });
         let cell_para = Paragraph {
             chars: "셀 본문"
@@ -1712,6 +1714,7 @@ mod tests {
                 }),
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             })
         };
         let anchor = |idx: u32| HwpChar::ExtCtrl {
@@ -2049,6 +2052,7 @@ mod tests {
                 equation: None,
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             })
         };
         let anchor = |idx: u32, id: &[u8; 4]| HwpChar::ExtCtrl {
@@ -2388,6 +2392,7 @@ mod tests {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         })
     }
 
@@ -2655,6 +2660,7 @@ mod tests {
             }),
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         })
     }
 

--- a/crates/hwp-convert/src/merge.rs
+++ b/crates/hwp-convert/src/merge.rs
@@ -166,6 +166,8 @@ fn remap_paragraph(
                         remap_paragraph(p, ps_off, cs_off, rename);
                     }
                 }
+                // ID 재매핑으로 개체 안 문단의 모양 참조가 바뀐다 — 원문 XML은 stale.
+                g.hwpx_raw_xml = None;
             }
             Control::Picture(pic) => {
                 if let hwp_model::BinRef::ItemRef(name) = &mut pic.bin_ref

--- a/crates/hwp-model/src/control.rs
+++ b/crates/hwp-model/src/control.rs
@@ -367,6 +367,11 @@ pub struct GenericControl {
     /// HWP5 controls, so this field is the semantic render/text view.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub caption: Option<Caption>,
+    /// hwpx 원본 run-level 개체(hp:container 등 미해석 개체)의 원문 XML —
+    /// 무손실 재직렬화용. hwpx reader가 캡처하며, 존재하면 hwpx writer가
+    /// 이 문자열을 그대로 방출한다. hwp5 출신·합성 IR이면 None.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hwpx_raw_xml: Option<String>,
 }
 
 /// 다단(multi-column) 정의 — COLDEF(`cold`)/hp:colPr. 렌더러가 단 배치·구분선에 사용.

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -52,6 +52,18 @@ pub struct Document {
     /// 가리키게 한다. hwp5 출신·합성 문서는 빈 벡터(기존 image{N} 할당 유지).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub hwpx_bin_manifest: Vec<(String, String)>,
+    /// hwpx 원본 OPF manifest 중 writer가 재생성하지 않는 확장 파트 항목의
+    /// (id, href, media-type) — BinData/header/section/settings 외 항목(예:
+    /// DocOptions/Layout.xml). content.hpf 재생성 시 그대로 다시 등재해 패키지
+    /// 엔트리가 고아(미등재)가 되지 않게 한다. hwp5 출신·합성 문서는 빈 벡터.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hwpx_opf_extra_items: Vec<(String, String, String)>,
+    /// hwpx 원본 섹션 루트의 추가 xmlns 선언(원문 속성 문자열 `xmlns:foo="uri"`,
+    /// writer 표준 hs/hp/hc 제외, 전 섹션 합집합). 원문 캡처 개체가 루트에만
+    /// 선언된 확장 접두어(hp10:, 벤더 접두어 등)를 쓸 수 있어, 재직렬화된 섹션
+    /// 루트에 그대로 실어야 namespace-well-formed하다. hwp5 출신·합성 문서는 빈 벡터.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hwpx_section_xmlns: Vec<String>,
 }
 
 /// 문서 수준 메타데이터 (요약 정보 / OPF 메타).

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -42,6 +42,10 @@ pub struct Document {
     /// 해석하지 않는다(§4.4 파서는 범위 밖). hwpx 출신·이력이 없는 문서는 빈 벡터.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub hwp5_doc_history: Vec<(String, Vec<u8>)>,
+    /// hwpx 원본 패키지 중 writer가 재생성하지 않는 엔트리(원본 순서·바이트 보존).
+    /// 예: DocOptions, 스크립트, 추가 Preview, 원본 META-INF/*. hwpx 출신이 아니면 비어 있다.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hwpx_extra_entries: Vec<(String, Vec<u8>)>,
 }
 
 /// 문서 수준 메타데이터 (요약 정보 / OPF 메타).

--- a/crates/hwp-model/src/document.rs
+++ b/crates/hwp-model/src/document.rs
@@ -46,6 +46,12 @@ pub struct Document {
     /// 예: DocOptions, 스크립트, 추가 Preview, 원본 META-INF/*. hwpx 출신이 아니면 비어 있다.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub hwpx_extra_entries: Vec<(String, Vec<u8>)>,
+    /// hwpx 원본 `Contents/content.hpf`의 OPF manifest 중 BinData 항목의
+    /// (id, href) 매핑. 전체 재작성 경로에서 BinCollector id를 원본 manifest id로
+    /// 시드해, 원문 캡처된 개체 안의 `binaryItemIDRef`가 원본 바이트를 계속
+    /// 가리키게 한다. hwp5 출신·합성 문서는 빈 벡터(기존 image{N} 할당 유지).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub hwpx_bin_manifest: Vec<(String, String)>,
 }
 
 /// 문서 수준 메타데이터 (요약 정보 / OPF 메타).

--- a/crates/hwp-model/src/text.rs
+++ b/crates/hwp-model/src/text.rs
@@ -288,6 +288,7 @@ mod tests {
             equation: None,
             column_def: None,
             caption: Some(caption(CaptionSide::Top, "shape caption")),
+            hwpx_raw_xml: None,
         });
         let mut out = String::new();
         extract_control(&picture, &mut out, &TextOptions::default());

--- a/crates/hwp-render/src/footnote.rs
+++ b/crates/hwp-render/src/footnote.rs
@@ -117,6 +117,7 @@ mod tests {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         }
     }
 

--- a/crates/hwp-render/src/layout.rs
+++ b/crates/hwp-render/src/layout.rs
@@ -5108,6 +5108,7 @@ mod certification_budget_tests {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         })
     }
 

--- a/crates/hwp-render/src/shape_draw.rs
+++ b/crates/hwp-render/src/shape_draw.rs
@@ -1256,6 +1256,7 @@ mod tests {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         };
         let doc = Document::default();
         let mut page = PageList {

--- a/crates/hwp-render/tests/render.rs
+++ b/crates/hwp-render/tests/render.rs
@@ -313,6 +313,7 @@ fn authoritative_column_flags_preserve_an_empty_first_column() {
                 divider: None,
             }),
             caption: None,
+            hwpx_raw_xml: None,
         }));
     for paragraph in &mut doc.sections[0].paragraphs {
         assert_eq!(paragraph.line_segs.len(), 1);
@@ -403,6 +404,7 @@ fn 수식_조판_렌더() {
                 }),
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             }));
     }
     let out = render_document(
@@ -1181,6 +1183,7 @@ fn 글상자_내부_개요_번호_마커_렌더() {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         }));
 
     let mut store = hwp_render::FontStore::new();
@@ -1209,6 +1212,7 @@ fn generic_control(
         equation: None,
         column_def: None,
         caption: None,
+        hwpx_raw_xml: None,
     })
 }
 
@@ -1753,6 +1757,7 @@ fn generic_shape_caption_is_rendered() {
                     ..hwp_model::Paragraph::default()
                 }],
             }),
+            hwpx_raw_xml: None,
         }));
 
     let (list, _) = 표_레이아웃(&doc);
@@ -2200,6 +2205,7 @@ fn table_fragments_reserve_pending_footnote_space() {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         }));
 
     let (list, _report) = 표_레이아웃(&doc);
@@ -2366,6 +2372,7 @@ fn renders_multi_column_divider() {
                 }),
             }),
             caption: None,
+            hwpx_raw_xml: None,
         }));
 
     let mut store = hwp_render::FontStore::new();
@@ -2551,6 +2558,7 @@ fn 미주는_구역끝_각주는_앵커페이지() {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         })
     };
     let anchor = &mut doc.sections[0].paragraphs[0];
@@ -2620,6 +2628,7 @@ fn endnotes_paginate_across_all_required_pages() {
                 equation: None,
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             }));
     }
 

--- a/crates/hwp5/src/body_text.rs
+++ b/crates/hwp5/src/body_text.rs
@@ -273,6 +273,7 @@ fn parse_control(node: &RecordNode, warnings: &mut Vec<String>) -> Control {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         });
     }
     let mut ctrl_id = [node.data[0], node.data[1], node.data[2], node.data[3]];
@@ -830,6 +831,7 @@ fn parse_generic(
         equation,
         column_def,
         caption,
+        hwpx_raw_xml: None,
     };
     if let Some((start, end)) = caption_range {
         collect_paragraph_lists(&children[..start], &mut g, warnings);

--- a/crates/hwp5/src/read.rs
+++ b/crates/hwp5/src/read.rs
@@ -305,6 +305,8 @@ fn read_document_from_streams(
         hwpx_preview_image: None,
         hwp5_xml_template,
         hwp5_doc_history,
+        // hwp5 출신 문서는 hwpx 패키지 잉여 엔트리가 없다.
+        hwpx_extra_entries: Vec::new(),
     };
     Ok(ReadResult { document, warnings })
 }
@@ -390,6 +392,8 @@ pub fn read_document(path: &Path) -> Result<ReadResult> {
         hwpx_preview_image: None,
         hwp5_xml_template,
         hwp5_doc_history,
+        // hwp5 출신 문서는 hwpx 패키지 잉여 엔트리가 없다.
+        hwpx_extra_entries: Vec::new(),
     };
     Ok(ReadResult { document, warnings })
 }

--- a/crates/hwp5/src/read.rs
+++ b/crates/hwp5/src/read.rs
@@ -308,6 +308,8 @@ fn read_document_from_streams(
         // hwp5 출신 문서는 hwpx 패키지 잉여 엔트리가 없다.
         hwpx_extra_entries: Vec::new(),
         hwpx_bin_manifest: Vec::new(),
+        hwpx_opf_extra_items: Vec::new(),
+        hwpx_section_xmlns: Vec::new(),
     };
     Ok(ReadResult { document, warnings })
 }
@@ -396,6 +398,8 @@ pub fn read_document(path: &Path) -> Result<ReadResult> {
         // hwp5 출신 문서는 hwpx 패키지 잉여 엔트리가 없다.
         hwpx_extra_entries: Vec::new(),
         hwpx_bin_manifest: Vec::new(),
+        hwpx_opf_extra_items: Vec::new(),
+        hwpx_section_xmlns: Vec::new(),
     };
     Ok(ReadResult { document, warnings })
 }

--- a/crates/hwp5/src/read.rs
+++ b/crates/hwp5/src/read.rs
@@ -307,6 +307,7 @@ fn read_document_from_streams(
         hwp5_doc_history,
         // hwp5 출신 문서는 hwpx 패키지 잉여 엔트리가 없다.
         hwpx_extra_entries: Vec::new(),
+        hwpx_bin_manifest: Vec::new(),
     };
     Ok(ReadResult { document, warnings })
 }
@@ -394,6 +395,7 @@ pub fn read_document(path: &Path) -> Result<ReadResult> {
         hwp5_doc_history,
         // hwp5 출신 문서는 hwpx 패키지 잉여 엔트리가 없다.
         hwpx_extra_entries: Vec::new(),
+        hwpx_bin_manifest: Vec::new(),
     };
     Ok(ReadResult { document, warnings })
 }

--- a/crates/hwp5/src/write.rs
+++ b/crates/hwp5/src/write.rs
@@ -3459,6 +3459,7 @@ mod tests {
                 equation: None,
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             })
         }
 
@@ -3729,6 +3730,7 @@ mod tests {
                 last_width: 200,
                 paragraphs: vec![hwp_model::Paragraph::default()],
             }),
+            hwpx_raw_xml: None,
         };
         let node = emit_control(
             &Control::Generic(generic),
@@ -3863,6 +3865,7 @@ mod tests {
                 equation: None,
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             }));
         let output =
             std::env::temp_dir().join(format!("hwp5-typed-report-{}.hwp", std::process::id()));

--- a/crates/hwp5/tests/synth.rs
+++ b/crates/hwp5/tests/synth.rs
@@ -791,6 +791,7 @@ fn 글상자_hwpx출신_안전저하_텍스트보존() {
         equation: None,
         column_def: None,
         caption: None,
+        hwpx_raw_xml: None,
     };
     // 둘째 문단에 앵커(ExtCtrl 코드 11) + 컨트롤 부착.
     let para = &mut doc.sections[0].paragraphs[1];

--- a/crates/hwpx/src/patch.rs
+++ b/crates/hwpx/src/patch.rs
@@ -743,8 +743,12 @@ pub fn rewrite_document_staged(
             .iter()
             .map(|(id, href, mime, _)| (id.clone(), href.clone(), mime.clone()))
             .collect();
-        let xml =
-            crate::write::templates::content_hpf(doc.sections.len(), &bin_meta, &doc.metadata);
+        let xml = crate::write::templates::content_hpf(
+            doc.sections.len(),
+            &bin_meta,
+            &doc.hwpx_opf_extra_items,
+            &doc.metadata,
+        );
         replacements.insert("Contents/content.hpf".to_string(), xml.into_bytes());
     }
 

--- a/crates/hwpx/src/patch.rs
+++ b/crates/hwpx/src/patch.rs
@@ -9,18 +9,21 @@
 //! <hp:t>관명}}</hp:t>`) 문자열 치환이 매칭하지 못한다. XML 이벤트 단위 재구성이
 //! 필요한 편집은 IR 경로(`hwp edit`)를 쓴다.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use hwp_model::WriteReport;
+
 use crate::error::{HwpxError, Result};
 use crate::package::{
     HwpxPackage, PackageLimits, inspect_archive, preflight_central_directory, read_bounded,
     verify_archive_integrity,
 };
+use crate::write::section::BinCollector;
 
 static PATCH_TEMP_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 const HWPX_PARAGRAPH_NAMESPACE: &str = "http://www.hancom.co.kr/hwpml/2011/paragraph";
@@ -611,6 +614,231 @@ fn invalid_data(e: std::string::FromUtf8Error) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::InvalidData, e)
 }
 
+/// 외과 수술 재작성에서 다시 직렬화할 콘텐츠 엔트리 집합.
+///
+/// 여기 열거되지 않은 엔트리(BinData, META-INF, Preview, DocOptions, 비대상
+/// section 등)는 모두 원본 패키지에서 raw 복사로 바이트 보존한다.
+#[derive(Debug, Clone)]
+pub struct DirtyEntries {
+    /// 재직렬화할 `Contents/section{i}.xml` 인덱스. `None`이면 전체 섹션.
+    pub sections: Option<Vec<usize>>,
+    /// `Contents/header.xml` 재생성 여부.
+    pub header: bool,
+    /// `Contents/content.hpf` 재생성 여부. 새 BinData 엔트리가 추가되면
+    /// 매니페스트 갱신을 위해 패치가 강제로 켠다.
+    pub content_hpf: bool,
+}
+
+impl DirtyEntries {
+    /// 모든 콘텐츠 엔트리를 다시 직렬화한다.
+    pub fn all() -> Self {
+        Self {
+            sections: None,
+            header: true,
+            content_hpf: true,
+        }
+    }
+}
+
+/// 편집된 IR을 원본 HWPX 패키지에 외과적으로 반영한다: `dirty`로 표시된 콘텐츠
+/// 엔트리만 IR에서 재직렬화하고, 나머지 엔트리는 raw 복사로 바이트 보존한다.
+/// 편집으로 새로 들어온 바이너리는 새 `BinData/*` 엔트리로 패키지 끝에 추가하고
+/// content.hpf 매니페스트를 갱신한다(이 경우 content.hpf는 dirty 여부와 무관하게
+/// 재생성된다).
+///
+/// 기존 바이너리는 원본 패키지의 OPF 매니페스트 id로 [`BinCollector`]를 seed해서
+/// 재직렬화된 섹션의 `binaryItemIDRef`가 원본 id/href를 그대로 유지하게 한다.
+pub fn rewrite_document_staged(
+    input: &Path,
+    output: &Path,
+    doc: &hwp_model::Document,
+    dirty: &DirtyEntries,
+    limits: &PackageLimits,
+) -> Result<WriteReport> {
+    // 원본 패키지의 엔트리 목록과 OPF 매니페스트 (href → id)를 읽는다.
+    // in-place 편집도 입력 파일은 게시 전까지 바뀌지 않으므로 여기서 읽어도 안전하다.
+    let mut source = HwpxPackage::open_with_limits(input, limits)?;
+    let source_entry_names: BTreeSet<String> = source
+        .entries()?
+        .into_iter()
+        .map(|entry| entry.name)
+        .collect();
+    let manifest_ids = source
+        .read_entry("Contents/content.hpf")
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+        .map(|xml| opf_item_ids(&xml))
+        .unwrap_or_default();
+    drop(source);
+
+    // seed: 원본 패키지에 실제로 존재하는 BinData 엔트리만 심는다. 편집으로 새로
+    // 들어온 스트림(패키지에 없는 이름)은 seed하지 않는다 — 뒤에서 새 엔트리로 추가된다.
+    let mut bins = BinCollector::default();
+    let mut used_ids: BTreeSet<String> = BTreeSet::new();
+    for stream in &doc.bin_streams {
+        if !stream.name.starts_with("BinData/") || !source_entry_names.contains(&stream.name) {
+            continue;
+        }
+        let base_id = manifest_ids
+            .get(&stream.name)
+            .cloned()
+            .unwrap_or_else(|| bin_stem_id(&stream.name));
+        let id = unique_bin_id(base_id, &mut used_ids);
+        let (_, mime) = crate::write::section::sniff(&stream.data);
+        bins.seed(
+            id,
+            stream.name.clone(),
+            mime.to_string(),
+            stream.data.clone(),
+        );
+    }
+    let seed_count = bins.items.len();
+
+    // dirty 섹션만 IR에서 재직렬화한다.
+    let section_indices: Vec<usize> = match &dirty.sections {
+        Some(indices) => indices.clone(),
+        None => (0..doc.sections.len()).collect(),
+    };
+    let mut report = WriteReport::new();
+    let mut replacements: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+    for &i in &section_indices {
+        let Some(section) = doc.sections.get(i) else {
+            return Err(HwpxError::PackageIntegrity(format!(
+                "dirty 섹션 인덱스가 문서 범위를 벗어납니다: {i}"
+            )));
+        };
+        let xml = crate::write::section::write_section_with_report(
+            doc,
+            section,
+            false, // 편집으로 낡은 줄 배치는 한글이 재계산(보안 경고 방지)
+            &mut bins,
+            &mut report,
+        );
+        replacements.insert(format!("Contents/section{i}.xml"), xml.into_bytes());
+    }
+
+    // 패키지에 없는 신규 스트림이 섹션 직렬화에서 수집되지 않았으면(참조 없는 추가)
+    // write/mod.rs의 passthrough와 같은 규칙으로 새 엔트리를 배정한다.
+    for stream in &doc.bin_streams {
+        if stream.name.starts_with("BinData/") && source_entry_names.contains(&stream.name) {
+            continue; // seed 처리됨
+        }
+        if bins.items.iter().any(|(.., bytes)| *bytes == stream.data) {
+            continue; // 같은 바이트가 이미 등록됨
+        }
+        let (ext, mime) = crate::write::section::sniff(&stream.data);
+        bins.allocate(ext, mime, stream.data.clone());
+    }
+    // seed 이후로 collector에 등록된 항목이 패키지에 추가할 새 엔트리다.
+    let appends: Vec<(String, Vec<u8>)> = bins.items[seed_count..]
+        .iter()
+        .map(|(_, href, _, bytes)| (href.clone(), bytes.clone()))
+        .collect();
+
+    // content.hpf: dirty이거나 새 BinData가 추가되면 seed+신규 전체 매니페스트로
+    // 재생성한다. seed id는 원본 매니페스트 id라 기존 항목 나열은 원본과 같다.
+    if dirty.content_hpf || !appends.is_empty() {
+        let bin_meta: Vec<(String, String, String)> = bins
+            .items
+            .iter()
+            .map(|(id, href, mime, _)| (id.clone(), href.clone(), mime.clone()))
+            .collect();
+        let xml =
+            crate::write::templates::content_hpf(doc.sections.len(), &bin_meta, &doc.metadata);
+        replacements.insert("Contents/content.hpf".to_string(), xml.into_bytes());
+    }
+
+    if dirty.header {
+        let xml = crate::write::header::write_header(&doc.header, doc.sections.len().max(1));
+        replacements.insert("Contents/header.xml".to_string(), xml.into_bytes());
+    }
+
+    // replacements에 있는데 원본 패키지에 없는 엔트리는 조용히 유실되므로 감지한다.
+    let mut consumed: BTreeSet<String> = BTreeSet::new();
+    process_package_with_appends(
+        input,
+        output,
+        limits,
+        |name| replacements.contains_key(name),
+        |name, _data| {
+            consumed.insert(name.to_string());
+            Ok(replacements.get(name).cloned())
+        },
+        appends,
+    )?;
+    if consumed.len() != replacements.len() {
+        let missing: Vec<&String> = replacements
+            .keys()
+            .filter(|name| !consumed.contains(*name))
+            .collect();
+        return Err(HwpxError::PackageIntegrity(format!(
+            "dirty 엔트리가 원본 패키지에 없습니다: {missing:?}"
+        )));
+    }
+    Ok(report)
+}
+
+/// OPF(content.hpf) 매니페스트에서 `opf:item`의 (href → id) 매핑을 읽는다.
+/// seed id를 원본 매니페스트 id와 맞추는 데 쓴다 — 재직렬화된 섹션의
+/// `binaryItemIDRef`가 raw 복사된 매니페스트와 어긋나지 않게 한다.
+/// 파싱에 실패하면 빈 매핑을 돌려준다(호출자가 파일명 stem으로 폴백).
+fn opf_item_ids(xml: &str) -> BTreeMap<String, String> {
+    use quick_xml::events::Event;
+
+    let mut map = BTreeMap::new();
+    let mut reader = quick_xml::Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(event)) | Ok(Event::Empty(event)) => {
+                if event.name().local_name().as_ref() != b"item" {
+                    continue;
+                }
+                let mut id = None;
+                let mut href = None;
+                for attr in event.attributes().flatten() {
+                    let value = String::from_utf8_lossy(&attr.value).into_owned();
+                    match attr.key.local_name().as_ref() {
+                        b"id" => id = Some(value),
+                        b"href" => href = Some(value),
+                        _ => {}
+                    }
+                }
+                if let (Some(id), Some(href)) = (id, href) {
+                    map.insert(href, id);
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+    map
+}
+
+/// OPF 매니페스트에 해당 항목이 없을 때 쓰는 stem 규칙: `BinData/<파일>`의
+/// 파일명 stem(확장자 앞까지)을 item id로 뽑는다.
+/// [`hwp_model::Document::resolve_bin`]의 stem 휴리스틱과 같은 규칙을 쓴다.
+fn bin_stem_id(name: &str) -> String {
+    let fname = name.rsplit('/').next().unwrap_or(name);
+    fname.split('.').next().unwrap_or(fname).to_string()
+}
+
+/// 매니페스트/stem에서 얻은 id가 이미 쓰였으면 `_2`, `_3`… 접미로 유일하게 만든다.
+fn unique_bin_id(base: String, used: &mut BTreeSet<String>) -> String {
+    if used.insert(base.clone()) {
+        return base;
+    }
+    let mut n = 2u32;
+    loop {
+        let candidate = format!("{base}_{n}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+        n += 1;
+    }
+}
+
 /// 변환 대상 엔트리 판별 (본문 섹션 XML).
 fn is_section_entry(name: &str) -> bool {
     name.starts_with("Contents/section") && name.ends_with(".xml")
@@ -626,8 +854,29 @@ fn process_package(
     input: &Path,
     output: &Path,
     limits: &PackageLimits,
+    should_transform: impl FnMut(&str) -> bool,
+    transform: impl FnMut(&str, Vec<u8>) -> Result<Option<Vec<u8>>>,
+) -> Result<()> {
+    process_package_with_appends(
+        input,
+        output,
+        limits,
+        should_transform,
+        transform,
+        Vec::new(),
+    )
+}
+
+/// [`process_package`] + 엔트리 루프 뒤 새 엔트리(`appends`)를 패키지 끝에
+/// 추가하는 확장. 외과 수술 재작성에서 편집으로 새로 들어온 BinData를 싣는 데 쓴다.
+/// 추가 엔트리 이름이 기존 엔트리와 겹치면 거부한다(중복 엔트리 패키지 방지).
+fn process_package_with_appends(
+    input: &Path,
+    output: &Path,
+    limits: &PackageLimits,
     mut should_transform: impl FnMut(&str) -> bool,
     mut transform: impl FnMut(&str, Vec<u8>) -> Result<Option<Vec<u8>>>,
+    appends: Vec<(String, Vec<u8>)>,
 ) -> Result<()> {
     let destination = inspect_destination(output)?;
     let (_source_guard, snapshot) = snapshot_input(input, output, limits)?;
@@ -647,8 +896,10 @@ fn process_package(
     zip.set_raw_comment(source_comment.clone().into_boxed_slice())?;
     let mut output_total = 0u64;
     let mut preserve_raw = vec![false; entries.len()];
+    let mut written_names: BTreeSet<String> = BTreeSet::new();
 
     for (i, info) in entries.into_iter().enumerate() {
+        written_names.insert(info.name.clone());
         if should_transform(&info.name) {
             let limit = limits.entry_uncompressed_limit(&info.name);
             let transformed = {
@@ -680,6 +931,20 @@ fn process_package(
             zip.raw_copy_file(raw)?;
             preserve_raw[i] = true;
         }
+    }
+    // 편집으로 새로 들어온 엔트리(신규 BinData 등)를 패키지 끝에 추가한다.
+    for (name, data) in &appends {
+        if !written_names.insert(name.clone()) {
+            return Err(HwpxError::PackageIntegrity(format!(
+                "추가 엔트리 이름이 기존 패키지와 중복됩니다: {name}"
+            )));
+        }
+        limits.check_entry(name, data.len() as u64, None)?;
+        output_total = limits.add_uncompressed_total(output_total, data.len() as u64)?;
+        let opts = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        zip.start_file(name, opts)?;
+        zip.write_all(data)?;
     }
     let staged_file = zip.finish()?;
     staged_file.sync_all()?;
@@ -831,9 +1096,10 @@ fn rebuild_with_preserved_entries(
     comment: &[u8],
 ) -> Result<()> {
     let generated = capture_zip_layout(generated_path)?;
-    if source.entries.len() != generated.entries.len()
+    // generated는 source 엔트리(같은 순서) 뒤에 0개 이상의 추가 엔트리를 붙인 형태다.
+    if generated.entries.len() < source.entries.len()
         || source.entries.len() != preserve_raw.len()
-        || source.entries.len() > usize::from(u16::MAX)
+        || generated.entries.len() > usize::from(u16::MAX)
         || comment.len() > usize::from(u16::MAX)
     {
         return Err(HwpxError::PackageIntegrity(
@@ -844,8 +1110,11 @@ fn rebuild_with_preserved_entries(
     let (_guard, mut rebuilt) = SiblingTemp::create(generated_path, "rebuild")?;
     let mut source_file = File::open(source_path)?;
     let mut generated_file = File::open(generated_path)?;
-    let mut new_offsets = Vec::with_capacity(source.entries.len());
-    for (index, preserve) in preserve_raw.iter().copied().enumerate() {
+    let mut new_offsets = Vec::with_capacity(generated.entries.len());
+    let mut source_entries = source.entries.iter();
+    // source 범위를 넘어서는 추가 엔트리는 raw 보존 대상이 아니다(항상 generated에서 복사).
+    let mut preserved = preserve_raw.iter().copied().chain(std::iter::repeat(false));
+    for generated_entry in &generated.entries {
         let offset = rebuilt.stream_position()?;
         if offset > u64::from(u32::MAX) {
             return Err(HwpxError::PackageIntegrity(
@@ -853,11 +1122,11 @@ fn rebuild_with_preserved_entries(
             ));
         }
         new_offsets.push(offset as u32);
-        let (reader, range): (&mut File, &Range<u64>) = if preserve {
-            (&mut source_file, &source.entries[index].local_range)
-        } else {
-            (&mut generated_file, &generated.entries[index].local_range)
-        };
+        let (reader, range): (&mut File, &Range<u64>) =
+            match (source_entries.next(), preserved.next().unwrap_or(false)) {
+                (Some(source_entry), true) => (&mut source_file, &source_entry.local_range),
+                _ => (&mut generated_file, &generated_entry.local_range),
+            };
         copy_range(reader, &mut rebuilt, range)?;
     }
 
@@ -867,17 +1136,24 @@ fn rebuild_with_preserved_entries(
             "ZIP64 central offset은 exact raw 보존 범위를 벗어납니다".to_string(),
         ));
     }
-    for (index, preserve) in preserve_raw.iter().copied().enumerate() {
-        let original = if preserve {
-            &source.entries[index].central_record
-        } else {
-            &generated.entries[index].central_record
-        };
-        if central_name(original)? != central_name(&generated.entries[index].central_record)? {
+    let mut source_entries = source.entries.iter();
+    let mut preserved = preserve_raw.iter().copied().chain(std::iter::repeat(false));
+    for (generated_entry, new_offset) in generated.entries.iter().zip(&new_offsets) {
+        // source 범위 안의 엔트리는 generated와 순서·이름이 같아야 한다(1:1 대응).
+        // 그 뒤의 엔트리는 새로 추가된 것이라 대응하는 source 레코드가 없다.
+        let source_entry = source_entries.next();
+        if let Some(source_entry) = source_entry
+            && central_name(&source_entry.central_record)?
+                != central_name(&generated_entry.central_record)?
+        {
             return Err(HwpxError::PackageIntegrity(
                 "ZIP raw metadata 엔트리 이름이 일치하지 않습니다".to_string(),
             ));
         }
+        let original = match (source_entry, preserved.next().unwrap_or(false)) {
+            (Some(source_entry), true) => &source_entry.central_record,
+            _ => &generated_entry.central_record,
+        };
         if u32::from_le_bytes(original[42..46].try_into().expect("fixed central header"))
             == u32::MAX
         {
@@ -886,7 +1162,7 @@ fn rebuild_with_preserved_entries(
             ));
         }
         let mut record = original.clone();
-        record[42..46].copy_from_slice(&new_offsets[index].to_le_bytes());
+        record[42..46].copy_from_slice(&new_offset.to_le_bytes());
         rebuilt.write_all(&record)?;
     }
     let central_end = rebuilt.stream_position()?;
@@ -898,7 +1174,7 @@ fn rebuild_with_preserved_entries(
                 "ZIP64 central size는 exact raw 보존 범위를 벗어납니다".to_string(),
             )
         })?;
-    let entries = source.entries.len() as u16;
+    let entries = generated.entries.len() as u16;
     rebuilt.write_all(END_OF_CENTRAL_SIGNATURE)?;
     rebuilt.write_all(&0u16.to_le_bytes())?;
     rebuilt.write_all(&0u16.to_le_bytes())?;

--- a/crates/hwpx/src/read/mod.rs
+++ b/crates/hwpx/src/read/mod.rs
@@ -50,8 +50,27 @@ fn read_document_impl(path: &Path, load_binary_data: bool) -> Result<ReadResult>
     );
 
     let mut sections = Vec::new();
+    let mut hwpx_section_xmlns: Vec<String> = Vec::new();
     for entry in pkg.section_entries()? {
         let xml = pkg.read_entry_string(&entry)?;
+        // 루트에만 선언된 확장 접두어를 전 섹션 합집합으로 보존한다(접두어 기준 dedup —
+        // 같은 접두어의 다른 URI 선언이 중복 속성으로 방출되면 not well-formed).
+        for decl in section::extract_section_root_xmlns(&xml) {
+            let prefix = decl
+                .strip_prefix("xmlns:")
+                .and_then(|rest| rest.split('=').next())
+                .unwrap_or("");
+            let dominated = hwpx_section_xmlns.iter().any(|existing| {
+                existing
+                    .strip_prefix("xmlns:")
+                    .and_then(|rest| rest.split('=').next())
+                    .unwrap_or("")
+                    == prefix
+            });
+            if !dominated {
+                hwpx_section_xmlns.push(decl);
+            }
+        }
         let (section, sec_warnings) = section::parse_section(&xml)?;
         warnings.extend(sec_warnings.into_iter().map(|w| format!("[{entry}] {w}")));
         sections.push(section);
@@ -127,6 +146,12 @@ fn read_document_impl(path: &Path, load_binary_data: bool) -> Result<ReadResult>
         .as_deref()
         .map(parse_bin_manifest)
         .unwrap_or_default();
+    // writer가 재생성하지 않는 확장 파트의 매니페스트 항목 — content.hpf 재생성 시
+    // 다시 등재해 raw-copy된 엔트리가 고아 파트가 되지 않게 한다.
+    let hwpx_opf_extra_items = content_hpf
+        .as_deref()
+        .map(parse_opf_extra_items)
+        .unwrap_or_default();
 
     // 부속 파트 원문 pass-through 슬롯: settings.xml(앱 설정·캐럿)·version.xml(버전
     // 메타)을 통째로 보존한다. 없으면 None → 쓰기 시 기본 상수. "모르는 데이터는
@@ -161,6 +186,8 @@ fn read_document_impl(path: &Path, load_binary_data: bool) -> Result<ReadResult>
             hwp5_doc_history: Vec::new(),
             hwpx_extra_entries,
             hwpx_bin_manifest,
+            hwpx_opf_extra_items,
+            hwpx_section_xmlns,
         },
         warnings,
     })
@@ -247,13 +274,10 @@ pub fn parse_content_meta(xml: &str) -> hwp_model::Metadata {
     meta
 }
 
-/// content.hpf OPF 매니페스트에서 BinData 항목의 (id, href) 매핑을 읽는다(최선 노력).
-///
-/// 전체 재작성 writer가 BinCollector id를 원본 매니페스트 id로 시드하는 데 쓴다 —
-/// 원문 캡처된 개체(hp:container 등) 안의 `binaryItemIDRef`가 재직렬화 후에도
-/// 원본 바이트를 가리키게 한다. 파싱 실패·BinData 항목 없음이면 빈 벡터(호출자는
-/// 기존 image{N} 할당 경로를 그대로 탄다).
-pub fn parse_bin_manifest(xml: &str) -> Vec<(String, String)> {
+/// content.hpf OPF 매니페스트의 모든 `<opf:item>`을 (id, href, media-type)으로 읽는다
+/// (최선 노력). id/href가 없는 항목은 건너뛰고, media-type이 없으면 None이다.
+/// 속성값은 원문(이스케이프 상태 그대로)을 유지해 재방출 시 이중 이스케이프를 피한다.
+fn parse_opf_items(xml: &str) -> Vec<(String, String, Option<String>)> {
     use quick_xml::events::Event;
 
     let mut items = Vec::new();
@@ -267,18 +291,18 @@ pub fn parse_bin_manifest(xml: &str) -> Vec<(String, String)> {
                 }
                 let mut id = None;
                 let mut href = None;
+                let mut mime = None;
                 for attr in event.attributes().flatten() {
                     let value = String::from_utf8_lossy(&attr.value).into_owned();
                     match attr.key.local_name().as_ref() {
                         b"id" => id = Some(value),
                         b"href" => href = Some(value),
+                        b"media-type" => mime = Some(value),
                         _ => {}
                     }
                 }
-                if let (Some(id), Some(href)) = (id, href)
-                    && href.starts_with("BinData/")
-                {
-                    items.push((id, href));
+                if let (Some(id), Some(href)) = (id, href) {
+                    items.push((id, href, mime));
                 }
             }
             Ok(Event::Eof) => break,
@@ -287,6 +311,43 @@ pub fn parse_bin_manifest(xml: &str) -> Vec<(String, String)> {
         }
     }
     items
+}
+
+/// content.hpf OPF 매니페스트에서 BinData 항목의 (id, href) 매핑을 읽는다(최선 노력).
+///
+/// 전체 재작성 writer가 BinCollector id를 원본 매니페스트 id로 시드하는 데 쓴다 —
+/// 원문 캡처된 개체(hp:container 등) 안의 `binaryItemIDRef`가 재직렬화 후에도
+/// 원본 바이트를 가리키게 한다. 파싱 실패·BinData 항목 없음이면 빈 벡터(호출자는
+/// 기존 image{N} 할당 경로를 그대로 탄다).
+pub fn parse_bin_manifest(xml: &str) -> Vec<(String, String)> {
+    parse_opf_items(xml)
+        .into_iter()
+        .filter(|(_, href, _)| href.starts_with("BinData/"))
+        .map(|(id, href, _)| (id, href))
+        .collect()
+}
+
+/// OPF 매니페스트에서 writer가 재생성하지 않는 확장 파트 항목의 (id, href, media-type)을
+/// 읽는다(최선 노력) — BinData·header·section·settings 외 항목(예: DocOptions/Layout.xml).
+/// content.hpf 재생성 시 이 항목들을 다시 등재해 raw-copy된 패키지 엔트리가 매니페스트에서
+/// 사라지는(고아 파트) 일을 막는다.
+pub fn parse_opf_extra_items(xml: &str) -> Vec<(String, String, String)> {
+    parse_opf_items(xml)
+        .into_iter()
+        .filter(|(_, href, _)| {
+            !href.starts_with("BinData/")
+                && href != "Contents/header.xml"
+                && href != "settings.xml"
+                && !(href.starts_with("Contents/section") && href.ends_with(".xml"))
+        })
+        .map(|(id, href, mime)| {
+            (
+                id,
+                href,
+                mime.unwrap_or_else(|| "application/octet-stream".to_string()),
+            )
+        })
+        .collect()
 }
 
 fn resolve_entity(r: &quick_xml::events::BytesRef<'_>) -> Option<char> {

--- a/crates/hwpx/src/read/mod.rs
+++ b/crates/hwpx/src/read/mod.rs
@@ -80,6 +80,41 @@ fn read_document_impl(path: &Path, load_binary_data: bool) -> Result<ReadResult>
         .collect::<Vec<_>>()
         .join(".");
 
+    // writer가 재생성·슬롯으로 보존하는 엔트리 외의 모든 패키지 엔트리를 원본
+    // 순서·바이트 그대로 보존한다(원본 META-INF/*, DocOptions, 스크립트, 추가
+    // Preview 등). "모르는 데이터는 버리지 않는다". BinData/*는 bin_streams가,
+    // section/header/settings/version/preview는 기존 슬롯이 담당하므로 제외한다.
+    let mut hwpx_extra_entries = Vec::new();
+    if load_binary_data {
+        const REGENERATED: &[&str] = &[
+            "mimetype",
+            "version.xml",
+            "Contents/content.hpf",
+            "Contents/header.xml",
+            "Preview/PrvText.txt",
+            "Preview/PrvImage.png",
+            "settings.xml",
+        ];
+        for entry in pkg.entries()? {
+            let name = &entry.name;
+            if name.ends_with('/')
+                || REGENERATED.contains(&name.as_str())
+                // section 목록은 패키지 실제 엔트리 기준(section_entries와 같은 판정).
+                || (name.starts_with("Contents/section") && name.ends_with(".xml"))
+                || name.starts_with("BinData/")
+            {
+                continue;
+            }
+            let data = pkg.read_entry(name)?;
+            // writer가 기본 템플릿으로 바이트 동일하게 재생성하는 엔트리는 잉여가
+            // 아니다(캡처하면 의미 검증이 writer 기본값 슬롯 유무를 차이로 오인한다).
+            if is_writer_default_entry(name, &data) {
+                continue;
+            }
+            hwpx_extra_entries.push((name.clone(), data));
+        }
+    }
+
     // 문서 메타데이터 (content.hpf OPF — 최선 노력: 없거나 손상돼도 진단 계속)
     let metadata = pkg
         .read_entry_string("Contents/content.hpf")
@@ -118,9 +153,22 @@ fn read_document_impl(path: &Path, load_binary_data: bool) -> Result<ReadResult>
             // hwpx 출신은 hwp5 전용 스토리지가 없다(GE-β7/β8 경로 무관).
             hwp5_xml_template: Vec::new(),
             hwp5_doc_history: Vec::new(),
+            hwpx_extra_entries,
         },
         warnings,
     })
+}
+
+/// writer가 기본 템플릿으로 바이트 동일하게 재생성하는 META-INF 엔트리인가.
+/// 이런 엔트리는 `hwpx_extra_entries`에 담지 않는다(재생성이 곧 보존).
+fn is_writer_default_entry(name: &str, bytes: &[u8]) -> bool {
+    let default = match name {
+        "META-INF/container.rdf" => crate::write::templates::CONTAINER_RDF,
+        "META-INF/container.xml" => crate::write::templates::CONTAINER_XML,
+        "META-INF/manifest.xml" => crate::write::templates::MANIFEST_XML,
+        _ => return false,
+    };
+    bytes == default.as_bytes()
 }
 
 /// content.hpf OPF 메타데이터에서 요약정보를 추출한다(최선 노력).

--- a/crates/hwpx/src/read/mod.rs
+++ b/crates/hwpx/src/read/mod.rs
@@ -116,10 +116,16 @@ fn read_document_impl(path: &Path, load_binary_data: bool) -> Result<ReadResult>
     }
 
     // 문서 메타데이터 (content.hpf OPF — 최선 노력: 없거나 손상돼도 진단 계속)
-    let metadata = pkg
-        .read_entry_string("Contents/content.hpf")
-        .ok()
-        .map(|xml| parse_content_meta(&xml))
+    let content_hpf = pkg.read_entry_string("Contents/content.hpf").ok();
+    let metadata = content_hpf
+        .as_deref()
+        .map(parse_content_meta)
+        .unwrap_or_default();
+    // OPF 매니페스트의 BinData (id, href) 매핑 — 전체 재작성 writer가 BinCollector
+    // id를 원본 id로 시드해 원문 캡처 개체의 binaryItemIDRef가 어긋나지 않게 한다.
+    let hwpx_bin_manifest = content_hpf
+        .as_deref()
+        .map(parse_bin_manifest)
         .unwrap_or_default();
 
     // 부속 파트 원문 pass-through 슬롯: settings.xml(앱 설정·캐럿)·version.xml(버전
@@ -154,6 +160,7 @@ fn read_document_impl(path: &Path, load_binary_data: bool) -> Result<ReadResult>
             hwp5_xml_template: Vec::new(),
             hwp5_doc_history: Vec::new(),
             hwpx_extra_entries,
+            hwpx_bin_manifest,
         },
         warnings,
     })
@@ -238,6 +245,48 @@ pub fn parse_content_meta(xml: &str) -> hwp_model::Metadata {
         }
     }
     meta
+}
+
+/// content.hpf OPF 매니페스트에서 BinData 항목의 (id, href) 매핑을 읽는다(최선 노력).
+///
+/// 전체 재작성 writer가 BinCollector id를 원본 매니페스트 id로 시드하는 데 쓴다 —
+/// 원문 캡처된 개체(hp:container 등) 안의 `binaryItemIDRef`가 재직렬화 후에도
+/// 원본 바이트를 가리키게 한다. 파싱 실패·BinData 항목 없음이면 빈 벡터(호출자는
+/// 기존 image{N} 할당 경로를 그대로 탄다).
+pub fn parse_bin_manifest(xml: &str) -> Vec<(String, String)> {
+    use quick_xml::events::Event;
+
+    let mut items = Vec::new();
+    let mut reader = quick_xml::Reader::from_str(xml);
+    reader.config_mut().trim_text(true);
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(event)) | Ok(Event::Empty(event)) => {
+                if event.name().local_name().as_ref() != b"item" {
+                    continue;
+                }
+                let mut id = None;
+                let mut href = None;
+                for attr in event.attributes().flatten() {
+                    let value = String::from_utf8_lossy(&attr.value).into_owned();
+                    match attr.key.local_name().as_ref() {
+                        b"id" => id = Some(value),
+                        b"href" => href = Some(value),
+                        _ => {}
+                    }
+                }
+                if let (Some(id), Some(href)) = (id, href)
+                    && href.starts_with("BinData/")
+                {
+                    items.push((id, href));
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(_) => break,
+            _ => {}
+        }
+    }
+    items
 }
 
 fn resolve_entity(r: &quick_xml::events::BytesRef<'_>) -> Option<char> {

--- a/crates/hwpx/src/read/section.rs
+++ b/crates/hwpx/src/read/section.rs
@@ -173,6 +173,7 @@ fn parse_paragraph(
                             equation: Some(eq),
                             column_def: None,
                             caption: None,
+                            hwpx_raw_xml: None,
                         }));
                     }
                     b"linesegarray" => {
@@ -208,9 +209,11 @@ fn parse_paragraph(
                             equation: None,
                             column_def: None,
                             caption: None,
+                            hwpx_raw_xml: None,
                         };
-                        if !empty {
-                            if let Some(kind) = shape_kind(&name) {
+                        if let Some(kind) = shape_kind(&name) {
+                            // 도형은 의미 파싱(gso_shapes) 경로를 유지한다(원문 캡처 없음).
+                            if !empty {
                                 // 둥근 사각형: <hp:rect ratio="N"> (모서리 곡률 %).
                                 let round_ratio = if kind == ShapeKind::Rect {
                                     attr_i32(e, "ratio").unwrap_or(0).clamp(0, 100) as u8
@@ -225,9 +228,25 @@ fn parse_paragraph(
                                     &mut generic,
                                     warnings,
                                 )?;
-                            } else {
-                                collect_sub_lists(reader, &name, &mut generic, warnings)?;
                             }
+                        } else {
+                            // 미해석 개체(hp:container 등)는 원문 XML을 통째로 캡처해
+                            // 무손실 재직렬화에 쓰고, subList/caption은 텍스트 추출·
+                            // 렌더용으로 캡처본 위에서 다시 수집한다(capture_element가
+                            // 원본 reader의 서브트리를 소비하므로 순서가 바뀌면 안 된다).
+                            let raw = capture_element(reader, e, empty)?;
+                            if !empty {
+                                let mut raw_reader = Reader::from_str(&raw);
+                                // 캡처본의 첫 이벤트(개체 자신의 여는 태그)를 소비한다.
+                                let _ = next_event(&mut raw_reader)?;
+                                collect_sub_lists(
+                                    &mut raw_reader,
+                                    &name,
+                                    &mut generic,
+                                    warnings,
+                                )?;
+                            }
+                            generic.hwpx_raw_xml = Some(raw);
                         }
                         push_ext_ctrl(&mut para, &mut wchar_pos, 11, ctrl_id);
                         para.controls.push(Control::Generic(generic));
@@ -660,6 +679,7 @@ fn parse_ctrl(
                         equation: None,
                         column_def: None,
                         caption: None,
+                        hwpx_raw_xml: None,
                     };
                     push_ext_ctrl(para, wchar_pos, 3, ctrl_id);
                     para.controls.push(Control::Generic(generic));
@@ -693,6 +713,7 @@ fn parse_ctrl(
                         equation: None,
                         column_def: None,
                         caption: None,
+                        hwpx_raw_xml: None,
                     };
                     push_ext_ctrl(para, wchar_pos, 22, *b"bokm");
                     para.controls.push(Control::Generic(generic));
@@ -738,6 +759,7 @@ fn parse_ctrl(
                     equation: None,
                     column_def,
                     caption: None,
+                    hwpx_raw_xml: None,
                 };
                 // parse_col_pr has already consumed a colPr subtree.
                 if matches!(event, Event::Start(_)) && name.as_slice() != b"colPr" {

--- a/crates/hwpx/src/read/section.rs
+++ b/crates/hwpx/src/read/section.rs
@@ -239,12 +239,7 @@ fn parse_paragraph(
                                 let mut raw_reader = Reader::from_str(&raw);
                                 // 캡처본의 첫 이벤트(개체 자신의 여는 태그)를 소비한다.
                                 let _ = next_event(&mut raw_reader)?;
-                                collect_sub_lists(
-                                    &mut raw_reader,
-                                    &name,
-                                    &mut generic,
-                                    warnings,
-                                )?;
+                                collect_sub_lists(&mut raw_reader, &name, &mut generic, warnings)?;
                             }
                             generic.hwpx_raw_xml = Some(raw);
                         }

--- a/crates/hwpx/src/read/section.rs
+++ b/crates/hwpx/src/read/section.rs
@@ -49,6 +49,43 @@ fn skip_subtree(reader: &mut XmlReader<'_>, name: &[u8]) -> Result<()> {
     }
 }
 
+/// 섹션 루트 요소의 xmlns 선언 중 writer 표준 셋(hs/hp/hc) 외의 것을 원문 속성
+/// 문자열(`xmlns:foo="uri"`)로 수집한다(첫 시작 태그만 본다). 원문 캡처 개체가
+/// 루트에만 선언된 확장 접두어(hp10:, 벤더 접두어 등)를 쓸 수 있어, writer가
+/// 재직렬화 루트에 이 선언들을 그대로 실어야 namespace-well-formed하다.
+/// 속성값은 원문(이스케이프 상태) 그대로 보존한다.
+pub fn extract_section_root_xmlns(xml: &str) -> Vec<String> {
+    // writer 표준 선언 — 이 접두어들은 루트 상수가 이미 방출한다.
+    const STANDARD: &[&str] = &["hs", "hp", "hc"];
+    let mut reader = Reader::from_str(xml);
+    let mut out = Vec::new();
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(e)) | Ok(Event::Empty(e)) => {
+                for attr in e.attributes().flatten() {
+                    let key = String::from_utf8_lossy(attr.key.as_ref()).into_owned();
+                    let keep = if key == "xmlns" {
+                        true
+                    } else if let Some(prefix) = key.strip_prefix("xmlns:") {
+                        !STANDARD.contains(&prefix)
+                    } else {
+                        false
+                    };
+                    if !keep {
+                        continue;
+                    }
+                    let value = String::from_utf8_lossy(&attr.value).into_owned();
+                    out.push(format!("{key}=\"{value}\""));
+                }
+                break; // 루트 요소만 본다
+            }
+            Ok(Event::Eof) | Err(_) => break,
+            _ => {}
+        }
+    }
+    out
+}
+
 pub fn parse_section(xml: &str) -> Result<(Section, Vec<String>)> {
     let mut reader = Reader::from_str(xml);
     let mut section = Section::default();

--- a/crates/hwpx/src/write/mod.rs
+++ b/crates/hwpx/src/write/mod.rs
@@ -86,6 +86,36 @@ pub fn write_document_with_report_with_limits(
 
     // 본문 먼저 직렬화 (BinData 수집 포함)
     let mut bins = BinCollector::default();
+    // hwpx 원본이면 OPF 매니페스트의 원본 id/href로 seed한다(외과 수술 경로
+    // patch.rs의 시드와 같은 의미). 원문 캡처된 개체(hp:container 등) 안의
+    // binaryItemIDRef는 원본 id를 그대로 방출하므로, collector가 원본 id 체계를
+    // 알아야 그 참조가 원본 바이트를 계속 가리킨다. 소스 바이너리 전부가 seed되면
+    // 아래 미참조 바이너리 passthrough는 자연히 no-op이 된다.
+    if !doc.hwpx_bin_manifest.is_empty() {
+        let mut used_ids: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        let mut seeded_hrefs: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+        for (id, href) in &doc.hwpx_bin_manifest {
+            let Some(stream) = doc.bin_streams.iter().find(|s| s.name == *href) else {
+                continue; // 매니페스트에만 있고 스트림이 없으면 시드할 바이트가 없다
+            };
+            if !seeded_hrefs.insert(stream.name.as_str()) {
+                continue;
+            }
+            let mut candidate = id.clone();
+            let mut n = 2u32;
+            while !used_ids.insert(candidate.clone()) {
+                candidate = format!("{id}_{n}");
+                n += 1;
+            }
+            let (_, mime) = section::sniff(&stream.data);
+            bins.seed(
+                candidate,
+                href.clone(),
+                mime.to_string(),
+                stream.data.clone(),
+            );
+        }
+    }
     let sections: Vec<String> = doc
         .sections
         .iter()

--- a/crates/hwpx/src/write/mod.rs
+++ b/crates/hwpx/src/write/mod.rs
@@ -5,7 +5,7 @@
 
 pub mod header;
 pub mod section;
-mod templates;
+pub(crate) mod templates;
 
 use std::fs::File;
 use std::io::Write as _;
@@ -110,10 +110,53 @@ pub fn write_document_with_report_with_limits(
             .map_or(preview.len(), |(i, _)| i),
     );
 
+    // BinCollector가 수집하지 않은(참조되지 않는) 바이너리를 패키지에 복원한다.
+    // 바이트 동일 판정은 BinCollector의 dedup 규칙과 같다. 이름은 hwpx 원본이면
+    // `BinData/...`를 그대로, hwp5 출신 등이면 `BinData/<파일명>`을 쓰되 이번
+    // 패키지에서 이미 쓴 이름과 충돌하면 `_2`, `_3`… 접미를 붙인다.
+    let mut written_names: std::collections::BTreeSet<String> = bins
+        .items
+        .iter()
+        .map(|(_, href, _, _)| href.clone())
+        .collect();
+    let mut used_ids: std::collections::BTreeSet<String> =
+        bins.items.iter().map(|(id, ..)| id.clone()).collect();
+    // (id, href, mime, bytes) — content_hpf 매니페스트와 패키지 방출이 함께 쓴다.
+    let mut passthrough_bins: Vec<(String, String, String, &[u8])> = Vec::new();
+    for stream in &doc.bin_streams {
+        if bins.items.iter().any(|(.., bytes)| *bytes == stream.data) {
+            continue;
+        }
+        let (_, mime) = section::sniff(&stream.data);
+        let base = if stream.name.starts_with("BinData/") {
+            stream.name.clone()
+        } else {
+            let fname = stream.name.rsplit('/').next().unwrap_or(&stream.name);
+            format!("BinData/{}", sanitize_bin_name(fname))
+        };
+        let (dir, stem, ext) = split_dir_stem_ext(&base);
+        let mut href = base.clone();
+        let mut id = stem.clone();
+        let mut n = 2u32;
+        while written_names.contains(&href) || used_ids.contains(&id) {
+            href = format!("{dir}{stem}_{n}{ext}");
+            id = format!("{stem}_{n}");
+            n += 1;
+        }
+        written_names.insert(href.clone());
+        used_ids.insert(id.clone());
+        passthrough_bins.push((id, href, mime.to_string(), &stream.data));
+    }
+
     let bin_meta: Vec<(String, String, String)> = bins
         .items
         .iter()
         .map(|(id, href, mime, _)| (id.clone(), href.clone(), mime.clone()))
+        .chain(
+            passthrough_bins
+                .iter()
+                .map(|(id, href, mime, _)| (id.clone(), href.clone(), mime.clone())),
+        )
         .collect();
 
     let content_hpf = templates::content_hpf(sections.len(), &bin_meta, &doc.metadata);
@@ -126,6 +169,51 @@ pub fn write_document_with_report_with_limits(
         .as_deref()
         .unwrap_or(templates::SETTINGS_XML);
 
+    // 원본 패키지 잉여 엔트리 pass-through. META-INF 3종은 표준 위치에서 원본
+    // 바이트로 대체하고, 나머지는 표준 시퀀스 뒤에 원본 순서대로 방출한다.
+    let extra_map: std::collections::BTreeMap<&str, &[u8]> = doc
+        .hwpx_extra_entries
+        .iter()
+        .map(|(name, bytes)| (name.as_str(), bytes.as_slice()))
+        .collect();
+    let container_rdf = extra_map
+        .get("META-INF/container.rdf")
+        .copied()
+        .unwrap_or(templates::CONTAINER_RDF.as_bytes());
+    let container_xml = extra_map
+        .get("META-INF/container.xml")
+        .copied()
+        .unwrap_or(templates::CONTAINER_XML.as_bytes());
+    let manifest_xml = extra_map
+        .get("META-INF/manifest.xml")
+        .copied()
+        .unwrap_or(templates::MANIFEST_XML.as_bytes());
+    // 표준 시퀀스에 속하지 않아 뒤에 그대로 방출할 잉여 엔트리(원본 순서).
+    let standard_names: std::collections::BTreeSet<&str> = [
+        "mimetype",
+        "version.xml",
+        "META-INF/container.rdf",
+        "META-INF/container.xml",
+        "META-INF/manifest.xml",
+        "Contents/content.hpf",
+        "Contents/header.xml",
+        "Preview/PrvText.txt",
+        "Preview/PrvImage.png",
+        "settings.xml",
+    ]
+    .into_iter()
+    .collect();
+    let trailing_extras: Vec<(&str, &[u8])> = doc
+        .hwpx_extra_entries
+        .iter()
+        .filter(|(name, _)| {
+            !standard_names.contains(name.as_str())
+                && !name.starts_with("Contents/section")
+                && !written_names.contains(name)
+        })
+        .map(|(name, bytes)| (name.as_str(), bytes.as_slice()))
+        .collect();
+
     // 실제 파일을 만들기 전에 생성 패키지도 읽기 경로와 같은 크기·중복 정책으로
     // 검증한다. 직렬화된 XML과 이미 수집된 바이너리만 계상하므로 출력은 남지 않는다.
     let mut output_entries: Vec<(String, u64)> = vec![
@@ -133,15 +221,15 @@ pub fn write_document_with_report_with_limits(
         ("version.xml".to_string(), version_xml.len() as u64),
         (
             "META-INF/container.rdf".to_string(),
-            templates::CONTAINER_RDF.len() as u64,
+            container_rdf.len() as u64,
         ),
         (
             "META-INF/container.xml".to_string(),
-            templates::CONTAINER_XML.len() as u64,
+            container_xml.len() as u64,
         ),
         (
             "META-INF/manifest.xml".to_string(),
-            templates::MANIFEST_XML.len() as u64,
+            manifest_xml.len() as u64,
         ),
         ("Contents/content.hpf".to_string(), content_hpf.len() as u64),
         ("Contents/header.xml".to_string(), header_xml.len() as u64),
@@ -157,6 +245,11 @@ pub fn write_document_with_report_with_limits(
             .iter()
             .map(|(_, href, _, bytes)| (href.clone(), bytes.len() as u64)),
     );
+    output_entries.extend(
+        passthrough_bins
+            .iter()
+            .map(|(_, href, _, bytes)| (href.clone(), bytes.len() as u64)),
+    );
     output_entries.push(("Preview/PrvText.txt".to_string(), preview.len() as u64));
     if let Some(preview_image) = &doc.hwpx_preview_image {
         output_entries.push((
@@ -165,6 +258,11 @@ pub fn write_document_with_report_with_limits(
         ));
     }
     output_entries.push(("settings.xml".to_string(), settings_xml.len() as u64));
+    output_entries.extend(
+        trailing_extras
+            .iter()
+            .map(|(name, bytes)| (name.to_string(), bytes.len() as u64)),
+    );
     validate_output_entries(output_entries, limits)?;
 
     let file = File::create(path)?;
@@ -193,21 +291,10 @@ pub fn write_document_with_report_with_limits(
 
     // version.xml — 슬롯이 있으면 원문 pass-through, 없으면 기본 상수(바이트 동일).
     put(&mut zip, "version.xml", version_xml.as_bytes())?;
-    put(
-        &mut zip,
-        "META-INF/container.rdf",
-        templates::CONTAINER_RDF.as_bytes(),
-    )?;
-    put(
-        &mut zip,
-        "META-INF/container.xml",
-        templates::CONTAINER_XML.as_bytes(),
-    )?;
-    put(
-        &mut zip,
-        "META-INF/manifest.xml",
-        templates::MANIFEST_XML.as_bytes(),
-    )?;
+    // META-INF 3종 — 원본 패키지에 있으면 원본 바이트, 없으면 템플릿(바이트 동일).
+    put(&mut zip, "META-INF/container.rdf", container_rdf)?;
+    put(&mut zip, "META-INF/container.xml", container_xml)?;
+    put(&mut zip, "META-INF/manifest.xml", manifest_xml)?;
     put(&mut zip, "Contents/content.hpf", content_hpf.as_bytes())?;
     put(&mut zip, "Contents/header.xml", header_xml.as_bytes())?;
     for (i, xml) in sections.iter().enumerate() {
@@ -220,13 +307,48 @@ pub fn write_document_with_report_with_limits(
     for (_, href, _, bytes) in &bins.items {
         put(&mut zip, href, bytes)?;
     }
+    // 참조되지 않아 collector가 수집하지 않은 원본 바이너리 복원.
+    for (_, href, _, bytes) in &passthrough_bins {
+        put(&mut zip, href, bytes)?;
+    }
     put(&mut zip, "Preview/PrvText.txt", preview.as_bytes())?;
     if let Some(preview_image) = &doc.hwpx_preview_image {
         put(&mut zip, "Preview/PrvImage.png", preview_image)?;
     }
     // settings.xml — 슬롯이 있으면 원문 pass-through, 없으면 기본 상수(바이트 동일).
     put(&mut zip, "settings.xml", settings_xml.as_bytes())?;
+    // writer가 재생성하지 않는 원본 패키지 잉여 엔트리(DocOptions·스크립트 등)를
+    // 원본 순서·바이트 그대로 방출한다.
+    for (name, bytes) in &trailing_extras {
+        put(&mut zip, name, bytes)?;
+    }
 
     zip.finish()?;
     Ok(report)
+}
+
+/// 패키지 경로를 (디렉터리 접두, 확장자 없는 파일명 stem, 확장자)로 나눈다.
+/// 예: `BinData/image1.png` → ("BinData/", "image1", ".png").
+fn split_dir_stem_ext(name: &str) -> (String, String, String) {
+    let (dir, fname) = match name.rsplit_once('/') {
+        Some((d, f)) => (format!("{d}/"), f),
+        None => (String::new(), name),
+    };
+    match fname.rsplit_once('.') {
+        Some((stem, ext)) if !stem.is_empty() => (dir, stem.to_string(), format!(".{ext}")),
+        _ => (dir, fname.to_string(), String::new()),
+    }
+}
+
+/// hwp5 출신 등 패키지 경로가 아닌 바이너리 이름을 OPC part 파일명으로 정제한다.
+fn sanitize_bin_name(name: &str) -> String {
+    name.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-') {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }

--- a/crates/hwpx/src/write/mod.rs
+++ b/crates/hwpx/src/write/mod.rs
@@ -141,7 +141,10 @@ pub fn write_document_with_report_with_limits(
     );
 
     // BinCollector가 수집하지 않은(참조되지 않는) 바이너리를 패키지에 복원한다.
-    // 바이트 동일 판정은 BinCollector의 dedup 규칙과 같다. 이름은 hwpx 원본이면
+    // hwpx 원본(BinData/ 이름)은 엔트리 정체성(이름+바이트) 기준으로 건너뛴다 —
+    // 같은 바이트가 이미 방출됐어도 원본 이름이 출력에 없으면 원본 이름으로 보존한다
+    // (엔트리 유실 방지). hwp5 출신 등 패키지 이름이 아닌 스트림은 기존처럼 바이트
+    // 동일 판정(BinCollector dedup 규칙)으로 건너뛴다. 이름은 hwpx 원본이면
     // `BinData/...`를 그대로, hwp5 출신 등이면 `BinData/<파일명>`을 쓰되 이번
     // 패키지에서 이미 쓴 이름과 충돌하면 `_2`, `_3`… 접미를 붙인다.
     let mut written_names: std::collections::BTreeSet<String> = bins
@@ -154,7 +157,18 @@ pub fn write_document_with_report_with_limits(
     // (id, href, mime, bytes) — content_hpf 매니페스트와 패키지 방출이 함께 쓴다.
     let mut passthrough_bins: Vec<(String, String, String, &[u8])> = Vec::new();
     for stream in &doc.bin_streams {
-        if bins.items.iter().any(|(.., bytes)| *bytes == stream.data) {
+        if stream.name.starts_with("BinData/") {
+            let represented = bins
+                .items
+                .iter()
+                .any(|(_, href, _, bytes)| *href == stream.name && *bytes == stream.data)
+                || passthrough_bins
+                    .iter()
+                    .any(|(_, href, _, bytes)| *href == stream.name && *bytes == stream.data);
+            if represented {
+                continue;
+            }
+        } else if bins.items.iter().any(|(.., bytes)| *bytes == stream.data) {
             continue;
         }
         let (_, mime) = section::sniff(&stream.data);
@@ -189,7 +203,12 @@ pub fn write_document_with_report_with_limits(
         )
         .collect();
 
-    let content_hpf = templates::content_hpf(sections.len(), &bin_meta, &doc.metadata);
+    let content_hpf = templates::content_hpf(
+        sections.len(),
+        &bin_meta,
+        &doc.hwpx_opf_extra_items,
+        &doc.metadata,
+    );
     let version_xml = doc
         .hwpx_version_xml
         .as_deref()

--- a/crates/hwpx/src/write/section.rs
+++ b/crates/hwpx/src/write/section.rs
@@ -24,18 +24,42 @@ pub struct BinCollector {
 }
 
 impl BinCollector {
+    /// 외과 수술 재작성용 seed: 원본 패키지에 이미 있는 바이너리를 원본 id/href로
+    /// 미리 등록한다. 시드된 바이트를 참조하는 그림은 원본 `binaryItemIDRef`를
+    /// 그대로 유지하므로, 재직렬화된 섹션과 (raw 복사되거나 재생성되는)
+    /// content.hpf 매니페스트가 같은 id 체계를 공유한다.
+    pub(crate) fn seed(&mut self, id: String, href: String, mime: String, bytes: Vec<u8>) {
+        self.items.push((id, href, mime, bytes));
+    }
+
     /// BinRef를 해석해 패키지 항목으로 등록하고 item id를 돌려준다.
     fn register(&mut self, doc: &Document, bin_ref: &BinRef) -> Option<String> {
         let bytes = doc.resolve_bin(bin_ref)?.to_vec();
-        // 같은 바이트는 재사용
+        // 같은 바이트는 재사용 (seed 포함)
         if let Some((id, ..)) = self.items.iter().find(|(.., b)| *b == bytes) {
             return Some(id.clone());
         }
         let (ext, mime) = sniff(&bytes);
-        let id = format!("image{}", self.items.len() + 1);
-        let href = format!("BinData/{id}.{ext}");
-        self.items.push((id.clone(), href, mime.to_string(), bytes));
-        Some(id)
+        Some(self.allocate(ext, mime, bytes))
+    }
+
+    /// seed·기수집 항목과 id/href가 충돌하지 않는 새 이름으로 항목을 추가하고
+    /// id를 돌려준다. seed가 없으면 기존과 같은 image1, image2, … 순서가 나온다.
+    pub(crate) fn allocate(&mut self, ext: &str, mime: &str, bytes: Vec<u8>) -> String {
+        let mut n = self.items.len() + 1;
+        loop {
+            let id = format!("image{n}");
+            let href = format!("BinData/{id}.{ext}");
+            if !self
+                .items
+                .iter()
+                .any(|(taken_id, taken_href, ..)| *taken_id == id || *taken_href == href)
+            {
+                self.items.push((id.clone(), href, mime.to_string(), bytes));
+                return id;
+            }
+            n += 1;
+        }
     }
 }
 

--- a/crates/hwpx/src/write/section.rs
+++ b/crates/hwpx/src/write/section.rs
@@ -96,8 +96,16 @@ pub fn write_section_with_report(
 ) -> String {
     let mut out = String::with_capacity(16 * 1024);
     out.push_str(
-        r##"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">"##,
+        r##"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core""##,
     );
+    // 원본 섹션 루트의 추가 xmlns 선언을 그대로 싣는다 — 원문 캡처 개체가 루트에만
+    // 선언된 확장 접두어를 쓰면, 이 선언 없이는 재방출 XML이 namespace-well-formed하지
+    // 않다. 빈 슬롯(hwp5 출신·합성 문서)이면 기존과 바이트 동일한 루트가 나온다.
+    for decl in &doc.hwpx_section_xmlns {
+        out.push(' ');
+        out.push_str(decl);
+    }
+    out.push('>');
     let mut ids = IdSeq::default();
     for (pi, para) in section.paragraphs.iter().enumerate() {
         // 첫 문단에 구역 정의가 없으면 기본 secPr 주입

--- a/crates/hwpx/src/write/section.rs
+++ b/crates/hwpx/src/write/section.rs
@@ -39,7 +39,7 @@ impl BinCollector {
     }
 }
 
-fn sniff(data: &[u8]) -> (&'static str, &'static str) {
+pub(crate) fn sniff(data: &[u8]) -> (&'static str, &'static str) {
     match data {
         [0x89, b'P', b'N', b'G', ..] => ("png", "image/png"),
         [0xFF, 0xD8, ..] => ("jpg", "image/jpeg"),
@@ -412,6 +412,18 @@ fn write_paragraph(
                         let eq = g.equation.as_ref().expect("is_some 가드");
                         let before = out.len();
                         write_equation(out, g, eq, ids);
+                        run_shapes += count_shape_tags(&out[before..]);
+                    }
+                    Control::Generic(g) if g.hwpx_raw_xml.is_some() => {
+                        // hwpx 원본 run-level 개체(hp:container 등) 원문 pass-through —
+                        // reader가 캡처한 XML을 의미 해석 없이 그대로 방출한다.
+                        // 도형 개수 bookkeeping은 picture arm과 같게 센다(원문 안에
+                        // hp:pic 등 개체 요소가 중첩돼 있을 수 있다).
+                        open_run!(cur_shape);
+                        flush_text(out, &mut text_buf, &mut pending_tabs);
+                        shape_break!();
+                        let before = out.len();
+                        out.push_str(g.hwpx_raw_xml.as_deref().expect("is_some 가드"));
                         run_shapes += count_shape_tags(&out[before..]);
                     }
                     Control::Generic(_) => {

--- a/crates/hwpx/src/write/section.rs
+++ b/crates/hwpx/src/write/section.rs
@@ -1388,8 +1388,12 @@ fn write_shape_element(
     };
     write_obj_scaffold(out, sz.0, sz.1, cur_w, cur_h);
     if s.border_width <= 0 {
-        out.push_str(
-            r##"<hp:lineShape color="#000000" width="0" style="NONE" endCap="FLAT" headStyle="NORMAL" tailStyle="NORMAL" headfill="1" tailfill="1" headSz="SMALL_SMALL" tailSz="SMALL_SMALL" outlineStyle="NORMAL" alpha="0"/>"##,
+        // 테두리 없음(NONE)이어도 원본 lineShape 색 속성은 보존한다 — 정품은
+        // NONE 테두리에도 실측 색을 싣는데, #000000으로 뭉개면 왕복이 깨진다.
+        let _ = write!(
+            out,
+            r##"<hp:lineShape color="{}" width="0" style="NONE" endCap="FLAT" headStyle="NORMAL" tailStyle="NORMAL" headfill="1" tailfill="1" headSz="SMALL_SMALL" tailSz="SMALL_SMALL" outlineStyle="NORMAL" alpha="0"/>"##,
+            color_hex(s.border_color),
         );
     } else {
         let _ = write!(
@@ -1897,9 +1901,12 @@ fn write_picture(
         .map(|c| [c[0] as i32, c[1] as i32, c[2] as i32, c[3] as i32])
         .unwrap_or([0, 0, w, h]);
     if pic.treat_as_char {
+        // 인라인 그림도 원본 z-순서를 보존한다(정품 소스는 인라인 그림에도 0이 아닌
+        // zOrder를 싣는다 — 0으로 뭉개면 왕복 의미 검증이 깨진다).
+        let zorder = pic.z_order;
         let _ = write!(
             out,
-            r##"<hp:pic id="{id}" zOrder="0" numberingType="PICTURE" textWrap="SQUARE" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" href="" groupLevel="0" instid="{id}" reverse="0"><hp:offset x="0" y="0"/><hp:orgSz width="{w}" height="{h}"/><hp:curSz width="{w}" height="{h}"/><hp:flip horizontal="{flip_h}" vertical="{flip_v}"/><hp:rotationInfo angle="{angle}" centerX="{}" centerY="{}" rotateimage="1"/><hp:renderingInfo><hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/><hc:scaMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/><hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/></hp:renderingInfo><hc:img binaryItemIDRef="{item}" bright="{}" contrast="{}" effect="REAL_PIC" alpha="0"/><hp:imgRect><hc:pt0 x="0" y="0"/><hc:pt1 x="{w}" y="0"/><hc:pt2 x="{w}" y="{h}"/><hc:pt3 x="0" y="{h}"/></hp:imgRect><hp:imgClip left="{cl}" right="{cr}" top="{ct}" bottom="{cb}"/><hp:inMargin left="0" right="0" top="0" bottom="0"/><hp:imgDim dimwidth="{w}" dimheight="{h}"/><hp:sz width="{w}" widthRelTo="ABSOLUTE" height="{h}" heightRelTo="ABSOLUTE" protect="0"/><hp:pos treatAsChar="1" affectLSpacing="0" flowWithText="1" allowOverlap="0" holdAnchorAndSO="0" vertRelTo="PARA" horzRelTo="PARA" vertAlign="TOP" horzAlign="LEFT" vertOffset="0" horzOffset="0"/><hp:outMargin left="0" right="0" top="0" bottom="0"/>{caption_xml}{description}</hp:pic>"##,
+            r##"<hp:pic id="{id}" zOrder="{zorder}" numberingType="PICTURE" textWrap="SQUARE" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" href="" groupLevel="0" instid="{id}" reverse="0"><hp:offset x="0" y="0"/><hp:orgSz width="{w}" height="{h}"/><hp:curSz width="{w}" height="{h}"/><hp:flip horizontal="{flip_h}" vertical="{flip_v}"/><hp:rotationInfo angle="{angle}" centerX="{}" centerY="{}" rotateimage="1"/><hp:renderingInfo><hc:transMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/><hc:scaMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/><hc:rotMatrix e1="1" e2="0" e3="0" e4="0" e5="1" e6="0"/></hp:renderingInfo><hc:img binaryItemIDRef="{item}" bright="{}" contrast="{}" effect="REAL_PIC" alpha="0"/><hp:imgRect><hc:pt0 x="0" y="0"/><hc:pt1 x="{w}" y="0"/><hc:pt2 x="{w}" y="{h}"/><hc:pt3 x="0" y="{h}"/></hp:imgRect><hp:imgClip left="{cl}" right="{cr}" top="{ct}" bottom="{cb}"/><hp:inMargin left="0" right="0" top="0" bottom="0"/><hp:imgDim dimwidth="{w}" dimheight="{h}"/><hp:sz width="{w}" widthRelTo="ABSOLUTE" height="{h}" heightRelTo="ABSOLUTE" protect="0"/><hp:pos treatAsChar="1" affectLSpacing="0" flowWithText="1" allowOverlap="0" holdAnchorAndSO="0" vertRelTo="PARA" horzRelTo="PARA" vertAlign="TOP" horzAlign="LEFT" vertOffset="0" horzOffset="0"/><hp:outMargin left="0" right="0" top="0" bottom="0"/>{caption_xml}{description}</hp:pic>"##,
             w / 2,
             h / 2,
             brightness,

--- a/crates/hwpx/src/write/templates.rs
+++ b/crates/hwpx/src/write/templates.rs
@@ -25,9 +25,13 @@ pub const SETTINGS_XML: &str = r##"<?xml version="1.0" encoding="UTF-8" standalo
 pub const FULL_XMLNS: &str = r##"xmlns:ha="http://www.hancom.co.kr/hwpml/2011/app" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" xmlns:hp10="http://www.hancom.co.kr/hwpml/2016/paragraph" xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core" xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head" xmlns:hhs="http://www.hancom.co.kr/hwpml/2011/history" xmlns:hm="http://www.hancom.co.kr/hwpml/2011/master-page" xmlns:hpf="http://www.hancom.co.kr/schema/2011/hpf" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf/" xmlns:ooxmlchart="http://www.hancom.co.kr/hwpml/2016/ooxmlchart" xmlns:hwpunitchar="http://www.hancom.co.kr/hwpml/2016/HwpUnitChar" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:config="urn:oasis:names:tc:opendocument:xmlns:config:1.0""##;
 
 /// content.hpf — manifest 항목(섹션 수, 바이너리 항목) + 문서 메타데이터를 끼워 만든다.
+/// `extra_items`는 writer가 재생성하지 않는 확장 파트의 원본 매니페스트 항목
+/// (id, href, media-type — 예: DocOptions/Layout.xml)으로, bin 항목 뒤에 그대로
+/// 등재해 raw-copy된 패키지 엔트리가 고아 파트가 되지 않게 한다.
 pub fn content_hpf(
     section_count: usize,
     bin_items: &[(String, String, String)],
+    extra_items: &[(String, String, String)],
     meta: &hwp_model::Metadata,
 ) -> String {
     use std::fmt::Write as _;
@@ -53,6 +57,13 @@ pub fn content_hpf(
         let _ = write!(
             manifest,
             r##"<opf:item id="{id}" href="{href}" media-type="{mime}" isEmbeded="1"/>"##
+        );
+    }
+    // 확장 파트 원본 항목 — 값은 원문 속성(이스케이프 상태) 그대로라 esc 없이 방출한다.
+    for (id, href, mime) in extra_items {
+        let _ = write!(
+            manifest,
+            r##"<opf:item id="{id}" href="{href}" media-type="{mime}"/>"##
         );
     }
     // 정품 표본(content.hpf)의 metadata 형식·순서를 그대로 재현한다:
@@ -164,7 +175,7 @@ mod tests {
             create_time: Some(created),
             modify_time: Some(modified),
         };
-        let xml = content_hpf(1, &[], &meta);
+        let xml = content_hpf(1, &[], &[], &meta);
         // 정품 형식(요소 텍스트) 방출 확인.
         assert!(xml.contains("<opf:title>제목 A=B=&gt;C &amp; &lt;x&gt;</opf:title>"));
         assert!(xml.contains(r##"<opf:meta name="creator" content="text">지은이</opf:meta>"##));
@@ -202,7 +213,7 @@ mod tests {
     /// creator는 author None일 때 앱 이름 "hwp-cli"를 유지한다.
     #[test]
     fn content_hpf_none_필드_빈요소() {
-        let xml = content_hpf(1, &[], &hwp_model::Metadata::default());
+        let xml = content_hpf(1, &[], &[], &hwp_model::Metadata::default());
         // 빈 요소로 존재.
         assert!(xml.contains(r##"<opf:meta name="subject" content="text"/>"##));
         assert!(xml.contains(r##"<opf:meta name="description" content="text"/>"##));

--- a/crates/hwpx/tests/patch.rs
+++ b/crates/hwpx/tests/patch.rs
@@ -493,3 +493,330 @@ fn replace_texts_xml_이스케이프() {
     let _ = std::fs::remove_file(&src);
     let _ = std::fs::remove_file(&out);
 }
+
+// ---- patch::rewrite_document_staged (IR 외과 수술 재작성) ----
+
+const SURG_PNG_REFERENCED: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 1, 1, 1, 1];
+const SURG_PNG_NEW: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 7, 7, 7, 7];
+const SURG_CONTAINER_RDF: &[u8] = br#"<?xml version="1.0"?><rdf:RDF>SURGICAL-RDF-MARKER</rdf:RDF>"#;
+const SURG_LAYOUT_XML: &[u8] =
+    br#"<?xml version="1.0"?><layout>SURGICAL-DOCOPTIONS-MARKER</layout>"#;
+const SURG_SETTINGS_XML: &[u8] =
+    br#"<?xml version="1.0"?><setting>SURGICAL-SETTINGS-MARKER</setting>"#;
+
+const SURG_HEADER_XML: &str = r##"<?xml version="1.0" encoding="UTF-8"?><hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head"/>"##;
+
+const SURG_CONTENT_HPF: &str = r##"<?xml version="1.0" encoding="UTF-8"?><opf:package xmlns:opf="http://www.idpf.org/2007/opf/"><opf:metadata><opf:title>원본 제목</opf:title></opf:metadata><opf:manifest><opf:item id="header" href="Contents/header.xml" media-type="application/xml"/><opf:item id="section0" href="Contents/section0.xml" media-type="application/xml"/><opf:item id="section1" href="Contents/section1.xml" media-type="application/xml"/><opf:item id="settings" href="settings.xml" media-type="application/xml"/><opf:item id="image1" href="BinData/image1.png" media-type="image/png" isEmbeded="1"/></opf:manifest><opf:spine><opf:itemref idref="header" linear="yes"/><opf:itemref idref="section0" linear="yes"/><opf:itemref idref="section1" linear="yes"/></opf:spine></opf:package>"##;
+
+/// 컨테이너(미해석 개체 원문) + image1을 참조하는 그림을 담은 첫째 구역.
+const SURG_SECTION0_XML: &str = r##"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core"><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:t>원본 본문</hp:t><hp:container id="77" zOrder="3"><hp:sz width="1000" height="500"/><hp:subList><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:t>컨테이너 텍스트</hp:t></hp:run></hp:p></hp:subList></hp:container><hp:pic id="5" zOrder="0"><hp:sz width="100" height="100"/><hp:pos treatAsChar="1" vertOffset="0" horzOffset="0"/><hp:img binaryItemIDRef="image1" bright="0" contrast="0"/></hp:pic></hp:run></hp:p></hs:sec>"##;
+
+const SURG_SECTION1_XML: &str = r##"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:t>둘째 구역</hp:t></hp:run></hp:p></hs:sec>"##;
+
+fn build_surgical_fixture(path: &std::path::Path) {
+    let file = std::fs::File::create(path).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("mimetype", stored).unwrap();
+    zip.write_all(b"application/hwp+zip").unwrap();
+    zip.start_file("version.xml", deflated).unwrap();
+    zip.write_all(br#"<version major="1" minor="4" micro="0" buildNumber="0"/>"#)
+        .unwrap();
+    zip.start_file("META-INF/container.rdf", deflated).unwrap();
+    zip.write_all(SURG_CONTAINER_RDF).unwrap();
+    zip.start_file("Contents/content.hpf", deflated).unwrap();
+    zip.write_all(SURG_CONTENT_HPF.as_bytes()).unwrap();
+    zip.start_file("Contents/header.xml", deflated).unwrap();
+    zip.write_all(SURG_HEADER_XML.as_bytes()).unwrap();
+    zip.start_file("Contents/section0.xml", deflated).unwrap();
+    zip.write_all(SURG_SECTION0_XML.as_bytes()).unwrap();
+    zip.start_file("Contents/section1.xml", deflated).unwrap();
+    zip.write_all(SURG_SECTION1_XML.as_bytes()).unwrap();
+    zip.start_file("BinData/image1.png", deflated).unwrap();
+    zip.write_all(SURG_PNG_REFERENCED).unwrap();
+    zip.start_file("Preview/PrvImage.png", deflated).unwrap();
+    zip.write_all(PRV_IMAGE).unwrap();
+    zip.start_file("settings.xml", deflated).unwrap();
+    zip.write_all(SURG_SETTINGS_XML).unwrap();
+    zip.start_file("DocOptions/Layout.xml", deflated).unwrap();
+    zip.write_all(SURG_LAYOUT_XML).unwrap();
+    zip.finish().unwrap();
+}
+
+fn surgical_dir(tag: &str) -> std::path::PathBuf {
+    // PID 포함 — 병렬 cargo test 세션끼리 산출물을 덮어쓰지 않게.
+    let dir = std::env::temp_dir().join(format!("hwpx-surgical-{}-{tag}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn read_surgical_doc(path: &std::path::Path) -> hwp_model::Document {
+    hwpx::read_document(path).unwrap().document
+}
+
+/// 외과 수술 후에도 비대상 엔트리가 압축 바이트·ZIP 메타데이터까지 동일한지 검사.
+fn assert_raw_preserved(src: &std::path::Path, out: &std::path::Path, names: &[&str]) {
+    for name in names {
+        assert_eq!(
+            raw_entry(out, name),
+            raw_entry(src, name),
+            "{name} raw 보존"
+        );
+    }
+}
+
+/// 불투명 엔트리 전체(본문 콘텐츠 외 모든 것) — 어떤 dirty 조합에서도 보존돼야 한다.
+const SURG_OPAQUE_ENTRIES: &[&str] = &[
+    "mimetype",
+    "version.xml",
+    "META-INF/container.rdf",
+    "BinData/image1.png",
+    "Preview/PrvImage.png",
+    "settings.xml",
+    "DocOptions/Layout.xml",
+];
+
+#[test]
+fn rewrite_staged_텍스트편집_비대상_엔트리_바이트보존() {
+    let dir = surgical_dir("text");
+    let src = dir.join("src.hwpx");
+    let out = dir.join("out.hwpx");
+    build_surgical_fixture(&src);
+
+    let mut doc = read_surgical_doc(&src);
+    // section0 첫 문단 텍스트 한 글자 편집 ("원본 본문" → "개본 본문").
+    for ch in &mut doc.sections[0].paragraphs[0].chars {
+        if let hwp_model::HwpChar::Text('원') = ch {
+            *ch = hwp_model::HwpChar::Text('개');
+            break;
+        }
+    }
+    let dirty = hwpx::patch::DirtyEntries {
+        sections: Some(vec![0]),
+        header: false,
+        content_hpf: false,
+    };
+    let report = hwpx::patch::rewrite_document_staged(
+        &src,
+        &out,
+        &doc,
+        &dirty,
+        &hwpx::PackageLimits::default(),
+    )
+    .unwrap();
+    assert!(
+        report.preservation.is_lossless(),
+        "preservation events: {:?}",
+        report.preservation.events
+    );
+
+    // 비대상 콘텐츠 엔트리(section1·header·content.hpf)까지 raw 보존.
+    let mut preserved = SURG_OPAQUE_ENTRIES.to_vec();
+    preserved.extend([
+        "Contents/section1.xml",
+        "Contents/header.xml",
+        "Contents/content.hpf",
+    ]);
+    assert_raw_preserved(&src, &out, &preserved);
+
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(&out).unwrap()).unwrap();
+    let section = String::from_utf8(read_entry(&mut zip, "Contents/section0.xml")).unwrap();
+    assert!(section.contains("개본 본문"), "편집 반영: {section}");
+    assert!(
+        section.contains(r#"<hp:container id="77" zOrder="3">"#),
+        "컨테이너 원문 유지: {section}"
+    );
+    assert!(
+        section.contains(r#"binaryItemIDRef="image1""#),
+        "기존 그림이 원본 id 유지: {section}"
+    );
+}
+
+#[test]
+fn rewrite_staged_이미지추가_새엔트리와_매니페스트_갱신() {
+    let dir = surgical_dir("image");
+    let src = dir.join("src.hwpx");
+    let out = dir.join("out.hwpx");
+    build_surgical_fixture(&src);
+
+    let mut doc = read_surgical_doc(&src);
+    // 새 바이너리 + 그림 컨트롤 삽입 (insert-image op과 같은 IR 변화).
+    doc.bin_streams.push(hwp_model::BinStream {
+        name: "inserted1.png".to_string(),
+        data: SURG_PNG_NEW.to_vec(),
+    });
+    let para = &mut doc.sections[0].paragraphs[0];
+    let pic_pos = para
+        .controls
+        .iter()
+        .position(|c| matches!(c, hwp_model::Control::Picture(_)))
+        .unwrap();
+    let mut new_pic = match &para.controls[pic_pos] {
+        hwp_model::Control::Picture(pic) => pic.clone(),
+        _ => unreachable!(),
+    };
+    new_pic.bin_ref = hwp_model::BinRef::ItemRef("inserted1.png".to_string());
+    para.controls.push(hwp_model::Control::Picture(new_pic));
+    let new_index = (para.controls.len() - 1) as u32;
+    // 기존 그림 앵커 문자에서 확장 컨트롤 문자 형태(code/ctrl_id/payload)를 복사한다.
+    let (code, ctrl_id, payload) = para
+        .chars
+        .iter()
+        .find_map(|ch| match ch {
+            hwp_model::HwpChar::ExtCtrl {
+                code,
+                ctrl_id,
+                payload,
+                ctrl_index,
+            } if *ctrl_index == Some(pic_pos as u32) => Some((*code, *ctrl_id, payload.clone())),
+            _ => None,
+        })
+        .expect("기존 그림 앵커 문자");
+    para.chars.push(hwp_model::HwpChar::ExtCtrl {
+        code,
+        ctrl_id,
+        payload,
+        ctrl_index: Some(new_index),
+    });
+
+    // content.hpf는 dirty가 아니지만, 새 BinData가 생겨 패치가 강제로 재생성해야 한다.
+    let dirty = hwpx::patch::DirtyEntries {
+        sections: Some(vec![0]),
+        header: false,
+        content_hpf: false,
+    };
+    let report = hwpx::patch::rewrite_document_staged(
+        &src,
+        &out,
+        &doc,
+        &dirty,
+        &hwpx::PackageLimits::default(),
+    )
+    .unwrap();
+    assert!(
+        report.preservation.is_lossless(),
+        "preservation events: {:?}",
+        report.preservation.events
+    );
+
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(&out).unwrap()).unwrap();
+    // 새 바이너리는 seed와 충돌하지 않는 새 엔트리로 추가됐다.
+    assert_eq!(
+        read_entry(&mut zip, "BinData/image2.png"),
+        SURG_PNG_NEW,
+        "새 BinData 엔트리"
+    );
+    // content.hpf 강제 재생성: 신규 항목 추가 + 기존 항목 유지.
+    let hpf = String::from_utf8(read_entry(&mut zip, "Contents/content.hpf")).unwrap();
+    assert!(
+        hpf.contains(
+            r#"<opf:item id="image2" href="BinData/image2.png" media-type="image/png" isEmbeded="1"/>"#
+        ),
+        "신규 매니페스트 항목: {hpf}"
+    );
+    assert!(
+        hpf.contains(r#"id="image1" href="BinData/image1.png""#),
+        "기존 매니페스트 항목 유지: {hpf}"
+    );
+    let section = String::from_utf8(read_entry(&mut zip, "Contents/section0.xml")).unwrap();
+    assert!(
+        section.contains(r#"binaryItemIDRef="image2""#),
+        "새 그림은 새 id: {section}"
+    );
+    assert!(
+        section.contains(r#"binaryItemIDRef="image1""#),
+        "기존 그림은 원본 id: {section}"
+    );
+    drop(zip);
+
+    let mut preserved = SURG_OPAQUE_ENTRIES.to_vec();
+    preserved.extend(["Contents/section1.xml", "Contents/header.xml"]);
+    assert_raw_preserved(&src, &out, &preserved);
+}
+
+#[test]
+fn rewrite_staged_메타데이터편집_content_hpf만_재생성() {
+    let dir = surgical_dir("meta");
+    let src = dir.join("src.hwpx");
+    let out = dir.join("out.hwpx");
+    build_surgical_fixture(&src);
+
+    let mut doc = read_surgical_doc(&src);
+    doc.metadata.title = Some("새 제목".to_string());
+    // 섹션 0개 dirty — 본문은 전부 raw 복사돼야 한다.
+    let dirty = hwpx::patch::DirtyEntries {
+        sections: Some(vec![]),
+        header: false,
+        content_hpf: true,
+    };
+    hwpx::patch::rewrite_document_staged(&src, &out, &doc, &dirty, &hwpx::PackageLimits::default())
+        .unwrap();
+
+    let mut preserved = SURG_OPAQUE_ENTRIES.to_vec();
+    preserved.extend([
+        "Contents/section0.xml",
+        "Contents/section1.xml",
+        "Contents/header.xml",
+    ]);
+    assert_raw_preserved(&src, &out, &preserved);
+
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(&out).unwrap()).unwrap();
+    let hpf = String::from_utf8(read_entry(&mut zip, "Contents/content.hpf")).unwrap();
+    assert!(
+        hpf.contains("<opf:title>새 제목</opf:title>"),
+        "메타데이터 반영: {hpf}"
+    );
+    assert!(
+        hpf.contains(r#"id="image1" href="BinData/image1.png""#),
+        "기존 매니페스트 항목 유지: {hpf}"
+    );
+}
+
+#[test]
+fn rewrite_staged_전체_dirty도_불투명_엔트리는_보존() {
+    let dir = surgical_dir("all");
+    let src = dir.join("src.hwpx");
+    let out = dir.join("out.hwpx");
+    build_surgical_fixture(&src);
+
+    let doc = read_surgical_doc(&src);
+    let report = hwpx::patch::rewrite_document_staged(
+        &src,
+        &out,
+        &doc,
+        &hwpx::patch::DirtyEntries::all(),
+        &hwpx::PackageLimits::default(),
+    )
+    .unwrap();
+    assert!(
+        report.preservation.is_lossless(),
+        "preservation events: {:?}",
+        report.preservation.events
+    );
+
+    assert_raw_preserved(&src, &out, SURG_OPAQUE_ENTRIES);
+
+    let mut zip = zip::ZipArchive::new(std::fs::File::open(&out).unwrap()).unwrap();
+    let section = String::from_utf8(read_entry(&mut zip, "Contents/section0.xml")).unwrap();
+    assert!(section.contains("원본 본문"), "본문 유지: {section}");
+    assert!(
+        section.contains(r#"<hp:container id="77" zOrder="3">"#),
+        "컨테이너 원문 유지: {section}"
+    );
+    assert!(
+        section.contains(r#"binaryItemIDRef="image1""#),
+        "기존 그림이 원본 id 유지: {section}"
+    );
+    // content.hpf가 재생성돼도 원본 매니페스트 id 체계를 유지한다.
+    let hpf = String::from_utf8(read_entry(&mut zip, "Contents/content.hpf")).unwrap();
+    assert!(
+        hpf.contains(r#"id="image1" href="BinData/image1.png""#),
+        "매니페스트 id 유지: {hpf}"
+    );
+    assert!(
+        hpf.contains("<opf:title>원본 제목</opf:title>"),
+        "메타 유지: {hpf}"
+    );
+}

--- a/crates/hwpx/tests/roundtrip_preserve.rs
+++ b/crates/hwpx/tests/roundtrip_preserve.rs
@@ -1,0 +1,250 @@
+//! hwpx→IR→hwpx 무수정 왕복 무손실 계약 테스트 (Phase 0, epic #90).
+//!
+//! 합성 HWPX를 코드로 만들어(read → write) 재작성한 뒤, writer가 예전에
+//! silently drop하던 세 축이 보존되는지 검증한다:
+//! - 미해석 run-level 개체(hp:container·hp:chartex)의 원문 XML
+//! - 참조되지 않는/중복 바이트의 BinData/* 엔트리
+//! - writer 고정 목록 밖 패키지 엔트리(원본 META-INF/*, DocOptions 등)
+
+use std::io::{Read, Write};
+
+use zip::CompressionMethod;
+use zip::write::SimpleFileOptions;
+
+const PNG_REFERENCED: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 1, 1, 1, 1];
+const PNG_ORPHAN: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 2, 2, 2, 2];
+const PNG_DUP: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 3, 3, 3, 3];
+const PRV_IMAGE: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 9, 9, 9, 9];
+const CONTAINER_RDF: &[u8] =
+    br#"<?xml version="1.0" encoding="UTF-8"?><rdf:RDF>DISTINCTIVE-RDF-MARKER</rdf:RDF>"#;
+const CONTAINER_XML: &[u8] =
+    br#"<?xml version="1.0" encoding="UTF-8"?><container>DISTINCTIVE-CONTAINER-MARKER</container>"#;
+const MANIFEST_XML: &[u8] =
+    br#"<?xml version="1.0" encoding="UTF-8"?><manifest>DISTINCTIVE-MANIFEST-MARKER</manifest>"#;
+const LAYOUT_XML: &[u8] =
+    br#"<?xml version="1.0" encoding="UTF-8"?><layout>DISTINCTIVE-DOCOPTIONS-MARKER</layout>"#;
+
+const HEADER_XML: &str =
+    r##"<?xml version="1.0" encoding="UTF-8"?><hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head"/>"##;
+
+/// run-level 미해석 개체 2종(hp:container + 하위 subList 텍스트, hp:chartex)과
+/// image1을 참조하는 hp:pic을 담은 본문.
+const SECTION_XML: &str = r##"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core"><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:t>본문</hp:t><hp:container id="77" zOrder="3"><hp:sz width="1000" height="500"/><hp:subList><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:t>컨테이너 텍스트</hp:t></hp:run></hp:p></hp:subList></hp:container><hp:chartex version="9"><hp:extData>차트확장</hp:extData></hp:chartex><hp:pic id="5" zOrder="0"><hp:sz width="100" height="100"/><hp:pos treatAsChar="1" vertOffset="0" horzOffset="0"/><hp:img binaryItemIDRef="image1" bright="0" contrast="0"/></hp:pic></hp:run></hp:p></hs:sec>"##;
+
+fn build_fixture(path: &std::path::Path) {
+    let file = std::fs::File::create(path).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("mimetype", stored).unwrap();
+    zip.write_all(b"application/hwp+zip").unwrap();
+
+    zip.start_file("version.xml", deflated).unwrap();
+    zip.write_all(br#"<version major="1" minor="4" micro="0" buildNumber="0"/>"#)
+        .unwrap();
+
+    // writer가 템플릿으로 대체하던 META-INF 3종 — 원본 바이트 보존 대상.
+    zip.start_file("META-INF/container.rdf", deflated).unwrap();
+    zip.write_all(CONTAINER_RDF).unwrap();
+    zip.start_file("META-INF/container.xml", deflated).unwrap();
+    zip.write_all(CONTAINER_XML).unwrap();
+    zip.start_file("META-INF/manifest.xml", deflated).unwrap();
+    zip.write_all(MANIFEST_XML).unwrap();
+
+    zip.start_file("Contents/header.xml", deflated).unwrap();
+    zip.write_all(HEADER_XML.as_bytes()).unwrap();
+    zip.start_file("Contents/section0.xml", deflated).unwrap();
+    zip.write_all(SECTION_XML.as_bytes()).unwrap();
+
+    // 참조됨 1 + 미참조 1 + 동일 바이트 2.
+    zip.start_file("BinData/image1.png", deflated).unwrap();
+    zip.write_all(PNG_REFERENCED).unwrap();
+    zip.start_file("BinData/orphan.png", deflated).unwrap();
+    zip.write_all(PNG_ORPHAN).unwrap();
+    zip.start_file("BinData/dupA.png", deflated).unwrap();
+    zip.write_all(PNG_DUP).unwrap();
+    zip.start_file("BinData/dupB.png", deflated).unwrap();
+    zip.write_all(PNG_DUP).unwrap();
+
+    zip.start_file("Preview/PrvText.txt", deflated).unwrap();
+    zip.write_all("원본 미리보기 텍스트".as_bytes()).unwrap();
+    zip.start_file("Preview/PrvImage.png", deflated).unwrap();
+    zip.write_all(PRV_IMAGE).unwrap();
+
+    // writer 고정 목록 밖 임의 엔트리.
+    zip.start_file("DocOptions/Layout.xml", deflated).unwrap();
+    zip.write_all(LAYOUT_XML).unwrap();
+
+    zip.finish().unwrap();
+}
+
+fn read_entries(path: &std::path::Path) -> Vec<(String, Vec<u8>)> {
+    let file = std::fs::File::open(path).unwrap();
+    let mut zip = zip::ZipArchive::new(file).unwrap();
+    let mut out = Vec::new();
+    for i in 0..zip.len() {
+        let mut entry = zip.by_index(i).unwrap();
+        if entry.is_dir() {
+            continue;
+        }
+        let mut buf = Vec::new();
+        entry.read_to_end(&mut buf).unwrap();
+        out.push((entry.name().to_string(), buf));
+    }
+    out
+}
+
+#[test]
+fn 무수정_왕복은_개체_바이너리_패키지엔트리를_보존한다() {
+    let dir = std::env::temp_dir().join("hwpx-roundtrip-preserve");
+    std::fs::create_dir_all(&dir).unwrap();
+    let src = dir.join("src.hwpx");
+    let out = dir.join("out.hwpx");
+    build_fixture(&src);
+    let source_entries = read_entries(&src);
+
+    let read = hwpx::read_document(&src).unwrap();
+    let report = hwpx::write_document_with_report(&read.document, &out).unwrap();
+
+    // 1. 무손실 계약: typed preservation 이벤트가 없어야 한다.
+    assert!(
+        report.preservation.is_lossless(),
+        "preservation events: {:?}",
+        report.preservation.events
+    );
+
+    let out_entries = read_entries(&out);
+    let out_map: std::collections::BTreeMap<&str, &[u8]> = out_entries
+        .iter()
+        .map(|(name, bytes)| (name.as_str(), bytes.as_slice()))
+        .collect();
+
+    // 2. 엔트리 집합 상위(superset): 원본의 모든 엔트리 이름이 남아 있어야 한다.
+    for (name, _) in &source_entries {
+        assert!(out_map.contains_key(name.as_str()), "엔트리 유실: {name}");
+    }
+
+    // 3. 바이트 보존 대상: BinData 전부 + 원본 META-INF + DocOptions + Preview 이미지.
+    for name in [
+        "BinData/image1.png",
+        "BinData/orphan.png",
+        "BinData/dupA.png",
+        "BinData/dupB.png",
+        "META-INF/container.rdf",
+        "META-INF/container.xml",
+        "META-INF/manifest.xml",
+        "DocOptions/Layout.xml",
+        "Preview/PrvImage.png",
+    ] {
+        let source_bytes = source_entries
+            .iter()
+            .find(|(n, _)| n == name)
+            .unwrap_or_else(|| panic!("원본에 {name} 없음"))
+            .1
+            .as_slice();
+        assert_eq!(
+            out_map.get(name).copied(),
+            Some(source_bytes),
+            "{name} 바이트가 원본과 다르다"
+        );
+    }
+
+    // 4. 미해석 개체 원문 보존: container + subList 텍스트 + chartex.
+    let section = String::from_utf8(
+        out_entries
+            .iter()
+            .find(|(n, _)| n == "Contents/section0.xml")
+            .unwrap()
+            .1
+            .clone(),
+    )
+    .unwrap();
+    assert!(
+        section.contains(r#"<hp:container id="77" zOrder="3">"#),
+        "container 원문 유실: {section}"
+    );
+    assert!(
+        section.contains("컨테이너 텍스트"),
+        "container subList 텍스트 유실: {section}"
+    );
+    assert!(
+        section.contains(r#"<hp:chartex version="9">"#),
+        "chartex 원문 유실: {section}"
+    );
+}
+
+/// 원문 캡처된 개체는 write_section_with_report에서 그대로 방출되고,
+/// 원문이 없는 불투명 개체는 기존처럼 OpaqueControlUnrepresentable 손실 이벤트를 낸다.
+#[test]
+fn 원문_보유_개체는_방출하고_없으면_손실이벤트를_낸다() {
+    fn section_with(generic: hwp_model::GenericControl) -> hwp_model::Section {
+        let mut para = hwp_model::Paragraph::default();
+        para.chars.push(hwp_model::HwpChar::Text('가'));
+        para.chars.push(hwp_model::HwpChar::ExtCtrl {
+            code: 11,
+            ctrl_id: generic.ctrl_id,
+            payload: Vec::new(),
+            ctrl_index: Some(0),
+        });
+        para.controls.push(hwp_model::Control::Generic(generic));
+        hwp_model::Section {
+            paragraphs: vec![para],
+            extras: Vec::new(),
+        }
+    }
+
+    fn blank_generic(ctrl_id: [u8; 4]) -> hwp_model::GenericControl {
+        hwp_model::GenericControl {
+            ctrl_id,
+            data: Vec::new(),
+            paragraph_lists: Vec::new(),
+            extras: Vec::new(),
+            raw_children: Vec::new(),
+            gso_shapes: Vec::new(),
+            equation: None,
+            column_def: None,
+            caption: None,
+            hwpx_raw_xml: None,
+        }
+    }
+
+    let doc = hwp_model::Document::default();
+
+    // (a) 원문 보유 개체 → 원문 그대로 방출, 손실 없음.
+    let raw = r#"<hp:container id="9"><hp:subList><hp:p><hp:run><hp:t>상자</hp:t></hp:run></hp:p></hp:subList></hp:container>"#;
+    let mut generic = blank_generic(*b"cont");
+    generic.hwpx_raw_xml = Some(raw.to_string());
+    let mut report = hwp_model::WriteReport::new();
+    let mut bins = hwpx::write::section::BinCollector::default();
+    let xml = hwpx::write::section::write_section_with_report(
+        &doc,
+        &section_with(generic),
+        false,
+        &mut bins,
+        &mut report,
+    );
+    assert!(xml.contains(raw), "원문 미방출: {xml}");
+    assert!(
+        report.preservation.is_lossless(),
+        "preservation events: {:?}",
+        report.preservation.events
+    );
+
+    // (b) 원문 없음 + 표현 수단 없음 → 기존 OpaqueControlUnrepresentable 유지.
+    let generic = blank_generic(*b"zzzz");
+    let mut report = hwp_model::WriteReport::new();
+    let mut bins = hwpx::write::section::BinCollector::default();
+    let _ = hwpx::write::section::write_section_with_report(
+        &doc,
+        &section_with(generic),
+        false,
+        &mut bins,
+        &mut report,
+    );
+    assert_eq!(report.preservation.events.len(), 1);
+    assert_eq!(
+        report.preservation.events[0].code,
+        hwp_model::PreservationCode::OpaqueControlUnrepresentable
+    );
+}

--- a/crates/hwpx/tests/roundtrip_preserve.rs
+++ b/crates/hwpx/tests/roundtrip_preserve.rs
@@ -272,10 +272,13 @@ fn build_manifest_seed_fixture(path: &std::path::Path) {
         .unwrap();
     zip.start_file("Contents/content.hpf", deflated).unwrap();
     zip.write_all(
-        r##"<?xml version="1.0"?><opf:package xmlns:opf="http://www.idpf.org/2007/opf/"><opf:metadata><opf:title>시드 문서</opf:title></opf:metadata><opf:manifest><opf:item id="header" href="Contents/header.xml" media-type="application/xml"/><opf:item id="section0" href="Contents/section0.xml" media-type="application/xml"/><opf:item id="settings" href="settings.xml" media-type="application/xml"/><opf:item id="image1" href="BinData/image1.png" media-type="image/png" isEmbeded="1"/><opf:item id="image2" href="BinData/image2.png" media-type="image/png" isEmbeded="1"/><opf:item id="unused1" href="BinData/image3.png" media-type="image/png" isEmbeded="1"/><opf:item id="chartA" href="BinData/image4.png" media-type="image/png" isEmbeded="1"/></opf:manifest><opf:spine><opf:itemref idref="header" linear="yes"/><opf:itemref idref="section0" linear="yes"/></opf:spine></opf:package>"##
+        r##"<?xml version="1.0"?><opf:package xmlns:opf="http://www.idpf.org/2007/opf/"><opf:metadata><opf:title>시드 문서</opf:title></opf:metadata><opf:manifest><opf:item id="header" href="Contents/header.xml" media-type="application/xml"/><opf:item id="section0" href="Contents/section0.xml" media-type="application/xml"/><opf:item id="settings" href="settings.xml" media-type="application/xml"/><opf:item id="layout" href="DocOptions/Layout.xml" media-type="application/xml"/><opf:item id="image1" href="BinData/image1.png" media-type="image/png" isEmbeded="1"/><opf:item id="image2" href="BinData/image2.png" media-type="image/png" isEmbeded="1"/><opf:item id="unused1" href="BinData/image3.png" media-type="image/png" isEmbeded="1"/><opf:item id="chartA" href="BinData/image4.png" media-type="image/png" isEmbeded="1"/></opf:manifest><opf:spine><opf:itemref idref="header" linear="yes"/><opf:itemref idref="section0" linear="yes"/></opf:spine></opf:package>"##
             .as_bytes(),
     )
     .unwrap();
+    zip.start_file("DocOptions/Layout.xml", deflated).unwrap();
+    zip.write_all(br#"<?xml version="1.0"?><layout>DISTINCTIVE-DOCOPTIONS-MARKER</layout>"#)
+        .unwrap();
     zip.start_file("Contents/header.xml", deflated).unwrap();
     zip.write_all(HEADER_XML.as_bytes()).unwrap();
     zip.start_file("Contents/section0.xml", deflated).unwrap();
@@ -369,4 +372,190 @@ fn 전체_재작성은_원본_manifest_id로_binary참조를_보존한다() {
             assert_eq!(&bytes_of(&out_entries, name), bytes, "{name} 바이트 보존");
         }
     }
+
+    // 4. 확장 파트(DocOptions/Layout.xml): 엔트리 바이트 보존 + 재생성된 매니페스트에
+    //    원본 항목(id/href/media-type)이 그대로 등재돼야 한다(고아 파트 방지).
+    assert_eq!(
+        &bytes_of(&out_entries, "DocOptions/Layout.xml"),
+        &bytes_of(&source_entries, "DocOptions/Layout.xml"),
+        "DocOptions 엔트리 바이트 보존"
+    );
+    let out_hpf = String::from_utf8(bytes_of(&out_entries, "Contents/content.hpf")).unwrap();
+    assert!(
+        out_hpf.contains(
+            r#"<opf:item id="layout" href="DocOptions/Layout.xml" media-type="application/xml"/>"#
+        ),
+        "재생성 매니페스트에 확장 파트 항목 유지: {out_hpf}"
+    );
+}
+
+/// content.hpf에 BinData 항목이 없어(매니페스트 슬롯 빔) 시드되지 않는 문서에서,
+/// 이름이 다른 동일 바이트 BinData 엔트리는 바이트 dedup으로 붕괴하지 않고 모두
+/// 원본 이름으로 보존돼야 한다. pic 참조는 출력 매니페스트에서 같은 바이트로 해석된다.
+#[test]
+fn 미시드_경로도_이름_다른_동일바이트_bin_data를_모두_보존한다() {
+    let dir = std::env::temp_dir().join("hwpx-roundtrip-unseeded-dup");
+    std::fs::create_dir_all(&dir).unwrap();
+    let src = dir.join("src.hwpx");
+    let out = dir.join("out.hwpx");
+
+    {
+        let file = std::fs::File::create(&src).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+        zip.start_file("mimetype", stored).unwrap();
+        zip.write_all(b"application/hwp+zip").unwrap();
+        zip.start_file("version.xml", deflated).unwrap();
+        zip.write_all(br#"<version major="1" minor="4" micro="0" buildNumber="0"/>"#)
+            .unwrap();
+        // 매니페스트에 BinData 항목이 없다 → hwpx_bin_manifest 슬롯이 비어 미시드 경로.
+        zip.start_file("Contents/content.hpf", deflated).unwrap();
+        zip.write_all(
+            r##"<?xml version="1.0"?><opf:package xmlns:opf="http://www.idpf.org/2007/opf/"><opf:metadata><opf:title>중복 바이너리</opf:title></opf:metadata><opf:manifest><opf:item id="header" href="Contents/header.xml" media-type="application/xml"/><opf:item id="section0" href="Contents/section0.xml" media-type="application/xml"/><opf:item id="settings" href="settings.xml" media-type="application/xml"/></opf:manifest><opf:spine><opf:itemref idref="header" linear="yes"/><opf:itemref idref="section0" linear="yes"/></opf:spine></opf:package>"##
+                .as_bytes(),
+        )
+        .unwrap();
+        zip.start_file("Contents/header.xml", deflated).unwrap();
+        zip.write_all(HEADER_XML.as_bytes()).unwrap();
+        zip.start_file("Contents/section0.xml", deflated).unwrap();
+        zip.write_all(
+            r##"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:t>본문</hp:t><hp:pic id="5" zOrder="0"><hp:sz width="100" height="100"/><hp:pos treatAsChar="1" vertOffset="0" horzOffset="0"/><hp:img binaryItemIDRef="dupA" bright="0" contrast="0"/></hp:pic></hp:run></hp:p></hs:sec>"##
+                .as_bytes(),
+        )
+        .unwrap();
+        zip.start_file("BinData/dupA.png", deflated).unwrap();
+        zip.write_all(PNG_DUP).unwrap();
+        zip.start_file("BinData/dupB.png", deflated).unwrap();
+        zip.write_all(PNG_DUP).unwrap();
+        zip.finish().unwrap();
+    }
+
+    let read = hwpx::read_document(&src).unwrap();
+    assert!(
+        read.document.hwpx_bin_manifest.is_empty(),
+        "미시드 경로여야 한다"
+    );
+    hwpx::write_document_with_report(&read.document, &out).unwrap();
+
+    let out_entries = read_entries(&out);
+    let bytes_of = |name: &str| -> Vec<u8> {
+        out_entries
+            .iter()
+            .find(|(n, _)| n == name)
+            .unwrap_or_else(|| panic!("엔트리 없음: {name}"))
+            .1
+            .clone()
+    };
+    // 두 엔트리 모두 원본 이름·바이트로 보존.
+    assert_eq!(bytes_of("BinData/dupA.png"), PNG_DUP, "dupA 보존");
+    assert_eq!(bytes_of("BinData/dupB.png"), PNG_DUP, "dupB 보존");
+
+    // pic 참조는 출력 매니페스트에서 같은 바이트로 해석된다.
+    let section = String::from_utf8(bytes_of("Contents/section0.xml")).unwrap();
+    let marker = "binaryItemIDRef=\"";
+    let at = section.find(marker).unwrap();
+    let rest = &section[at + marker.len()..];
+    let pic_ref = &rest[..rest.find('"').unwrap()];
+    let out_manifest =
+        manifest_bin_map(&String::from_utf8(bytes_of("Contents/content.hpf")).unwrap());
+    let href = out_manifest
+        .get(pic_ref)
+        .unwrap_or_else(|| panic!("출력 매니페스트에 {pic_ref} 없음"));
+    assert_eq!(bytes_of(href), PNG_DUP, "pic 참조 바이트 보존");
+}
+
+/// 루트에만 선언된 벤더 접두어(xmlns:vnd)를 쓰는 원문 캡처 개체는, 재직렬화된
+/// 섹션 루트가 그 선언을 실어야 namespace-well-formed하다. 빈 슬롯이면 루트는
+/// 기존과 바이트 동일해야 한다(표준 hs/hp/hc만).
+#[test]
+fn 전체_재작성은_루트의_확장_xmlns_선언을_보존한다() {
+    let dir = std::env::temp_dir().join("hwpx-roundtrip-xmlns");
+    std::fs::create_dir_all(&dir).unwrap();
+    let src = dir.join("src.hwpx");
+    let out = dir.join("out.hwpx");
+
+    {
+        let file = std::fs::File::create(&src).unwrap();
+        let mut zip = zip::ZipWriter::new(file);
+        let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+        zip.start_file("mimetype", stored).unwrap();
+        zip.write_all(b"application/hwp+zip").unwrap();
+        zip.start_file("version.xml", deflated).unwrap();
+        zip.write_all(br#"<version major="1" minor="4" micro="0" buildNumber="0"/>"#)
+            .unwrap();
+        zip.start_file("Contents/content.hpf", deflated).unwrap();
+        zip.write_all(
+            r##"<?xml version="1.0"?><opf:package xmlns:opf="http://www.idpf.org/2007/opf/"><opf:metadata><opf:title>벤더 접두어</opf:title></opf:metadata><opf:manifest><opf:item id="header" href="Contents/header.xml" media-type="application/xml"/><opf:item id="section0" href="Contents/section0.xml" media-type="application/xml"/><opf:item id="settings" href="settings.xml" media-type="application/xml"/></opf:manifest><opf:spine><opf:itemref idref="header" linear="yes"/><opf:itemref idref="section0" linear="yes"/></opf:spine></opf:package>"##
+                .as_bytes(),
+        )
+        .unwrap();
+        zip.start_file("Contents/header.xml", deflated).unwrap();
+        zip.write_all(HEADER_XML.as_bytes()).unwrap();
+        zip.start_file("Contents/section0.xml", deflated).unwrap();
+        // xmlns:vnd는 루트에만 선언 — 컨테이너 원문 안의 <vnd:mark>는 이 선언에 의존한다.
+        zip.write_all(
+            r##"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" xmlns:vnd="urn:example"><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:t>본문</hp:t><hp:container id="77" zOrder="3"><hp:sz width="1000" height="500"/><hp:subList><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:t>컨테이너 텍스트</hp:t></hp:run></hp:p></hp:subList><vnd:mark key="k1"/></hp:container></hp:run></hp:p></hs:sec>"##
+                .as_bytes(),
+        )
+        .unwrap();
+        zip.finish().unwrap();
+    }
+
+    let read = hwpx::read_document(&src).unwrap();
+    assert_eq!(
+        read.document.hwpx_section_xmlns,
+        vec!["xmlns:vnd=\"urn:example\"".to_string()],
+        "확장 xmlns 캡처"
+    );
+    hwpx::write_document_with_report(&read.document, &out).unwrap();
+
+    let out_entries = read_entries(&out);
+    let section = String::from_utf8(
+        out_entries
+            .iter()
+            .find(|(n, _)| n == "Contents/section0.xml")
+            .unwrap()
+            .1
+            .clone(),
+    )
+    .unwrap();
+    assert!(
+        section.contains(r#"xmlns:vnd="urn:example""#),
+        "루트 확장 xmlns 유실: {section}"
+    );
+    assert!(
+        section.contains(r#"<vnd:mark key="k1"/>"#),
+        "원문 프래그먼트 유실: {section}"
+    );
+
+    // namespace-aware 검증: 모든 접두어가 해석돼야 하고(Unknown 없음), vnd:mark는
+    // urn:example에 바인드돼야 한다.
+    use quick_xml::events::Event;
+    use quick_xml::name::ResolveResult;
+    let mut ns_reader = quick_xml::NsReader::from_str(&section);
+    let mut mark_bound = false;
+    loop {
+        match ns_reader.read_resolved_event() {
+            Ok((ns, Event::Start(e))) | Ok((ns, Event::Empty(e))) => {
+                assert!(
+                    !matches!(ns, ResolveResult::Unknown(_)),
+                    "미바인딩 접두어: {:?}",
+                    String::from_utf8_lossy(e.name().as_ref())
+                );
+                if e.local_name().as_ref() == b"mark" {
+                    mark_bound =
+                        matches!(ns, ResolveResult::Bound(ns) if ns.as_ref() == b"urn:example");
+                }
+            }
+            Ok((_, Event::Eof)) => break,
+            Err(e) => panic!("섹션 XML 파싱 실패: {e}"),
+            _ => {}
+        }
+    }
+    assert!(
+        mark_bound,
+        "vnd:mark가 urn:example에 바인드돼야 한다: {section}"
+    );
 }

--- a/crates/hwpx/tests/roundtrip_preserve.rs
+++ b/crates/hwpx/tests/roundtrip_preserve.rs
@@ -24,8 +24,7 @@ const MANIFEST_XML: &[u8] =
 const LAYOUT_XML: &[u8] =
     br#"<?xml version="1.0" encoding="UTF-8"?><layout>DISTINCTIVE-DOCOPTIONS-MARKER</layout>"#;
 
-const HEADER_XML: &str =
-    r##"<?xml version="1.0" encoding="UTF-8"?><hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head"/>"##;
+const HEADER_XML: &str = r##"<?xml version="1.0" encoding="UTF-8"?><hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head"/>"##;
 
 /// run-level 미해석 개체 2종(hp:container + 하위 subList 텍스트, hp:chartex)과
 /// image1을 참조하는 hp:pic을 담은 본문.

--- a/crates/hwpx/tests/roundtrip_preserve.rs
+++ b/crates/hwpx/tests/roundtrip_preserve.rs
@@ -247,3 +247,126 @@ fn 원문_보유_개체는_방출하고_없으면_손실이벤트를_낸다() {
         hwp_model::PreservationCode::OpaqueControlUnrepresentable
     );
 }
+
+// ── #90 PR3 후속: 전체 재작성 경로의 binaryItemIDRef 매니페스트 시드 ──────────
+
+const PNG_ONE: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 1, 0, 0, 1];
+const PNG_TWO: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 2, 0, 0, 2];
+const PNG_THREE: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 3, 0, 0, 3];
+const PNG_FOUR: &[u8] = &[0x89, b'P', b'N', b'G', 0x0D, 0x0A, 0x1A, 0x0A, 4, 0, 0, 4];
+
+/// OPF manifest id ≠ 파일명 stem·참조 등장 순서 ≠ 파일명 순서인 합성 HWPX.
+/// - image2.png를 참조하는 typed pic이 image1.png 참조 pic보다 먼저 등장
+/// - 원문 캡처 hp:container 안의 pic이 id "chartA"(stem 불일치)를 참조
+/// - 미참조 image3.png (id "unused1", stem 불일치)
+fn build_manifest_seed_fixture(path: &std::path::Path) {
+    let file = std::fs::File::create(path).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    let stored = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    let deflated = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("mimetype", stored).unwrap();
+    zip.write_all(b"application/hwp+zip").unwrap();
+    zip.start_file("version.xml", deflated).unwrap();
+    zip.write_all(br#"<version major="1" minor="4" micro="0" buildNumber="0"/>"#)
+        .unwrap();
+    zip.start_file("Contents/content.hpf", deflated).unwrap();
+    zip.write_all(
+        r##"<?xml version="1.0"?><opf:package xmlns:opf="http://www.idpf.org/2007/opf/"><opf:metadata><opf:title>시드 문서</opf:title></opf:metadata><opf:manifest><opf:item id="header" href="Contents/header.xml" media-type="application/xml"/><opf:item id="section0" href="Contents/section0.xml" media-type="application/xml"/><opf:item id="settings" href="settings.xml" media-type="application/xml"/><opf:item id="image1" href="BinData/image1.png" media-type="image/png" isEmbeded="1"/><opf:item id="image2" href="BinData/image2.png" media-type="image/png" isEmbeded="1"/><opf:item id="unused1" href="BinData/image3.png" media-type="image/png" isEmbeded="1"/><opf:item id="chartA" href="BinData/image4.png" media-type="image/png" isEmbeded="1"/></opf:manifest><opf:spine><opf:itemref idref="header" linear="yes"/><opf:itemref idref="section0" linear="yes"/></opf:spine></opf:package>"##
+            .as_bytes(),
+    )
+    .unwrap();
+    zip.start_file("Contents/header.xml", deflated).unwrap();
+    zip.write_all(HEADER_XML.as_bytes()).unwrap();
+    zip.start_file("Contents/section0.xml", deflated).unwrap();
+    zip.write_all(
+        r##"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section" xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:t>본문</hp:t><hp:pic id="5" zOrder="0"><hp:sz width="100" height="100"/><hp:pos treatAsChar="1" vertOffset="0" horzOffset="0"/><hp:img binaryItemIDRef="image2" bright="0" contrast="0"/></hp:pic><hp:pic id="6" zOrder="1"><hp:sz width="100" height="100"/><hp:pos treatAsChar="1" vertOffset="0" horzOffset="0"/><hp:img binaryItemIDRef="image1" bright="0" contrast="0"/></hp:pic><hp:container id="77" zOrder="3"><hp:sz width="1000" height="500"/><hp:subList><hp:p id="0" paraPrIDRef="0" styleIDRef="0" pageBreak="0" columnBreak="0" merged="0"><hp:run charPrIDRef="0"><hp:pic id="7" zOrder="0"><hp:sz width="50" height="50"/><hp:pos treatAsChar="1" vertOffset="0" horzOffset="0"/><hp:img binaryItemIDRef="chartA" bright="0" contrast="0"/></hp:pic></hp:run></hp:p></hp:subList></hp:container></hp:run></hp:p></hs:sec>"##
+            .as_bytes(),
+    )
+    .unwrap();
+    zip.start_file("BinData/image1.png", deflated).unwrap();
+    zip.write_all(PNG_ONE).unwrap();
+    zip.start_file("BinData/image2.png", deflated).unwrap();
+    zip.write_all(PNG_TWO).unwrap();
+    zip.start_file("BinData/image3.png", deflated).unwrap();
+    zip.write_all(PNG_THREE).unwrap();
+    zip.start_file("BinData/image4.png", deflated).unwrap();
+    zip.write_all(PNG_FOUR).unwrap();
+    zip.finish().unwrap();
+}
+
+/// content.hpf 매니페스트에서 BinData 항목의 (id → href) 매핑을 뽑는다.
+fn manifest_bin_map(xml: &str) -> std::collections::BTreeMap<String, String> {
+    hwpx::read::parse_bin_manifest(xml).into_iter().collect()
+}
+
+/// 전체 재작성(hwpx→IR→hwpx) 후에도 모든 binaryItemIDRef가 원본과 같은 바이트를
+/// 가리켜야 한다 — 원문 캡처 컨테이너 안의 참조·id≠stem 매니페스트 항목까지.
+#[test]
+fn 전체_재작성은_원본_manifest_id로_binary참조를_보존한다() {
+    let dir = std::env::temp_dir().join("hwpx-roundtrip-manifest-seed");
+    std::fs::create_dir_all(&dir).unwrap();
+    let src = dir.join("src.hwpx");
+    let out = dir.join("out.hwpx");
+    build_manifest_seed_fixture(&src);
+    let source_entries = read_entries(&src);
+
+    let read = hwpx::read_document(&src).unwrap();
+    let report = hwpx::write_document_with_report(&read.document, &out).unwrap();
+    assert!(
+        report.preservation.is_lossless(),
+        "preservation events: {:?}",
+        report.preservation.events
+    );
+
+    let out_entries = read_entries(&out);
+    let bytes_of = |entries: &[(String, Vec<u8>)], name: &str| -> Vec<u8> {
+        entries
+            .iter()
+            .find(|(n, _)| n == name)
+            .unwrap_or_else(|| panic!("엔트리 없음: {name}"))
+            .1
+            .clone()
+    };
+    let src_manifest = manifest_bin_map(
+        &String::from_utf8(bytes_of(&source_entries, "Contents/content.hpf")).unwrap(),
+    );
+    let out_manifest = manifest_bin_map(
+        &String::from_utf8(bytes_of(&out_entries, "Contents/content.hpf")).unwrap(),
+    );
+
+    // 1. 매니페스트의 BinData 항목 수 보존(미참조 항목 포함).
+    assert_eq!(out_manifest.len(), src_manifest.len(), "매니페스트 항목 수");
+
+    // 2. 출력의 모든 binaryItemIDRef(원문 컨테이너 안 포함)가 출력 매니페스트에서
+    //    원본과 같은 바이트로 해석돼야 한다.
+    let section = String::from_utf8(bytes_of(&out_entries, "Contents/section0.xml")).unwrap();
+    let refs: Vec<&str> = section
+        .match_indices("binaryItemIDRef=\"")
+        .map(|(i, _)| {
+            let rest = &section[i + "binaryItemIDRef=\"".len()..];
+            &rest[..rest.find('"').unwrap()]
+        })
+        .collect();
+    assert_eq!(refs.len(), 3, "pic 2 + 컨테이너 안 pic 1: {section}");
+    for r in refs {
+        let out_href = out_manifest
+            .get(r)
+            .unwrap_or_else(|| panic!("출력 매니페스트에 {r} 없음(댕글링 참조)"));
+        let src_href = src_manifest
+            .get(r)
+            .unwrap_or_else(|| panic!("원본 매니페스트에 {r} 없음"));
+        assert_eq!(
+            bytes_of(&out_entries, out_href),
+            bytes_of(&source_entries, src_href),
+            "{r} 참조 바이트가 원본과 다르다"
+        );
+    }
+
+    // 3. 원본 BinData 엔트리 집합·바이트 보존(미참조 image3.png 포함).
+    for (name, bytes) in &source_entries {
+        if name.starts_with("BinData/") {
+            assert_eq!(&bytes_of(&out_entries, name), bytes, "{name} 바이트 보존");
+        }
+    }
+}

--- a/crates/hwpx/tests/write.rs
+++ b/crates/hwpx/tests/write.rs
@@ -60,6 +60,7 @@ fn typed_report_records_unsupported_control_without_warning_parsing() {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         }),
     );
 
@@ -155,6 +156,7 @@ fn typed_report_records_both_gso_drop_paths() {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         })
     };
 
@@ -541,6 +543,7 @@ fn caption_round_trip() {
             last_width: 3000,
             paragraphs: vec![caption_para("Shape 1")],
         }),
+        hwpx_raw_xml: None,
     };
     let para = &mut doc.sections[0].paragraphs[0];
     para.chars.push(hwp_model::HwpChar::ExtCtrl {
@@ -844,6 +847,7 @@ fn 머리말_적용쪽_hwpx_왕복() {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         };
         // 머리말 컨트롤을 문단에 ExtCtrl(코드 16)로 부착.
         let para = &mut doc.sections[0].paragraphs[0];
@@ -1038,6 +1042,7 @@ fn 확장필드_hwp5출신_hwpx_방출() {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         }));
     }
     para.header.ctrl_mask = 0;
@@ -1792,6 +1797,7 @@ fn eqed_control(equation: hwp_model::Equation) -> hwp_model::GenericControl {
         equation: Some(equation),
         column_def: None,
         caption: None,
+        hwpx_raw_xml: None,
     }
 }
 
@@ -1837,6 +1843,7 @@ fn 수식_hwpx_왕복() {
                 equation: Some(eq),
                 column_def: None,
                 caption: None,
+                hwpx_raw_xml: None,
             },
         );
     }
@@ -1900,6 +1907,7 @@ fn 글상자_hwp5출신_hwpx_왕복() {
         equation: None,
         column_def: None,
         caption: None,
+        hwpx_raw_xml: None,
     };
     attach_gso(&mut doc.sections[0].paragraphs[1], gso);
 
@@ -2001,6 +2009,7 @@ fn 도형_shapegeom_hwpx_왕복() {
         equation: None,
         column_def: None,
         caption: None,
+        hwpx_raw_xml: None,
     };
     attach_gso(&mut doc.sections[0].paragraphs[1], gso);
 
@@ -2107,6 +2116,7 @@ fn 장식_도형_hwp5출신_hwpx_왕복() {
         equation: None,
         column_def: None,
         caption: None,
+        hwpx_raw_xml: None,
     };
     attach_gso(&mut doc.sections[0].paragraphs[1], gso);
 
@@ -2557,6 +2567,7 @@ fn 쪽_컨트롤_hwpx_페이로드_왕복() {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         }));
     }
     para.header.ctrl_mask = 0;
@@ -2743,6 +2754,7 @@ fn 각주_미주_왕복() {
                         equation: None,
                         column_def: None,
                         caption: None,
+                        hwpx_raw_xml: None,
                     })],
                     ..Paragraph::default()
                 }],
@@ -2753,6 +2765,7 @@ fn 각주_미주_왕복() {
             equation: None,
             column_def: None,
             caption: None,
+            hwpx_raw_xml: None,
         })
     };
     let anchor = |idx: u32, id: &[u8; 4]| HwpChar::ExtCtrl {

--- a/docs/design/04-hwpx-owpml.ko.md
+++ b/docs/design/04-hwpx-owpml.ko.md
@@ -38,6 +38,8 @@ HWPX는 OPC(Open Packaging Conventions) 규약의 ZIP 아카이브다. 항목·�
 - `mimetype`은 ZIP의 **첫 로컬 헤더**여야 하고 `CompressionMethod::Stored`여야 한다. 파일 앞부분에 무압축 매직이 오도록 하는 OPC 규약. 위반 시 한글이 손상 파일로 판단.
 - `version.xml`의 `major="5" minor="1" micro="1" buildNumber="0" xmlVersion="1.5"`는 **고정 상수**(포맷 호환). `application`/`appVersion`만 작성 프로그램(hwp-cli, `CARGO_PKG_VERSION`) 값.
 
+**기존 문서 되쓰기(2026-08-14, #90).** 위 표는 *신규* 쓰기의 모습이다. 입력이 기존 HWPX이면 writer가 재생성하지 않는 엔트리를 버리지 않는다: 원본 META-INF override, DocOptions, `Contents/memoExtended.xml`, 추가 Preview 등 미지 엔트리는 `Document.hwpx_extra_entries`에 실려 원본 바이트·순서 그대로 재방출되고, 본문이 더는 참조하지 않는 BinData 엔트리도 드롭 대신 통과시켜 재생성된 content.hpf manifest에 등재한다. 같은 포맷 편집은 전체 되쓰기 경로조차 타지 않는다: `hwpx::patch::rewrite_document_staged`가 변경된 콘텐츠 엔트리(header.xml / content.hpf / section*.xml — before/after IR 비교로 판정)만 재직렬화하고 나머지 ZIP 엔트리는 바이트 그대로 raw-copy한다.
+
 ### 1.2 읽기 경로 (`package.rs`, `read/mod.rs`)
 
 `HwpxPackage::open(path)`:
@@ -61,7 +63,7 @@ n.trim_start_matches("Contents/section").trim_end_matches(".xml").parse::<u32>()
 
 `templates::content_hpf(section_count, bin_items, meta)`가 합성. `<opf:package>` 안에:
 - `<opf:metadata>`: `<opf:title>`, `<opf:language>ko`, `<dc:creator>`, `<dc:subject>`, `<opf:meta name="keywords" content="…"/>`, 그리고 앱 표식 `<opf:meta name="creator" content="text">hwp-cli</opf:meta>`.
-- `<opf:manifest>`: `header` + `section{i}` + `settings` + 바이너리 항목(`isEmbeded="1"`).
+- `<opf:manifest>`: `header` + `section{i}` + `settings` + 바이너리 항목(`isEmbeded="1"`). 되쓰기에서는 통과시킨 미참조 BinData 엔트리도 여기 등재한다(§1.1).
 - `<opf:spine>`: `header`·`section{i}`를 `<opf:itemref linear="yes"/>`로.
 
 바이너리 항목 id/href/mime는 `BinCollector`가 채운다. `read/mod.rs::parse_content_meta`는 이 파일의 `title`/`creator`/`subject` local-name과 `meta[name=keywords]`만 읽는다(`name="creator"`인 앱 표식은 local-name이 `meta`라 무시).
@@ -248,7 +250,7 @@ hwpx 표/도형은 `<hp:pos>`/`<hp:sz>`/`<hp:outMargin>`/`zOrder`를 읽어 `Gso
 
 ## 5. hp:ctrl 자식 컨트롤 (parse_ctrl ↔ writer arms)
 
-`hp:ctrl` 안의 컨트롤은 hwp5 ctrl_id + 컨트롤 문자 코드로 매핑되고, 페이로드를 여기서 합성한다. writer는 빈 페이로드 GenericControl을 드롭한다.
+`hp:ctrl` 안의 컨트롤은 hwp5 ctrl_id + 컨트롤 문자 코드로 매핑되고, 페이로드를 여기서 합성한다. writer는 빈 페이로드 GenericControl을 드롭한다 — 단 2026-08-14(#90)부터 원문 XML을 보존한 GenericControl(`hwpx_raw_xml`, 예: HWPX 입력에서 읽은 `hp:container`)은 그대로 재방출하므로, 페이로드도 보존 XML도 없을 때만 드롭이 발화한다.
 
 | OWPML | ctrl_id | 코드 | 페이로드 | 빌더/역 |
 |-------|---------|------|----------|---------|
@@ -340,7 +342,7 @@ hwpx 표/도형은 `<hp:pos>`/`<hp:sz>`/`<hp:outMargin>`/`zOrder`를 읽어 `Gso
 | gso 공통 attr | `<hp:pos>` 개별 속성 | attr(u32) 비트 합성 | 인라인/부동 보존 |
 | z-order | hwpx ShapeGeom엔 없음 | 순서 인덱스 or gso*Z_SCALE+i | 겹침 순서 |
 
-**미지원 컨트롤**은 `DROP:` 경고로 집계하고 드롭한다(글상자 일부·해석 실패 gso 등). 경고는 `Vec<String>`로 상위(`read_document`/`write_document`)까지 전파.
+**미지원 컨트롤**은 typed 보존 이벤트(`hwp-preservation-report-v1` ledger — 레거시 `DROP: <code>` 경고 형태로도 표면화)로 집계하고 드롭한다(글상자 일부·해석 실패 gso 등). 단 같은 포맷 HWPX 되쓰기의 run 수준 컨트롤은 예외: 원문 XML을 `GenericControl.hwpx_raw_xml`에 보존해 재방출한다(§5). 경고는 `Vec<String>`로 상위(`read_document`/`write_document`)까지 전파.
 
 ---
 

--- a/docs/design/04-hwpx-owpml.md
+++ b/docs/design/04-hwpx-owpml.md
@@ -49,6 +49,16 @@ The order produced by `write/mod.rs::write_document_with` (leftmost first):
   constants** (format compatibility). Only `application` and `appVersion` carry the authoring program
   (hwp-cli, `CARGO_PKG_VERSION`).
 
+**Rewriting an existing document (2026-08-14, #90).** The table above is the shape of a *fresh*
+write. When the input is an existing HWPX, entries the writer does not regenerate are not dropped:
+the original META-INF overrides, DocOptions, `Contents/memoExtended.xml`, extra previews and any
+other unrecognized entry ride `Document.hwpx_extra_entries` and are re-emitted with their original
+bytes and order, and BinData entries the body no longer references pass through instead of being
+dropped, listed in the regenerated content.hpf manifest. A same-format edit does not even take the
+full-rewrite path: `hwpx::patch::rewrite_document_staged` reserializes only the dirty content
+entries (header.xml / content.hpf / section*.xml, decided by a before/after IR comparison) and
+raw-copies every other ZIP entry byte-for-byte.
+
 ### 1.2 The read path (`package.rs`, `read/mod.rs`)
 
 `HwpxPackage::open(path)`:
@@ -82,7 +92,8 @@ Entries that fail to parse sort last as `u32::MAX`.
 - `<opf:metadata>`: `<opf:title>`, `<opf:language>ko`, `<dc:creator>`, `<dc:subject>`,
   `<opf:meta name="keywords" content="..."/>`, plus the application marker
   `<opf:meta name="creator" content="text">hwp-cli</opf:meta>`.
-- `<opf:manifest>`: `header`, `section{i}`, `settings` and the binary items (`isEmbeded="1"`).
+- `<opf:manifest>`: `header`, `section{i}`, `settings` and the binary items (`isEmbeded="1"`); on a
+  rewrite, passed-through unreferenced BinData entries are listed here too (§1.1).
 - `<opf:spine>`: `header` and `section{i}` as `<opf:itemref linear="yes"/>`.
 
 `BinCollector` fills the binary items' id, href and mime. `read/mod.rs::parse_content_meta` reads only
@@ -319,7 +330,10 @@ increasing by shape index (`i`).
 ## 5. Controls under hp:ctrl (parse_ctrl ↔ the writer arms)
 
 A control inside `hp:ctrl` maps to an hwp5 ctrl_id plus a control character code, and its payload is
-synthesized here. The writer drops a GenericControl with an empty payload.
+synthesized here. The writer drops a GenericControl with an empty payload — but since 2026-08-14
+(#90) a GenericControl that retains its source XML (`hwpx_raw_xml`, e.g. an `hp:container` read from
+an HWPX input) is re-emitted verbatim, so the drop fires only when neither a payload nor retained
+raw XML exists.
 
 | OWPML | ctrl_id | Code | Payload | Builder / inverse |
 |-------|---------|------|----------|---------|
@@ -456,8 +470,11 @@ inside a shape is always preserved, as in §3.5.
 | gso common attr | the individual `<hp:pos>` attributes | the attr(u32) bits composed | preserves inline versus floating |
 | z-order | absent from hwpx ShapeGeom | the order index, or gso*Z_SCALE+i | overlap order |
 
-**Unsupported controls** are dropped with a `DROP:` warning (some text boxes, gso that failed to
-parse and so on). Warnings propagate as a `Vec<String>` up to `read_document` and `write_document`.
+**Unsupported controls** are dropped with a typed preservation event (the
+`hwp-preservation-report-v1` ledger, still surfaced in the legacy `DROP: <code>` warning form) —
+some text boxes, gso that failed to parse and so on. Same-format HWPX rewrites are exempt for
+run-level controls: their verbatim XML is carried in `GenericControl.hwpx_raw_xml` and re-emitted
+(§5). Warnings propagate as a `Vec<String>` up to `read_document` and `write_document`.
 
 ---
 

--- a/docs/design/07-hangul-compat-rules.ko.md
+++ b/docs/design/07-hangul-compat-rules.ko.md
@@ -39,7 +39,9 @@ code, resource class, disposition은 닫힌 enum이며 개수만 집계한다. �
 - 원본 없는 HWP/HWPX 작성은 typed loss event가 하나라도 있으면 atomic publication 전에 거부한다.
 - 같은 포맷 변환·편집은 HWP stream/storage 또는 HWPX entry inventory도 대조한다. 예상하지 않은
   제거 또는 opaque non-target 항목 변경은 `--strict` 없이도 발행을 차단한다.
-- 포맷 간 `--strict` 변환은 asset, control, relationship, metadata의 의미 손실을 거부한다.
+- 포맷 간 `--strict` 변환은 asset, control, relationship, metadata의 의미 손실과 IR이 옮길 수
+  없는 패키지/컨테이너 수준 자산(HWPX 잉여 엔트리 → HWP, HWP XMLTemplate/DocHistory 슬롯 →
+  HWPX)을 거부한다. `--loss-report <PATH>`는 성공 시에도 ledger를 JSON으로 기록한다.
   non-strict 변환은 typed ledger를 명시적으로 반환하는 경우에만 발행할 수 있다.
 
 이 게이트는 알려진 silent loss를 막지만 한컴 호환성을 인증하지 않는다. 현재 HWP full rewriter에는

--- a/docs/design/07-hangul-compat-rules.md
+++ b/docs/design/07-hangul-compat-rules.md
@@ -49,8 +49,10 @@ container paths, payload fragments and hashes are never part of the public repor
 - Same-format conversion and editing additionally inventory HWP streams/storages or HWPX entries.
   Any unexpected removal or change to an opaque non-target item blocks publication even without
   `--strict`.
-- Cross-format `--strict` rejects semantic asset, control, relationship or metadata loss. Non-strict
-  conversion may publish only while returning the explicit typed ledger.
+- Cross-format `--strict` rejects semantic asset, control, relationship or metadata loss, and
+  package/container-level assets the IR cannot carry (HWPX extra entries → HWP; HWP
+  XMLTemplate/DocHistory slots → HWPX). `--loss-report <PATH>` writes the ledger as JSON even on
+  success. Non-strict conversion may publish only while returning the explicit typed ledger.
 
 This gate prevents known silent loss; it does not certify Hancom compatibility. The current full HWP
 rewriter still requires the source-preserving repair and independent Hancom-open checks tracked by

--- a/docs/design/12-feature-gaps.ko.md
+++ b/docs/design/12-feature-gaps.ko.md
@@ -41,8 +41,8 @@
 - hwp5의 `OpaqueRecord`(서브트리째 보존, [10](10-hwp5-structure-map.ko.md) §0 상태표)는
   `hwp5→hwp5` 왕복에서 **바이트를 잃지 않는다** → 레코드 수준에서는 그 경로의 갭이 아니다.
   2026-08-14부터 네이티브 HWP 되쓰기는 불변 source CFB를 복사한 뒤 계획된 stream만 교체하여
-  부속 stream, storage, 미변경 binary payload까지 보존한다. package-surgical HWPX 편집은 이슈
-  #90에 남아 있다.
+  부속 stream, storage, 미변경 binary payload까지 보존한다. package-surgical HWPX 편집도 같은 날
+  착수되어 해소 이력(§0.5)의 세 번째 #90 항목을 참조한다.
 - 같은 레코드를 `hwp5→hwpx`로 **합성**하려면 의미를 해석해 OWPML로 다시 써야 하는데, 그 지식이
   없으므로 **드롭**된다 → 합성 경로에선 갭.
 - 렌더러가 그 개체(차트·OLE 등)를 그리려면 페이로드 해석이 필요한데 안 되므로 **빈자리** →
@@ -80,15 +80,37 @@
   `hwp-preservation-report-v1` ledger를 추가했다. 원본 없는 작성과 같은 포맷 write는 writer omission
   또는 예상하지 않은 container/package loss가 있으면 atomic하게 실패하고, 포맷 간 strict 변환은
   semantic asset, control, relationship, metadata도 비교한다. 이는 silent publication을 해소한 것이며
-  writer 자체의 갭을 해소한 것은 아니며, 다음 해소 이력에 HWP repair를 별도로 기록한다.
-  package-surgical HWPX 편집은 이슈 #90에 남아 있다.
+  writer 자체의 갭을 해소한 것은 아니며, 다음 해소 이력에 HWP repair와 HWPX repair를 차례로
+  기록한다.
 
 - **2026-08-14 (이슈 #90 source-preserving HWP writer)**: 같은 포맷 HWP `convert`, `edit`, IR
   `fill`이 불변 input snapshot을 기준으로 쓴다. 무수정은 exact file copy이며, 편집은 stream
   mutation plan을 만들고 미변경 CFB entry와 BinData를 바이트 동일하게 유지한다. BodyText는
   미변경 subtree를 보존하고 변경·삽입 문단에만 line layout을 합성한다. 비공개 복합 문서로
   no-op, metadata, text, paragraph, table-cell, image를 검증했으며 한글 손상 경고 없이 모두
-  통과했다. #90의 잔여 작업에는 package-surgical HWPX 편집이 포함된다.
+  통과했다. package-surgical HWPX 편집은 다음 항목에서 해소한다.
+
+- **2026-08-14 (이슈 #90 package-surgical HWPX 편집 + 포맷 간 손실 감지)**: hwpx reader가
+  IR이 모델링하지 못하는 run 수준 컨트롤(예: `hp:container`)의 원문 XML을
+  `GenericControl.hwpx_raw_xml`에 보존하고 writer가 그대로 재방출해, 전체 되쓰기에서도
+  드롭되지 않는다. writer가 재생성하지 않는 패키지 엔트리(원본 META-INF override,
+  DocOptions, `Contents/memoExtended.xml`, 추가 Preview)는 `Document.hwpx_extra_entries`로
+  옮겨 보존하고, 본문이 참조하지 않는 BinData 엔트리도 드롭 대신 통과시켜 재생성된
+  content.hpf manifest에 등재한다. 모든 같은 포맷 HWPX `edit`은
+  `hwpx::patch::rewrite_document_staged`를 거쳐, 변경된 콘텐츠 엔트리(header.xml /
+  content.hpf / section*.xml — before/after IR 비교로 판정)만 IR에서 재직렬화하고 나머지
+  ZIP 엔트리는 바이트 그대로 raw-copy한다. 삽입 이미지는 원본 OPF manifest id를 보존한 채
+  새 BinData 엔트리로 추가된다. 포맷 간 변환은 타깃 포맷이 표현 못 하는 패키지 자산
+  (HWP→HWPX 방향의 hwp5 XMLTemplate/DocHistory 슬롯, HWPX→HWP 방향의 hwpx 잉여 엔트리)을
+  typed `hwp-preservation-report-v1` 이벤트로 집계해 `--strict`는 이런 손실에서 fail-closed로
+  실패하고, `hwp convert --loss-report <PATH>`는 어느 쪽이든 JSON verdict를 기록한다.
+  과정에서 선재 writer 결함 2건(인라인 `hp:pic` zOrder, 테두리 없는 lineShape 색상)도
+  고쳤다. 비공개 복합 문서 검증(패키지 36엔트리, BinData 24 — WMF 7 포함, `hp:container`
+  5): metadata·text·paragraph·table-cell·image HWPX 편집 모두 엔트리 집합 동일, opaque
+  엔트리 전량 바이트 동일(미디어 24→24, 이미지 삽입 후 25; container 5→5), `hwp validate`
+  클린, non-strict hwp→hwpx는 미디어 24개 전량 보존(종전 9), strict 변환은 양방향 모두
+  fail-closed, 8개 결과물 모두 한글에서 손상/복구 대화상자 없이 열림. #90 잔여(PR 4+):
+  표 삽입(#77/#78), WMF 벡터, pagination/font 게이트, 인증.
 
 - **2026-07-15**: GA-5(버전 게이트), GE-α1~α5·α7(글자효과·밑줄모양·번호형식 hwpx 왕복),
   GE-β4(요약정보 필드), GH-1·GH-2(md/html 링크·이미지), GL-1(추출 옵션 CLI 노출) —
@@ -189,9 +211,10 @@
 
 - **hwp5** = `OpaqueRecord`로 서브트리째 보존 → `hwp5→hwp5` 왕복 무손실([10](10-hwp5-structure-map.ko.md) §8 Opaque 목록).
 - **hwpx read** = `GenericControl` fallback → 개체 고유 속성은 버리고 **자식 subList 텍스트만** IR에 남김([11](11-hwpx-structure-map.ko.md) §3.3).
-- **hwpx write** = 그 Generic이 알려진 ctrl_id도 gso_shapes도 아니면 최종 `DROP`(`hwpx/src/write/section.rs:364`) → **텍스트까지 소실**.
+- **hwpx write** = 그 Generic이 알려진 ctrl_id도 gso_shapes도 아니고 보존된 원문 XML도 없으면 최종 `DROP` → **텍스트까지 소실**. 단 같은 포맷 경로에서는 2026-08-14(#90)부터 reader가 컨트롤 원문 XML(`GenericControl.hwpx_raw_xml`)을 보존하고 writer가 그대로 재방출하므로 이 DROP은 발화하지 않는다.
 
-따라서 같은 개체가 "hwp5 왕복=무손실 / hwpx 왕복=소실 / 합성=소실 / 렌더=빈자리"로 경로마다 다르다.
+따라서 같은 개체가 "hwp5 왕복=무손실 / hwpx 왕복=소실 / 합성=소실 / 렌더=빈자리"로 경로마다 다르다
+(GB-6은 2026-08-14, #90부터 hwpx 왕복 예외).
 
 | ID | 개체(hwp5 태그 / hwpx 요소) | 근거 코드 | 스펙/포맷 근거 | 현 동작 | 영향 경로 | 난이도 |
 |---|---|---|---|---|---|---|
@@ -200,7 +223,7 @@
 | GB-3 | **동영상**(`VIDEO_DATA` 0x62 / `hp:video`) | hwp5 `body_text.rs:617`, hwpx `write/section.rs:364` | §4.3.9.8 | hwp5=Opaque 보존 / hwpx=드롭 | 왕복(hwpx만)·합성·렌더 | L |
 | GB-4 | **글맵시**(`SHAPE_COMPONENT_TEXTART` 0x5A / `hp:textart`) | hwp5 `body_text.rs:617`, hwpx `read/section.rs:191`(fallback 텍스트)→`write/section.rs:364`(DROP) | §4.3.9(글맵시) | hwp5=Opaque 보존 / hwpx=텍스트만 fallback 후 드롭 | 왕복(hwpx만)·합성·렌더 | M |
 | GB-5 | **양식 개체**(`FORM_OBJECT` 0x5B / `hp:formObject`) | hwp5 `body_text.rs:617`, hwpx `read/section.rs:191`→`:364` | §4.3.9(양식) | hwp5=Opaque 보존 / hwpx=텍스트만 후 드롭 | 왕복(hwpx만)·합성·렌더 | M |
-| GB-6 | **묶음 개체**(`SHAPE_COMPONENT_CONTAINER` 0x56 / `hp:container`) — ★**비대칭**: hwp5는 raw보존이라 **렌더까지 됨**(자식 재귀), hwpx는 fallback 후 DROP | hwp5 렌더 `hwp-render/src/shape_draw.rs`([10](10-hwp5-structure-map.ko.md) §8 raw보존), hwpx `read/section.rs:191`→`write/section.rs:364` | §4.3.9.7 | hwp5=raw보존(렌더 O) / hwpx=드롭 | 왕복(hwpx만)·합성 | M |
+| GB-6 | **묶음 개체**(`SHAPE_COMPONENT_CONTAINER` 0x56 / `hp:container`) — ★**비대칭**: hwp5는 raw보존이라 **렌더까지 됨**(자식 재귀), hwpx는 해석 없이 fallback — 단 2026-08-14(#90)부터 같은 포맷 되쓰기에서 원문 XML을 보존·재방출해 왕복은 무손실, 손실은 합성·렌더에만 남음 | hwp5 렌더 `hwp-render/src/shape_draw.rs`([10](10-hwp5-structure-map.ko.md) §8 raw보존), hwpx `read/section.rs`(GenericControl 원문 XML 보존) | §4.3.9.7 | hwp5=raw보존(렌더 O) / hwpx=원문 XML 보존(왕복 무손실, 렌더 X) | 합성·렌더 | M |
 | GB-7 | **메모**(`MEMO_LIST` 0x5D 본문 + `MEMO_SHAPE` 0x5C DocInfo / hwpx `hp:` 미방출) | hwp5 `body_text.rs:617`·`doc_info.rs:148`(Opaque), hwpx 네임스페이스 선언만([11](11-hwpx-structure-map.ko.md) §2) | §4.3(메모)·§4.2 표13 | hwp5=Opaque 보존 / hwpx=미구현 | 왕복(hwpx만)·합성·렌더 | M |
 | GB-8 | **변경추적·편집이력**(`TRACKCHANGE` 0x20·`TRACK_CHANGE` 0x60·`TRACK_CHANGE_AUTHOR` 0x61·`PARA_RANGE_TAG` 0x46 / hwpx `hhs:` history — PARA_RANGE_TAG 용도는 스펙상 **형광펜·교정부호 등 영역 마킹**도 포함(§4.3.5), 변경추적만이 아님) | hwp5 `doc_info.rs:148`·`body_text.rs:73`(Opaque), hwpx 미구현([11](11-hwpx-structure-map.ko.md) §5(c)) | §4.2 표13·§4.3.5 | hwp5=Opaque 보존 / hwpx=미구현 | 왕복(hwpx만)·합성 | L |
 | GB-9 | **문서 임의·배포 데이터**(`DOC_DATA` 0x1B·`DISTRIBUTE_DOC_DATA` 0x1C·`COMPATIBLE_DOCUMENT` 0x1E·`LAYOUT_COMPATIBILITY` 0x1F) | hwp5 `doc_info.rs:57`(Opaque). 단 writer는 COMPATIBLE/LAYOUT을 **별도 합성**([07](07-hangul-compat-rules.ko.md) A4) | §4.2.12~4.2.15 | hwp5=Opaque 보존(+합성 처리 有) / hwpx=미구현 | 합성(부분 해소) | L |
@@ -213,7 +236,8 @@
 
 **GB 교훈:** hwp5→hwp5 왕복만 보면 GB 전체가 "무손실"이라 갭이 안 보인다(그게 §0.3의 함정). 결함은
 **hwpx 왕복·포맷 간 합성·렌더**에서만 터진다. GB-6(묶음)은 특히 미묘하다 — hwp5는 렌더까지 되는데
-hwpx로만 가면 사라진다. 이 계열의 복원은 대부분 **정품 파일에 그 개체를 담아 페이로드를 역설계**
+hwpx에서는 해석이 안 된다. 2026-08-14(#90)부터는 원문 XML이 같은 포맷 되쓰기에서 살아남아 손실은
+합성·렌더로 한정된다. 이 계열의 복원은 대부분 **정품 파일에 그 개체를 담아 페이로드를 역설계**
 (M/L)해야 하므로 정답지 확보가 선행 조건이다([00](00-overview.ko.md) §4).
 ★예외가 **GB-1의 hwpx 경로**다: HWPX에서 차트는 OLE가 아니라 **OOXML DrawingML `chartSpace`
 XML 파트**(`Chart/chartN.xml` + manifest 등재 + `hp:chart chartIDRef`)여서, 기존 hwpx 쓰기

--- a/docs/design/12-feature-gaps.ko.md
+++ b/docs/design/12-feature-gaps.ko.md
@@ -110,7 +110,10 @@
   엔트리 전량 바이트 동일(미디어 24→24, 이미지 삽입 후 25; container 5→5), `hwp validate`
   클린, non-strict hwp→hwpx는 미디어 24개 전량 보존(종전 9), strict 변환은 양방향 모두
   fail-closed, 8개 결과물 모두 한글에서 손상/복구 대화상자 없이 열림. #90 잔여(PR 4+):
-  표 삽입(#77/#78), WMF 벡터, pagination/font 게이트, 인증.
+  표 삽입(#77/#78), WMF 벡터, pagination/font 게이트, 인증. hwpx→hwp 변환은
+  settings.xml/version.xml/preview 슬롯 손실을 아직 typed 이벤트로 집계하지 않는다.
+  content.hpf 재생성은 모델링된 manifest 항목/메타데이터만 유지하므로, 비모델 manifest
+  항목은 고아 엔트리로 남는다(raw-copy는 되지만 목록에는 미등재).
 
 - **2026-07-15**: GA-5(버전 게이트), GE-α1~α5·α7(글자효과·밑줄모양·번호형식 hwpx 왕복),
   GE-β4(요약정보 필드), GH-1·GH-2(md/html 링크·이미지), GL-1(추출 옵션 CLI 노출) —

--- a/docs/design/12-feature-gaps.md
+++ b/docs/design/12-feature-gaps.md
@@ -47,7 +47,8 @@ The same record can be a gap or not **depending on which path you look from**. T
   [10](10-hwp5-structure-map.md) §0) **loses no bytes** in an `hwp5 → hwp5` round-trip, so it is
   not a record-level gap on that path. Since 2026-08-14, native HWP rewrites copy the immutable source
   CFB and patch only planned streams, preserving ancillary streams, storages and untouched binary
-  payloads. Package-surgical HWPX editing remains tracked by issue #90.
+  payloads. Package-surgical HWPX editing landed the same day; see the third #90 entry in
+  the resolution history (§0.5).
 - To **synthesize** that same record as `hwp5 → hwpx`, its meaning would have to be interpreted and
   rewritten as OWPML; that knowledge is missing, so it is **dropped**, making it a gap on the
   synthesis path.
@@ -90,15 +91,39 @@ is itself knowledge).
   content-free `hwp-preservation-report-v1` ledger. Source-free authoring and same-format writes now
   fail atomically on writer omissions or unexpected container/package loss; cross-format strict
   conversion also compares semantic assets, controls, relationships and metadata. This resolves
-  silent publication but did not itself repair either native writer; the next resolution entry
-  records the HWP repair. Package-surgical HWPX editing remains open in #90.
+  silent publication but did not itself repair either native writer; the next resolution entries
+  record the HWP repair and then the HWPX repair.
 
 - **2026-08-14 (issue #90 source-preserving HWP writer)**: same-format HWP `convert`, `edit` and IR
   `fill` now write against an immutable input snapshot. A no-op is an exact file copy; edits derive a
   stream mutation plan, retain untouched CFB entries and BinData byte-for-byte, preserve unchanged
   BodyText subtrees, and synthesize line layout only for changed or inserted paragraphs. Private
   complex-document acceptance passed no-op, metadata, text, paragraph, table-cell and image cases in
-  Hancom with no corruption warning. The remaining #90 work includes package-surgical HWPX editing.
+  Hancom with no corruption warning. Package-surgical HWPX editing followed in the next entry.
+
+- **2026-08-14 (issue #90 package-surgical HWPX editing and cross-format loss detection)**:
+  the hwpx reader retains verbatim XML for opaque run-level controls
+  (`GenericControl.hwpx_raw_xml`, e.g. `hp:container`) and the writer re-emits it, so a full
+  HWPX rewrite no longer drops them. Non-regenerated package entries (original META-INF
+  overrides, DocOptions, `Contents/memoExtended.xml`, extra previews) ride
+  `Document.hwpx_extra_entries`, and unreferenced BinData entries pass through into the
+  regenerated content.hpf manifest instead of being dropped. Every same-format HWPX `edit`
+  now goes through `hwpx::patch::rewrite_document_staged`, which reserializes only the
+  dirty content entries (header.xml / content.hpf / section*.xml, decided by before/after
+  IR comparison) and raw-copies every other ZIP entry byte-for-byte; inserted images append
+  as new BinData entries with the original OPF manifest ids preserved. Cross-format
+  conversion now inventories package assets the target format cannot represent (HWPX extra
+  entries on the way to HWP; the hwp5 XMLTemplate/DocHistory slots on the way to HWPX) as
+  typed `hwp-preservation-report-v1` events, so `--strict` fails closed on such loss and
+  `hwp convert --loss-report <PATH>` writes the JSON verdict either way. Two latent writer
+  fidelity bugs were fixed en route (inline `hp:pic` zOrder, no-border lineShape color).
+  Private complex-document acceptance (36 package entries, 24 BinData including 7 WMF, 5
+  `hp:container`): metadata, text, paragraph, table-cell and image HWPX edits keep the
+  entry set identical with all opaque entries byte-identical (media 24→24, 25 after an
+  image insert; containers 5→5), `hwp validate` is clean, non-strict hwp→hwpx preserves all
+  24 media (previously 9), strict conversion fails closed in both directions, and all eight
+  outputs opened in Hancom with no corruption or repair dialog. Still open in #90 (PR 4+):
+  table insertion (#77/#78), WMF vectors, the pagination/font gate and certification.
 
 - **2026-07-15**: GA-5 (version gate), GE-α1 to α5 and α7 (character effects, underline shape and
   numbering format in the hwpx round-trip), GE-β4 (summary information fields), GH-1 and GH-2
@@ -229,10 +254,12 @@ key point is **the difference per format**:
 - **hwpx read** falls back to `GenericControl`, discarding the object's own properties and keeping
   **only the child subList text** in the IR ([11](11-hwpx-structure-map.md) §3.3).
 - **hwpx write** finally emits `DROP` when that Generic is neither a known ctrl_id nor a gso_shape
-  (`hwpx/src/write/section.rs:364`), **losing even the text**.
+  and carries no retained raw XML, **losing even the text**. On the same-format path this no longer
+  fires: since 2026-08-14 (#90) the reader retains the control's verbatim XML
+  (`GenericControl.hwpx_raw_xml`) and the writer re-emits it unchanged.
 
 The same object therefore behaves differently per path: "hwp5 round-trip lossless / hwpx round-trip
-lost / synthesis lost / render blank".
+lost / synthesis lost / render blank" (GB-6 excepted on the hwpx round-trip since 2026-08-14, #90).
 
 | ID | Object (hwp5 tag / hwpx element) | Code evidence | Spec | Current behavior | Paths | Difficulty |
 |---|---|---|---|---|---|---|
@@ -241,7 +268,7 @@ lost / synthesis lost / render blank".
 | GB-3 | **Video** (`VIDEO_DATA` 0x62 / `hp:video`) | hwp5 `body_text.rs:617`, hwpx `write/section.rs:364` | §4.3.9.8 | hwp5 Opaque preserved / hwpx dropped | round-trip (hwpx only), synthesis, render | L |
 | GB-4 | **Word art** (`SHAPE_COMPONENT_TEXTART` 0x5A / `hp:textart`) | hwp5 `body_text.rs:617`, hwpx `read/section.rs:191` (text fallback) → `write/section.rs:364` (DROP) | §4.3.9 (word art) | hwp5 Opaque preserved / hwpx falls back to text then drops | round-trip (hwpx only), synthesis, render | M |
 | GB-5 | **Form objects** (`FORM_OBJECT` 0x5B / `hp:formObject`) | hwp5 `body_text.rs:617`, hwpx `read/section.rs:191` → `:364` | §4.3.9 (forms) | hwp5 Opaque preserved / hwpx text only then dropped | round-trip (hwpx only), synthesis, render | M |
-| GB-6 | **Grouped objects** (`SHAPE_COMPONENT_CONTAINER` 0x56 / `hp:container`): ★ **asymmetric**, because hwp5 raw-preserves it and therefore **even renders it** (recursing into children) while hwpx falls back then drops | hwp5 rendering in `hwp-render/src/shape_draw.rs` ([10](10-hwp5-structure-map.md) §8 raw-preserved), hwpx `read/section.rs:191` → `write/section.rs:364` | §4.3.9.7 | hwp5 raw-preserved (renders) / hwpx dropped | round-trip (hwpx only), synthesis | M |
+| GB-6 | **Grouped objects** (`SHAPE_COMPONENT_CONTAINER` 0x56 / `hp:container`): ★ **asymmetric**, because hwp5 raw-preserves it and therefore **even renders it** (recursing into children) while hwpx falls back without interpreting it — since 2026-08-14 (#90) the verbatim XML is carried through a same-format rewrite, so only synthesis and rendering still lose it | hwp5 rendering in `hwp-render/src/shape_draw.rs` ([10](10-hwp5-structure-map.md) §8 raw-preserved), hwpx `read/section.rs` (GenericControl raw-XML carry) | §4.3.9.7 | hwp5 raw-preserved (renders) / hwpx raw-XML carried (round-trip lossless, not rendered) | synthesis, render | M |
 | GB-7 | **Memos** (`MEMO_LIST` 0x5D in the body plus `MEMO_SHAPE` 0x5C in DocInfo / no `hp:` emission in hwpx) | hwp5 `body_text.rs:617`, `doc_info.rs:148` (Opaque); hwpx declares only the namespace ([11](11-hwpx-structure-map.md) §2) | §4.3 (memos), §4.2 table 13 | hwp5 Opaque preserved / hwpx unimplemented | round-trip (hwpx only), synthesis, render | M |
 | GB-8 | **Change tracking and edit history** (`TRACKCHANGE` 0x20, `TRACK_CHANGE` 0x60, `TRACK_CHANGE_AUTHOR` 0x61, `PARA_RANGE_TAG` 0x46 / hwpx `hhs:` history). PARA_RANGE_TAG's purpose in the specification also covers **range marking such as highlighting and proofreading marks** (§4.3.5), not only change tracking | hwp5 `doc_info.rs:148`, `body_text.rs:73` (Opaque); hwpx unimplemented ([11](11-hwpx-structure-map.md) §5(c)) | §4.2 table 13, §4.3.5 | hwp5 Opaque preserved / hwpx unimplemented | round-trip (hwpx only), synthesis | L |
 | GB-9 | **Arbitrary document and distribution data** (`DOC_DATA` 0x1B, `DISTRIBUTE_DOC_DATA` 0x1C, `COMPATIBLE_DOCUMENT` 0x1E, `LAYOUT_COMPATIBILITY` 0x1F) | hwp5 `doc_info.rs:57` (Opaque), though the writer **synthesizes** COMPATIBLE and LAYOUT separately ([07](07-hangul-compat-rules.md) A4) | §4.2.12 to §4.2.15 | hwp5 Opaque preserved (plus synthesis handling) / hwpx unimplemented | synthesis (partly resolved) | L |
@@ -255,7 +282,8 @@ lost / synthesis lost / render blank".
 **GB lesson:** looking only at hwp5 → hwp5 round-trips, the entire GB series appears "lossless" and
 the gap is invisible (exactly the trap in §0.3). The defects appear only in **hwpx round-trips,
 cross-format synthesis and rendering**. GB-6 (grouping) is especially subtle: hwp5 even renders it,
-and it disappears only on the way to hwpx. Restoring most of this series requires **reverse
+and on the hwpx side it used to vanish entirely; since 2026-08-14 (#90) its raw XML survives a
+same-format rewrite, so the loss is now confined to synthesis and rendering. Restoring most of this series requires **reverse
 engineering the payload from a genuine file containing that object** (M/L), so obtaining ground truth
 comes first ([00](00-overview.md) §4). ★ The exception is **the hwpx path of GB-1**: in HWPX a
 chart is not OLE but an **OOXML DrawingML `chartSpace` XML part** (`Chart/chartN.xml` plus a manifest

--- a/docs/design/12-feature-gaps.md
+++ b/docs/design/12-feature-gaps.md
@@ -124,6 +124,9 @@ is itself knowledge).
   24 media (previously 9), strict conversion fails closed in both directions, and all eight
   outputs opened in Hancom with no corruption or repair dialog. Still open in #90 (PR 4+):
   table insertion (#77/#78), WMF vectors, the pagination/font gate and certification.
+  hwpx→hwp conversion does not yet flag settings.xml/version.xml/preview slot loss with
+  typed events. And content.hpf regeneration keeps only modeled manifest items/metadata,
+  so unmodeled manifest items survive as orphan package entries (raw-copied but unlisted).
 
 - **2026-07-15**: GA-5 (version gate), GE-α1 to α5 and α7 (character effects, underline shape and
   numbering format in the hwpx round-trip), GE-β4 (summary information fields), GH-1 and GH-2

--- a/docs/hancom-verification-checklist.ko.md
+++ b/docs/hancom-verification-checklist.ko.md
@@ -219,6 +219,32 @@ commit하지 않는다. 모든 케이스는 같은 불변 source snapshot에서 
 각 결과에서 `FileHeader`, `MemoExtended`, scripts, document options, 미지 entry, 미변경 BinData를
 확인한 뒤 실제 한글로 연다. parser-only 통과는 충분하지 않다.
 
+## N. package-surgical HWPX 편집과 포맷 간 손실 게이트 (이슈 #90)
+
+비공개 정품 복합 HWPX(패키지 36엔트리, BinData 24 — WMF 7 포함, `hp:container` 5)를 사용한다.
+source와 파생 결과는 commit하지 않는다. 하네스는 `run-authoring-validation-c.sh`(비공개, 미커밋),
+오라클은 Hancom Office HWP 12.30.0 macOS.
+
+| 케이스 | 필수 결과 |
+|---|---|
+| metadata 편집 (HWPX→HWPX) | ZIP 엔트리 집합 동일, opaque 엔트리 전량 바이트 동일, 경고 없이 열림 |
+| text 편집 | 동일 + 변경 텍스트 표시 |
+| paragraph 삽입 | 동일 + 삽입 문단 표시, 주변 layout 안정 |
+| table-cell 편집 | 동일 + 대상 셀 내용만 변경 |
+| image 삽입 | 동일 + 새 BinData 1개 추가(미디어 24→25), 경고 없이 열림 |
+| non-strict hwpx→hwp 변환 | typed loss report가 제거된 HWPX 패키지 엔트리를 열거, 경고 없이 열림 |
+| non-strict hwp→hwpx 변환 | 미디어 24개 전량 보존(종전 9), 경고 없이 열림 |
+| HWP 편집(source-preserving writer) | 컨테이너 왕복, 경고 없이 열림 |
+
+열기 전 CLI 측 게이트: 모든 surgical 편집의 ZIP 엔트리 집합 동일, opaque 엔트리 전량 바이트
+동일(미디어 24→24, container 5→5), 모든 결과물 `hwp validate` 클린, strict hwpx→hwp는
+fail-closed(`binary_asset_removed`, `control_removed`, `hwpx_package_entry_removed`,
+`opaque_control_unrepresentable`), strict hwp→hwpx도 fail-closed(`control_removed`,
+`metadata_value_removed`).
+
+**한글 실기 결과(2026-08-14):** 8개 결과물(HWPX 편집 5, non-strict 변환 2, HWP 편집 1) 모두
+손상/복구 대화상자 없이 열림.
+
 ## 결과 회수
 각 파일에 O/X와 (실패 시) 팝업 메시지·증상을 알려주시면, 실패 항목만 정품 대조 패턴
 (가나다·다문단 실측)으로 수정합니다. 통과 항목은 미검증 → 실기 통과로 확정합니다.

--- a/docs/hancom-verification-checklist.md
+++ b/docs/hancom-verification-checklist.md
@@ -256,6 +256,33 @@ commit the source or derived outputs. Run each case from the same immutable sour
 For every output, verify `FileHeader`, `MemoExtended`, scripts, document options, unknown entries and
 untouched BinData before opening it in Hancom. A parser-only pass is insufficient.
 
+## N. Package-surgical HWPX edits and cross-format loss gates (issue #90)
+
+Use a private, genuinely complex HWPX (36 package entries, 24 BinData items including 7 WMF, 5
+`hp:container` groups). Do not commit the source or derived outputs. The harness is
+`run-authoring-validation-c.sh` (private, not committed); the oracle is Hancom Office HWP 12.30.0
+on macOS.
+
+| Case | Required result |
+|---|---|
+| Metadata edit (HWPX→HWPX) | ZIP entry set identical; every opaque entry byte-identical; opens without a warning |
+| Text edit | The same, with the edited text visible |
+| Paragraph insertion | The same, with the inserted paragraph visible and the surrounding layout stable |
+| Table-cell edit | The same, with only the target cell content changed |
+| Image insertion | The same plus one new BinData item (media 24→25); opens without a warning |
+| Non-strict hwpx→hwp convert | The typed loss report lists the removed HWPX package entries; opens without a warning |
+| Non-strict hwp→hwpx convert | All 24 media preserved (previously 9); opens without a warning |
+| HWP edit (the source-preserving writer) | The container round-trips; opens without a warning |
+
+CLI-side gates to check before opening: ZIP entry-set identity for every surgical edit, byte
+identity of every opaque entry (media 24→24, containers 5→5), `hwp validate` clean on all outputs,
+strict hwpx→hwp failing closed (`binary_asset_removed`, `control_removed`,
+`hwpx_package_entry_removed`, `opaque_control_unrepresentable`) and strict hwp→hwpx failing closed
+(`control_removed`, `metadata_value_removed`).
+
+**Hancom results (2026-08-14):** all eight outputs (5 HWPX edits, 2 non-strict conversions, 1 HWP
+edit) opened with no corruption or repair dialog.
+
 ## Reporting results
 
 Tell us pass or fail per file and, on failure, the popup message and symptom; we then fix only the

--- a/docs/manual/cli-reference.ko.md
+++ b/docs/manual/cli-reference.ko.md
@@ -82,6 +82,7 @@
 | `--out-dir` | `<OUT_DIR>` |  | 여러 입력의 출력 디렉터리 (파일명은 "<스템>.<확장자>", --to 필요) |
 | `--to` | `hwp` \| `hwpx` \| `md` \| `json` \| `html` \| `pdf` \| `odt` \| `txt` \| `csv` \| `docx` |  | 출력 포맷 (생략 시 확장자에서 추론) |
 | `--strict` |  |  | 변환 중 보존 불가능한(opaque) 데이터 발견 시 실패 처리 |
+| `--loss-report` | `<LOSS_REPORT>` |  | typed 보존 ledger(hwp-preservation-report-v1)를 JSON으로 기록 — 무손실 성공 시에도 작성 (단일 입력 전용) |
 | `--preserve-layout` |  |  | 줄 배치 캐시 보존 (무수정 왕복 전용 — 한글은 내용과 어긋난 줄 배치를 변조로 판정하므로 기본은 제거) |
 | `--embed-bin` |  |  | JSON 출력 시 첨부 바이너리(이미지)를 base64로 임베드 (자급식 JSON) |
 | `--media-dir` | `<MEDIA_DIR>` |  | (md) 이미지 추출 디렉터리 — 기본 "<출력스템>.media". 상대경로는 출력 파일 기준으로 해석하고 링크는 입력한 경로 그대로 쓴다 (예: figs) |

--- a/docs/manual/cli-reference.ko.md
+++ b/docs/manual/cli-reference.ko.md
@@ -82,7 +82,7 @@
 | `--out-dir` | `<OUT_DIR>` |  | 여러 입력의 출력 디렉터리 (파일명은 "<스템>.<확장자>", --to 필요) |
 | `--to` | `hwp` \| `hwpx` \| `md` \| `json` \| `html` \| `pdf` \| `odt` \| `txt` \| `csv` \| `docx` |  | 출력 포맷 (생략 시 확장자에서 추론) |
 | `--strict` |  |  | 변환 중 보존 불가능한(opaque) 데이터 발견 시 실패 처리 |
-| `--loss-report` | `<LOSS_REPORT>` |  | typed 보존 ledger(hwp-preservation-report-v1)를 JSON으로 기록 — 무손실 성공 시에도 작성 (단일 입력 전용) |
+| `--loss-report` | `<LOSS_REPORT>` |  | typed 보존 ledger(hwp-preservation-report-v1)를 JSON으로 기록 — 무손실 성공 시에도 작성 (단일 입력 전용). 보존 검사는 hwp/hwpx 출력에서만 실행되므로 그 외 포맷(docx, md 등)에서는 항상 빈 ledger |
 | `--preserve-layout` |  |  | 줄 배치 캐시 보존 (무수정 왕복 전용 — 한글은 내용과 어긋난 줄 배치를 변조로 판정하므로 기본은 제거) |
 | `--embed-bin` |  |  | JSON 출력 시 첨부 바이너리(이미지)를 base64로 임베드 (자급식 JSON) |
 | `--media-dir` | `<MEDIA_DIR>` |  | (md) 이미지 추출 디렉터리 — 기본 "<출력스템>.media". 상대경로는 출력 파일 기준으로 해석하고 링크는 입력한 경로 그대로 쓴다 (예: figs) |

--- a/docs/manual/cli-reference.md
+++ b/docs/manual/cli-reference.md
@@ -82,7 +82,7 @@ Convert between formats
 | `--out-dir` | `<OUT_DIR>` |  | Output directory for multiple inputs (file names are "<stem>.<ext>", requires --to) |
 | `--to` | `hwp` \| `hwpx` \| `md` \| `json` \| `html` \| `pdf` \| `odt` \| `txt` \| `csv` \| `docx` |  | Output format (inferred from the extension when omitted) |
 | `--strict` |  |  | Fail when data that cannot be preserved (opaque) is found during conversion |
-| `--loss-report` | `<LOSS_REPORT>` |  | Write the typed preservation ledger (hwp-preservation-report-v1) as JSON to this path, even when the conversion succeeds without loss (single input only) |
+| `--loss-report` | `<LOSS_REPORT>` |  | Write the typed preservation ledger (hwp-preservation-report-v1) as JSON to this path, even when the conversion succeeds without loss (single input only). The preservation inspection only runs for hwp/hwpx targets — for other output formats (docx, md, ...) the ledger is always empty |
 | `--preserve-layout` |  |  | Preserve the line layout cache (unmodified round-trips only; Hancom treats a layout inconsistent with the content as tampering, so it is dropped by default) |
 | `--embed-bin` |  |  | Embed attached binaries (images) as base64 in JSON output (self-contained JSON) |
 | `--media-dir` | `<MEDIA_DIR>` |  | (md) Image extraction directory, default "<output stem>.media". A relative path resolves against the output file and links use the path as given (e.g. figs) |

--- a/docs/manual/cli-reference.md
+++ b/docs/manual/cli-reference.md
@@ -82,6 +82,7 @@ Convert between formats
 | `--out-dir` | `<OUT_DIR>` |  | Output directory for multiple inputs (file names are "<stem>.<ext>", requires --to) |
 | `--to` | `hwp` \| `hwpx` \| `md` \| `json` \| `html` \| `pdf` \| `odt` \| `txt` \| `csv` \| `docx` |  | Output format (inferred from the extension when omitted) |
 | `--strict` |  |  | Fail when data that cannot be preserved (opaque) is found during conversion |
+| `--loss-report` | `<LOSS_REPORT>` |  | Write the typed preservation ledger (hwp-preservation-report-v1) as JSON to this path, even when the conversion succeeds without loss (single input only) |
 | `--preserve-layout` |  |  | Preserve the line layout cache (unmodified round-trips only; Hancom treats a layout inconsistent with the content as tampering, so it is dropped by default) |
 | `--embed-bin` |  |  | Embed attached binaries (images) as base64 in JSON output (self-contained JSON) |
 | `--media-dir` | `<MEDIA_DIR>` |  | (md) Image extraction directory, default "<output stem>.media". A relative path resolves against the output file and links use the path as given (e.g. figs) |

--- a/schemas/preservation-report-v1.schema.json
+++ b/schemas/preservation-report-v1.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hwp-cli.dev/schemas/preservation-report-v1.schema.json",
+  "title": "hwp-preservation-report-v1",
+  "description": "Typed, content-free preservation ledger emitted by hwp convert --loss-report and the native writers. Reports carry only stable codes, resource classes, dispositions and aggregate counts — never paths, entry names, text or hashes.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract", "events"],
+  "properties": {
+    "contract": { "const": "hwp-preservation-report-v1" },
+    "events": {
+      "type": "array",
+      "maxItems": 1000,
+      "items": { "$ref": "#/$defs/event" }
+    }
+  },
+  "$defs": {
+    "event": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "resource", "disposition", "count"],
+      "properties": {
+        "code": {
+          "enum": [
+            "binary_asset_removed",
+            "binary_relationship_removed",
+            "control_metadata_unrepresentable",
+            "control_removed",
+            "gso_header_unrepresentable",
+            "gso_shape_unrepresentable",
+            "hwp_container_storage_removed",
+            "hwp_container_stream_removed",
+            "hwp_opaque_stream_changed",
+            "hwpx_opaque_entry_changed",
+            "hwpx_package_entry_removed",
+            "metadata_value_removed",
+            "opaque_control_unrepresentable",
+            "picture_control_removed"
+          ]
+        },
+        "resource": {
+          "enum": [
+            "container_stream",
+            "container_storage",
+            "package_entry",
+            "control",
+            "binary_asset",
+            "relationship",
+            "metadata"
+          ]
+        },
+        "disposition": {
+          "enum": ["removed", "changed_non_target", "unrepresentable"]
+        },
+        "count": { "type": "integer", "minimum": 1 }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Third PR of epic #90. Same-format HWPX edits become package-surgical (only dirty content entries are reserialized; every other ZIP entry is raw-copied byte-for-byte), the HWPX full-rewrite round-trip becomes content-lossless, and cross-format conversion gains package-level loss detection with an explicit typed loss report.

- **Lossless round-trip**: `GenericControl.hwpx_raw_xml` carries verbatim XML for opaque run-level controls (hp:container etc.); `Document.hwpx_extra_entries` preserves non-regenerated package entries (original META-INF/*, DocOptions, memoExtended.xml); unreferenced BinData entries pass through and stay listed in content.hpf.
- **Surgical edit path**: all same-format HWPX `hwp edit` ops route through `hwpx::patch::rewrite_document_staged` (dirty set from before/after IR comparison; BinCollector seeded from the original OPF manifest so binaryItemIDRef ids/hrefs are stable; new images append as new BinData entries and force content.hpf regeneration). The `inspect_same_format_container` fail-closed gate remains as backstop.
- **Cross-format loss detection**: `inspect_cross_format_container` emits typed events for package assets the target format cannot represent (HWPX extra entries → HWP; hwp5 XMLTemplate/DocHistory slots → HWPX). `--strict` now fails closed on these; non-strict proceeds only with the typed report, and `hwp convert --loss-report <PATH>` writes the `hwp-preservation-report-v1` JSON verdict (schema: `schemas/preservation-report-v1.schema.json`), even when strict rejects.
- **Writer fidelity fixes** exposed by the first verify-passing corpus edits: inline hp:pic `zOrder` and no-border `lineShape` color now round-trip.

## Validation (content-free)

- `scripts/check.sh` green: fmt, clippy -D warnings, workspace tests, structured corpus.
- Private complex corpus (36 entries, 24 BinData incl. 7 WMF, 5 hp:container): HWPX metadata/text/paragraph/table-cell/image edits keep the entry set identical, all opaque entries byte-identical, media 24→24 (25 after image insert), containers 5→5, `hwp validate` clean, `--verify` passes.
- Hancom receipt (12.30.0 macOS): all 8 outputs (5 HWPX edits, 2 non-strict conversions, 1 HWP edit) open with no corruption/repair dialog.
- Strict fail-closed now correct both directions: hwpx→hwp rejects with binary_asset_removed/control_removed/hwpx_package_entry_removed/opaque_control_unrepresentable; hwp→hwpx rejects with control_removed/metadata_value_removed; non-strict hwp→hwpx preserves all 24 media (previously 9).

## Known limits (follow-ups, not regressions)

- hwp→hwpx: opaque CFB streams the IR never captures (MemoExtended, Scripts, …) still escape cross-format detection; they are preserved only on same-format HWP writes (PR 2).
- hwpx→hwp: modified settings.xml/version.xml/preview originals are not yet flagged as unrepresentable.
- content.hpf regeneration keeps only modeled manifest items/metadata; unmodeled items remain as raw-copied but unlisted entries.
- Sections are conservatively reserialized on any IR-path edit (semantically lossless, not byte-identical); per-section selectivity would need op-level section attribution.

Refs #90 (remains open: PRs 4-8 — #77/#78 table authoring, WMF vectors, pagination/font gate, certification).
