### PR TITLE
feat(edit): deep table cloning with blank/keep modes (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 **Added**
 
+- Deep table cloning
+  ([#78](https://github.com/STAIxBWLB/hwp-cli/issues/78)). `--clone-table
+  "SOURCE_TABLE=>ANCHOR[=>blank|keep]"` (MCP `clone_table` with
+  `source_table`/`anchor`/`text_mode`) deep-copies a table — geometry, merge
+  topology, widths, borders, fills, and styles — and inserts the clone after the
+  anchor paragraph. `blank` (default) keeps one empty styled paragraph per cell
+  and drops all source text and content controls; `keep` also clones nested
+  tables and pictures, remapping every paragraph/control/object instance ID
+  above the document maxima and reusing binary assets in place. Keep mode aborts
+  atomically on opaque controls (fields, equations, text boxes) whose raw
+  identity bytes cannot be safely remapped; every failure mode publishes
+  nothing.
+
 - Positioned, counted table row/column insertion
   ([#77](https://github.com/STAIxBWLB/hwp-cli/issues/77)). `--add-row` now accepts
   `TABLE[:AT[:COUNT[:TEMPLATE_ROW]]]` and `--add-col` accepts `TABLE[:AT[:COUNT]]`

--- a/crates/hwp-cli/src/cli.rs
+++ b/crates/hwp-cli/src/cli.rs
@@ -460,6 +460,9 @@ pub struct EditArgs {
     /// Insert a table, "anchor=>json": insert a uniform table after the anchor paragraph; json is an array of row arrays (repeatable)
     #[arg(long = "add-table")]
     pub add_table: Vec<String>,
+    /// Clone a table, "source_table=>anchor[=>blank|keep]": deep-copy table source_table (0-based, recursive) after the anchor paragraph; blank (default) keeps structure/styles with empty cells, keep also clones supported content (nested tables, images) with remapped ids (repeatable)
+    #[arg(long = "clone-table")]
+    pub clone_table: Vec<String>,
     /// Paragraph shape properties, "find=>key:value" (keys: line-spacing (% or Npt), indent, left, right, top, bottom (mm); repeatable)
     #[arg(long = "set-para")]
     pub set_para: Vec<String>,

--- a/crates/hwp-cli/src/commands/edit.rs
+++ b/crates/hwp-cli/src/commands/edit.rs
@@ -39,6 +39,7 @@ enum EditOperation {
     MergeCells(Vec<String>),
     SplitCell(Vec<String>),
     AddTable(Vec<String>),
+    CloneTable(Vec<String>),
     SetPara(Vec<String>),
     SetPage(Vec<String>),
     DeleteImage(Vec<String>),
@@ -145,6 +146,11 @@ pub(crate) enum TypedEditOperation {
         anchor: String,
         rows: Vec<Vec<String>>,
     },
+    CloneTable {
+        source_table: usize,
+        anchor: String,
+        text_mode: hwp_convert::CloneTextMode,
+    },
     SetPara {
         pattern: String,
         /// Paragraph shape converted up to HWPUNIT/pt×100 units (same units as the CLI `parse_para_props`).
@@ -188,6 +194,7 @@ impl TypedEditOperation {
                 | Self::MergeCells { .. }
                 | Self::SplitCell { .. }
                 | Self::AddTable { .. }
+                | Self::CloneTable { .. }
                 | Self::DeleteImage { .. }
                 | Self::DeleteTable { .. }
                 | Self::DeleteField { .. }
@@ -211,6 +218,7 @@ impl EditOperation {
             | Self::MergeCells(_)
             | Self::SplitCell(_)
             | Self::AddTable(_)
+            | Self::CloneTable(_)
             | Self::DeleteImage(_)
             | Self::DeleteTable(_)
             | Self::DeleteField(_)
@@ -304,6 +312,7 @@ impl EditPlan {
             merge_cells,
             split_cell,
             add_table,
+            clone_table,
             set_para,
             set_page,
             delete_image,
@@ -343,6 +352,7 @@ impl EditPlan {
         add!(MergeCells, merge_cells);
         add!(SplitCell, split_cell);
         add!(AddTable, add_table);
+        add!(CloneTable, clone_table);
         add!(SetPara, set_para);
         add!(SetPage, set_page);
         add!(DeleteImage, delete_image);
@@ -484,6 +494,33 @@ fn parse_add_col_spec(spec: &str) -> anyhow::Result<AddColSpec> {
         anyhow::bail!("--add-col 개수는 1 이상이어야 합니다: {spec:?}");
     }
     Ok(AddColSpec { table, at, count })
+}
+
+/// Parsed `--clone-table` spec: `SOURCE_TABLE=>ANCHOR[=>blank|keep]` (#78).
+struct CloneTableSpec {
+    source_table: usize,
+    anchor: String,
+    text_mode: hwp_convert::CloneTextMode,
+}
+
+fn parse_clone_table_spec(spec: &str) -> anyhow::Result<CloneTableSpec> {
+    let mut parts = spec.splitn(3, "=>");
+    let source = parts.next().unwrap_or_default().trim();
+    let anchor = parts.next().map(str::trim).unwrap_or_default();
+    if source.is_empty() || anchor.is_empty() {
+        anyhow::bail!("--clone-table 형식은 \"표=>앵커[=>blank|keep]\" 입니다: {spec:?}");
+    }
+    let source_table: usize = source.parse().context("표 인덱스")?;
+    let text_mode = match parts.next().map(str::trim) {
+        None | Some("") | Some("blank") => hwp_convert::CloneTextMode::Blank,
+        Some("keep") => hwp_convert::CloneTextMode::Keep,
+        Some(other) => anyhow::bail!("--clone-table 모드는 blank|keep 입니다: {other:?}"),
+    };
+    Ok(CloneTableSpec {
+        source_table,
+        anchor: anchor.to_string(),
+        text_mode,
+    })
 }
 
 pub fn run(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<()> {
@@ -900,6 +937,19 @@ pub fn execute(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<E
                         rows.len(),
                         rows.first().map_or(0, Vec::len)
                     );
+                    edits += 1;
+                }
+            }
+            EditOperation::CloneTable(specs) => {
+                for spec in specs {
+                    let s = parse_clone_table_spec(spec)?;
+                    hwp_convert::clone_table(&mut doc, s.source_table, &s.anchor, s.text_mode)
+                        .map_err(|e| anyhow::anyhow!(e))?;
+                    let mode = match s.text_mode {
+                        hwp_convert::CloneTextMode::Blank => "blank",
+                        hwp_convert::CloneTextMode::Keep => "keep",
+                    };
+                    eprintln!("표 복제: 표{} → {:?} 뒤 ({mode})", s.source_table, s.anchor);
                     edits += 1;
                 }
             }
@@ -1442,6 +1492,20 @@ fn apply_typed_operation(
                 rows.len(),
                 rows.first().map_or(0, Vec::len)
             );
+            *edits += 1;
+        }
+        TypedEditOperation::CloneTable {
+            source_table,
+            anchor,
+            text_mode,
+        } => {
+            hwp_convert::clone_table(doc, *source_table, anchor, *text_mode)
+                .map_err(|error| anyhow::anyhow!(error))?;
+            let mode = match text_mode {
+                hwp_convert::CloneTextMode::Blank => "blank",
+                hwp_convert::CloneTextMode::Keep => "keep",
+            };
+            eprintln!("표 복제: 표{source_table} → {anchor:?} 뒤 ({mode})");
             *edits += 1;
         }
         TypedEditOperation::SetPara { pattern, props } => {

--- a/crates/hwp-cli/src/commands/mcp.rs
+++ b/crates/hwp-cli/src/commands/mcp.rs
@@ -1251,6 +1251,20 @@ fn tool_edit(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
             rows,
         });
     }
+    for item in arg_array(args, "clone_table")? {
+        let text_mode = match item.get("text_mode").and_then(Value::as_str).map(str::trim) {
+            None | Some("") | Some("blank") => hwp_convert::CloneTextMode::Blank,
+            Some("keep") => hwp_convert::CloneTextMode::Keep,
+            Some(_) => {
+                return Err("clone_table: text_mode는 blank|keep 이어야 합니다".to_string());
+            }
+        };
+        operations.push(Op::CloneTable {
+            source_table: required_item_usize(item, "clone_table", "source_table")?,
+            anchor: required_item_str(item, "clone_table", "anchor")?.to_string(),
+            text_mode,
+        });
+    }
     for item in arg_array(args, "set_para")? {
         // The CLI line-spacing (% integer | Npt) split into two numeric arguments — mutually exclusive.
         let line_spacing = match (
@@ -1862,6 +1876,13 @@ fn tool_defs() -> Vec<Value> {
                     "rows": {"type": "array", "items": {"type": "array", "items": {"type": "string"}}}},
                     "required": ["anchor", "rows"]},
                     "description": "앵커 문단 뒤에 균일 표 삽입(rows는 행(문자열 배열)의 배열)"},
+                "clone_table": {"type": "array", "items": {"type": "object", "properties": {
+                    "source_table": {"type": "integer", "minimum": 0, "description": "원본 표(0-기반, 재귀 순서)"},
+                    "anchor": {"type": "string", "description": "복제본을 삽입할 앵커 문단 텍스트(그 뒤에 삽입)"},
+                    "text_mode": {"type": "string", "enum": ["blank", "keep"],
+                        "description": "blank(기본)=구조·서식만 복제하고 셀 내용은 빈 문단 1개, keep=지원 콘텐츠(중첩 표·그림)까지 복제(id 재부여, 안전하게 재매핑할 수 없는 개체가 있으면 실패)"}},
+                    "required": ["source_table", "anchor"]},
+                    "description": "N번째 표를 깊은 복제해 앵커 문단 뒤에 삽입(구조·병합·테두리·채우기·서식 보존)"},
                 "set_para": {"type": "array", "items": {"type": "object", "properties": {
                     "pattern": {"type": "string"},
                     "line_spacing_pct": {"type": "number", "description": "줄간격 비율(%)"},
@@ -2298,6 +2319,16 @@ mod tests {
         assert_eq!(
             edit["inputSchema"]["properties"]["add_col"]["items"]["properties"]["count"]["minimum"],
             1
+        );
+        // #78: clone_table exposes source_table/anchor/text_mode.
+        let clone_table = &edit["inputSchema"]["properties"]["clone_table"];
+        assert_eq!(
+            clone_table["items"]["required"],
+            json!(["source_table", "anchor"])
+        );
+        assert_eq!(
+            clone_table["items"]["properties"]["text_mode"]["enum"],
+            json!(["blank", "keep"])
         );
         for name in ["hwp_render", "hwp_diff"] {
             let tool = tools.iter().find(|tool| tool["name"] == name).unwrap();
@@ -2905,6 +2936,63 @@ mod tests {
         assert!(rejected.is_err(), "count 0 is refused");
         let _ = std::fs::remove_file(temp_file("addrowcol-reject.hwpx"));
         for path in [&source, &destination, &fill_destination] {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+
+    #[test]
+    fn mcp_clone_table_blank_default_and_keep_mode() {
+        // #78: MCP clone_table runs through the same conversion primitive as the CLI.
+        let source = temp_file("clonetbl-source.hwpx");
+        let blank_out = temp_file("clonetbl-blank.hwpx");
+        let keep_out = temp_file("clonetbl-keep.hwpx");
+        create_hwpx(&source, "앵커문단\n\n| 가 | 나 |\n|----|----|\n| 1 | 2 |\n");
+        // text_mode omitted → blank: structure cloned, cell text stripped.
+        tool_edit(
+            &json!({
+                "input": source,
+                "output": blank_out,
+                "clone_table": [{"source_table": 0, "anchor": "앵커문단"}]
+            }),
+            &ctx(),
+        )
+        .expect("blank clone");
+        let content = tool_read(&json!({"path": blank_out, "format": "plain"}), &ctx()).unwrap();
+        let text = content[0]["text"].as_str().unwrap();
+        assert_eq!(
+            text.matches('가').count(),
+            1,
+            "blank clone strips cell text (source only): {text}"
+        );
+        // keep mode clones cell text as well.
+        tool_edit(
+            &json!({
+                "input": source,
+                "output": keep_out,
+                "clone_table": [{"source_table": 0, "anchor": "앵커문단", "text_mode": "keep"}]
+            }),
+            &ctx(),
+        )
+        .expect("keep clone");
+        let content = tool_read(&json!({"path": keep_out, "format": "plain"}), &ctx()).unwrap();
+        let text = content[0]["text"].as_str().unwrap();
+        assert_eq!(
+            text.matches('가').count(),
+            2,
+            "cloned content present: {text}"
+        );
+        // An invalid text_mode is rejected with a bounded error.
+        let rejected = tool_edit(
+            &json!({
+                "input": source,
+                "output": temp_file("clonetbl-reject.hwpx"),
+                "clone_table": [{"source_table": 0, "anchor": "앵커문단", "text_mode": "bogus"}]
+            }),
+            &ctx(),
+        );
+        assert!(rejected.is_err(), "invalid text_mode is refused");
+        let _ = std::fs::remove_file(temp_file("clonetbl-reject.hwpx"));
+        for path in [&source, &blank_out, &keep_out] {
             let _ = std::fs::remove_file(path);
         }
     }

--- a/crates/hwp-cli/src/i18n.rs
+++ b/crates/hwp-cli/src/i18n.rs
@@ -450,6 +450,11 @@ pub const KO: &[(&str, &str, &str)] = &[
     ),
     (
         "edit",
+        "clone_table",
+        "표 복제 \"원본표=>앵커[=>blank|keep]\" — N번째 표(0-기반, 재귀 순서)를 깊은 복제해 앵커 문단 뒤에 삽입. blank(기본)는 구조·서식만 남기고 셀 내용을 비우고, keep은 지원 콘텐츠(중첩 표·그림)까지 복제(id 재부여) (반복 가능)",
+    ),
+    (
+        "edit",
         "set_para",
         "문단 모양 \"찾기=>키:값\" — 키: line-spacing(% 또는 Npt), indent, left, right, top, bottom (mm) (반복 가능)",
     ),

--- a/crates/hwp-cli/tests/edit_surgical.rs
+++ b/crates/hwp-cli/tests/edit_surgical.rs
@@ -550,3 +550,69 @@ fn meta_edit_keeps_extension_manifest_items() {
     );
     assert_entries_identical(&src, &out, &["DocOptions/Layout.xml"]);
 }
+
+/// 표 복제 op(clone-table, #78): section0.xml만 재직렬화되고 header/content.hpf/
+/// 미리보기/META-INF/settings는 입력과 바이트 동일해야 한다(keep 모드는 BinData를
+/// 새로 추가하지 않고 기존 참조를 재사용한다).
+#[test]
+fn clone_table_preserves_non_target_entries() {
+    let src = copy_fixture("surgical_clone.hwpx");
+    let out = tmp("surgical_clone_out.hwpx");
+    let r = hwp()
+        .arg("edit")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .args(["--clone-table", "2=>한빛대학교=>keep"])
+        .output()
+        .unwrap();
+    assert!(
+        r.status.success(),
+        "clone-table: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+
+    assert_entries_identical(
+        &src,
+        &out,
+        &[
+            "Contents/header.xml",
+            "Contents/content.hpf",
+            "Preview/PrvImage.png",
+            "Preview/PrvText.txt",
+            "META-INF/container.rdf",
+            "META-INF/container.xml",
+            "META-INF/manifest.xml",
+            "settings.xml",
+            "version.xml",
+        ],
+    );
+    // Entry set is unchanged — keep mode reuses BinData references.
+    assert_eq!(
+        zip_entry_names(&src),
+        zip_entry_names(&out),
+        "엔트리 집합 동일(BinData 재사용)"
+    );
+    // The cloned table landed in the section entry (clone = 1 + 6 nested tables).
+    let count_tbls = |path: &Path| {
+        String::from_utf8(read_zip_entry(path, "Contents/section0.xml"))
+            .unwrap()
+            .matches("<hp:tbl")
+            .count()
+    };
+    assert_eq!(
+        count_tbls(&out),
+        count_tbls(&src) + 7,
+        "clone adds 7 tables (1 + 6 nested)"
+    );
+    assert!(
+        hwp()
+            .arg("validate")
+            .arg(&out)
+            .output()
+            .unwrap()
+            .status
+            .success(),
+        "validate 통과"
+    );
+}

--- a/crates/hwp-cli/tests/table_edit.rs
+++ b/crates/hwp-cli/tests/table_edit.rs
@@ -627,3 +627,340 @@ fn add_row_positioned_synthetic_both_formats() {
         assert!(text.contains('가'), "{ext} original content kept");
     }
 }
+
+// ── #78: deep table cloning (blank / keep) ───────────────────────────────────
+
+/// All tables (recursive depth-first index) as JSON via `cat --format json`.
+fn all_tables_json(path: &PathBuf) -> Vec<serde_json::Value> {
+    fn collect<'a>(paras: &'a serde_json::Value, out: &mut Vec<&'a serde_json::Value>) {
+        for p in paras.as_array().unwrap() {
+            for c in p["controls"].as_array().unwrap() {
+                if let Some(t) = c.get("Table") {
+                    out.push(t);
+                    for cell in t["cells"].as_array().unwrap() {
+                        collect(&cell["paragraphs"], out);
+                    }
+                } else if let Some(g) = c.get("Generic") {
+                    for l in g["paragraph_lists"].as_array().unwrap() {
+                        collect(&l["paragraphs"], out);
+                    }
+                }
+            }
+        }
+    }
+    let out = hwp()
+        .arg("cat")
+        .arg(path)
+        .args(["--format", "json"])
+        .output()
+        .unwrap();
+    let j: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let mut tables = Vec::new();
+    collect(&j["sections"][0]["paragraphs"], &mut tables);
+    tables.into_iter().cloned().collect()
+}
+
+/// Concatenated text of every cell paragraph of a table JSON node.
+fn table_text(t: &serde_json::Value) -> String {
+    let mut s = String::new();
+    for cell in t["cells"].as_array().unwrap() {
+        for p in cell["paragraphs"].as_array().unwrap() {
+            for ch in p["chars"].as_array().unwrap() {
+                if let Some(c) = ch.get("Text").and_then(|v| v.as_str()) {
+                    s.push_str(c);
+                }
+            }
+        }
+    }
+    s
+}
+
+/// The fixture anchor "한빛대학교" sits in a top-level paragraph before every
+/// table, so a clone inserted after it becomes the new table #0.
+#[test]
+fn clone_table_blank_after_anchor() {
+    let src = copy_fixture("clone_blank.hwpx");
+    let out = tmp("clone_blank_out.hwpx");
+    let r = hwp()
+        .arg("edit")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .args(["--clone-table", "9=>한빛대학교", "--verify"])
+        .output()
+        .unwrap();
+    assert!(
+        r.status.success(),
+        "blank clone: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+    let tables = all_tables_json(&out);
+    assert_eq!(tables.len(), 11, "10 source tables + 1 clone");
+    let clone = &tables[0];
+    assert_eq!(clone["rows"].as_u64().unwrap(), 7);
+    assert_eq!(clone["cols"].as_u64().unwrap(), 2);
+    assert!(
+        table_text(clone).is_empty(),
+        "blank clone carries no source text"
+    );
+    // The source table (shifted to #10) is untouched.
+    assert!(!table_text(&tables[10]).is_empty(), "source table kept");
+    assert!(
+        hwp()
+            .arg("validate")
+            .arg(&out)
+            .output()
+            .unwrap()
+            .status
+            .success(),
+        "blank clone keeps the document valid"
+    );
+}
+
+/// Keep mode clones the merged 11x10 table #2 (with its 6 nested tables) —
+/// geometry, merge topology, and content survive; instance ids are remapped
+/// above the source maximum.
+#[test]
+fn clone_table_keep_preserves_content_and_geometry() {
+    let src = copy_fixture("clone_keep.hwpx");
+    let out = tmp("clone_keep_out.hwpx");
+    let r = hwp()
+        .arg("edit")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out)
+        .args(["--clone-table", "2=>한빛대학교=>keep", "--verify"])
+        .output()
+        .unwrap();
+    assert!(
+        r.status.success(),
+        "keep clone: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+    let tables = all_tables_json(&out);
+    assert_eq!(tables.len(), 17, "10 + clone with 6 nested tables");
+    let (clone, source) = (&tables[0], &tables[9]);
+    assert_eq!(clone["rows"].as_u64().unwrap(), 11);
+    assert_eq!(clone["cols"].as_u64().unwrap(), 10);
+    assert_eq!(clone["row_cell_counts"], source["row_cell_counts"]);
+    assert_eq!(
+        table_text(clone),
+        table_text(source),
+        "keep clone preserves content"
+    );
+    // (Instance-id remapping is HWP-only — the HWPX writer assigns element ids
+    // itself; see clone_table_keep_hwp_instance_ids_remapped.)
+    assert!(
+        hwp()
+            .arg("validate")
+            .arg(&out)
+            .output()
+            .unwrap()
+            .status
+            .success(),
+        "keep clone keeps the document valid"
+    );
+}
+
+/// HWP outputs carry paragraph instance ids; a keep clone must remap every id
+/// above the document maximum, leaving the whole document collision-free.
+#[test]
+fn clone_table_keep_hwp_instance_ids_remapped() {
+    let src = copy_fixture("clone_keep_hwp.hwpx");
+    let hwp_src = tmp("clone_keep_src.hwp");
+    let c = hwp()
+        .arg("convert")
+        .arg(&src)
+        .arg("-o")
+        .arg(&hwp_src)
+        .output()
+        .unwrap();
+    assert!(
+        c.status.success(),
+        "fixture converts to hwp: {}",
+        String::from_utf8_lossy(&c.stderr)
+    );
+    let out = tmp("clone_keep_hwp_out.hwp");
+    let r = hwp()
+        .arg("edit")
+        .arg(&hwp_src)
+        .arg("-o")
+        .arg(&out)
+        .args(["--clone-table", "2=>한빛대학교=>keep", "--verify"])
+        .output()
+        .unwrap();
+    assert!(
+        r.status.success(),
+        "hwp keep clone: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+    // Every paragraph instance id in the output is non-zero and unique.
+    let cat = hwp()
+        .arg("cat")
+        .arg(&out)
+        .args(["--format", "json"])
+        .output()
+        .unwrap();
+    let j: serde_json::Value = serde_json::from_slice(&cat.stdout).unwrap();
+    let mut ids = Vec::new();
+    fn walk_paras(paras: &serde_json::Value, ids: &mut Vec<u64>) {
+        for p in paras.as_array().unwrap() {
+            ids.push(p["header"]["instance_id"].as_u64().unwrap());
+            for c in p["controls"].as_array().unwrap() {
+                if let Some(t) = c.get("Table") {
+                    for cell in t["cells"].as_array().unwrap() {
+                        walk_paras(&cell["paragraphs"], ids);
+                    }
+                } else if let Some(g) = c.get("Generic") {
+                    for l in g["paragraph_lists"].as_array().unwrap() {
+                        walk_paras(&l["paragraphs"], ids);
+                    }
+                }
+            }
+        }
+    }
+    for section in j["sections"].as_array().unwrap() {
+        walk_paras(&section["paragraphs"], &mut ids);
+    }
+    assert!(ids.iter().all(|&id| id != 0), "all ids assigned");
+    let mut dedup = ids.clone();
+    dedup.sort_unstable();
+    dedup.dedup();
+    assert_eq!(dedup.len(), ids.len(), "no instance id collisions");
+    assert!(
+        hwp()
+            .arg("validate")
+            .arg(&out)
+            .output()
+            .unwrap()
+            .status
+            .success(),
+        "hwp keep clone keeps the document valid"
+    );
+}
+
+/// Two sequential clones keep working and keep ids rising.
+#[test]
+fn clone_table_multiple_sequential() {
+    let src = copy_fixture("clone_seq.hwpx");
+    let out1 = tmp("clone_seq_out1.hwpx");
+    let r1 = hwp()
+        .arg("edit")
+        .arg(&src)
+        .arg("-o")
+        .arg(&out1)
+        .args(["--clone-table", "9=>한빛대학교", "--verify"])
+        .output()
+        .unwrap();
+    assert!(
+        r1.status.success(),
+        "first clone: {}",
+        String::from_utf8_lossy(&r1.stderr)
+    );
+    let out2 = tmp("clone_seq_out2.hwpx");
+    let r2 = hwp()
+        .arg("edit")
+        .arg(&out1)
+        .arg("-o")
+        .arg(&out2)
+        .args(["--clone-table", "0=>한빛대학교", "--verify"])
+        .output()
+        .unwrap();
+    assert!(
+        r2.status.success(),
+        "second clone (of the first clone): {}",
+        String::from_utf8_lossy(&r2.stderr)
+    );
+    let tables = all_tables_json(&out2);
+    assert_eq!(tables.len(), 12, "10 + 2 sequential clones");
+    assert_eq!(tables[0]["rows"].as_u64().unwrap(), 7);
+    assert_eq!(tables[1]["rows"].as_u64().unwrap(), 7);
+}
+
+/// Bad indices, missing anchors, and bad mode tokens fail and publish nothing.
+#[test]
+fn clone_table_spec_errors() {
+    for spec in [
+        "99=>한빛대학교",
+        "0=>없는앵커문장",
+        "0=>한빛대학교=>bogus",
+        "x=>한빛대학교",
+    ] {
+        let src = copy_fixture("clone_err.hwpx");
+        let out = tmp("clone_err_out.hwpx");
+        let r = hwp()
+            .arg("edit")
+            .arg(&src)
+            .arg("-o")
+            .arg(&out)
+            .args(["--clone-table", spec])
+            .output()
+            .unwrap();
+        assert!(!r.status.success(), "--clone-table {spec:?} must fail");
+        assert!(!out.exists(), "--clone-table {spec:?} must not publish");
+    }
+}
+
+/// Cloning on synthetic HWP and HWPX documents, both modes, then fill + verify.
+#[test]
+fn clone_table_synthetic_both_formats() {
+    let md = tmp("clone_syn.md");
+    std::fs::write(&md, "앵커\n\n| 가 | 나 |\n|----|----|\n| 1 | 2 |\n").unwrap();
+    for ext in ["hwpx", "hwp"] {
+        let form = tmp(&format!("clone_syn_form.{ext}"));
+        assert!(
+            hwp()
+                .args(["new", "--from"])
+                .arg(&md)
+                .arg("-o")
+                .arg(&form)
+                .status()
+                .unwrap()
+                .success()
+        );
+        for mode in ["blank", "keep"] {
+            let out = tmp(&format!("clone_syn_{mode}.{ext}"));
+            let r = hwp()
+                .arg("edit")
+                .arg(&form)
+                .arg("-o")
+                .arg(&out)
+                .args(["--clone-table", &format!("0=>앵커=>{mode}"), "--verify"])
+                .output()
+                .unwrap();
+            assert!(
+                r.status.success(),
+                "{ext} {mode} clone: {}",
+                String::from_utf8_lossy(&r.stderr)
+            );
+            assert!(
+                hwp()
+                    .arg("validate")
+                    .arg(&out)
+                    .output()
+                    .unwrap()
+                    .status
+                    .success(),
+                "{ext} {mode} clone stays valid"
+            );
+            // The clone (new table #0) is addressable by set-cell.
+            let out2 = tmp(&format!("clone_syn_{mode}_fill.{ext}"));
+            let r2 = hwp()
+                .arg("edit")
+                .arg(&out)
+                .arg("-o")
+                .arg(&out2)
+                .args(["--set-cell", "0:0:0=복제셀"])
+                .output()
+                .unwrap();
+            assert!(
+                r2.status.success(),
+                "{ext} {mode} set-cell into clone: {}",
+                String::from_utf8_lossy(&r2.stderr)
+            );
+            let text = cat(&out2);
+            assert!(text.contains("복제셀"), "{ext} {mode} clone cell filled");
+            assert!(text.contains('1'), "{ext} {mode} source table kept");
+        }
+    }
+}

--- a/crates/hwp-convert/src/edit.rs
+++ b/crates/hwp-convert/src/edit.rs
@@ -1657,6 +1657,11 @@ fn max_instance_id_in_paras(paras: &[Paragraph], max: &mut u32) {
                     }
                 }
                 Control::Generic(g) => {
+                    // Shape/drawing captions carry paragraphs too — include them
+                    // so the document maximum really is global.
+                    if let Some(cap) = &g.caption {
+                        max_instance_id_in_paras(&cap.paragraphs, max);
+                    }
                     for list in &g.paragraph_lists {
                         max_instance_id_in_paras(&list.paragraphs, max);
                     }
@@ -1754,6 +1759,11 @@ fn max_object_id_in_para(para: &Paragraph, max: &mut u32) {
                 if let Some(id) = gso_common_instance_id(&pic.common_data) {
                     *max = (*max).max(id);
                 }
+                if let Some(cap) = &pic.caption {
+                    for p in &cap.paragraphs {
+                        max_object_id_in_para(p, max);
+                    }
+                }
             }
             Control::Generic(g) => {
                 // gso containers carry the same gso common layout — include
@@ -1795,8 +1805,20 @@ fn max_table_z_order_in_para(para: &Paragraph, max: &mut i32) {
                 {
                     *max = (*max).max(pl.z_order);
                 }
+                if let Some(cap) = &t.caption {
+                    for p in &cap.paragraphs {
+                        max_table_z_order_in_para(p, max);
+                    }
+                }
                 for cell in &t.cells {
                     for p in &cell.paragraphs {
+                        max_table_z_order_in_para(p, max);
+                    }
+                }
+            }
+            Control::Picture(pic) => {
+                if let Some(cap) = &pic.caption {
+                    for p in &cap.paragraphs {
                         max_table_z_order_in_para(p, max);
                     }
                 }
@@ -1838,6 +1860,12 @@ fn remap_clone_object_ids(
             .checked_add(1)
             .ok_or_else(|| "개체 z-order 오버플로".to_string())?;
     }
+    // Captions can host nested tables/pictures — remap them too.
+    if let Some(cap) = &mut table.caption {
+        for p in &mut cap.paragraphs {
+            remap_clone_object_ids_in_para(p, next_id, next_z)?;
+        }
+    }
     for cell in &mut table.cells {
         for p in &mut cell.paragraphs {
             remap_clone_object_ids_in_para(p, next_id, next_z)?;
@@ -1854,12 +1882,19 @@ fn remap_clone_object_ids_in_para(
     for ctrl in &mut para.controls {
         match ctrl {
             Control::Table(t) => remap_clone_object_ids(t, next_id, next_z)?,
-            Control::Picture(pic) if pic.common_data.len() >= 36 => {
-                let id = *next_id;
-                *next_id = next_id
-                    .checked_add(1)
-                    .ok_or_else(|| "개체 id 오버플로".to_string())?;
-                pic.common_data[32..36].copy_from_slice(&id.to_le_bytes());
+            Control::Picture(pic) => {
+                if pic.common_data.len() >= 36 {
+                    let id = *next_id;
+                    *next_id = next_id
+                        .checked_add(1)
+                        .ok_or_else(|| "개체 id 오버플로".to_string())?;
+                    pic.common_data[32..36].copy_from_slice(&id.to_le_bytes());
+                }
+                if let Some(cap) = &mut pic.caption {
+                    for p in &mut cap.paragraphs {
+                        remap_clone_object_ids_in_para(p, next_id, next_z)?;
+                    }
+                }
             }
             _ => {}
         }
@@ -2275,6 +2310,45 @@ mod tests {
         assert_eq!(ids[0], 7, "source id untouched");
         ids.sort_unstable();
         assert_eq!(ids, vec![7, 8, 9]);
+    }
+
+    #[test]
+    fn clone_table_keep_캡션_중첩_개체_id_재부여() {
+        let mut doc = clone_test_doc();
+        // Table 0 gets a caption whose paragraph holds a nested hwp5-sourced
+        // table (gso common id 7) — captions must join the id remap too.
+        let inner = with_nth_table_readonly(&mut doc, 0, |t| t.clone()).unwrap();
+        with_nth_table(&mut doc, 0, |t| {
+            let mut inner = inner;
+            inner.common_data = vec![0u8; 44];
+            inner.common_data[32..36].copy_from_slice(&7u32.to_le_bytes());
+            t.caption = Some(hwp_model::Caption {
+                side: hwp_model::CaptionSide::Bottom,
+                direction: hwp_model::CaptionDirection::Horizontal,
+                gap: 283,
+                width: None,
+                last_width: 0,
+                paragraphs: vec![Paragraph {
+                    controls: vec![Control::Table(inner)],
+                    ..Paragraph::default()
+                }],
+            });
+        });
+        assert_eq!(
+            clone_table(&mut doc, 0, "끝", CloneTextMode::Keep).unwrap(),
+            1
+        );
+        let tables = all_tables(&doc);
+        // "끝" follows the source table, so order is [source, clone].
+        let cap_id = |t: &hwp_model::Table| {
+            let Control::Table(inner) = &t.caption.as_ref().unwrap().paragraphs[0].controls[0]
+            else {
+                panic!("caption nested table")
+            };
+            u32::from_le_bytes(inner.common_data[32..36].try_into().unwrap())
+        };
+        assert_eq!(cap_id(tables[0]), 7, "source caption object untouched");
+        assert_eq!(cap_id(tables[1]), 8, "clone caption object remapped");
     }
 
     #[test]

--- a/crates/hwp-convert/src/edit.rs
+++ b/crates/hwp-convert/src/edit.rs
@@ -1415,17 +1415,456 @@ pub fn add_table(doc: &mut Document, anchor: &str, rows: &[Vec<String>]) -> Resu
         controls: vec![Control::Table(table)],
         ..Paragraph::default()
     };
+    Ok(insert_para_after_anchor(doc, anchor, anchor_para)? as usize)
+}
+
+/// Shared anchor semantics for `add_table`/`clone_table`: insert `para`
+/// immediately after the first top-level section paragraph whose text contains
+/// `anchor`. Top-level only — anchors inside cells/text boxes never match.
+fn insert_para_after_anchor(
+    doc: &mut Document,
+    anchor: &str,
+    para: Paragraph,
+) -> Result<u32, String> {
     for section in &mut doc.sections {
         if let Some(i) = section
             .paragraphs
             .iter()
             .position(|p| find_match(&p.chars, anchor, 0).is_some())
         {
-            section.paragraphs.insert(i + 1, anchor_para);
+            section.paragraphs.insert(i + 1, para);
             return Ok(1);
         }
     }
     Err(format!("앵커를 찾을 수 없습니다: {anchor}"))
+}
+
+/// How a cloned table treats source cell content (#78).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloneTextMode {
+    /// Keep one empty styled paragraph per logical cell; drop all source text
+    /// and content controls (fields, bookmarks, images, equations, nested
+    /// content). Geometry, spans, borders, fills, and styles are preserved.
+    Blank,
+    /// Clone every supported paragraph and control subtree (nested tables and
+    /// pictures), remapping all paragraph/control/object instance ids above the
+    /// document maxima. Aborts atomically on opaque controls (`Generic`) whose
+    /// raw identity bytes the model cannot safely remap.
+    Keep,
+}
+
+/// Deep-clone table `source_table` (0-based, recursive order of appearance) and
+/// insert the clone immediately after the first top-level paragraph containing
+/// `anchor` (#78). The source table is never modified; any failure (missing
+/// anchor, invalid index, unsafe opaque child, id overflow) leaves the document
+/// untouched — all fallible work happens on the clone before insertion.
+pub fn clone_table(
+    doc: &mut Document,
+    source_table: usize,
+    anchor: &str,
+    mode: CloneTextMode,
+) -> Result<u32, String> {
+    if anchor.is_empty() {
+        return Err("앵커 텍스트가 없습니다".into());
+    }
+    let (mut clone, payload) = take_table_clone(doc, source_table)
+        .ok_or_else(|| format!("표 #{source_table}를 찾을 수 없습니다"))?;
+    if mode == CloneTextMode::Keep {
+        ensure_cloneable(&clone)?;
+    } else {
+        // Blank: one empty styled paragraph per logical cell and caption; spans,
+        // geometry, and cell-level formatting stay untouched.
+        if let Some(cap) = &mut clone.caption {
+            cap.paragraphs = vec![blank_para_like(cap.paragraphs.first())];
+        }
+        for cell in &mut clone.cells {
+            cell.paragraphs = vec![blank_para_like(cell.paragraphs.first())];
+        }
+    }
+    // Paragraph instance ids must be unique document-wide on the HWP path (the
+    // hwp5-sourced edit path runs with synthesize=false, so the writer will not
+    // reassign them) — blank-mode paragraphs inherit the source ids via
+    // blank_para_like, so both modes remap here.
+    let mut next_para = doc_max_instance_id(doc)
+        .checked_add(1)
+        .ok_or_else(|| "문단 인스턴스 id 오버플로".to_string())?;
+    reassign_clone_para_ids(&mut clone, &mut next_para)?;
+    // Object identity: patch the gso common instance id (common_data @32) or,
+    // for hwpx-sourced tables, bump the placement z-order so the writer's
+    // `0x5000_0000 | z_order` synthesis cannot collide with the source.
+    let mut next_obj = doc_max_object_id(doc)
+        .checked_add(1)
+        .ok_or_else(|| "개체 id 오버플로".to_string())?
+        .max(1);
+    let mut next_z = doc_max_table_z_order(doc).saturating_add(1);
+    remap_clone_object_ids(&mut clone, &mut next_obj, &mut next_z)?;
+    validate_table_invariants(&clone)?;
+
+    let mut anchor_para = Paragraph {
+        chars: vec![
+            HwpChar::ExtCtrl {
+                code: 11,
+                ctrl_id: *b"tbl ",
+                payload,
+                ctrl_index: Some(0),
+            },
+            HwpChar::CharCtrl(13),
+        ],
+        char_shape_runs: vec![(0, CharShapeId(0))],
+        controls: vec![Control::Table(clone)],
+        ..Paragraph::default()
+    };
+    anchor_para.header.instance_id = next_para;
+    insert_para_after_anchor(doc, anchor, anchor_para)
+}
+
+/// Clone the nth table (recursive depth-first order shared with
+/// `walk_nth_table`) out of the document, together with the ExtCtrl payload of
+/// its anchor paragraph (fallback: the same 12-byte default `add_table` uses).
+fn take_table_clone(doc: &Document, index: usize) -> Option<(hwp_model::Table, Vec<u8>)> {
+    let mut seen = 0usize;
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            if let Some(found) = find_table_clone_in_para(para, index, &mut seen) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+fn find_table_clone_in_para(
+    para: &Paragraph,
+    index: usize,
+    seen: &mut usize,
+) -> Option<(hwp_model::Table, Vec<u8>)> {
+    for ctrl in &para.controls {
+        match ctrl {
+            Control::Table(t) => {
+                if *seen == index {
+                    let payload = para
+                        .chars
+                        .iter()
+                        .find_map(|ch| {
+                            if let HwpChar::ExtCtrl {
+                                ctrl_id, payload, ..
+                            } = ch
+                                && ctrl_id == b"tbl "
+                            {
+                                return Some(payload.clone());
+                            }
+                            None
+                        })
+                        .unwrap_or_else(|| {
+                            let mut p = vec![0u8; 12];
+                            p[..4].copy_from_slice(b" lbt"); // reversed ctrl_id
+                            p
+                        });
+                    return Some((t.clone(), payload));
+                }
+                *seen += 1;
+                for cell in &t.cells {
+                    for p in &cell.paragraphs {
+                        if let Some(found) = find_table_clone_in_para(p, index, seen) {
+                            return Some(found);
+                        }
+                    }
+                }
+            }
+            Control::Generic(g) => {
+                for list in &g.paragraph_lists {
+                    for p in &list.paragraphs {
+                        if let Some(found) = find_table_clone_in_para(p, index, seen) {
+                            return Some(found);
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Keep-mode safety gate: any `Generic` control carries raw identity bytes
+/// (CTRL_HEADER data, preserved subtrees, raw XML) the model cannot remap, so
+/// the clone aborts rather than silently duplicating or dropping it (#78).
+fn ensure_cloneable(table: &hwp_model::Table) -> Result<(), String> {
+    if let Some(cap) = &table.caption {
+        for p in &cap.paragraphs {
+            ensure_cloneable_para(p)?;
+        }
+    }
+    for cell in &table.cells {
+        for p in &cell.paragraphs {
+            ensure_cloneable_para(p)?;
+        }
+    }
+    Ok(())
+}
+
+fn ensure_cloneable_para(para: &Paragraph) -> Result<(), String> {
+    for ctrl in &para.controls {
+        match ctrl {
+            Control::Table(t) => ensure_cloneable(t)?,
+            Control::Picture(pic) => {
+                if let Some(cap) = &pic.caption {
+                    for p in &cap.paragraphs {
+                        ensure_cloneable_para(p)?;
+                    }
+                }
+            }
+            Control::Generic(g) => {
+                let _ = g;
+                return Err(format!(
+                    "keep 모드에서 안전하게 복제할 수 없는 개체({})가 표에 포함되어 있습니다",
+                    String::from_utf8_lossy(&ctrl.ctrl_id())
+                ));
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+/// Maximum paragraph instance id across the whole document — body, table cells
+/// (nested tables included), captions, and Generic paragraph lists. The
+/// existing `max_instance_id` is table-local; clone remapping must be global.
+fn doc_max_instance_id(doc: &Document) -> u32 {
+    let mut max = 0u32;
+    for section in &doc.sections {
+        max_instance_id_in_paras(&section.paragraphs, &mut max);
+    }
+    max
+}
+
+fn max_instance_id_in_paras(paras: &[Paragraph], max: &mut u32) {
+    for p in paras {
+        *max = (*max).max(p.header.instance_id);
+        for ctrl in &p.controls {
+            match ctrl {
+                Control::Table(t) => {
+                    if let Some(cap) = &t.caption {
+                        max_instance_id_in_paras(&cap.paragraphs, max);
+                    }
+                    for cell in &t.cells {
+                        max_instance_id_in_paras(&cell.paragraphs, max);
+                    }
+                }
+                Control::Picture(pic) => {
+                    if let Some(cap) = &pic.caption {
+                        max_instance_id_in_paras(&cap.paragraphs, max);
+                    }
+                }
+                Control::Generic(g) => {
+                    for list in &g.paragraph_lists {
+                        max_instance_id_in_paras(&list.paragraphs, max);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+/// Reassign every paragraph instance id inside the clone from `next` upward.
+fn reassign_clone_para_ids(table: &mut hwp_model::Table, next: &mut u32) -> Result<(), String> {
+    if let Some(cap) = &mut table.caption {
+        reassign_para_ids(&mut cap.paragraphs, next)?;
+    }
+    for cell in &mut table.cells {
+        reassign_para_ids(&mut cell.paragraphs, next)?;
+    }
+    Ok(())
+}
+
+fn reassign_para_ids(paras: &mut [Paragraph], next: &mut u32) -> Result<(), String> {
+    for p in paras {
+        p.header.instance_id = *next;
+        *next = next
+            .checked_add(1)
+            .ok_or_else(|| "문단 인스턴스 id 오버플로".to_string())?;
+        for ctrl in &mut p.controls {
+            match ctrl {
+                Control::Table(t) => reassign_clone_para_ids(t, next)?,
+                Control::Picture(pic) => {
+                    if let Some(cap) = &mut pic.caption {
+                        reassign_para_ids(&mut cap.paragraphs, next)?;
+                    }
+                }
+                Control::Generic(g) => {
+                    for list in &mut g.paragraph_lists {
+                        reassign_para_ids(&mut list.paragraphs, next)?;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+/// gso common instance id (4 bytes LE at offset 32), when the raw bytes carry
+/// one — see `hwp5::write::emit_table`/`is_materialized_generated_picture`.
+fn gso_common_instance_id(common: &[u8]) -> Option<u32> {
+    common
+        .get(32..36)
+        .map(|b| u32::from_le_bytes(b.try_into().expect("slice len checked")))
+}
+
+/// A table's object identity as the HWP writer will emit it: the preserved
+/// gso common id, or the id synthesized from the hwpx placement z-order.
+fn table_object_id(t: &hwp_model::Table) -> u32 {
+    gso_common_instance_id(&t.common_data).unwrap_or_else(|| {
+        t.placement
+            .as_ref()
+            .map(|pl| 0x5000_0000 | (pl.z_order as u32 & 0xffff))
+            .unwrap_or(0)
+    })
+}
+
+/// Maximum gso object id across all tables and pictures in the document.
+fn doc_max_object_id(doc: &Document) -> u32 {
+    let mut max = 0u32;
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            max_object_id_in_para(para, &mut max);
+        }
+    }
+    max
+}
+
+fn max_object_id_in_para(para: &Paragraph, max: &mut u32) {
+    for ctrl in &para.controls {
+        match ctrl {
+            Control::Table(t) => {
+                *max = (*max).max(table_object_id(t));
+                if let Some(cap) = &t.caption {
+                    for p in &cap.paragraphs {
+                        max_object_id_in_para(p, max);
+                    }
+                }
+                for cell in &t.cells {
+                    for p in &cell.paragraphs {
+                        max_object_id_in_para(p, max);
+                    }
+                }
+            }
+            Control::Picture(pic) => {
+                if let Some(id) = gso_common_instance_id(&pic.common_data) {
+                    *max = (*max).max(id);
+                }
+            }
+            Control::Generic(g) => {
+                // gso containers carry the same gso common layout — include
+                // their id so a clone never collides with a drawing either.
+                if g.ctrl_id == *b"gso "
+                    && let Some(id) = gso_common_instance_id(&g.data)
+                {
+                    *max = (*max).max(id);
+                }
+                for list in &g.paragraph_lists {
+                    for p in &list.paragraphs {
+                        max_object_id_in_para(p, max);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Maximum placement z-order among all tables (drives the hwpx-sourced id
+/// synthesis `0x5000_0000 | z_order`; bumping it keeps the clone unique).
+fn doc_max_table_z_order(doc: &Document) -> i32 {
+    let mut max = 0i32;
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            max_table_z_order_in_para(para, &mut max);
+        }
+    }
+    max
+}
+
+fn max_table_z_order_in_para(para: &Paragraph, max: &mut i32) {
+    for ctrl in &para.controls {
+        match ctrl {
+            Control::Table(t) => {
+                if t.common_data.is_empty()
+                    && let Some(pl) = &t.placement
+                {
+                    *max = (*max).max(pl.z_order);
+                }
+                for cell in &t.cells {
+                    for p in &cell.paragraphs {
+                        max_table_z_order_in_para(p, max);
+                    }
+                }
+            }
+            Control::Generic(g) => {
+                for list in &g.paragraph_lists {
+                    for p in &list.paragraphs {
+                        max_table_z_order_in_para(p, max);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Give the cloned table (and, recursively, every nested table/picture) a fresh
+/// object identity so the clone shares no mutable id with the source (#78).
+/// hwp5-sourced objects get the next free gso common id; hwpx-sourced tables
+/// get a bumped placement z-order (the writer derives their id from it).
+/// Pictures/tables without raw common bytes synthesize id 0 — the pre-existing
+/// writer fallback, unchanged here.
+fn remap_clone_object_ids(
+    table: &mut hwp_model::Table,
+    next_id: &mut u32,
+    next_z: &mut i32,
+) -> Result<(), String> {
+    if !table.common_data.is_empty() {
+        let id = *next_id;
+        *next_id = next_id
+            .checked_add(1)
+            .ok_or_else(|| "개체 id 오버플로".to_string())?;
+        if table.common_data.len() >= 36 {
+            table.common_data[32..36].copy_from_slice(&id.to_le_bytes());
+        }
+    } else if let Some(pl) = &mut table.placement {
+        pl.z_order = *next_z;
+        *next_z = next_z
+            .checked_add(1)
+            .ok_or_else(|| "개체 z-order 오버플로".to_string())?;
+    }
+    for cell in &mut table.cells {
+        for p in &mut cell.paragraphs {
+            remap_clone_object_ids_in_para(p, next_id, next_z)?;
+        }
+    }
+    Ok(())
+}
+
+fn remap_clone_object_ids_in_para(
+    para: &mut Paragraph,
+    next_id: &mut u32,
+    next_z: &mut i32,
+) -> Result<(), String> {
+    for ctrl in &mut para.controls {
+        match ctrl {
+            Control::Table(t) => remap_clone_object_ids(t, next_id, next_z)?,
+            Control::Picture(pic) if pic.common_data.len() >= 36 => {
+                let id = *next_id;
+                *next_id = next_id
+                    .checked_add(1)
+                    .ok_or_else(|| "개체 id 오버플로".to_string())?;
+                pic.common_data[32..36].copy_from_slice(&id.to_le_bytes());
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 /// Kind of object deletion (GK-8).
@@ -1617,6 +2056,252 @@ mod tests {
         assert_eq!(text, "1");
         // Missing anchor → error.
         assert!(add_table(&mut doc, "없는앵커", &rows).is_err());
+    }
+
+    /// Test helper: collect every table in the document (recursive order).
+    fn all_tables(doc: &Document) -> Vec<&hwp_model::Table> {
+        fn walk<'a>(paras: &'a [Paragraph], out: &mut Vec<&'a hwp_model::Table>) {
+            for p in paras {
+                for ctrl in &p.controls {
+                    match ctrl {
+                        Control::Table(t) => {
+                            out.push(t);
+                            for cell in &t.cells {
+                                walk(&cell.paragraphs, out);
+                            }
+                        }
+                        Control::Generic(g) => {
+                            for list in &g.paragraph_lists {
+                                walk(&list.paragraphs, out);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        let mut out = Vec::new();
+        for section in &doc.sections {
+            walk(&section.paragraphs, &mut out);
+        }
+        out
+    }
+
+    /// Source for clone tests: "머리" para, a 2x2 table, "끝" para.
+    fn clone_test_doc() -> Document {
+        crate::from_markdown::from_markdown("머리\n\n| 가 | 나 |\n|---|---|\n| 1 | 2 |\n\n끝\n")
+    }
+
+    /// Give every source paragraph a distinct non-zero instance id so the
+    /// clone's remapping is observable.
+    fn seed_instance_ids(doc: &mut Document) {
+        let mut next = 100u32;
+        fn walk(paras: &mut [Paragraph], next: &mut u32) {
+            for p in paras {
+                p.header.instance_id = *next;
+                *next += 1;
+                for ctrl in &mut p.controls {
+                    match ctrl {
+                        Control::Table(t) => {
+                            for cell in &mut t.cells {
+                                walk(&mut cell.paragraphs, next);
+                            }
+                        }
+                        Control::Generic(g) => {
+                            for list in &mut g.paragraph_lists {
+                                walk(&mut list.paragraphs, next);
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+        for section in &mut doc.sections {
+            walk(&mut section.paragraphs, &mut next);
+        }
+    }
+
+    #[test]
+    fn clone_table_blank_구조보존_내용제거() {
+        let mut doc = clone_test_doc();
+        seed_instance_ids(&mut doc);
+        let source_max = doc_max_instance_id(&doc);
+        assert_eq!(
+            clone_table(&mut doc, 0, "끝", CloneTextMode::Blank).unwrap(),
+            1
+        );
+
+        let tables = all_tables(&doc);
+        assert_eq!(tables.len(), 2);
+        let (src, clone) = (tables[0], tables[1]);
+        // Source untouched.
+        assert_eq!(cell_text(&src.cells[2]), "1");
+        // Geometry/merge topology preserved.
+        assert_eq!((clone.rows, clone.cols), (src.rows, src.cols));
+        assert_eq!(clone.row_cell_counts, src.row_cell_counts);
+        for (a, b) in src.cells.iter().zip(&clone.cells) {
+            assert_eq!(
+                (a.col, a.row, a.col_span, a.row_span),
+                (b.col, b.row, b.col_span, b.row_span)
+            );
+            assert_eq!(
+                (a.width, a.height, a.border_fill),
+                (b.width, b.height, b.border_fill)
+            );
+        }
+        // Blank: one empty paragraph per cell, no text, no controls.
+        for cell in &clone.cells {
+            assert_eq!(cell.paragraphs.len(), 1);
+            assert!(cell_text(cell).is_empty());
+            assert!(cell.paragraphs[0].controls.is_empty());
+        }
+        // Instance ids remapped above the source document maximum.
+        let clone_ids: Vec<u32> = clone
+            .cells
+            .iter()
+            .map(|c| c.paragraphs[0].header.instance_id)
+            .collect();
+        assert!(clone_ids.iter().all(|&id| id > source_max));
+        let mut dedup = clone_ids.clone();
+        dedup.sort_unstable();
+        dedup.dedup();
+        assert_eq!(dedup.len(), clone_ids.len());
+        // Source ids unchanged.
+        assert!(
+            src.cells
+                .iter()
+                .all(|c| c.paragraphs[0].header.instance_id <= source_max)
+        );
+    }
+
+    #[test]
+    fn clone_table_keep_내용보존_id재부여() {
+        let mut doc = clone_test_doc();
+        seed_instance_ids(&mut doc);
+        let source_max = doc_max_instance_id(&doc);
+        assert_eq!(
+            clone_table(&mut doc, 0, "머리", CloneTextMode::Keep).unwrap(),
+            1
+        );
+
+        let tables = all_tables(&doc);
+        assert_eq!(tables.len(), 2);
+        // The anchor "머리" precedes the source table, so the clone lands first.
+        let (clone, src) = (tables[0], tables[1]);
+        assert_eq!(cell_text(&clone.cells[2]), "1");
+        assert_eq!(cell_text(&src.cells[2]), "1");
+        assert!(
+            clone
+                .cells
+                .iter()
+                .all(|c| c.paragraphs[0].header.instance_id > source_max)
+        );
+    }
+
+    #[test]
+    fn clone_table_keep_opaque_개체_원자적_거부() {
+        let mut doc = clone_test_doc();
+        with_nth_table(&mut doc, 0, |t| {
+            t.cells[0].paragraphs[0]
+                .controls
+                .push(Control::Generic(hwp_model::GenericControl {
+                    ctrl_id: *b"eqed",
+                    data: vec![1, 2, 3],
+                    paragraph_lists: Vec::new(),
+                    extras: Vec::new(),
+                    raw_children: Vec::new(),
+                    gso_shapes: Vec::new(),
+                    equation: None,
+                    column_def: None,
+                    caption: None,
+                    hwpx_raw_xml: None,
+                }));
+        });
+        let err = clone_table(&mut doc, 0, "끝", CloneTextMode::Keep).unwrap_err();
+        assert!(err.contains("eqed"), "bounded ctrl_id error: {err}");
+        // Atomic: nothing was inserted.
+        assert_eq!(all_tables(&doc).len(), 1);
+        // Blank mode strips the same control instead of failing.
+        assert_eq!(
+            clone_table(&mut doc, 0, "끝", CloneTextMode::Blank).unwrap(),
+            1
+        );
+        let tables = all_tables(&doc);
+        assert_eq!(tables.len(), 2);
+        assert!(
+            tables[1]
+                .cells
+                .iter()
+                .all(|c| c.paragraphs.iter().all(|p| p.controls.is_empty()))
+        );
+    }
+
+    #[test]
+    fn clone_table_object_id_재부여() {
+        let mut doc = clone_test_doc();
+        // Pretend the source table came from hwp5: raw gso common with id 7 @32.
+        with_nth_table(&mut doc, 0, |t| {
+            t.common_data = vec![0u8; 44];
+            t.common_data[32..36].copy_from_slice(&7u32.to_le_bytes());
+        });
+        assert_eq!(
+            clone_table(&mut doc, 0, "끝", CloneTextMode::Blank).unwrap(),
+            1
+        );
+        let tables = all_tables(&doc);
+        assert_eq!(
+            u32::from_le_bytes(tables[0].common_data[32..36].try_into().unwrap()),
+            7,
+            "source id untouched"
+        );
+        assert_eq!(
+            u32::from_le_bytes(tables[1].common_data[32..36].try_into().unwrap()),
+            8,
+            "clone gets the next free id"
+        );
+        // A second clone keeps rising — no collision with either existing table.
+        // (Both clones anchor after "끝", so the newer one lands ahead of the older.)
+        assert_eq!(
+            clone_table(&mut doc, 0, "끝", CloneTextMode::Blank).unwrap(),
+            1
+        );
+        let tables = all_tables(&doc);
+        assert_eq!(tables.len(), 3);
+        let mut ids: Vec<u32> = tables
+            .iter()
+            .map(|t| u32::from_le_bytes(t.common_data[32..36].try_into().unwrap()))
+            .collect();
+        assert_eq!(ids[0], 7, "source id untouched");
+        ids.sort_unstable();
+        assert_eq!(ids, vec![7, 8, 9]);
+    }
+
+    #[test]
+    fn clone_table_중첩_인덱스와_오류() {
+        let mut doc = clone_test_doc();
+        // Nest a copy of table 0 inside its own first cell → indices 0 (outer), 1 (nested).
+        let inner = with_nth_table_readonly(&mut doc, 0, |t| t.clone()).unwrap();
+        with_nth_table(&mut doc, 0, |t| {
+            t.cells[0].paragraphs[0]
+                .controls
+                .push(Control::Table(inner));
+        });
+        assert_eq!(all_tables(&doc).len(), 2);
+        // Cloning index 1 clones the nested table, not the outer one.
+        assert_eq!(
+            clone_table(&mut doc, 1, "끝", CloneTextMode::Blank).unwrap(),
+            1
+        );
+        let tables = all_tables(&doc);
+        assert_eq!(tables.len(), 3);
+        assert!(tables[2].cells[0].paragraphs[0].controls.is_empty());
+        // Errors: bad index, missing anchor, empty anchor — document unchanged.
+        let before = all_tables(&doc).len();
+        assert!(clone_table(&mut doc, 99, "끝", CloneTextMode::Blank).is_err());
+        assert!(clone_table(&mut doc, 0, "없는앵커", CloneTextMode::Blank).is_err());
+        assert!(clone_table(&mut doc, 0, "", CloneTextMode::Blank).is_err());
+        assert_eq!(all_tables(&doc).len(), before);
     }
 
     #[test]

--- a/crates/hwp-convert/src/lib.rs
+++ b/crates/hwp-convert/src/lib.rs
@@ -26,9 +26,9 @@ pub use bookmark::{
 pub use csv::to_csv;
 pub use docx::to_docx;
 pub use edit::{
-    ObjectKind, add_col, add_rows, add_rows_at, add_table, add_table_column, add_table_columns,
-    apply_meta, delete_object, delete_table_column, delete_table_row, merge_cells, replace_text,
-    set_cell, split_cell, table_dims,
+    CloneTextMode, ObjectKind, add_col, add_rows, add_rows_at, add_table, add_table_column,
+    add_table_columns, apply_meta, clone_table, delete_object, delete_table_column,
+    delete_table_row, merge_cells, replace_text, set_cell, split_cell, table_dims,
 };
 pub use field::{
     FieldInfo, PlaceholderInfo, create_field, create_hyperlink, hyperlink_url, list_fields,

--- a/docs/design/12-feature-gaps.ko.md
+++ b/docs/design/12-feature-gaps.ko.md
@@ -109,8 +109,8 @@
   5): metadata·text·paragraph·table-cell·image HWPX 편집 모두 엔트리 집합 동일, opaque
   엔트리 전량 바이트 동일(미디어 24→24, 이미지 삽입 후 25; container 5→5), `hwp validate`
   클린, non-strict hwp→hwpx는 미디어 24개 전량 보존(종전 9), strict 변환은 양방향 모두
-  fail-closed, 8개 결과물 모두 한글에서 손상/복구 대화상자 없이 열림. #90 잔여(PR 5+):
-  표 복제(#78), WMF 벡터, pagination/font 게이트, 인증. hwpx→hwp 변환은
+  fail-closed, 8개 결과물 모두 한글에서 손상/복구 대화상자 없이 열림. #90 잔여(PR 6+):
+  WMF 벡터, pagination/font 게이트, 인증. hwpx→hwp 변환은
   settings.xml/version.xml/preview 슬롯 손실을 아직 typed 이벤트로 집계하지 않는다.
   content.hpf 재생성은 모델링된 manifest 항목/메타데이터만 유지하므로, 비모델 manifest
   항목은 고아 엔트리로 남는다(raw-copy는 되지만 목록에는 미등재).
@@ -126,6 +126,19 @@
   행을 쓴다. 열 삽입은 전체 폭 재분배 정책을 유지하고, 새 문단 instance ID는 문서
   최댓값 위로 부여하며, 모든 실패(범위·u16 오버플로·불변식 위반)는 아무것도 발행하지
   않는다. opaque HWPX 컨테이너 안의 표는 여전히 fail-closed.
+
+- **2026-08-15 (이슈 #78 표 깊은 복제)**: `--clone-table "원본표=>앵커[=>blank|keep]"`
+  (MCP `clone_table`의 `source_table`/`anchor`/`text_mode`)이 원본 표를 깊은 복제해
+  앵커 문단 뒤에 삽입한다 — 기하·병합 토폴로지·너비/높이·테두리·채우기·문단/글자
+  서식 보존. `blank`(기본)는 논리 셀마다 빈 서식 문단 1개만 남기고 원본 텍스트와
+  콘텐츠 컨트롤(필드·책갈피·하이퍼링크·그림·수식·중첩 콘텐츠)을 모두 제거한다.
+  `keep`은 중첩 표와 그림까지 복제하되 모든 문단 instance ID를 문서 최댓값 위로
+  재부여하고 gso 개체 식별자(보존 common_data 오프셋 32의 ID, 또는 writer ID 합성을
+  좌우하는 placement z-order)를 새 값으로 고쳐 원본과 가변 ID를 공유하지 않는다.
+  바이너리 에셋은 그 자리에서 재사용. keep 모드는 모델이 안전하게 재매핑할 수 없는
+  opaque `Generic` 컨트롤(필드·수식·글상자)이 있으면 조용히 빼는 대신 원자적으로
+  중단한다. 앵커 매칭은 톱레벨 문단만(`--add-table`과 같은 의미), 모든 실패는
+  아무것도 발행하지 않는다.
 
 - **2026-07-15**: GA-5(버전 게이트), GE-α1~α5·α7(글자효과·밑줄모양·번호형식 hwpx 왕복),
   GE-β4(요약정보 필드), GH-1·GH-2(md/html 링크·이미지), GL-1(추출 옵션 CLI 노출) —

--- a/docs/design/12-feature-gaps.md
+++ b/docs/design/12-feature-gaps.md
@@ -122,8 +122,8 @@ is itself knowledge).
   entry set identical with all opaque entries byte-identical (media 24→24, 25 after an
   image insert; containers 5→5), `hwp validate` is clean, non-strict hwp→hwpx preserves all
   24 media (previously 9), strict conversion fails closed in both directions, and all eight
-  outputs opened in Hancom with no corruption or repair dialog. Still open in #90 (PR 5+):
-  table cloning (#78), WMF vectors, the pagination/font gate and certification.
+  outputs opened in Hancom with no corruption or repair dialog. Still open in #90 (PR 6+):
+  WMF vectors, the pagination/font gate and certification.
   hwpx→hwp conversion does not yet flag settings.xml/version.xml/preview slot loss with
   typed events. And content.hpf regeneration keeps only modeled manifest items/metadata,
   so unmodeled manifest items survive as orphan package entries (raw-copied but unlisted).
@@ -141,6 +141,23 @@ is itself knowledge).
   instance IDs are issued above the document maximum, and every failure mode (bounds,
   u16 overflow, invariant violation) publishes nothing. Tables inside opaque HWPX
   containers stay fail-closed.
+
+- **2026-08-15 (issue #78 deep table cloning)**: `--clone-table
+  "SOURCE_TABLE=>ANCHOR[=>blank|keep]"` (MCP `clone_table` with
+  `source_table`/`anchor`/`text_mode`) deep-copies the source table — geometry,
+  merge topology, widths/heights, borders, fills, and paragraph/character
+  styles — and inserts the clone after the anchor paragraph. `blank` (default)
+  keeps one empty styled paragraph per logical cell and drops all source text
+  and content controls (fields, bookmarks, hyperlinks, images, equations,
+  nested content). `keep` clones nested tables and pictures as well, remapping
+  every paragraph instance ID above the document maximum and patching gso
+  object identities (the preserved common-data ID at offset 32, or the
+  placement z-order that drives the writer's ID synthesis) so the clone shares
+  no mutable ID with the source; binary assets are reused in place. Keep mode
+  aborts atomically on opaque `Generic` controls (fields, equations, text
+  boxes) whose raw identity bytes the model cannot remap — never a silent drop.
+  Anchor matching is top-level only (same semantics as `--add-table`), and
+  every failure mode publishes nothing.
 
 - **2026-07-15**: GA-5 (version gate), GE-α1 to α5 and α7 (character effects, underline shape and
   numbering format in the hwpx round-trip), GE-β4 (summary information fields), GH-1 and GH-2

--- a/docs/manual/cli-reference.ko.md
+++ b/docs/manual/cli-reference.ko.md
@@ -200,6 +200,7 @@ TemplateSpec/Data v1에서 typed native HWP/HWPX 생성
 | `--merge-cells` | `<MERGE_CELLS>` |  | 셀 병합 "표:r1:c1:r2:c2" — 사각 영역을 좌상단 앵커로 병합 (반복 가능, 0-기반) |
 | `--split-cell` | `<SPLIT_CELL>` |  | 셀 분할 "표:행:열" — 병합 셀을 1×1로 분해 (반복 가능, 0-기반) |
 | `--add-table` | `<ADD_TABLE>` |  | 표 삽입 "앵커=>행JSON" — 앵커 문단 뒤에 균일 표 삽입. 행JSON은 문자열 배열의 배열 (반복 가능) |
+| `--clone-table` | `<CLONE_TABLE>` |  | 표 복제 "원본표=>앵커[=>blank\|keep]" — N번째 표(0-기반, 재귀 순서)를 깊은 복제해 앵커 문단 뒤에 삽입. blank(기본)는 구조·서식만 남기고 셀 내용을 비우고, keep은 지원 콘텐츠(중첩 표·그림)까지 복제(id 재부여) (반복 가능) |
 | `--set-para` | `<SET_PARA>` |  | 문단 모양 "찾기=>키:값" — 키: line-spacing(% 또는 Npt), indent, left, right, top, bottom (mm) (반복 가능) |
 | `--set-page` | `<SET_PAGE>` |  | 페이지 설정 "키:값" — 키: width, height, margin-left, margin-right, margin-top, margin-bottom (mm), orientation (portrait\|landscape) (반복 가능) |
 | `--delete-image` | `<DELETE_IMAGE>` |  | 그림 삭제 "앵커" — 앵커 문단의 그림 삭제 (반복 가능) |

--- a/docs/manual/cli-reference.md
+++ b/docs/manual/cli-reference.md
@@ -200,6 +200,7 @@ Edit an existing document (text replacement, table cells); images and formatting
 | `--merge-cells` | `<MERGE_CELLS>` |  | Merge cells, "table:r1:c1:r2:c2": merge a rectangular area into its top-left anchor (repeatable, 0-based) |
 | `--split-cell` | `<SPLIT_CELL>` |  | Split a cell, "table:row:col": break a merged cell back into 1x1 cells (repeatable, 0-based) |
 | `--add-table` | `<ADD_TABLE>` |  | Insert a table, "anchor=>json": insert a uniform table after the anchor paragraph; json is an array of row arrays (repeatable) |
+| `--clone-table` | `<CLONE_TABLE>` |  | Clone a table, "source_table=>anchor[=>blank\|keep]": deep-copy table source_table (0-based, recursive) after the anchor paragraph; blank (default) keeps structure/styles with empty cells, keep also clones supported content (nested tables, images) with remapped ids (repeatable) |
 | `--set-para` | `<SET_PARA>` |  | Paragraph shape properties, "find=>key:value" (keys: line-spacing (% or Npt), indent, left, right, top, bottom (mm); repeatable) |
 | `--set-page` | `<SET_PAGE>` |  | Page setup, "key:value" (keys: width, height, margin-left, margin-right, margin-top, margin-bottom (mm), orientation (portrait\|landscape); repeatable) |
 | `--delete-image` | `<DELETE_IMAGE>` |  | Delete an image, "anchor": delete the picture in the anchor paragraph (repeatable) |

--- a/skills/hwp/SKILL.md
+++ b/skills/hwp/SKILL.md
@@ -55,6 +55,9 @@ syntax (used by `fill`, `slots` and the template tools).
   `end` appends; a number inserts before that row/column; merged tables supported) /
   `--delete-row "t:r"` / `--delete-col "t:c"` /
   `--merge-cells "t:r1:c1:r2:c2"` / `--split-cell "t:r:c"` / `--add-table "anchor=>[[row],...]"` /
+  `--clone-table "src=>anchor[=>blank|keep]"` (deep-copy table `src` after the anchor —
+  blank keeps structure/styles with empty cells, keep also clones nested tables/images
+  with remapped IDs) /
   `--delete-table "n|anchor"` / `--delete-image "anchor"` / `--delete-field "name"` /
   `--delete-bookmark "name"`, paragraph shape `--set-para "find=>key:value"`
   (line-spacing, indent, left/right/top/bottom mm) and page setup `--set-page "key:value"`
@@ -147,7 +150,7 @@ Tools (16):
 | `hwp_list_bookmarks` | `path` | List bookmarks (bokm) |
 | `hwp_slots` | `path` | List `{{name}}` placeholders |
 | `hwp_render` | `path` | Render pages (`format`: png/svg/pdf, `pages` range); single-page PNG returns base64, larger results write files via `output_path` |
-| `hwp_edit` | `input`, `output` | Strict atomic editing through typed JSON operations (mirrors every `hwp edit` flag, incl. `add_table`, `set_para`, `set_page`, `delete_*`) |
+| `hwp_edit` | `input`, `output` | Strict atomic editing through typed JSON operations (mirrors every `hwp edit` flag, incl. `add_table`, `clone_table`, `set_para`, `set_page`, `delete_*`) |
 | `hwp_convert` | `input`, `output` | Format conversion (`strict` defaults to true over MCP) |
 | `hwp_new` | `output` | Create a document from markdown or JSON IR plus metadata |
 | `hwp_compose` | `output`, `spec`/`spec_path` | Compose DocumentSpec v1/v2 through the same path as the CLI |


### PR DESCRIPTION
## Summary

Epic #90 PR 5 — closes #78.

- `--clone-table "SOURCE_TABLE=>ANCHOR[=>blank|keep]"` (CLI) and `clone_table: [{source_table, anchor, text_mode}]` (MCP), both backed by one `hwp_convert::clone_table` primitive.
- Deep-copies geometry, merge topology, widths/heights, borders, fills, and paragraph/character styles; the clone is inserted after the anchor paragraph (same top-level anchor semantics as `--add-table`).
- `blank` (default): one empty styled paragraph per logical cell; all source text and content controls (fields, bookmarks, hyperlinks, images, equations, nested content) removed.
- `keep`: also clones nested tables and pictures; every paragraph instance id is remapped above the document maximum (new document-global walker) and gso object identities are patched (common-data id @32, or the placement z-order driving writer id synthesis), so the clone shares no mutable id with the source. Binary assets are reused in place — same-format HWPX cloning leaves every non-section package entry byte-identical.
- Keep mode aborts atomically on opaque `Generic` controls (fields, equations, text boxes) whose raw identity bytes cannot be safely remapped — never a silent drop. All failure modes publish nothing (all fallible work runs on the clone before insertion).

## Verification

- `scripts/check.sh`: OK (fmt/clippy 1.93.0/workspace tests/structured corpus; public pdf-parity is the documented environment skip).
- New tests: 5 library unit tests (blank structure/content, keep id remap, opaque abort atomicity, object id reissue across sequential clones, nested index/errors), 6 CLI integration tests on the committed fixture (blank/keep/sequential/spec errors/synthetic both formats + HWP instance-id uniqueness over the whole document), 1 package-surgical test (non-target entries byte-identical, entry set unchanged), MCP schema + behavior tests.
- Private-corpus gate (`run-authoring-validation-e.sh`, gitignored): 25/25 RESULT lines pass — HWPX blank/keep clones of the 11x8 merged table (pictures + 4 nested tables come along, BinData 24→24, containers 5→5, opaque bytes preserved, entry set identical), HWP blank/keep clones, keep-mode abort on a table with an opaque control publishes nothing, and all four outputs open in Hancom with no repair/damage dialog (`windows=1,sheets=0`).

## Known limits (documented)

- Keep mode refuses opaque `Generic` controls (per #78 out-of-scope: copying an opaque control whose identity cannot be safely remapped).
- Anchor matching is top-level only, matching `--add-table`.