### PR TITLE
ci(release): cross-build the Linux asset against glibc 2.17

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,15 @@ jobs:
       fail-fast: false # one target's failure must not cancel the others
       matrix:
         include:
-          - target: x86_64-unknown-linux-gnu
+          # Cross-built against a glibc 2.17 baseline: a native ubuntu-24.04 build needs
+          # GLIBC_2.39, which serverless runtimes do not have (Vercel and AWS Lambda run
+          # Amazon Linux 2023 = glibc 2.34), so the asset was unusable there. The action
+          # strips the `.2.17` suffix when naming the archive, so the published asset name
+          # is unchanged — install.sh, update.rs, update_formula.sh and the formula all
+          # keep matching it.
+          - target: x86_64-unknown-linux-gnu.2.17
             os: ubuntu-latest
+            build-tool: cargo-zigbuild
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-apple-darwin
@@ -102,10 +109,17 @@ jobs:
       # Release binaries build on stable (latest optimizations); MSRV compatibility is
       # already guaranteed by CI, which builds and tests on the pinned MSRV toolchain.
       - uses: dtolnay/rust-toolchain@stable
+      # Ahead of the action, whose own fallback is a bare `pip3 install` that PEP 668
+      # rejects on ubuntu-24.04. The PyPI package depends on `ziglang`, so this also
+      # provides zig — no separate toolchain step.
+      - if: matrix.build-tool == 'cargo-zigbuild'
+        run: pip3 install --break-system-packages cargo-zigbuild
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: hwp
           target: ${{ matrix.target }}
+          # Empty for the native targets — the action then picks its own default.
+          build-tool: ${{ matrix.build-tool }}
           archive: $bin-$tag-$target
           checksum: sha256
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -129,6 +143,13 @@ jobs:
             --pattern "hwp-$GITHUB_REF_NAME-x86_64-unknown-linux-gnu.tar.gz" \
             --dir "$work" --clobber
           tar -xzf "$work/hwp-$GITHUB_REF_NAME-x86_64-unknown-linux-gnu.tar.gz" -C "$work"
+          # The asset is already extracted here, so the serverless-compatibility gate is
+          # free: it must run, and its glibc floor must stay at the cross-build baseline
+          # (a native build would silently raise it back to the runner's glibc).
+          "$work/hwp" --version
+          floor=$(strings -a "$work/hwp" | grep -o 'GLIBC_[0-9.]*' | sort -uV | tail -1)
+          echo "glibc floor: $floor"
+          [ "$floor" = "GLIBC_2.17" ] || { echo "::error::glibc floor regressed ($floor) — the Linux asset no longer runs on Vercel/Lambda"; exit 1; }
           bundle="$work/bundle"
           mkdir -p "$bundle/bin"
           cp skills/hwp/SKILL.md "$bundle/SKILL.md"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,9 @@ jobs:
           fi
 
   # Create the release shell once (notes come from the CHANGELOG section). Skipped if it
-  # already exists (rerun-safe).
+  # already exists (rerun-safe). Created as a draft: `releases/latest` ignores drafts, so
+  # install.sh and `hwp update` cannot pick the release up until publish-release flips it,
+  # which happens only after every asset gate has passed.
   create-release:
     needs: [verify-ci, verify-version]
     runs-on: ubuntu-latest
@@ -78,7 +80,7 @@ jobs:
           if ! gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
             bash scripts/release_notes.sh "$GITHUB_REF_NAME" > /tmp/release-notes.md
             gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" \
-              --notes-file /tmp/release-notes.md --verify-tag
+              --notes-file /tmp/release-notes.md --verify-tag --draft
           fi
 
   # Build platform `hwp` binaries -> upload archives (tar.gz/zip) + sha256 to the release.
@@ -163,13 +165,25 @@ jobs:
             "$work/hwp-skill-claude-web.zip.sha256" \
             --clobber
 
+  # Everything is uploaded and gated — make the release public. Any earlier job failing
+  # leaves the release a draft, so a broken or serverless-incompatible asset is never the
+  # release install.sh and `hwp update` resolve to.
+  publish-release:
+    needs: skill-bundle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false
+
   # Homebrew formula (the repo itself is the tap): update version/sha256 from the freshly
   # uploaded assets. main is a protected branch, so the bot cannot push directly — open a PR
   # and merge it: squash auto-merge when possible, an immediate squash merge as fallback
   # (repos with no required checks refuse auto-merge on clean PRs). The release is valid
   # either way, and scripts/update_formula.sh X.Y.Z remains the local recovery path.
   update-formula:
-    needs: upload-assets
+    needs: publish-release
     runs-on: ubuntu-latest
     steps:
       # Check out main, not the tag — the formula change targets main.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,16 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
   (`table_split_across_pages` info, `table_row_too_tall_clipped`). Hancom Office oracle comparison
   remains pending, so this does not yet certify output parity.
 
+**Changed**
+
+- The Linux release asset is now cross-built with `cargo-zigbuild` against a glibc 2.17 baseline
+  instead of natively on the ubuntu-24.04 runner. The native build required `GLIBC_2.39`, so it
+  could not run on serverless runtimes (Vercel's Node runtime and AWS Lambda are Amazon Linux 2023,
+  glibc 2.34) and downstream projects had to hand-build and vendor their own binary. The asset name,
+  archive layout and `.sha256` scheme are unchanged, so `scripts/install.sh`, `hwp update` and the
+  Homebrew formula keep working as before; the release workflow now asserts the floor stays at
+  `GLIBC_2.17`. No other platform's build changed.
+
 **Fixed**
 
 - Synthesized line spacing misread the margin-only mode (2) as a ratio and clamped the fixed

--- a/README.ko.md
+++ b/README.ko.md
@@ -120,6 +120,24 @@ hwp --version
 
 압축을 풀어 `hwp`를 PATH에 둔다(검증: `shasum -a 256 -c hwp-*.sha256`).
 
+### 서버리스·컨테이너 (Vercel, AWS Lambda, Docker)
+
+Linux 아카이브는 **glibc 2.17** 기준으로 크로스 빌드한다. 그래서 Amazon Linux 2·2023, Debian 8+,
+RHEL/CentOS 7+ 및 그 이후 배포판에서 그대로 돌아간다. 빌드 러너보다 glibc가 낮은 Vercel Node
+런타임과 AWS Lambda도 포함된다.
+
+바이너리를 커밋하지 말고 빌드 단계에서 받는다. 그러면 갱신할 것은 고정한 태그 하나뿐이다.
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
+  | sh -s -- --tag v0.8.5 --dir ./bin
+```
+
+플랫폼이 배포 번들을 수집하기 전에 바이너리가 있어야 하므로(Vercel `includeFiles`, Next.js
+`outputFileTracingIncludes`, Docker 레이어) 요청 시점이 아니라 빌드 커맨드나 `prebuild`
+스크립트에서 실행한다. 폰트는 동봉되지 않으니 렌더 계열 명령에는 폰트를 함께 올리고
+`--font-dir`(또는 `HWP_FONT_DIR`)로 지정한다.
+
 ### 소스 빌드
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -134,6 +134,25 @@ Every [release](https://github.com/STAIxBWLB/hwp-cli/releases) attaches per-plat
 
 Extract and put `hwp` on PATH (verify with `shasum -a 256 -c hwp-*.sha256`).
 
+### Serverless and containers (Vercel, AWS Lambda, Docker)
+
+The Linux archive is cross-built against a **glibc 2.17** baseline, so it runs on Amazon Linux 2 and
+2023, Debian 8+, RHEL/CentOS 7+ and anything newer — including Vercel's Node runtime and AWS Lambda,
+whose glibc is older than the build runner's.
+
+Fetch it in the build step instead of committing the binary; then the pinned tag is the only thing
+to bump:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
+  | sh -s -- --tag v0.8.5 --dir ./bin
+```
+
+Run this from the build command (or a `prebuild` script) so the binary exists before the platform
+collects the deployment bundle — Vercel `includeFiles`, Next.js `outputFileTracingIncludes`, or a
+Docker layer. Fonts are not bundled: mount them and pass `--font-dir` (or `HWP_FONT_DIR`) for
+rendering commands.
+
 ### Building from source
 
 ```sh


### PR DESCRIPTION
## Why

The Linux release asset is a native build on `ubuntu-latest` (24.04), so it requires `GLIBC_2.39` and cannot run on serverless runtimes: Vercel's Node runtime and AWS Lambda are Amazon Linux 2023 (glibc 2.34).

Three downstream projects work around this by hand-running `cargo zigbuild --target x86_64-unknown-linux-gnu.2.17` and committing a ~17 MB ELF into git. Each is stale at a different version (0.8.4 / 0.7.0 / 0.1.0) because bumping needs a Rust cross-build no dependency bot can perform.

## What

- `upload-assets`: the Linux matrix entry builds `x86_64-unknown-linux-gnu.2.17` with `build-tool: cargo-zigbuild`. `upload-rust-binary-action` strips the glibc suffix when naming the archive (`main.sh` `target="${target%%.*}"`), so **the published asset name, archive layout and `.sha256` scheme are unchanged** - `scripts/install.sh`, `hwp update` (`update.rs`), `scripts/update_formula.sh` and `Formula/hwp.rb` all keep matching. No other platform changed.
- `cargo-zigbuild` is installed in a step ahead of the action, because the action's own fallback is a bare `pip3 install`, which PEP 668 rejects on ubuntu-24.04. The PyPI package depends on `ziglang`, so no separate zig setup is needed.
- `skill-bundle` already extracts the Linux archive, so the gate costs nothing: it now runs `hwp --version` and fails the release if the glibc floor rises above `GLIBC_2.17`.
- README (en + ko): new "Serverless and containers" section documenting the build-time download recipe as the canonical way to consume `hwp` on Vercel/Lambda/Docker.

## Verification

Local reproduction of the exact release build:

```
$ cargo zigbuild --release --target x86_64-unknown-linux-gnu.2.17 -p hwp-cli
$ file target/x86_64-unknown-linux-gnu/release/hwp
ELF 64-bit LSB pie executable, x86-64 ... dynamically linked, stripped
$ strings -a target/x86_64-unknown-linux-gnu/release/hwp | grep -o 'GLIBC_[0-9.]*' | sort -uV | tail -1
GLIBC_2.17
```

The workspace has no `build.rs`; its only C dependency is `zstd-sys` (via `zip` default features), which `zig cc` compiles. Execution on Linux is verified by the new `hwp --version` step on the ubuntu runner at release time.

No Rust source changed.