### PR TITLE
chore(release): prepare v0.8.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,10 @@ name: Release
 # Pushing a vX.Y.Z tag publishes platform `hwp` binaries to a GitHub Release (archive +
 # sha256) only after (1) the tagged commit already has a green CI run and (2) the tag
 # matches the Cargo.toml version.
-# Release flow: scripts/release.sh X.Y.Z  ->  git push origin main && git push origin vX.Y.Z
+# Release flow (main is protected, so the version bump cannot be pushed to it directly):
+# close the CHANGELOG section and run scripts/release.sh X.Y.Z on a branch, discard the tag
+# it creates there (`git tag -d vX.Y.Z`), open a PR, squash merge it, then tag the merge
+# commit once CI is green on main:  git tag -a vX.Y.Z -m vX.Y.Z && git push origin vX.Y.Z
 on:
   push:
     # glob pattern (not regex) — matches multi-digit and prerelease tags (v10.2.3, v0.2.0-rc1).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.8.5]
+
 **Added**
 
 - Bounded WMF vector image rendering

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-cli"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "hwp-model",
  "image",
@@ -721,14 +721,14 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "hwp-render"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "encoding_rs",
  "flate2",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "cfb",
  "flate2",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "hwp-convert",
  "hwp-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.8.4"
+version = "0.8.5"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,10 +2,14 @@
 # scripts/release.sh X.Y.Z
 #
 # 워크스페이스 버전(Cargo.toml [workspace.package] version)을 bump 하고 커밋 + 태그를
-# 만든다. 푸시는 수동 — 태그 푸시가 release.yml 을 트리거해 실제 릴리스가 일어난다:
+# 만든다. main 은 보호 브랜치라 이 커밋을 직접 밀 수 없다 — 브랜치에서 실행하고 PR 로
+# 머지한 뒤, 머지 커밋에 태그를 다시 붙인다(태그 푸시가 release.yml 을 트리거한다):
 #
-#     scripts/release.sh 0.2.0
-#     git push origin main && git push origin v0.2.0
+#     git switch -c chore/release-v0.2.0
+#     scripts/release.sh 0.2.0 && git tag -d v0.2.0   # 브랜치 태그는 버린다
+#     gh pr create ... && gh pr merge --squash        # CHANGELOG 절 마감도 같은 PR 에서
+#     git switch main && git pull                     # main CI 가 초록인지 확인 후
+#     git tag -a v0.2.0 -m v0.2.0 && git push origin v0.2.0
 #
 # 자체 점검:  scripts/release.sh --self-test
 set -euo pipefail


### PR DESCRIPTION
Cuts v0.8.5: closes the `[Unreleased]` section as `## [0.8.5]` and bumps `[workspace.package] version` (`scripts/release.sh 0.8.5`).

Headline for this release is the serverless-compatible Linux asset (#99) — it is cross-built against a glibc 2.17 baseline, so the published `hwp-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz` runs on Vercel and AWS Lambda unchanged. Also ships the WMF vector renderer, HWPX container rendering, deep table cloning, positioned row/column insertion, cross-format loss detection and package-surgical HWPX editing.

The tag is created on main after this merges, once CI is green on the merge commit (`verify-ci` reads the tagged commit's check runs).