### PR TITLE
feat(render): paginate over-height CELL table rows (#90 PR 7a)

### DIFF
--- a/crates/hwp-render/src/layout.rs
+++ b/crates/hwp-render/src/layout.rs
@@ -1556,23 +1556,42 @@ struct CellSplitPlan {
 
 impl CellSplitPlan {
     fn is_usable(&self) -> bool {
-        self.groups.len() > 1 && self.groups.iter().all(|group| group.has_content)
+        // Trailing blank groups carry declared row-height remainder only, so
+        // they need no cached text.  Every fragment up to the last content
+        // run must own cached geometry — a split required for text can never
+        // be satisfied by a blank page.
+        let Some(last_content) = self.groups.iter().rposition(|group| group.has_content) else {
+            return false;
+        };
+        self.groups.len() > 1
+            && self.groups[..=last_content]
+                .iter()
+                .all(|group| group.has_content)
     }
 }
 
 /// Build Regime-A cell fragments from the line layout saved by Hancom.
 ///
 /// A CELL table is only safely splittable at a cached line boundary. Explicit
-/// cached page starts (`flags & 1` or a vertical-position reset) are preserved;
-/// otherwise a boundary is selected immediately before the first cached line
-/// that would exceed the remaining page capacity. A paragraph without line
-/// segments is not guessed into a page: callers must surface an incomplete
-/// render when that paragraph is part of a required split.
+/// cached page starts (`flags & 1`) are preserved as hard page breaks.  A
+/// vertical-position reset without that flag is a soft boundary: Hancom also
+/// restarts `v_pos` for reasons other than a page break, so the run after the
+/// reset is packed into the page capacity left by the previous fragment
+/// whenever a complete cached line still fits there.  Otherwise a boundary is
+/// selected immediately before the first cached line that would exceed the
+/// remaining page capacity. A paragraph without line segments is not guessed
+/// into a page: callers must surface an incomplete render when that paragraph
+/// is part of a required split.
+///
+/// `fragment_margin_v` is the vertical cell margin each emitted fragment
+/// spends on the page; it keeps the simulated capacity in step with the
+/// emitter's greedy fragment packing.
 fn cached_cell_split_plan(
     cell: &hwp_model::Cell,
     measured_content_h: f32,
     first_capacity_pt: f32,
     following_capacity_pt: f32,
+    fragment_margin_v: f32,
 ) -> Option<CellSplitPlan> {
     let para_count = cell.paragraphs.len();
     let mut first_v = vec![0i32];
@@ -1584,6 +1603,9 @@ fn cached_cell_split_plan(
     let mut saw_line = false;
     let mut current_capacity = first_capacity_pt.max(0.0);
     let following_capacity = following_capacity_pt.max(1.0);
+    // Simulated content-space capacity left on the current page.  Closing a
+    // fragment spends its height plus one vertical cell margin.
+    let mut capacity_left = current_capacity;
 
     for (para_index, para) in cell.paragraphs.iter().enumerate() {
         if para.line_segs.is_empty() {
@@ -1621,21 +1643,43 @@ fn cached_cell_split_plan(
                 // Size the first group for the fresh-page capacity; the
                 // emitter will move it before drawing.
                 current_capacity = following_capacity;
+                capacity_left = following_capacity;
             }
-            let explicit_boundary = saw_line
-                && (seg.flags & 0x1 != 0
-                    || previous_v.is_some_and(|previous| seg.v_pos < previous));
+            let explicit_boundary = saw_line && seg.flags & 0x1 != 0;
+            let reset_boundary = saw_line
+                && !explicit_boundary
+                && previous_v.is_some_and(|previous| seg.v_pos < previous);
             let capacity_boundary = saw_line
                 && !explicit_boundary
+                && !reset_boundary
                 && has_content[current]
                 && (end - first_v[current]) as f32 / 100.0 > current_capacity + 0.5;
-            if explicit_boundary || capacity_boundary {
+            if explicit_boundary || reset_boundary || capacity_boundary {
+                let closed_height = (max_end[current] - first_v[current]).max(0) as f32 / 100.0;
+                capacity_left = (capacity_left - closed_height - fragment_margin_v).max(0.0);
+                if explicit_boundary || capacity_boundary {
+                    // A hard page break or a filled page starts the next
+                    // fragment on a fresh page.
+                    capacity_left = following_capacity;
+                    current_capacity = following_capacity;
+                } else {
+                    // Soft reset: keep the following run on the current page
+                    // when its first complete cached line fits the remaining
+                    // capacity.  A fragment that may be moved by the emitter
+                    // is never sized beyond a fresh page.
+                    let soft = capacity_left.min(following_capacity);
+                    if (end - seg.v_pos) as f32 / 100.0 > soft + 0.5 {
+                        capacity_left = following_capacity;
+                        current_capacity = following_capacity;
+                    } else {
+                        current_capacity = soft;
+                    }
+                }
                 boundaries.insert((para_index, seg_index));
                 current += 1;
                 first_v.push(seg.v_pos);
                 max_end.push(seg.v_pos);
                 has_content.push(false);
-                current_capacity = following_capacity;
             }
             if !has_content[current] {
                 first_v[current] = seg.v_pos;
@@ -3184,6 +3228,21 @@ fn layout_table(
     (end_y, page_advanced, final_fragment_top)
 }
 
+/// Maximum full vertical extent of cells starting at `row`.  A row-spanning
+/// cell is drawn once with its whole span height, so fragment packing must
+/// keep that extent on a single page.
+fn row_span_extent(table: &Table, row: usize, rows: usize, row_h: &[f32]) -> f32 {
+    table
+        .cells
+        .iter()
+        .filter(|cell| cell.row as usize == row)
+        .map(|cell| {
+            let end = (row + usize::from(cell.row_span.max(1))).min(rows);
+            row_h[row..end].iter().sum()
+        })
+        .fold(row_h[row], f32::max)
+}
+
 /// CELL-policy table emitter.  It is intentionally separate from the row
 /// planner above: a row fragment has a different border contract and its
 /// content must be selected from the cached line ranges rather than replaying
@@ -3227,7 +3286,10 @@ fn layout_table_cell_fragments(
     let mut cell_plans: Vec<Option<CellSplitPlan>> = vec![None; table.cells.len()];
     let mut row_group_counts = vec![1usize; rows];
     let mut found_cached_split = false;
-    let has_any_row_span = table.cells.iter().any(|cell| cell.row_span.max(1) > 1);
+    // Page index each row starts on in the planned fragment sequence.  A row
+    // span is unsafe only when it crosses one of these planned transitions.
+    let mut row_start_page = vec![0usize; rows];
+    let mut planned_page = 0usize;
     let mut planned_cursor = y;
     let mut planned_bottom = first_body_bottom;
     let mut planned_emitted_parts = 0usize;
@@ -3251,7 +3313,41 @@ fn layout_table_cell_fragments(
 
         let row_crosses_page = planned_cursor + row_h[row] > planned_bottom + 0.5;
         if !row_crosses_page {
-            planned_cursor += row_h[row];
+            // A row-spanning cell starting here is drawn once with its full
+            // span height, so the row may stay on this page only when the
+            // whole span extent fits the remaining capacity.
+            let span_extent = row_span_extent(table, row, rows, row_h);
+            if planned_cursor + span_extent <= planned_bottom + 0.5 {
+                row_start_page[row] = planned_page;
+                planned_cursor += row_h[row];
+                planned_emitted_parts += 1;
+                continue;
+            }
+            let continuation_top = body_top
+                + if planned_emitted_parts == 0 {
+                    top_caption_extent
+                } else if header_rows > 0 && row >= header_rows {
+                    header_height
+                } else {
+                    0.0
+                };
+            // The emitter cannot break before the very first fragment when
+            // the table still sits at the page top, so that case cannot move.
+            let can_move =
+                planned_emitted_parts > 0 || planned_cursor > body_top + top_caption_extent + 0.5;
+            if !can_move || span_extent > body_bottom - continuation_top + 0.5 {
+                // The span fits nowhere this row can be placed: keep the
+                // fail-closed contract instead of clipping or splitting it.
+                warnings.push(
+                    RenderIssueCode::TableCellFragmentationIncomplete,
+                    format!("row={row}:row-span-height"),
+                );
+                return None;
+            }
+            planned_page += 1;
+            row_start_page[row] = planned_page;
+            planned_cursor = continuation_top + row_h[row];
+            planned_bottom = body_bottom;
             planned_emitted_parts += 1;
             continue;
         }
@@ -3266,8 +3362,17 @@ fn layout_table_cell_fragments(
                 0.0
             };
         let continuation_height = (body_bottom - continuation_top).max(1.0);
+        // The blank-remainder contract is the declared row height, decided
+        // once per row after all cell plans are known.
+        let declared_h: f32 = table
+            .cells
+            .iter()
+            .filter(|cell| cell.row as usize == row && cell.row_span.max(1) == 1)
+            .map(|cell| cell.height.to_pt() as f32)
+            .fold(0.0, f32::max);
         let mut row_groups = 1usize;
         let mut cells_requiring_boundary = Vec::new();
+        let mut row_plan_candidates: Vec<(usize, CellSplitPlan, f32)> = Vec::new();
         for &(cell_index, cell) in &row_cells {
             if cell.row as usize != row || cell.row_span.max(1) != 1 {
                 continue;
@@ -3291,52 +3396,125 @@ fn layout_table_cell_fragments(
                 measured,
                 remaining_height - mt - mb,
                 continuation_height - mt - mb,
+                mt + mb,
             ) else {
                 continue;
             };
-            if !plan.is_usable() {
-                continue;
-            }
             for group in &mut plan.groups {
                 group.height += mt + mb;
             }
             let cached_height: f32 = plan.groups.iter().map(|group| group.height).sum();
-            if row_h[row] > cached_height {
+            row_plan_candidates.push((cell_index, plan, cached_height));
+        }
+
+        // Pad the declared row-height remainder into at most one plan: the
+        // row-height owner with the largest cached fragment sum (first maximum
+        // wins ties).  Cached content taller than declared is trusted as-is,
+        // and our own re-measured cell height must not manufacture blank
+        // continuation area.  Other cells keep their cached content groups and
+        // emit Empty selections on continuation fragments, so they never
+        // manufacture independent blank pages.
+        let mut owner = None;
+        for (index, (_, _, cached_height)) in row_plan_candidates.iter().enumerate() {
+            if owner.is_none_or(|o: usize| *cached_height > row_plan_candidates[o].2) {
+                owner = Some(index);
+            }
+        }
+        if let Some(o) = owner {
+            let (cell_index, plan, cached_height) = &mut row_plan_candidates[o];
+            let target_h = if declared_h > 0.0 {
+                declared_h
+            } else {
+                row_h[row]
+            };
+            if target_h > *cached_height {
                 // Preserve the declared row height as blank continuation
-                // area.  It does not need a text boundary, but must not push
-                // a cached line outside the cell's visual fragment.
-                if let Some(group) = plan.groups.last_mut() {
-                    group.height += row_h[row] - cached_height;
+                // area.  Grow each cached fragment only up to its page
+                // capacity; the overflow becomes trailing blank-only
+                // fragments that draw background and borders but replay no
+                // text or nested objects.
+                let mut remainder = target_h - *cached_height;
+                for (index, group) in plan.groups.iter_mut().enumerate() {
+                    if remainder <= 0.0 {
+                        break;
+                    }
+                    let capacity = if index == 0 {
+                        remaining_height
+                    } else {
+                        continuation_height
+                    };
+                    let grow = remainder.min((capacity - group.height).max(0.0));
+                    group.height += grow;
+                    remainder -= grow;
                 }
+                let para_count = table.cells[*cell_index].paragraphs.len();
+                let last_v_pos = plan.groups.last().map_or(0, |group| group.first_v_pos);
+                while remainder > 0.0 {
+                    let height = remainder.min(continuation_height);
+                    plan.groups.push(CellFragmentGroup {
+                        selections: vec![BoxParaSelection::Empty; para_count],
+                        first_v_pos: last_v_pos,
+                        height,
+                        has_content: false,
+                    });
+                    remainder -= height;
+                }
+            }
+        }
+        for (cell_index, plan, _) in row_plan_candidates {
+            if !plan.is_usable() {
+                continue;
             }
             row_groups = row_groups.max(plan.groups.len());
             cell_plans[cell_index] = Some(plan);
         }
 
-        if row_groups > 1
-            && cells_requiring_boundary.iter().any(|cell_index| {
-                cell_plans[*cell_index]
+        if row_groups > 1 {
+            // A cell that needs a boundary but has no usable multi-fragment
+            // plan is drawn whole into fragment 0 (All selections).  That is
+            // safe only while its measured content is contained by the
+            // planned first fragment; otherwise the required split has no
+            // cached geometry and the render is incomplete.
+            let first_part_height = cell_plans
+                .iter()
+                .filter_map(|plan| plan.as_ref().and_then(|plan| plan.groups.first()))
+                .map(|group| group.height)
+                .fold(0.0f32, f32::max)
+                .max(1.0);
+            let uncontained = cells_requiring_boundary.iter().any(|&cell_index| {
+                if cell_plans[cell_index]
                     .as_ref()
-                    .is_none_or(|plan| !plan.is_usable())
-            })
-        {
-            warnings.push(
-                RenderIssueCode::TableCellFragmentationIncomplete,
-                format!("row={row}:cache"),
-            );
-            return None;
+                    .is_some_and(|plan| plan.is_usable())
+                {
+                    return false;
+                }
+                let cell = &table.cells[cell_index];
+                let (_, _, mt, mb) = cell_margins(table, cell);
+                let measured = content_h_by_cell.get(cell_index).copied().unwrap_or(0.0);
+                measured + mt + mb > first_part_height + 0.5
+            });
+            if uncontained {
+                warnings.push(
+                    RenderIssueCode::TableCellFragmentationIncomplete,
+                    format!("row={row}:cache"),
+                );
+                return None;
+            }
         }
 
         if row_groups == 1 {
             // No cached content needs to use the current-page remainder. Let
-            // the existing row-boundary planner move this row as a unit.
-            if row_h[row] > continuation_height + 0.5 {
+            // the existing row-boundary planner move this row as a unit.  A
+            // span starting here must fit a fresh page as a whole.
+            if row_span_extent(table, row, rows, row_h) > continuation_height + 0.5 {
                 warnings.push(
                     RenderIssueCode::TableCellFragmentationIncomplete,
                     format!("row={row}:boundary"),
                 );
                 return None;
             }
+            planned_page += 1;
+            row_start_page[row] = planned_page;
             planned_cursor = continuation_top + row_h[row];
             planned_bottom = body_bottom;
             planned_emitted_parts += 1;
@@ -3345,6 +3523,7 @@ fn layout_table_cell_fragments(
 
         found_cached_split = true;
         row_group_counts[row] = row_groups;
+        row_start_page[row] = planned_page;
         for group_index in 0..row_groups {
             let part_height = table
                 .cells
@@ -3360,6 +3539,7 @@ fn layout_table_cell_fragments(
                 .fold(0.0f32, f32::max)
                 .max(1.0);
             if planned_cursor + part_height > planned_bottom + 0.5 {
+                planned_page += 1;
                 planned_cursor = body_top
                     + if planned_emitted_parts == 0 {
                         top_caption_extent
@@ -3387,7 +3567,21 @@ fn layout_table_cell_fragments(
     if !found_cached_split {
         return None;
     }
-    if has_any_row_span {
+    // A row span is unsafe only where it intersects an internally fragmented
+    // row or crosses a planned page transition — the fragment emitter draws a
+    // spanning cell once, on the page where its first row starts.  Spans that
+    // live entirely on one page keep the CELL fragmenting path.
+    let unsafe_row_span = table.cells.iter().any(|cell| {
+        let start = cell.row as usize;
+        let span = usize::from(cell.row_span.max(1));
+        if start >= rows || span <= 1 {
+            return false;
+        }
+        let end = (start + span).min(rows);
+        row_group_counts[start..end].iter().any(|&count| count > 1)
+            || row_start_page[start] != row_start_page[end - 1]
+    });
+    if unsafe_row_span {
         warnings.push(
             RenderIssueCode::TableCellFragmentationIncomplete,
             b"row-span-with-cell-fragment",
@@ -3425,7 +3619,15 @@ fn layout_table_cell_fragments(
                     .max(1.0)
             };
             let mut replay_header = false;
-            if cursor + part_height > current_bottom + 0.5 {
+            // The page-break decision for an unfragmented row must cover the
+            // full extent of any span starting here; the planner already
+            // guaranteed that extent fits a fresh page.
+            let fit_extent = if group_count == 1 {
+                row_span_extent(table, row, rows, row_h)
+            } else {
+                part_height
+            };
+            if cursor + fit_extent > current_bottom + 0.5 {
                 let ctx = split.as_deref_mut()?;
                 if emitted_parts == 0 && cursor <= body_top + top_caption_extent + 0.5 {
                     warnings.push(
@@ -3494,6 +3696,15 @@ fn layout_table_cell_fragments(
                     vec![BoxParaSelection::Empty; cell.paragraphs.len()]
                 };
                 let v_origin = group.map_or(0, |fragment| fragment.first_v_pos);
+                // A spanning cell is drawn once with its full span height.
+                // The planner's row-span safety check guarantees the whole
+                // span stays on this page.
+                let span_end = (row + usize::from(cell.row_span.max(1))).min(rows);
+                let cell_height = if span_end > row + 1 {
+                    row_h[row..span_end].iter().sum()
+                } else {
+                    part_height
+                };
                 draw_table_cell_fragment(
                     doc,
                     store,
@@ -3504,7 +3715,7 @@ fn layout_table_cell_fragments(
                     col_x,
                     col_w,
                     cursor,
-                    part_height,
+                    cell_height,
                     content_h_by_cell.get(cell_index).copied().unwrap_or(0.0),
                     selections,
                     v_origin,

--- a/crates/hwp-render/src/layout.rs
+++ b/crates/hwp-render/src/layout.rs
@@ -1655,6 +1655,13 @@ fn cached_cell_split_plan(
                 && has_content[current]
                 && (end - first_v[current]) as f32 / 100.0 > current_capacity + 0.5;
             if explicit_boundary || reset_boundary || capacity_boundary {
+                // `closed_height` is content-only and both capacities were
+                // passed in already excluding one vertical margin per
+                // fragment, so charging `fragment_margin_v` exactly once per
+                // closed fragment is correct — not a double subtraction.
+                // The emitter draws each fragment as content + mt + mb, and
+                // every fragment after the first must reserve its own margin
+                // out of what remains on the simulated page.
                 let closed_height = (max_end[current] - first_v[current]).max(0) as f32 / 100.0;
                 capacity_left = (capacity_left - closed_height - fragment_margin_v).max(0.0);
                 if explicit_boundary || capacity_boundary {
@@ -3474,10 +3481,20 @@ fn layout_table_cell_fragments(
             // plan is drawn whole into fragment 0 (All selections).  That is
             // safe only while its measured content is contained by the
             // planned first fragment; otherwise the required split has no
-            // cached geometry and the render is incomplete.
-            let first_part_height = cell_plans
+            // cached geometry and the render is incomplete.  `cell_plans`
+            // persists across rows, so the containment height must come only
+            // from plans owned by THIS row — an earlier row's taller first
+            // fragment must not vouch for a later row.
+            let first_part_height = table
+                .cells
                 .iter()
-                .filter_map(|plan| plan.as_ref().and_then(|plan| plan.groups.first()))
+                .enumerate()
+                .filter(|(_, cell)| cell.row as usize == row)
+                .filter_map(|(cell_index, _)| {
+                    cell_plans[cell_index]
+                        .as_ref()
+                        .and_then(|plan| plan.groups.first())
+                })
                 .map(|group| group.height)
                 .fold(0.0f32, f32::max)
                 .max(1.0);
@@ -6163,5 +6180,60 @@ mod decor_tests {
             page.items.is_empty(),
             "a rejected run must be emitted atomically"
         );
+    }
+}
+
+#[cfg(test)]
+mod cell_split_plan_tests {
+    use super::cached_cell_split_plan;
+    use hwp_model::{BorderFillId, Cell, HwpChar, HwpUnit, LineSeg, Paragraph};
+
+    /// Two cached 10 pt runs (50 lines each) separated by a soft v_pos reset
+    /// (no page flag).  With first capacity 634.82 and a 2.82 fragment
+    /// margin, the simulated remainder after run 1 is exactly 132 pt, so 13
+    /// complete lines of run 2 pack into group 1.  Charging the margin twice
+    /// would leave 129.18 pt and pack only 12 lines.
+    #[test]
+    fn fragment_margin_is_charged_once_per_fragment() {
+        let mut chars = Vec::new();
+        let mut line_segs = Vec::new();
+        for _ in 0..2 {
+            for index in 0..50u32 {
+                chars.push(HwpChar::Text('a'));
+                line_segs.push(LineSeg {
+                    text_start: (chars.len() - 1) as u32,
+                    v_pos: index as i32 * 1000,
+                    line_height: 1000,
+                    text_height: 900,
+                    baseline_gap: 800,
+                    line_spacing: 0,
+                    col_start: 0,
+                    seg_width: 50000,
+                    flags: 0x0006_0000,
+                });
+            }
+        }
+        let cell = Cell {
+            list_attr: 0,
+            col: 0,
+            row: 0,
+            col_span: 1,
+            row_span: 1,
+            width: HwpUnit(5000),
+            height: HwpUnit(100000),
+            margins: [0; 4],
+            border_fill: BorderFillId(0),
+            header_tail: Vec::new(),
+            paragraphs: vec![Paragraph {
+                chars,
+                line_segs,
+                ..Paragraph::default()
+            }],
+        };
+
+        let plan =
+            cached_cell_split_plan(&cell, 0.0, 634.82, 654.80, 2.82).expect("two-run cached plan");
+        let heights: Vec<f32> = plan.groups.iter().map(|group| group.height).collect();
+        assert_eq!(heights, vec![500.0, 130.0, 370.0]);
     }
 }

--- a/crates/hwp-render/tests/render.rs
+++ b/crates/hwp-render/tests/render.rs
@@ -1825,6 +1825,639 @@ fn cell_split_without_cached_boundary_is_incomplete() {
     assert_eq!(issue.stage, hwp_render::RenderIssueStage::Layout);
 }
 
+/// A cell paragraph whose cached line layout places one character per 10 pt
+/// line.  All assertions stay structural so a font substitution cannot
+/// change the expected geometry.
+fn cached_cell_paragraph(lines: usize) -> hwp_model::Paragraph {
+    let mut para = hwp_convert::from_markdown("x")
+        .sections
+        .remove(0)
+        .paragraphs
+        .remove(0);
+    para.chars = (0..lines)
+        .map(|index| hwp_model::HwpChar::Text(char::from(b'a' + (index % 26) as u8)))
+        .collect();
+    para.line_segs = (0..lines as u32)
+        .map(|index| hwp_model::LineSeg {
+            text_start: index,
+            v_pos: index as i32 * 1000,
+            line_height: 1000,
+            text_height: 900,
+            baseline_gap: 800,
+            line_spacing: 0,
+            col_start: 0,
+            seg_width: 50000,
+            flags: 0x0006_0000,
+        })
+        .collect();
+    para.controls.clear();
+    para
+}
+
+fn outer_table(doc: &mut hwp_model::Document) -> &mut hwp_model::Table {
+    doc.sections[0]
+        .paragraphs
+        .iter_mut()
+        .flat_map(|paragraph| &mut paragraph.controls)
+        .find_map(|control| match control {
+            hwp_model::Control::Table(table) => Some(table),
+            _ => None,
+        })
+        .expect("outer table")
+}
+
+fn assert_no_fragment_issues(report: &hwp_render::RenderIssueReport) {
+    assert!(
+        report.issues.iter().all(|issue| {
+            !matches!(
+                issue.code,
+                hwp_render::RenderIssueCode::TableCellFragmentationIncomplete
+                    | hwp_render::RenderIssueCode::TableRowTooTallClipped
+            )
+        }),
+        "over-height CELL row must split cleanly: {:?}",
+        report.issues
+    );
+}
+
+/// An over-height CELL row with cached line boundaries must paginate: the
+/// text run splits at a cached boundary and the declared row-height remainder
+/// becomes page-capacity continuation fragments.
+#[test]
+fn cached_cell_row_taller_than_body_splits_cleanly() {
+    let mut doc = 표_분할_문서(2, 1, 900, 0, false, 0);
+    let table = outer_table(&mut doc);
+    table.cells[0].height = hwp_model::HwpUnit(90000);
+    table.cells[0].paragraphs = vec![cached_cell_paragraph(80)];
+
+    let (list, report) = 표_레이아웃(&doc);
+    assert_no_fragment_issues(&report);
+    assert_eq!(
+        list.pages.len(),
+        2,
+        "900 pt row over a smaller body paginates"
+    );
+    for page in &list.pages {
+        let rects = page
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                hwp_render::display::Item::Rect { y, h, .. } => Some((*y, *h)),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            rects
+                .iter()
+                .all(|(y, h)| *y >= 0.0 && *y + *h <= page.height_pt + 0.6),
+            "fragment bounds exceed page: {rects:?}"
+        );
+    }
+    let all_text =
+        list.pages
+            .iter()
+            .flat_map(page_texts)
+            .fold(String::new(), |mut text, fragment| {
+                text.push_str(fragment);
+                text
+            });
+    if all_text.is_empty() {
+        eprintln!("skip text assertion: no usable font");
+    } else {
+        assert_eq!(
+            all_text.chars().count(),
+            80,
+            "each cached line is emitted exactly once: {all_text:?}"
+        );
+    }
+    assert!(
+        report
+            .info
+            .iter()
+            .any(|issue| { issue.code == hwp_render::RenderIssueCode::TableSplitAcrossPages })
+    );
+}
+
+/// Declared row height beyond the cached content height is preserved as
+/// page-capacity blank continuation fragments instead of inflating the last
+/// text fragment past the page.
+#[test]
+fn declared_row_height_remainder_becomes_blank_continuation_fragments() {
+    let mut doc = 표_분할_문서(2, 1, 900, 0, false, 0);
+    let table = outer_table(&mut doc);
+    table.cells[0].height = hwp_model::HwpUnit(90000);
+    table.cells[0].paragraphs = vec![cached_cell_paragraph(5)];
+    let (_, body_bottom) = 본문_기하(&doc);
+
+    let (list, report) = 표_레이아웃(&doc);
+    assert_no_fragment_issues(&report);
+    assert_eq!(
+        list.pages.len(),
+        2,
+        "declared remainder continues on page 2"
+    );
+    let data_rects = |page: usize| -> Vec<(f32, f32)> {
+        채움_사각형(&list, page)
+            .into_iter()
+            .filter(|&(_, _, fill)| fill == 0x00C8_C8C8)
+            .map(|(y, h, _)| (y, h))
+            .collect()
+    };
+    let first = data_rects(0);
+    let second = data_rects(1);
+    assert_eq!(first.len(), 1, "one text fragment on page 1: {first:?}");
+    assert_eq!(second.len(), 1, "one blank fragment on page 2: {second:?}");
+    assert!(
+        (first[0].0 + first[0].1 - body_bottom).abs() <= 0.6,
+        "text fragment fills the remaining page capacity: {first:?} bottom={body_bottom}"
+    );
+    let declared: f32 = first[0].1 + second[0].1;
+    assert!(
+        (declared - 900.0).abs() <= 0.6,
+        "fragments preserve the declared row height: {declared}"
+    );
+    let second_page_text = page_texts(&list.pages[1]);
+    if second_page_text.is_empty() && page_texts(&list.pages[0]).is_empty() {
+        eprintln!("skip text assertion: no usable font");
+    } else {
+        assert!(
+            second_page_text.is_empty(),
+            "blank continuation replays no text: {second_page_text:?}"
+        );
+    }
+}
+
+/// A v_pos reset without an explicit page flag is a soft boundary: the run
+/// after the reset is packed into the remaining page capacity at complete
+/// cached line boundaries instead of forcing a fresh page.
+#[test]
+fn cached_cell_soft_v_pos_reset_packs_into_remaining_capacity() {
+    // Three cached 10 pt line runs ('a' x50, 'b' x50, 'c' x20) with a v_pos
+    // reset — and no page flag — before the 'b' and 'c' runs.  Declared row
+    // height equals the cached content height, so no blank remainder applies.
+    let mut doc = 표_분할_문서(2, 1, 1200, 0, false, 0);
+    let mut para = hwp_convert::from_markdown("x")
+        .sections
+        .remove(0)
+        .paragraphs
+        .remove(0);
+    para.chars = Vec::new();
+    para.line_segs = Vec::new();
+    for (ch, lines) in [('a', 50usize), ('b', 50), ('c', 20)] {
+        for index in 0..lines {
+            para.chars.push(hwp_model::HwpChar::Text(ch));
+            para.line_segs.push(hwp_model::LineSeg {
+                text_start: (para.chars.len() - 1) as u32,
+                v_pos: index as i32 * 1000,
+                line_height: 1000,
+                text_height: 900,
+                baseline_gap: 800,
+                line_spacing: 0,
+                col_start: 0,
+                seg_width: 50000,
+                flags: 0x0006_0000,
+            });
+        }
+    }
+    para.controls.clear();
+    let table = outer_table(&mut doc);
+    table.cells[0].height = hwp_model::HwpUnit(120000);
+    table.cells[0].paragraphs = vec![para];
+    let (_, body_bottom) = 본문_기하(&doc);
+
+    let (list, report) = 표_레이아웃(&doc);
+    assert_no_fragment_issues(&report);
+    assert_eq!(
+        list.pages.len(),
+        2,
+        "soft resets pack 1200 pt of cached runs into two pages"
+    );
+    for page in &list.pages {
+        let rects = page
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                hwp_render::display::Item::Rect { y, h, .. } => Some((*y, *h)),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            rects
+                .iter()
+                .all(|(y, h)| *y >= 0.0 && *y + *h <= page.height_pt + 0.6),
+            "fragment bounds exceed page: {rects:?}"
+        );
+    }
+    // Page 1 is filled to its capacity: complete lines from the run after the
+    // reset moved up instead of the run forcing a new page.  A hard reset
+    // would leave page 1 ending after the 500 pt 'a' run.
+    let page1_bottom = 채움_사각형(&list, 0)
+        .into_iter()
+        .filter(|&(_, _, fill)| fill == 0x00C8_C8C8)
+        .map(|(y, h, _)| y + h)
+        .fold(0.0f32, f32::max);
+    assert!(
+        page1_bottom > body_bottom - 10.6 && page1_bottom <= body_bottom + 0.6,
+        "page 1 filled to capacity by soft-reset packing: bottom={page1_bottom} body={body_bottom}"
+    );
+    let page_text = |page: usize| -> String {
+        page_texts(&list.pages[page])
+            .into_iter()
+            .fold(String::new(), |mut text, fragment| {
+                text.push_str(fragment);
+                text
+            })
+    };
+    let all_text: String = (0..list.pages.len()).map(page_text).collect();
+    if all_text.is_empty() {
+        eprintln!("skip text assertion: no usable font");
+    } else {
+        let page1 = page_text(0);
+        assert!(
+            page1.contains('b') && !page1.contains('c'),
+            "page 1 packs complete 'b' lines after the reset: {page1:?}"
+        );
+        assert_eq!(all_text.matches('a').count(), 50);
+        assert_eq!(all_text.matches('b').count(), 50);
+        assert_eq!(all_text.matches('c').count(), 20);
+    }
+}
+
+/// Builds a two-column CELL table document so row-span interaction with cell
+/// fragmenting can be exercised.  Returns the doc and the data/span fill ids.
+fn 이열_셀_표_문서() -> (hwp_model::Document, u16, u16) {
+    let mut doc = 표_분할_문서(2, 1, 900, 0, false, 0);
+    doc.header.border_fills.push(hwp_model::BorderFill {
+        bg_color: Some(0x00AA_AAAA),
+        ..Default::default()
+    });
+    let data_fill = doc.header.border_fills.len() as u16;
+    doc.header.border_fills.push(hwp_model::BorderFill {
+        bg_color: Some(0x0033_7777),
+        ..Default::default()
+    });
+    let span_fill = doc.header.border_fills.len() as u16;
+    (doc, data_fill, span_fill)
+}
+
+fn 이열_셀(row: u16, col: u16, row_span: u16, height_pt: i32, fill: u16) -> hwp_model::Cell {
+    hwp_model::Cell {
+        list_attr: 0,
+        col,
+        row,
+        col_span: 1,
+        row_span,
+        width: hwp_model::HwpUnit(2500),
+        height: hwp_model::HwpUnit(height_pt * 100),
+        margins: [0; 4],
+        border_fill: hwp_model::BorderFillId(fill),
+        header_tail: Vec::new(),
+        paragraphs: Vec::new(),
+    }
+}
+
+/// A row-spanned cell that lives entirely after the fragmented row (and on a
+/// single page) must not disable CELL fragmenting.
+#[test]
+fn row_span_outside_fragmented_row_keeps_cell_fragmenting() {
+    let (mut doc, data_fill, span_fill) = 이열_셀_표_문서();
+    let mut tall = 이열_셀(1, 0, 1, 900, data_fill);
+    tall.paragraphs = vec![cached_cell_paragraph(5)];
+    let table = outer_table(&mut doc);
+    table.cols = 2;
+    table.rows = 4;
+    table.row_cell_counts = vec![2, 2, 2, 1];
+    table.cells = vec![
+        이열_셀(0, 0, 1, 20, data_fill),
+        이열_셀(0, 1, 1, 20, data_fill),
+        tall,
+        이열_셀(1, 1, 1, 900, data_fill),
+        이열_셀(2, 0, 2, 20, span_fill),
+        이열_셀(2, 1, 1, 20, data_fill),
+        이열_셀(3, 1, 1, 20, data_fill),
+    ];
+
+    let (list, report) = 표_레이아웃(&doc);
+    assert_no_fragment_issues(&report);
+    assert_eq!(list.pages.len(), 2, "only the over-height row paginates");
+    let span_rects: Vec<(f32, f32)> = 채움_사각형(&list, 1)
+        .into_iter()
+        .filter(|&(_, _, fill)| fill == 0x0033_7777)
+        .map(|(y, h, _)| (y, h))
+        .collect();
+    assert_eq!(
+        span_rects.len(),
+        1,
+        "span cell emitted once: {span_rects:?}"
+    );
+    assert!(
+        (span_rects[0].1 - 40.0).abs() <= 0.6,
+        "span cell covers both spanned rows: {span_rects:?}"
+    );
+}
+
+/// A row-spanned cell intersecting the internally fragmented row stays
+/// fail-closed: the CELL fragment path reports incomplete and yields to the
+/// row-boundary planner.
+#[test]
+fn row_span_intersecting_fragmented_row_remains_fail_closed() {
+    let (mut doc, data_fill, span_fill) = 이열_셀_표_문서();
+    let mut tall = 이열_셀(1, 1, 1, 900, data_fill);
+    tall.paragraphs = vec![cached_cell_paragraph(5)];
+    let table = outer_table(&mut doc);
+    table.cols = 2;
+    table.rows = 3;
+    table.row_cell_counts = vec![2, 2, 1];
+    table.cells = vec![
+        이열_셀(0, 0, 1, 20, data_fill),
+        이열_셀(0, 1, 1, 20, data_fill),
+        이열_셀(1, 0, 2, 20, span_fill),
+        tall,
+        이열_셀(2, 1, 1, 20, data_fill),
+    ];
+
+    let (_list, report) = 표_레이아웃(&doc);
+    let issue = report
+        .issues
+        .iter()
+        .find(|issue| issue.code == hwp_render::RenderIssueCode::TableCellFragmentationIncomplete)
+        .expect("row span crossing a cell fragment must stay fail-closed");
+    assert_eq!(issue.severity, hwp_render::RenderIssueSeverity::Incomplete);
+    assert_eq!(issue.stage, hwp_render::RenderIssueStage::Layout);
+}
+
+/// The declared row-height remainder is a row-level contract: only the plan
+/// that owns the row height (largest cached fragment sum) is padded.  A short
+/// cell in the same fragmented row must not manufacture its own blank
+/// continuation fragments — that would misalign the per-fragment part heights
+/// and create an extra nearly blank page.
+#[test]
+fn declared_remainder_pads_only_the_row_height_owner() {
+    let (mut doc, data_fill, owner_fill) = 이열_셀_표_문서();
+    // Short left cell: 3 cached lines (30 pt).  Tall right cell: two cached
+    // 10 pt runs ('a' x50, soft v_pos reset, 'b' x60) = 1100 pt.  Both row-1
+    // cells declare 1200 pt.
+    let mut short_para = hwp_convert::from_markdown("x")
+        .sections
+        .remove(0)
+        .paragraphs
+        .remove(0);
+    short_para.chars = (0..3).map(|_| hwp_model::HwpChar::Text('L')).collect();
+    short_para.line_segs = (0..3u32)
+        .map(|index| hwp_model::LineSeg {
+            text_start: index,
+            v_pos: index as i32 * 1000,
+            line_height: 1000,
+            text_height: 900,
+            baseline_gap: 800,
+            line_spacing: 0,
+            col_start: 0,
+            seg_width: 50000,
+            flags: 0x0006_0000,
+        })
+        .collect();
+    short_para.controls.clear();
+    let mut tall_para = hwp_convert::from_markdown("x")
+        .sections
+        .remove(0)
+        .paragraphs
+        .remove(0);
+    tall_para.chars = Vec::new();
+    tall_para.line_segs = Vec::new();
+    for (ch, lines) in [('a', 50usize), ('b', 60)] {
+        for index in 0..lines {
+            tall_para.chars.push(hwp_model::HwpChar::Text(ch));
+            tall_para.line_segs.push(hwp_model::LineSeg {
+                text_start: (tall_para.chars.len() - 1) as u32,
+                v_pos: index as i32 * 1000,
+                line_height: 1000,
+                text_height: 900,
+                baseline_gap: 800,
+                line_spacing: 0,
+                col_start: 0,
+                seg_width: 50000,
+                flags: 0x0006_0000,
+            });
+        }
+    }
+    tall_para.controls.clear();
+    let mut short = 이열_셀(1, 0, 1, 1200, data_fill);
+    short.paragraphs = vec![short_para];
+    let mut tall = 이열_셀(1, 1, 1, 1200, owner_fill);
+    tall.paragraphs = vec![tall_para];
+    let table = outer_table(&mut doc);
+    table.cols = 2;
+    table.rows = 2;
+    table.row_cell_counts = vec![2, 2];
+    table.cells = vec![
+        이열_셀(0, 0, 1, 20, data_fill),
+        이열_셀(0, 1, 1, 20, data_fill),
+        short,
+        tall,
+    ];
+
+    let (list, report) = 표_레이아웃(&doc);
+    assert_no_fragment_issues(&report);
+    assert_eq!(
+        list.pages.len(),
+        2,
+        "short cell must not add an independent blank page"
+    );
+    // The row-level declared contract still holds: the owner cell's fragment
+    // heights sum to the declared 1200 pt.
+    let owner_h: f32 = (0..list.pages.len())
+        .flat_map(|page| 채움_사각형(&list, page))
+        .filter(|&(_, _, fill)| fill == 0x0033_7777)
+        .map(|(_, h, _)| h)
+        .sum();
+    assert!(
+        (owner_h - 1200.0).abs() <= 0.6,
+        "owner fragments preserve the declared row height: {owner_h}"
+    );
+    for page in &list.pages {
+        let rects = page
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                hwp_render::display::Item::Rect { y, h, .. } => Some((*y, *h)),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            rects
+                .iter()
+                .all(|(y, h)| *y >= 0.0 && *y + *h <= page.height_pt + 0.6),
+            "fragment bounds exceed page: {rects:?}"
+        );
+    }
+    let page_text = |page: usize| -> String {
+        page_texts(&list.pages[page])
+            .into_iter()
+            .fold(String::new(), |mut text, fragment| {
+                text.push_str(fragment);
+                text
+            })
+    };
+    let all_text: String = (0..list.pages.len()).map(page_text).collect();
+    if all_text.is_empty() {
+        eprintln!("skip text assertion: no usable font");
+    } else {
+        assert!(
+            page_text(0).contains('L'),
+            "short cell text is drawn in the first fragment"
+        );
+        assert_eq!(all_text.matches('a').count(), 50);
+        assert_eq!(all_text.matches('b').count(), 60);
+        assert_eq!(all_text.matches('L').count(), 3);
+    }
+}
+
+/// A row-spanned block following an over-height fragmented row: the span
+/// fits a fresh page but not the current-page remainder.  The row must move
+/// to a fresh page instead of tripping the row-span safety bail.
+#[test]
+fn row_span_after_fragmented_row_moves_to_fresh_page() {
+    let (mut doc, data_fill, span_fill) = 이열_셀_표_문서();
+    // Row 0 fragments across pages 1-2 (900 pt declared/cached).  Rows 1-2
+    // form a 400 pt span block: it fits a fresh page but not the ~385 pt
+    // remainder below the second fragment.
+    let mut short = 이열_셀(0, 0, 1, 900, data_fill);
+    short.paragraphs = vec![cached_cell_paragraph(3)];
+    let mut tall = 이열_셀(0, 1, 1, 900, data_fill);
+    tall.paragraphs = vec![cached_cell_paragraph(90)];
+    let table = outer_table(&mut doc);
+    table.cols = 2;
+    table.rows = 3;
+    table.row_cell_counts = vec![2, 2, 1];
+    table.cells = vec![
+        short,
+        tall,
+        이열_셀(1, 0, 2, 200, span_fill),
+        이열_셀(1, 1, 1, 200, data_fill),
+        이열_셀(2, 1, 1, 200, data_fill),
+    ];
+
+    let (list, report) = 표_레이아웃(&doc);
+    assert_no_fragment_issues(&report);
+    assert_eq!(
+        list.pages.len(),
+        3,
+        "fragmented row uses pages 1-2, span block moves to page 3"
+    );
+    let span_rects: Vec<(f32, f32)> = 채움_사각형(&list, 2)
+        .into_iter()
+        .filter(|&(_, _, fill)| fill == 0x0033_7777)
+        .map(|(y, h, _)| (y, h))
+        .collect();
+    assert_eq!(
+        span_rects.len(),
+        1,
+        "span cell emitted once on the fresh page: {span_rects:?}"
+    );
+    assert!(
+        (span_rects[0].1 - 400.0).abs() <= 0.6,
+        "span cell covers both spanned rows: {span_rects:?}"
+    );
+    for page in &list.pages {
+        let rects = page
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                hwp_render::display::Item::Rect { y, h, .. } => Some((*y, *h)),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            rects
+                .iter()
+                .all(|(y, h)| *y >= 0.0 && *y + *h <= page.height_pt + 0.6),
+            "fragment bounds exceed page: {rects:?}"
+        );
+    }
+    let all_text: String = (0..list.pages.len())
+        .flat_map(|page| page_texts(&list.pages[page]))
+        .fold(String::new(), |mut text, fragment| {
+            text.push_str(fragment);
+            text
+        });
+    if all_text.is_empty() {
+        eprintln!("skip text assertion: no usable font");
+    } else {
+        assert_eq!(
+            all_text.chars().count(),
+            93,
+            "each cached line is emitted exactly once"
+        );
+    }
+}
+
+/// A cell whose content fits one page must not force an incomplete render
+/// merely because the fragmented row starts on a page-bottom sliver: with no
+/// complete cached line fitting the sliver, the first fragment moves to a
+/// fresh page where the whole-cell draw is contained.
+#[test]
+fn cell_needing_boundary_only_for_page_sliver_is_contained_in_first_fragment() {
+    let (mut doc, data_fill, _span_fill) = 이열_셀_표_문서();
+    // Row 0 (640 pt) leaves a ~1.6 pt sliver on page 1.  Row 1: a short
+    // cached cell (3 lines) and a tall cached cell (90 lines = 900 pt).
+    let mut short = 이열_셀(1, 0, 1, 900, data_fill);
+    short.paragraphs = vec![cached_cell_paragraph(3)];
+    let mut tall = 이열_셀(1, 1, 1, 900, data_fill);
+    tall.paragraphs = vec![cached_cell_paragraph(90)];
+    let table = outer_table(&mut doc);
+    table.cols = 2;
+    table.rows = 2;
+    table.row_cell_counts = vec![2, 2];
+    table.cells = vec![
+        이열_셀(0, 0, 1, 640, data_fill),
+        이열_셀(0, 1, 1, 640, data_fill),
+        short,
+        tall,
+    ];
+
+    let (list, report) = 표_레이아웃(&doc);
+    assert_no_fragment_issues(&report);
+    assert_eq!(
+        list.pages.len(),
+        3,
+        "row 0 fills page 1; both fragments land on fresh pages"
+    );
+    for page in &list.pages {
+        let rects = page
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                hwp_render::display::Item::Rect { y, h, .. } => Some((*y, *h)),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert!(
+            rects
+                .iter()
+                .all(|(y, h)| *y >= 0.0 && *y + *h <= page.height_pt + 0.6),
+            "fragment bounds exceed page: {rects:?}"
+        );
+    }
+    let page_text = |page: usize| -> String {
+        page_texts(&list.pages[page])
+            .into_iter()
+            .fold(String::new(), |mut text, fragment| {
+                text.push_str(fragment);
+                text
+            })
+    };
+    let all_text: String = (0..list.pages.len()).map(page_text).collect();
+    if all_text.is_empty() {
+        eprintln!("skip text assertion: no usable font");
+    } else {
+        assert_eq!(all_text.chars().count(), 93);
+        assert!(
+            page_text(1).chars().count() > 63,
+            "short cell content travels with the moved first fragment"
+        );
+    }
+}
+
 /// GB-13: a bottom table caption is placed below cell text with its gap.
 #[test]
 fn 캡션_표_아래_배치() {

--- a/crates/hwp-render/tests/render.rs
+++ b/crates/hwp-render/tests/render.rs
@@ -2458,6 +2458,82 @@ fn cell_needing_boundary_only_for_page_sliver_is_contained_in_first_fragment() {
     }
 }
 
+/// Two independently fragmented rows: the containment height for a
+/// boundary-needing cell without a split plan must come only from its own
+/// row's plans.  An earlier row's taller first fragment must not vouch for a
+/// later row's unsplittable cell.
+#[test]
+fn uncached_cell_in_second_fragmented_row_stays_fail_closed() {
+    let (mut doc, data_fill, _span_fill) = 이열_셀_표_문서();
+    // Uncached payload with a font-independent height: a nested table with a
+    // 500 pt cell measures ~512 pt regardless of shaping.
+    let nested_fill = doc.header.border_fills.len() as u16 + 1;
+    doc.header.border_fills.push(hwp_model::BorderFill {
+        bg_color: Some(0x0011_2233),
+        ..Default::default()
+    });
+    let nested = hwp_model::Table {
+        common_data: Vec::new(),
+        placement: None,
+        attr: 0,
+        rows: 1,
+        cols: 1,
+        cell_spacing: 0,
+        inner_margins: [0; 4],
+        row_cell_counts: vec![1],
+        border_fill: hwp_model::BorderFillId(nested_fill),
+        table_tail: Vec::new(),
+        cells: vec![hwp_model::Cell {
+            list_attr: 0,
+            col: 0,
+            row: 0,
+            col_span: 1,
+            row_span: 1,
+            width: hwp_model::HwpUnit(1800),
+            height: hwp_model::HwpUnit(50000),
+            margins: [0; 4],
+            border_fill: hwp_model::BorderFillId(nested_fill),
+            header_tail: Vec::new(),
+            paragraphs: Vec::new(),
+        }],
+        caption: None,
+        extras: Vec::new(),
+    };
+    // Row 0 fragments with a ~633 pt first fragment.  Row 1 starts on page 2
+    // with ~385 pt remaining; its right cell splits into ~383/+423 pt
+    // fragments, while its left cell carries the uncached ~512 pt payload.
+    // That payload is contained by neither row 1 fragment (~383 pt) — only
+    // row 0's taller first fragment would wrongly vouch for it.
+    let mut tall_row0 = 이열_셀(0, 1, 1, 900, data_fill);
+    tall_row0.paragraphs = vec![cached_cell_paragraph(90)];
+    let mut uncached = 이열_셀(1, 0, 1, 800, data_fill);
+    uncached.paragraphs = vec![hwp_model::Paragraph {
+        controls: vec![hwp_model::Control::Table(nested)],
+        ..hwp_model::Paragraph::default()
+    }];
+    let mut tall_row1 = 이열_셀(1, 1, 1, 800, data_fill);
+    tall_row1.paragraphs = vec![cached_cell_paragraph(80)];
+    let table = outer_table(&mut doc);
+    table.cols = 2;
+    table.rows = 2;
+    table.row_cell_counts = vec![2, 2];
+    table.cells = vec![
+        이열_셀(0, 0, 1, 900, data_fill),
+        tall_row0,
+        uncached,
+        tall_row1,
+    ];
+
+    let (_list, report) = 표_레이아웃(&doc);
+    let issue = report
+        .issues
+        .iter()
+        .find(|issue| issue.code == hwp_render::RenderIssueCode::TableCellFragmentationIncomplete)
+        .expect("unsplittable cell must not borrow an earlier row's fragment height");
+    assert_eq!(issue.severity, hwp_render::RenderIssueSeverity::Incomplete);
+    assert_eq!(issue.stage, hwp_render::RenderIssueStage::Layout);
+}
+
 /// GB-13: a bottom table caption is placed below cell text with its gap.
 #[test]
 fn 캡션_표_아래_배치() {

--- a/docs/design/21-pdf-parity.ko.md
+++ b/docs/design/21-pdf-parity.ko.md
@@ -215,16 +215,19 @@ structured-corpus run(`scripts/check-structured-corpus.sh`)은 고정 Noto Sans 
 ## 6. 페이지네이션 정본 (F3)
 
 한글은 이미 페이지 경계를 알려준다: `LineSeg.flags` bit0(페이지 첫 줄)과 bit1(단 첫 줄)이
-IR에 파싱돼 있다. 렌더러는 이 비트를 1급 페이지/단 경계 신호로 읽고, 합성 lineseg(flags
-`0x0006_0000`)에서만 `v_pos` 리셋 휴리스틱으로 폴백한다. 표가 페이지를 걸쳐 잘리는 동안은
+IR에 파싱돼 있다. 렌더러는 이 비트를 1급 페이지/단 경계 신호로 읽는다. 명시 플래그가 없는
+`v_pos` 리셋은 soft boundary로만 보고 CELL fragment의 남은 용량에 채울 수 있으며, 합성 lineseg(flags
+`0x0006_0000`)에서는 unflagged reset을 soft boundary로 폴백한다. 표가 페이지를 걸쳐 잘리는 동안은
 페이지 인덱스 비교가 무의미하므로, 페이지네이션 정확성(표 분할 포함, PR 2)은 측정의
 **전제조건**이지 소비자가 아니다. **구현 상태 2026-08-13: PR #81**은 `Table.attr` pageBreak 정책에 따라 가능한 행 경계에서 표를 나누고 `row_span` 셀을 보존하며 제목 줄 자동 반복을 지원한다. 공개 한 쪽 프로파일은 이제 CI에서 대조하며, 더 넓은 한컴 코퍼스는 남아 있으므로 보편적인 대등성 인증은 아니다.
 **PR #89 후속 보완:** `CELL` 정책은 한 행도 기존 cached line 경계에서 이어 그린다. 명시적인
 page-reset flag가 없는 경우에도 현재 쪽의 남은 공간에 들어가는 마지막 cached line 다음에서
-분할한다. 각 조각의 내용은 한 번만 출력하고 이어지는 테두리를 유지한다. 안전한 cache 경계가
-없거나 row-span과 cell fragment가 결합된 경우에는 조용히 자르지 않고 typed
-`table_cell_fragmentation_incomplete`로 보고한다. 공개 한 쪽 프로파일은 CI에서 대조하며,
-더 넓은 한컴 코퍼스는 남아 있으므로 보편적인 대등성 인증은 아니다.
+분할한다. 각 조각의 내용은 한 번만 출력하고 이어지는 테두리를 유지하며, cached content를
+넘는 선언 행 높이는 페이지 용량에 맞춘 빈 continuation fragment로 보존한다. 하나로 옮길 수
+있는 row-span은 새 페이지에서 통째로 유지한다. 안전한 cache 경계가 없거나, row-span이 셀
+단편화가 일어난 행과 교차하거나, 새 페이지에도 전체 span이 들어가지 않으면 조용히 자르지
+않고 typed `table_cell_fragmentation_incomplete`로 보고한다. 공개 한 쪽 프로파일은 CI에서
+대조하며, 더 넓은 한컴 코퍼스는 남아 있으므로 보편적인 대등성 인증은 아니다.
 
 ## 7. 데이터 정책
 

--- a/docs/design/21-pdf-parity.md
+++ b/docs/design/21-pdf-parity.md
@@ -230,18 +230,20 @@ so **a parity number measured under substituted fonts is meaningless**.
 
 Hancom already tells us where its page breaks are: `LineSeg.flags` bit0 (페이지 첫 줄) and bit1
 (단 첫 줄) are parsed into the IR. The renderer reads these bits as the first-class page/column
-break signal and falls back to the `v_pos` reset heuristic only for synthesized linesegs (flags
-`0x0006_0000`). Page-indexed comparison is meaningless while a table clips across pages, so
+break signal. An unflagged `v_pos` reset is only a soft boundary and may pack into remaining CELL
+fragment capacity; the reset heuristic for synthesized linesegs (flags `0x0006_0000`) stays
+subordinate to explicit flags. Page-indexed comparison is meaningless while a table clips across pages, so
 pagination correctness (including table splitting, PR 2) is a **precondition** for measurement,
 not a consumer of it. **Implementation status 2026-08-13: PR #81** splits tables at legal row
 boundaries per `Table.attr` pageBreak policy, preserves row-spanning cells, and supports repeated
 header rows. **PR #89 follow-up:** `CELL` policy can also continue a single row at an existing
 cached line boundary, including the last line that fits the current-page remainder when the cache
-has no explicit page-reset flag. Fragment content is emitted once with continuation borders; an
-unsafe cache or a row-span/cell-fragment combination is surfaced as typed
-`table_cell_fragmentation_incomplete` instead of being silently clipped. The one-page public
-profile is now compared in CI; broader Hancom corpus coverage remains pending, so this is not a
-universal parity certification.
+has no explicit page-reset flag. Fragment content is emitted once with continuation borders, and
+declared row height beyond the cached content is preserved as page-capacity blank continuation
+fragments. A row span that can move as a unit is kept together on a fresh page. An unsafe cache,
+a row span that intersects an internally fragmented row, or a span too tall for a fresh page is
+surfaced as typed `table_cell_fragmentation_incomplete` instead of being silently clipped. The one-page public profile is now compared in CI; broader Hancom corpus
+coverage remains pending, so this is not a universal parity certification.
 
 ## 7. Data policy
 


### PR DESCRIPTION
Epic #90 PR 7a (first half of PR 7).

## Summary

- CELL-policy rows taller than a page now fragment at cached complete-line boundaries instead of clipping.
- Unflagged `v_pos` resets are soft boundaries and can pack into the current page's remaining capacity; explicit cached page flags remain hard page breaks.
- Declared row-height remainder is a row-level contract: only the row-height owner is padded, and trailing blank continuation fragments draw background/borders without replaying text or nested objects.
- Row-spanned cells outside the fragmented row remain on the CELL path. A span that fits a fresh page moves as a unit; spans intersecting an internally fragmented row or exceeding fresh-page capacity stay fail-closed.
- A cell that needs a boundary only because of a page-bottom sliver no longer forces a fallback when its whole content is contained by the planned first fragment.

## Validation

- `scripts/check.sh`: OK (fmt, clippy, workspace tests, PDF runner, structured corpus; local public-parity stage skipped on the known Poppler pin mismatch).
- `cargo test -p hwp-render`: 62 render integration tests and all crate tests pass.
- Private Hancom parity, content-free aggregate movement:
  - pages: 12 -> 13, matching the 13-page oracle (`delta=0`)
  - `table_cell_fragmentation_incomplete` / `table_row_too_tall_clipped`: 2 -> 0
  - unsupported: 0; incomplete: 0; fatal: 0
  - passed gates: 2/8 -> 4/8 (`page_count` and `media_box` now pass)
  - worst raster bad-pixel ratio improved from 0.377 to 0.234
- Remaining failures are outside PR 7a: 8 font substitutions (PR 7b), plus text/raster/ROI alignment.

## Remaining in epic #90

PR 7b (font identity reporting and manifest-backed font gate), then PR 8 (certification, documentation, and release gate).
