### PR TITLE
feat(render): add privacy-safe font identity gate (#90 PR 7b)

### DIFF
--- a/crates/hwp-cli/src/certification.rs
+++ b/crates/hwp-cli/src/certification.rs
@@ -414,7 +414,7 @@ pub struct RenderIssueReportEntry {
     pub samples_complete: bool,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct FontReport {
     pub requested_name_sha256: String,
     pub resolved_family_sha256: Option<String>,
@@ -2177,6 +2177,10 @@ fn run_render(
                 right.outcome,
             ))
     });
+    // Certification v1 has no requested-weight field.  Keep render resolutions
+    // weight-aware internally, but collapse report rows that differ only by
+    // that omitted dimension.
+    fonts.dedup();
     let mut report = RenderReport {
         profile: "hwp-cli-native-certification-render-v1",
         dpi: policy.render.dpi,

--- a/crates/hwp-cli/src/commands/render.rs
+++ b/crates/hwp-cli/src/commands/render.rs
@@ -27,6 +27,8 @@ struct RenderReportFile {
     total_pages: usize,
     selected_pages: Vec<usize>,
     font_coverage: RenderFontCoverage,
+    font_resolution_complete: bool,
+    fonts: Vec<RenderFontRecord>,
     issues: Vec<RenderIssueReportEntry>,
     info: Vec<RenderIssueReportEntry>,
     issue_count: u64,
@@ -34,6 +36,18 @@ struct RenderReportFile {
     issue_log_complete: bool,
     issue_sha256: String,
     complete: bool,
+}
+
+/// Deterministic privacy-safe per-font identity record: only hashed family
+/// names and font bytes, never raw names or paths.
+#[derive(Debug, Serialize, PartialEq, Eq, PartialOrd, Ord)]
+struct RenderFontRecord {
+    requested_sha256: String,
+    requested_bold: bool,
+    resolved_family_sha256: Option<String>,
+    resolved_sha256: Option<String>,
+    resolved_face_index: Option<u32>,
+    outcome: &'static str,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -121,6 +135,8 @@ pub fn run_with_report(
                     dpi,
                     result.total_pages,
                     selected,
+                    &result.diagnostics.fonts,
+                    result.diagnostics.font_resolution_complete,
                     result.report,
                 )?;
             }
@@ -162,6 +178,8 @@ pub fn run_with_report(
                     dpi,
                     total_pages,
                     selected,
+                    &result.fonts,
+                    result.font_resolution_complete,
                     result.report,
                 )?;
             }
@@ -190,6 +208,8 @@ pub fn run_with_report(
                     dpi,
                     total,
                     selected,
+                    &result.fonts,
+                    result.font_resolution_complete,
                     result.report,
                 )?;
             }
@@ -282,6 +302,27 @@ struct RenderReportIssueChannels {
     complete: bool,
 }
 
+fn sha256_text(value: &str) -> String {
+    hex_digest(Sha256::digest(value.as_bytes()).as_slice())
+}
+
+fn font_record(resolution: &hwp_render::FontResolution) -> RenderFontRecord {
+    RenderFontRecord {
+        requested_sha256: sha256_text(&resolution.requested),
+        requested_bold: resolution.requested_bold,
+        resolved_family_sha256: resolution.resolved.as_deref().map(sha256_text),
+        resolved_sha256: resolution.resolved_sha256.clone(),
+        resolved_face_index: resolution.resolved_face_index,
+        outcome: match resolution.outcome {
+            hwp_render::FontResolutionOutcome::Matched => "matched",
+            hwp_render::FontResolutionOutcome::Substituted => "substituted",
+            hwp_render::FontResolutionOutcome::Missing => "missing",
+            hwp_render::FontResolutionOutcome::CoverageSubstituted => "coverage_substituted",
+        },
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 fn write_report(
     report_path: &Path,
     input: RenderInputReport,
@@ -289,10 +330,15 @@ fn write_report(
     dpi: f32,
     total_pages: usize,
     selected_pages: Vec<usize>,
+    fonts: &[hwp_render::FontResolution],
+    font_resolution_complete: bool,
     source: hwp_render::RenderIssueReport,
 ) -> anyhow::Result<()> {
     let coverage = source.font_coverage();
     let channels = format_issue_report(source);
+    let mut font_records: Vec<RenderFontRecord> = fonts.iter().map(font_record).collect();
+    font_records.sort();
+    font_records.truncate(hwp_render::fonts::MAX_FONT_RESOLUTIONS);
     let report = RenderReportFile {
         schema_version: RENDER_REPORT_SCHEMA_VERSION,
         contract: RENDER_REPORT_CONTRACT,
@@ -308,6 +354,8 @@ fn write_report(
             subset_fallback: coverage.subset_fallback,
             substitution_free: coverage.substitution_free(),
         },
+        font_resolution_complete,
+        fonts: font_records,
         issues: channels.issues,
         info: channels.info,
         issue_count: channels.issue_count,

--- a/crates/hwp-cli/tests/cli.rs
+++ b/crates/hwp-cli/tests/cli.rs
@@ -99,6 +99,88 @@ fn render_report_is_closed_hashed_and_schema_validated() {
 }
 
 #[test]
+fn render_report_fonts_are_hashed_deterministic_records() {
+    let input = tmp("hwp_cli_render_report_fonts_input.hwpx");
+    let output = tmp("hwp_cli_render_report_fonts_output.pdf");
+    let report_a = tmp("hwp_cli_render_report_fonts_a.json");
+    let report_b = tmp("hwp_cli_render_report_fonts_b.json");
+    for path in [&input, &output, &report_a, &report_b] {
+        let _ = std::fs::remove_file(path);
+    }
+    let created = hwp().args(["new", "-o"]).arg(&input).output().unwrap();
+    assert!(created.status.success());
+
+    let mut reports = Vec::new();
+    for report_path in [&report_a, &report_b] {
+        let rendered = hwp()
+            .args(["render", "--format", "pdf", "--report"])
+            .arg(report_path)
+            .args(["-o"])
+            .arg(&output)
+            .arg(&input)
+            .output()
+            .expect("hwp render");
+        assert!(
+            rendered.status.success(),
+            "hwp render: {}",
+            String::from_utf8_lossy(&rendered.stderr)
+        );
+        reports.push(
+            serde_json::from_slice::<serde_json::Value>(&std::fs::read(report_path).unwrap())
+                .unwrap(),
+        );
+    }
+
+    let fonts_a = reports[0]["fonts"].as_array().expect("fonts array");
+    assert_eq!(
+        reports[0]["fonts"], reports[1]["fonts"],
+        "font identity records must be deterministic across runs"
+    );
+    assert_eq!(
+        reports[0]["font_resolution_complete"], true,
+        "a bounded render reports complete font resolution"
+    );
+    let hex64 = |value: &serde_json::Value| {
+        value.as_str().is_some_and(|text| {
+            text.len() == 64
+                && text
+                    .bytes()
+                    .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+        })
+    };
+    let serialized = reports[0]["fonts"].to_string();
+    assert!(
+        !serialized.contains("함초롬") && !serialized.contains('/'),
+        "font records carry only hashed identities: {serialized}"
+    );
+    for entry in fonts_a {
+        assert!(hex64(&entry["requested_sha256"]), "entry: {entry}");
+        assert!(entry["requested_bold"].is_boolean(), "entry: {entry}");
+        assert!(
+            entry["resolved_family_sha256"].is_null() || hex64(&entry["resolved_family_sha256"]),
+            "entry: {entry}"
+        );
+        assert!(
+            entry["resolved_sha256"].is_null() || hex64(&entry["resolved_sha256"]),
+            "entry: {entry}"
+        );
+        assert!(
+            entry["resolved_face_index"].is_null() || entry["resolved_face_index"].is_u64(),
+            "entry: {entry}"
+        );
+        assert!(
+            ["matched", "substituted", "missing", "coverage_substituted"]
+                .contains(&entry["outcome"].as_str().unwrap_or("")),
+            "entry: {entry}"
+        );
+    }
+
+    for path in [&input, &output, &report_a, &report_b] {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+#[test]
 fn render_report_alias_does_not_clobber_render_output() {
     let input = tmp("hwp_cli_render_report_alias_input.hwpx");
     let output = tmp("hwp_cli_render_report_alias_output.svg");

--- a/crates/hwp-render/src/fonts.rs
+++ b/crates/hwp-render/src/fonts.rs
@@ -115,6 +115,10 @@ enum FontCacheKey {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FontResolution {
     pub requested: String,
+    /// Whether the request asked for a bold face.  Regular and bold requests
+    /// for the same family can resolve to different faces and must stay
+    /// distinct records, so identity includes the requested weight state.
+    pub requested_bold: bool,
     pub resolved: Option<String>,
     pub resolved_sha256: Option<String>,
     pub resolved_face_index: Option<u32>,
@@ -123,7 +127,14 @@ pub struct FontResolution {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FontResolutionOutcome {
+    /// fontdb resolved the directly requested family name.  The requested
+    /// name may be a secondary family alias of the selected face (fontdb
+    /// matches every family name a face carries); that is still a direct
+    /// match, not a substitution.
     Matched,
+    /// Resolution through the document's alt name, a class fallback-list
+    /// entry, or the generic sans fallback — anything that is not the
+    /// directly requested family.
     Substituted,
     Missing,
     /// 주 글꼴에 특정 글리프가 없어 문자 단위 폴백을 사용한 경우.
@@ -274,6 +285,7 @@ impl FontStore {
                     );
                     self.record_resolution(FontResolution {
                         requested: requested.clone(),
+                        requested_bold: bold,
                         resolved: Some(font.family.clone()),
                         resolved_sha256: Some(sha256_hex(&font.data)),
                         resolved_face_index: Some(font.index),
@@ -286,6 +298,7 @@ impl FontStore {
                     );
                     self.record_resolution(FontResolution {
                         requested: requested.clone(),
+                        requested_bold: bold,
                         resolved: Some(font.family.clone()),
                         resolved_sha256: Some(sha256_hex(&font.data)),
                         resolved_face_index: Some(font.index),
@@ -312,6 +325,7 @@ impl FontStore {
             );
             self.record_resolution(FontResolution {
                 requested: requested.clone(),
+                requested_bold: bold,
                 resolved: Some(font.family.clone()),
                 resolved_sha256: Some(sha256_hex(&font.data)),
                 resolved_face_index: Some(font.index),
@@ -324,6 +338,7 @@ impl FontStore {
                 .push(RenderIssueCode::FontMissing, requested.as_bytes());
             self.record_resolution(FontResolution {
                 requested: requested.clone(),
+                requested_bold: bold,
                 resolved: None,
                 resolved_sha256: None,
                 resolved_face_index: None,
@@ -373,6 +388,7 @@ impl FontStore {
                 let font = &selection.font;
                 self.record_resolution(FontResolution {
                     requested: "coverage_fallback".to_string(),
+                    requested_bold: bold,
                     resolved: Some(font.family.clone()),
                     resolved_sha256: Some(sha256_hex(&font.data)),
                     resolved_face_index: Some(font.index),
@@ -385,6 +401,7 @@ impl FontStore {
         if result.is_none() {
             self.record_resolution(FontResolution {
                 requested: "coverage_fallback".to_string(),
+                requested_bold: bold,
                 resolved: None,
                 resolved_sha256: None,
                 resolved_face_index: None,
@@ -553,6 +570,13 @@ mod tests {
     }
 
     fn weight_font(family: &str, weight: u16) -> Vec<u8> {
+        weight_font_with_families(&[(family, 0x0409)], weight)
+    }
+
+    /// Build a single-face font carrying one family name per (name, language)
+    /// pair, so a face with a secondary family alias can be tested without a
+    /// host font directory.
+    fn weight_font_with_families(families: &[(&str, u16)], weight: u16) -> Vec<u8> {
         let base = hex_bytes(DEMO_TTF_HEX);
         let table_count = usize::from(be_u16(&base, 4));
         let mut tables = Vec::<([u8; 4], Vec<u8>)>::with_capacity(table_count + 2);
@@ -565,33 +589,40 @@ mod tests {
             tables.push((tag, base[offset..offset + length].to_vec()));
         }
 
-        let family_utf16: Vec<u8> = family.encode_utf16().flat_map(u16::to_be_bytes).collect();
-        let post_script = family.replace(' ', "");
-        let post_script_utf16: Vec<u8> = post_script
-            .encode_utf16()
-            .flat_map(u16::to_be_bytes)
+        let post_script = families[0].0.replace(' ', "");
+        let mut encoded: Vec<(u16, u16, Vec<u8>)> = families
+            .iter()
+            .map(|(name, language)| {
+                (
+                    1u16,
+                    *language,
+                    name.encode_utf16().flat_map(u16::to_be_bytes).collect(),
+                )
+            })
             .collect();
+        encoded.push((
+            6u16,
+            0x0409,
+            post_script
+                .encode_utf16()
+                .flat_map(u16::to_be_bytes)
+                .collect(),
+        ));
         let mut name = Vec::new();
         push_u16(&mut name, 0); // format
-        push_u16(&mut name, 2); // count
-        push_u16(&mut name, 30); // string offset: 6 + 2 * 12
-        for (name_id, bytes) in [(1u16, &family_utf16), (6u16, &post_script_utf16)] {
+        push_u16(&mut name, encoded.len() as u16); // count
+        push_u16(&mut name, 6 + encoded.len() as u16 * 12); // string storage offset
+        let mut storage = Vec::new();
+        for (name_id, language, bytes) in &encoded {
             push_u16(&mut name, 3); // Windows Unicode BMP
             push_u16(&mut name, 1);
-            push_u16(&mut name, 0x0409);
-            push_u16(&mut name, name_id);
+            push_u16(&mut name, *language);
+            push_u16(&mut name, *name_id);
             push_u16(&mut name, bytes.len() as u16);
-            push_u16(
-                &mut name,
-                if name_id == 1 {
-                    0
-                } else {
-                    family_utf16.len() as u16
-                },
-            );
+            push_u16(&mut name, storage.len() as u16);
+            storage.extend_from_slice(bytes);
         }
-        name.extend_from_slice(&family_utf16);
-        name.extend_from_slice(&post_script_utf16);
+        name.extend_from_slice(&storage);
         tables.push((*b"name", name));
 
         let mut os2 = vec![0; 78];
@@ -647,6 +678,7 @@ mod tests {
         for index in 0..=MAX_FONT_RESOLUTIONS {
             store.record_resolution(FontResolution {
                 requested: format!("font-{index}"),
+                requested_bold: false,
                 resolved: None,
                 resolved_sha256: None,
                 resolved_face_index: None,
@@ -687,6 +719,17 @@ mod tests {
         assert_eq!(sha256_hex(&regular.data), regular_hash);
         assert_eq!(sha256_hex(&bold.data), bold_hash);
         assert_eq!(store.resolutions.len(), 2);
+        let mut weight_states: Vec<bool> = store
+            .resolutions
+            .iter()
+            .map(|resolution| resolution.requested_bold)
+            .collect();
+        weight_states.sort();
+        assert_eq!(
+            weight_states,
+            vec![false, true],
+            "regular and bold requests stay distinct identity records"
+        );
         assert!(store.resolutions.iter().any(|resolution| {
             resolution.resolved_sha256.as_deref() == Some(regular_hash.as_str())
                 && resolution.resolved_face_index == Some(0)
@@ -718,5 +761,111 @@ mod tests {
 
         let _ = std::fs::remove_file(regular_path);
         let _ = std::fs::remove_file(bold_path);
+    }
+
+    #[test]
+    fn bold_request_on_a_regular_only_face_is_a_distinct_record() {
+        // Without the requested weight state, the bold resolution selects the
+        // same regular bytes and dedups into the regular record, hiding the
+        // bold request from the report.
+        let family = "HWP Bold Identity Fixture";
+        let bytes = weight_font(family, 400);
+        let hash = sha256_hex(&bytes);
+        let path = temp_font_path("regular-only");
+        std::fs::write(&path, &bytes).unwrap();
+
+        let document = test_document(family);
+        let mut store = FontStore::new_isolated();
+        store.load_file(&path).unwrap();
+        store.resolve(&document, 0, 0).unwrap();
+        store.resolve_with_style(&document, 0, 0, true).unwrap();
+        assert_eq!(store.resolutions.len(), 2);
+        let mut states: Vec<bool> = store
+            .resolutions
+            .iter()
+            .map(|resolution| resolution.requested_bold)
+            .collect();
+        states.sort();
+        assert_eq!(states, vec![false, true]);
+        assert!(store.resolutions.iter().all(|resolution| {
+            resolution.outcome == FontResolutionOutcome::Matched
+                && resolution.resolved_sha256.as_deref() == Some(hash.as_str())
+        }));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn secondary_family_alias_on_the_selected_face_stays_matched() {
+        // fontdb matches every family name a face carries, so requesting the
+        // secondary (Korean-language) alias resolves the same face directly.
+        let bytes = weight_font_with_families(
+            &[
+                ("HWP Alias Primary", 0x0409),
+                ("HWP Alias Secondary", 0x0412),
+            ],
+            400,
+        );
+        let hash = sha256_hex(&bytes);
+        let path = temp_font_path("aliased");
+        std::fs::write(&path, &bytes).unwrap();
+
+        let document = test_document("HWP Alias Secondary");
+        let mut store = FontStore::new_isolated();
+        store.load_file(&path).unwrap();
+        let resolved = store.resolve(&document, 0, 0).unwrap();
+        assert_eq!(sha256_hex(&resolved.data), hash);
+        assert_eq!(store.resolutions.len(), 1);
+        let resolution = &store.resolutions[0];
+        assert_eq!(resolution.outcome, FontResolutionOutcome::Matched);
+        assert_eq!(resolution.resolved_sha256.as_deref(), Some(hash.as_str()));
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn alt_name_and_class_fallback_are_substitution_outcomes() {
+        // The document's own alt name resolves the face but is not the
+        // directly requested family.
+        let alt_bytes = weight_font("HWP Alt Face", 400);
+        let alt_hash = sha256_hex(&alt_bytes);
+        let alt_path = temp_font_path("alt");
+        std::fs::write(&alt_path, &alt_bytes).unwrap();
+        let mut document = test_document("HWP Missing Primary");
+        document.header.fonts[0][0].alt_name = Some("HWP Alt Face".to_string());
+        let mut store = FontStore::new_isolated();
+        store.load_file(&alt_path).unwrap();
+        store.resolve(&document, 0, 0).unwrap();
+        assert_eq!(store.resolutions.len(), 1);
+        assert_eq!(
+            store.resolutions[0].outcome,
+            FontResolutionOutcome::Substituted
+        );
+        assert_eq!(
+            store.resolutions[0].resolved_sha256.as_deref(),
+            Some(alt_hash.as_str())
+        );
+
+        // A class fallback-list entry is likewise a typed substitution.
+        let fallback_bytes = weight_font("함초롬돋움", 400);
+        let fallback_hash = sha256_hex(&fallback_bytes);
+        let fallback_path = temp_font_path("fallback");
+        std::fs::write(&fallback_path, &fallback_bytes).unwrap();
+        let document = test_document("미지정 고딕체");
+        let mut store = FontStore::new_isolated();
+        store.load_file(&fallback_path).unwrap();
+        store.resolve(&document, 0, 0).unwrap();
+        assert_eq!(store.resolutions.len(), 1);
+        assert_eq!(
+            store.resolutions[0].outcome,
+            FontResolutionOutcome::Substituted
+        );
+        assert_eq!(
+            store.resolutions[0].resolved_sha256.as_deref(),
+            Some(fallback_hash.as_str())
+        );
+
+        let _ = std::fs::remove_file(alt_path);
+        let _ = std::fs::remove_file(fallback_path);
     }
 }

--- a/crates/hwp-render/src/lib.rs
+++ b/crates/hwp-render/src/lib.rs
@@ -120,6 +120,9 @@ pub struct SvgOutput {
     /// 페이지별 SVG 문서
     pub pages: Vec<String>,
     pub report: RenderIssueReport,
+    /// 렌더 중 관측한 글꼴 해석 결과 (폰트 게이트용). PNG `diagnostics.fonts`와 동일 출처.
+    pub fonts: Vec<FontResolution>,
+    pub font_resolution_complete: bool,
 }
 
 fn build_display_list(
@@ -286,10 +289,12 @@ pub fn load_png(path: &std::path::Path) -> Result<tiny_skia::Pixmap, RenderError
 
 /// 문서 전체를 SVG로 렌더링한다.
 pub fn render_document_svg(doc: &Document, opts: &RenderOptions) -> SvgOutput {
-    let (list, report, _, _) = build_display_list(doc, opts);
+    let (list, report, fonts, font_resolution_complete) = build_display_list(doc, opts);
     SvgOutput {
         pages: svg::render_svg(&list),
         report: report.finish(),
+        fonts,
+        font_resolution_complete,
     }
 }
 
@@ -298,6 +303,9 @@ pub struct PdfOutput {
     pub data: Vec<u8>,
     /// 경고 + 폰트 해석 리포트
     pub report: RenderIssueReport,
+    /// 렌더 중 관측한 글꼴 해석 결과 (폰트 게이트용). PNG `diagnostics.fonts`와 동일 출처.
+    pub fonts: Vec<FontResolution>,
+    pub font_resolution_complete: bool,
 }
 
 /// PDF output plus the pre-serialization text sequence used by corpus
@@ -316,8 +324,15 @@ pub fn render_document_pdf(
     opts: &RenderOptions,
     pages: Option<&[usize]>,
 ) -> Result<PdfOutput, RenderError> {
-    let (list, report, _, _) = build_display_list(doc, opts);
-    finish_pdf(list, report, pages, &doc.metadata)
+    let (list, report, fonts, font_resolution_complete) = build_display_list(doc, opts);
+    finish_pdf(
+        list,
+        report,
+        fonts,
+        font_resolution_complete,
+        pages,
+        &doc.metadata,
+    )
 }
 
 /// Isolated PDF render for certification. It searches only `font_files`, not
@@ -329,8 +344,16 @@ pub fn render_document_pdf_isolated(
     pages: Option<&[usize]>,
     font_files: &[std::path::PathBuf],
 ) -> Result<PdfOutput, RenderError> {
-    let (list, report, _, _) = build_display_list_with_font_scope(doc, opts, false, font_files);
-    finish_pdf(list, report, pages, &doc.metadata)
+    let (list, report, fonts, font_resolution_complete) =
+        build_display_list_with_font_scope(doc, opts, false, font_files);
+    finish_pdf(
+        list,
+        report,
+        fonts,
+        font_resolution_complete,
+        pages,
+        &doc.metadata,
+    )
 }
 
 /// Isolated PDF render with a pre-serialization text trace for corpus
@@ -349,6 +372,8 @@ pub fn render_document_pdf_isolated_with_text_trace(
 fn finish_pdf(
     mut list: display::DisplayList,
     mut report: RenderIssueAccumulator,
+    fonts: Vec<FontResolution>,
+    font_resolution_complete: bool,
     pages: Option<&[usize]>,
     meta: &Metadata,
 ) -> Result<PdfOutput, RenderError> {
@@ -357,6 +382,8 @@ fn finish_pdf(
     Ok(PdfOutput {
         data,
         report: report.finish(),
+        fonts,
+        font_resolution_complete,
     })
 }
 

--- a/docs/design/21-pdf-parity.ko.md
+++ b/docs/design/21-pdf-parity.ko.md
@@ -206,10 +206,13 @@ structured-corpus run(`scripts/check-structured-corpus.sh`)은 고정 Noto Sans 
 아래 잰 parity 수치는 무의미하다**.
 
 - `RenderIssueReport::font_coverage()`가 FontMatched / FontSubstituted / FontMissing /
-  FontSubsetFallback 횟수를 집계하고, CLI 렌더 리포트가 커버리지 줄을 출력한다.
-- `FontCoverage::substitution_free()`가 하드 게이트다: 대체 없이 렌더되지 않은 케이스의
-  parity 수치는 발행할 수 없다.
-- 커버리지 자체를 확인할 수 없는 경우도 게이트 실패로 처리한다. 두 PDF 중 하나라도
+  FontSubsetFallback 횟수를 집계하고, CLI 렌더 리포트는 해시화한 요청/해결 글꼴 identity,
+  요청 weight 상태, face index, 해석 완결성도 함께 발행한다.
+- `FontCoverage::substitution_free()`는 하드 게이트의 일부다: 대체 없이 렌더되지 않은 케이스의
+  parity 수치는 발행할 수 없다. 해석 완결성도 충족해야 하고, 해결된 모든 font-byte 해시는
+  manifest에 고정된 집합에 속해야 한다. 직접 요청한 패밀리(선택된 face의 검증된 보조 별칭 포함)만
+  matched로 인정한다.
+- 커버리지나 identity 증거를 확인할 수 없는 경우도 게이트 실패로 처리한다. 두 PDF 중 하나라도
   `pdffonts` 기준 임베드·서브셋·Unicode 지원을 모두 충족하지 못하면 역시 채점하지 않는다.
 
 ## 6. 페이지네이션 정본 (F3)

--- a/docs/design/21-pdf-parity.md
+++ b/docs/design/21-pdf-parity.md
@@ -220,11 +220,14 @@ sans-serif. Every substitution changes every advance, every wrap decision and ev
 so **a parity number measured under substituted fonts is meaningless**.
 
 - `RenderIssueReport::font_coverage()` aggregates FontMatched / FontSubstituted / FontMissing /
-  FontSubsetFallback counts; the CLI render report prints the coverage line.
-- `FontCoverage::substitution_free()` is the hard gate: no parity figure may be published for a
-  case whose render was not substitution-free.
-- Missing coverage is a gate failure, as is any font in either PDF that `pdffonts` does not report
-  as embedded, subset, and Unicode-capable.
+  FontSubsetFallback counts; the CLI render report also publishes hash-only requested/resolved font
+  identities, requested weight state, face index, and resolution completeness.
+- `FontCoverage::substitution_free()` is part of the hard gate: no parity figure may be published
+  for a case whose render was not substitution-free. Resolution must also be complete, and every
+  resolved font-byte hash must belong to the manifest-pinned set. Only a directly requested family,
+  including a proven secondary alias on the selected face, may count as matched.
+- Missing coverage or identity evidence is a gate failure, as is any font in either PDF that
+  `pdffonts` does not report as embedded, subset, and Unicode-capable.
 
 ## 6. Pagination truth (F3)
 

--- a/schemas/pdf-parity-scorecard-v2.schema.json
+++ b/schemas/pdf-parity-scorecard-v2.schema.json
@@ -75,6 +75,10 @@
         "oracle": { "type": "array", "items": { "$ref": "#/$defs/font" } },
         "candidate_all_embedded_subset_unicode": { "type": "boolean" },
         "oracle_all_embedded_subset_unicode": { "type": "boolean" },
+        "substitution_free": { "type": "boolean" },
+        "resolution_complete": { "type": "boolean" },
+        "pinned_faces": { "type": "boolean" },
+        "outside_manifest_faces": { "type": "integer", "minimum": 0 },
         "passed": { "type": "boolean" }
       }
     },

--- a/schemas/render-report-v1.schema.json
+++ b/schemas/render-report-v1.schema.json
@@ -56,6 +56,12 @@
         "substitution_free": { "type": "boolean" }
       }
     },
+    "font_resolution_complete": { "type": "boolean" },
+    "fonts": {
+      "type": "array",
+      "maxItems": 512,
+      "items": { "$ref": "#/$defs/renderFontRecord" }
+    },
     "issues": {
       "type": "array",
       "maxItems": 32,
@@ -76,6 +82,34 @@
   },
   "$defs": {
     "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "renderFontRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "requested_sha256",
+        "requested_bold",
+        "resolved_family_sha256",
+        "resolved_sha256",
+        "resolved_face_index",
+        "outcome"
+      ],
+      "properties": {
+        "requested_sha256": { "$ref": "#/$defs/sha256" },
+        "requested_bold": { "type": "boolean" },
+        "resolved_family_sha256": {
+          "oneOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }]
+        },
+        "resolved_sha256": {
+          "oneOf": [{ "$ref": "#/$defs/sha256" }, { "type": "null" }]
+        },
+        "resolved_face_index": {
+          "oneOf": [{ "type": "integer", "minimum": 0 }, { "type": "null" }]
+        },
+        "outcome": {
+          "enum": ["matched", "substituted", "missing", "coverage_substituted"]
+        }
+      }
+    },
     "renderIssue": {
       "type": "object",
       "additionalProperties": false,

--- a/tools/pdf_parity.py
+++ b/tools/pdf_parity.py
@@ -1165,12 +1165,25 @@ def score_case_v2(
         substitution_free = all(record["outcome"] == "matched" for record in font_records)
     else:
         substitution_free = False
+    if font_records is not None:
+        # A clean aggregate never overrides per-font evidence: any recorded
+        # substitution (including glyph-level coverage fallback) or missing
+        # font fails the gate even when the aggregate claims otherwise.
+        substitution_free = substitution_free and all(
+            record["outcome"] == "matched" for record in font_records
+        )
     if font_records is not None and pinned_font_hashes is not None:
+        # A resolved record without a valid byte hash is failed identity
+        # evidence: it cannot be proven pinned, so it counts as outside the
+        # manifest.  `missing` records legitimately carry no hash.
         outside_manifest = sum(
             1
             for record in font_records
-            if record["resolved_sha256"] is not None
-            and record["resolved_sha256"] not in pinned_font_hashes
+            if record["outcome"] != "missing"
+            and (
+                record["resolved_sha256"] is None
+                or record["resolved_sha256"] not in pinned_font_hashes
+            )
         )
     else:
         outside_manifest = 0

--- a/tools/pdf_parity.py
+++ b/tools/pdf_parity.py
@@ -363,6 +363,29 @@ def _iter_issue_mappings(value: object):
             yield from _iter_issue_mappings(entry)
 
 
+def _normalize_font_records(value: object) -> list | None:
+    """Normalize per-font identity records to outcome + byte hash only.
+
+    Accepts the render report's ``resolved_sha256`` and the certification
+    report's ``font_file_sha256``.  Records are already hash-only in the
+    source documents, so normalization never retains names or paths.
+    """
+    if not isinstance(value, list):
+        return None
+    records = []
+    for entry in value[:512]:
+        if not isinstance(entry, dict):
+            continue
+        outcome = str(entry.get("outcome", "")).lower()
+        if outcome not in {"matched", "substituted", "missing", "coverage_substituted"}:
+            continue
+        resolved = entry.get("resolved_sha256", entry.get("font_file_sha256"))
+        if not (isinstance(resolved, str) and SHA256_RE.fullmatch(resolved)):
+            resolved = None
+        records.append({"outcome": outcome, "resolved_sha256": resolved})
+    return records
+
+
 def normalize_render_report(payload: object) -> dict:
     """Normalize a JSON render report to counts only; never publish its paths/details."""
     if isinstance(payload, dict) and isinstance(payload.get("render"), dict):
@@ -499,6 +522,19 @@ def normalize_render_report(payload: object) -> dict:
     complete = bool(render_payload.get("complete", render_payload.get("issue_log_complete", True)))
     if render_payload.get("status") in {"failed", "partial", "skipped"}:
         complete = False
+
+    # Per-font identity records and the resolution completeness flag.  An
+    # explicitly incomplete resolution is incomplete render evidence even
+    # when the typed issue channel stayed within its budget.
+    font_records = _normalize_font_records(render_payload.get("fonts"))
+    font_resolution_complete = render_payload.get("font_resolution_complete")
+    if font_resolution_complete is False:
+        incomplete += 1
+        issue_summaries.append(
+            {"code": "font_resolution_incomplete", "severity": "incomplete", "count": 1}
+        )
+    elif font_resolution_complete is not True:
+        font_resolution_complete = None
     return {
         "coverage": coverage,
         "complete": complete,
@@ -507,6 +543,8 @@ def normalize_render_report(payload: object) -> dict:
         "fatal": fatal,
         "issue_codes": sorted({issue["code"] for issue in issue_summaries}),
         "report_available": bool(payload),
+        "fonts": font_records,
+        "font_resolution_complete": font_resolution_complete,
     }
 
 
@@ -546,6 +584,8 @@ def parse_render_stderr(stderr: str) -> dict:
         "fatal": fatal,
         "issue_codes": sorted({issue["code"] for issue in issues}),
         "report_available": bool(stderr),
+        "fonts": None,
+        "font_resolution_complete": None,
     }
 
 
@@ -575,6 +615,8 @@ def merge_render_reports(reports: list[tuple[str, dict]]) -> dict:
             "issue_codes": [],
             "report_available": False,
             "report_source": "none",
+            "fonts": None,
+            "font_resolution_complete": None,
         }
     coverages = [report["coverage"] for _, report in reports if report.get("coverage") is not None]
     coverage = None
@@ -588,6 +630,28 @@ def merge_render_reports(reports: list[tuple[str, dict]]) -> dict:
             and coverage["missing"] == 0
             and coverage["subset_fallback"] == 0
         )
+    # Per-font identity evidence merges only when every run produced it;
+    # otherwise the pinned-face check cannot be proven and must fail closed.
+    record_lists = [report.get("fonts") for _, report in reports]
+    if all(isinstance(records, list) for records in record_lists):
+        fonts = sorted(
+            {
+                (record["outcome"], record["resolved_sha256"])
+                for records in record_lists
+                for record in records
+            },
+            key=lambda item: (item[0], item[1] or ""),
+        )
+        fonts = [{"outcome": outcome, "resolved_sha256": resolved} for outcome, resolved in fonts]
+    else:
+        fonts = None
+    completeness = [report.get("font_resolution_complete") for _, report in reports]
+    if all(value is True for value in completeness):
+        font_resolution_complete: bool | None = True
+    elif any(value is False for value in completeness):
+        font_resolution_complete = False
+    else:
+        font_resolution_complete = None
     sources = {source for source, _ in reports}
     return {
         "coverage": coverage,
@@ -598,6 +662,8 @@ def merge_render_reports(reports: list[tuple[str, dict]]) -> dict:
         "issue_codes": sorted({code for _, report in reports for code in report.get("issue_codes", [])}),
         "report_available": any(report.get("report_available", False) for _, report in reports),
         "report_source": next(iter(sources)) if len(sources) == 1 else "mixed",
+        "fonts": fonts,
+        "font_resolution_complete": font_resolution_complete,
     }
 
 
@@ -1026,6 +1092,7 @@ def score_case_v2(
     thresholds: dict | None = None,
     rois: list | None = None,
     report_path: Path | None = None,
+    pinned_font_hashes: "frozenset | set | None" = None,
 ) -> dict:
     """Score all Issue #79 v2 gates for one source/oracle pair."""
     thresholds = {**V2_THRESHOLDS, **(thresholds or {})}
@@ -1083,8 +1150,44 @@ def score_case_v2(
         candidate_fonts_ok = oracle_fonts_ok = True
     # The normative F1 gate is about the candidate PDF.  Oracle font rows are
     # retained for diagnostics, but an unusual oracle producer must not turn a
-    # candidate that satisfies F1 into an ineligible result.
-    fonts_passed = fonts_parse_ok and candidate_fonts_ok
+    # candidate that satisfies F1 into an ineligible result.  The v2 fonts
+    # gate additionally folds in the render-side font evidence: no typed
+    # substitution, complete resolution, and every resolved face pinned by the
+    # manifest.  Without per-font records the pinned-face check cannot be
+    # proven and fails closed whenever the manifest pins fonts.
+    report = render["report"]
+    coverage = report.get("coverage")
+    font_records = report.get("fonts")
+    resolution_complete = report.get("font_resolution_complete")
+    if coverage is not None:
+        substitution_free = bool(coverage["substitution_free"])
+    elif font_records is not None:
+        substitution_free = all(record["outcome"] == "matched" for record in font_records)
+    else:
+        substitution_free = False
+    if font_records is not None and pinned_font_hashes is not None:
+        outside_manifest = sum(
+            1
+            for record in font_records
+            if record["resolved_sha256"] is not None
+            and record["resolved_sha256"] not in pinned_font_hashes
+        )
+    else:
+        outside_manifest = 0
+    if pinned_font_hashes is None:
+        # Direct harness use without a manifest keeps the pre-gate behavior.
+        pinned_faces_ok = True
+        resolution_ok = resolution_complete is not False
+    else:
+        pinned_faces_ok = font_records is not None and outside_manifest == 0
+        resolution_ok = resolution_complete is True
+    fonts_passed = (
+        fonts_parse_ok
+        and candidate_fonts_ok
+        and substitution_free
+        and pinned_faces_ok
+        and resolution_ok
+    )
 
     compared = min(ours_pages, oracle_pages)
     equal = 0
@@ -1150,15 +1253,13 @@ def score_case_v2(
         result["passed"] for result in roi_results
     )
 
-    report = render["report"]
-    coverage = report.get("coverage")
     substitutions = 0 if coverage is None else (
         coverage["substituted"] + coverage["missing"] + coverage["subset_fallback"]
     )
+    # render_issues stays the general incomplete/fatal gate; the font-specific
+    # substitution/completeness/pinned-face checks live in the fonts gate.
     render_passed = (
-        coverage is not None
-        and coverage.get("substitution_free", False)
-        and report.get("complete", False)
+        report.get("complete", False)
         and report.get("unsupported", 0) == 0
         and report.get("incomplete", 0) == 0
         and report.get("fatal", 0) == 0
@@ -1198,6 +1299,10 @@ def score_case_v2(
             "oracle": oracle_fonts,
             "candidate_all_embedded_subset_unicode": candidate_fonts_ok,
             "oracle_all_embedded_subset_unicode": oracle_fonts_ok,
+            "substitution_free": substitution_free,
+            "resolution_complete": resolution_complete is True,
+            "pinned_faces": pinned_faces_ok,
+            "outside_manifest_faces": outside_manifest,
             "passed": fonts_passed,
         },
         "render": {
@@ -1495,6 +1600,8 @@ def cmd_run_v2(args) -> int:
     actual_poppler = verify_manifest_pins_v2(manifest)
     cases = prepare_cases(manifest, manifest_path, oracle_dir)
     thresholds = _v2_thresholds(manifest)
+    # Every resolved candidate face must come from the manifest-pinned set.
+    pinned_font_hashes = frozenset(manifest["pins"]["fonts"].values())
 
     forbidden = [
         str(oracle_dir.resolve()),
@@ -1521,6 +1628,7 @@ def cmd_run_v2(args) -> int:
                 thresholds,
                 case.get("rois", []),
                 report_path,
+                pinned_font_hashes,
             )
         if card["source"]["sha256"] != case["source_sha256"]:
             raise die(f"케이스 {case['name']}: 측정 중 source 파일 변경 감지")

--- a/tools/test_pdf_parity.py
+++ b/tools/test_pdf_parity.py
@@ -468,5 +468,174 @@ class V2ContractTests(unittest.TestCase):
         self.assertTrue(rows[0]["name"].startswith("font-"))
 
 
+class V2FontGateTests(unittest.TestCase):
+    def test_fonts_array_normalization_keeps_only_outcome_and_byte_hash(self) -> None:
+        report = parity.normalize_render_report(
+            {
+                "complete": True,
+                "font_resolution_complete": True,
+                "font_coverage": {
+                    "matched": 2,
+                    "substituted": 0,
+                    "missing": 0,
+                    "subset_fallback": 0,
+                },
+                "fonts": [
+                    {
+                        "requested_sha256": "a" * 64,
+                        "requested_bold": False,
+                        "resolved_family_sha256": "b" * 64,
+                        "resolved_sha256": "c" * 64,
+                        "resolved_face_index": 0,
+                        "outcome": "matched",
+                    },
+                    {
+                        # Certification-style byte-hash field name.
+                        "requested_name_sha256": "d" * 64,
+                        "font_file_sha256": "e" * 64,
+                        "outcome": "substituted",
+                    },
+                    {
+                        "requested_sha256": "f" * 64,
+                        "resolved_sha256": "not-a-hash",
+                        "outcome": "missing",
+                    },
+                    {"outcome": "bogus"},
+                    "not-a-dict",
+                ],
+            }
+        )
+        self.assertEqual(
+            report["fonts"],
+            [
+                {"outcome": "matched", "resolved_sha256": "c" * 64},
+                {"outcome": "substituted", "resolved_sha256": "e" * 64},
+                {"outcome": "missing", "resolved_sha256": None},
+            ],
+        )
+        self.assertTrue(report["font_resolution_complete"])
+        self.assertEqual(report["incomplete"], 0)
+
+    def test_incomplete_font_resolution_is_incomplete_evidence(self) -> None:
+        report = parity.normalize_render_report(
+            {
+                "complete": True,
+                "font_resolution_complete": False,
+                "font_coverage": {
+                    "matched": 1,
+                    "substituted": 0,
+                    "missing": 0,
+                    "subset_fallback": 0,
+                },
+            }
+        )
+        self.assertFalse(report["font_resolution_complete"])
+        self.assertEqual(report["incomplete"], 1)
+        self.assertIn("font_resolution_incomplete", report["issue_codes"])
+
+    def score_with_report(self, report: dict, pinned) -> dict:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = root / "case.hwpx"
+            oracle = root / "case.pdf"
+            ours_pdf = root / "ours.pdf"
+            source.write_bytes(b"source")
+            oracle.write_bytes(b"oracle")
+            ours_pdf.write_bytes(b"ours")
+            render = {
+                "first": {"path": ours_pdf},
+                "report": report,
+                "byte_equal": True,
+                "sha256": [digest(b"ours"), digest(b"ours")],
+            }
+            valid_font = {
+                "name": "Pinned",
+                "type": "TrueType",
+                "embedded": True,
+                "subset": True,
+                "unicode": True,
+            }
+            with mock.patch.object(parity, "render_candidate_twice", return_value=render), mock.patch.object(
+                parity, "pdf_pages", return_value=1
+            ), mock.patch.object(
+                parity, "pdf_media_boxes", return_value=[(0.0, 0.0, 100.0, 100.0)]
+            ), mock.patch.object(
+                parity, "pdf_fonts", return_value=[valid_font]
+            ), mock.patch.object(
+                parity, "page_text", return_value="same"
+            ), mock.patch.object(
+                parity, "rasterize", return_value=root / "missing.png"
+            ), mock.patch.object(
+                parity, "raster_diff", return_value={
+                    "dx": 0,
+                    "dy": 0,
+                    "ink_ratio": 1.0,
+                    "bad_pixel_pct": 0.0,
+                    "mae": 0.0,
+                }
+            ):
+                return parity.score_case_v2(
+                    "case", source, oracle, root / "hwp", 150, root,
+                    rois=[], pinned_font_hashes=pinned,
+                )
+
+    def clean_report(self, fonts, complete=True) -> dict:
+        return {
+            "coverage": {
+                "matched": 1,
+                "substituted": 0,
+                "missing": 0,
+                "subset_fallback": 0,
+                "substitution_free": True,
+            },
+            "complete": True,
+            "unsupported": 0,
+            "incomplete": 0,
+            "fatal": 0,
+            "issue_codes": [],
+            "report_available": True,
+            "report_source": "json",
+            "fonts": fonts,
+            "font_resolution_complete": complete,
+        }
+
+    def test_outside_manifest_resolved_hash_fails_fonts_gate(self) -> None:
+        pinned = frozenset({"c" * 64})
+        clean = self.score_with_report(
+            self.clean_report([{"outcome": "matched", "resolved_sha256": "c" * 64}]),
+            pinned,
+        )
+        self.assertIn("fonts", clean["passed_gates"])
+        self.assertTrue(clean["fonts"]["pinned_faces"])
+        self.assertEqual(clean["fonts"]["outside_manifest_faces"], 0)
+
+        outside = self.score_with_report(
+            self.clean_report([{"outcome": "matched", "resolved_sha256": "9" * 64}]),
+            pinned,
+        )
+        self.assertIn("fonts", outside["failed_gates"])
+        self.assertFalse(outside["fonts"]["pinned_faces"])
+        self.assertEqual(outside["fonts"]["outside_manifest_faces"], 1)
+        self.assertFalse(outside["eligible"])
+
+        missing_records = self.score_with_report(self.clean_report(None), pinned)
+        self.assertIn("fonts", missing_records["failed_gates"])
+
+        incomplete = self.score_with_report(self.clean_report([], complete=False), pinned)
+        self.assertIn("fonts", incomplete["failed_gates"])
+        self.assertFalse(incomplete["fonts"]["resolution_complete"])
+
+    def test_fonts_gate_fails_on_substitution_not_render_issues(self) -> None:
+        report = self.clean_report([{"outcome": "substituted", "resolved_sha256": "c" * 64}])
+        report["coverage"]["substituted"] = 1
+        report["coverage"]["substitution_free"] = False
+        card = self.score_with_report(report, frozenset({"c" * 64}))
+        self.assertIn("fonts", card["failed_gates"])
+        self.assertFalse(card["fonts"]["substitution_free"])
+        # Substitution evidence moved to the fonts gate; the general
+        # incomplete/fatal gate is unaffected by it.
+        self.assertIn("render_issues", card["passed_gates"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_pdf_parity.py
+++ b/tools/test_pdf_parity.py
@@ -636,6 +636,43 @@ class V2FontGateTests(unittest.TestCase):
         # incomplete/fatal gate is unaffected by it.
         self.assertIn("render_issues", card["passed_gates"])
 
+    def test_clean_aggregate_does_not_override_coverage_substituted_record(self) -> None:
+        # The aggregate claims substitution-free, but a glyph-level coverage
+        # fallback record must still fail the fonts gate.
+        report = self.clean_report(
+            [{"outcome": "coverage_substituted", "resolved_sha256": "c" * 64}]
+        )
+        card = self.score_with_report(report, frozenset({"c" * 64}))
+        self.assertIn("fonts", card["failed_gates"])
+        self.assertFalse(card["fonts"]["substitution_free"])
+        self.assertFalse(card["eligible"])
+
+    def test_resolved_record_without_byte_hash_counts_as_outside_manifest(self) -> None:
+        records = [
+            {"outcome": "matched", "resolved_sha256": None},
+            {"outcome": "substituted", "resolved_sha256": None},
+            {"outcome": "coverage_substituted", "resolved_sha256": None},
+            # A missing font legitimately carries no hash and is not counted.
+            {"outcome": "missing", "resolved_sha256": None},
+        ]
+        card = self.score_with_report(self.clean_report(records), frozenset({"c" * 64}))
+        self.assertIn("fonts", card["failed_gates"])
+        self.assertFalse(card["fonts"]["pinned_faces"])
+        self.assertEqual(card["fonts"]["outside_manifest_faces"], 3)
+
+    def test_all_matched_pinned_records_pass_fonts_gate(self) -> None:
+        records = [
+            {"outcome": "matched", "resolved_sha256": "c" * 64},
+            {"outcome": "matched", "resolved_sha256": "d" * 64},
+        ]
+        pinned = frozenset({"c" * 64, "d" * 64})
+        card = self.score_with_report(self.clean_report(records), pinned)
+        self.assertIn("fonts", card["passed_gates"])
+        self.assertTrue(card["fonts"]["substitution_free"])
+        self.assertTrue(card["fonts"]["pinned_faces"])
+        self.assertTrue(card["fonts"]["resolution_complete"])
+        self.assertEqual(card["fonts"]["outside_manifest_faces"], 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Epic #90 PR 7b (second half of PR 7), stacked on merged PR 7a.

## Summary

- Font resolutions are weight-aware: regular and bold requests remain distinct identity records.
- Directly requested families stay `matched`, including a proven secondary family alias on the selected face; document alt names, class fallbacks, generic fallback, and coverage fallback remain typed substitutions.
- PDF and SVG outputs now carry the same font-resolution diagnostics already available on the PNG path.
- `hwp render --report` now publishes deterministic hash-only font identity records plus `font_resolution_complete`; no raw family names or paths are emitted. `render-report-v1` accepts the new fields additively.
- The v2 PDF parity `fonts` gate now requires: candidate `pdffonts` contract, zero substitutions/missing/subset fallbacks, complete font resolution, and every resolved font-byte hash present in the manifest-pinned set. `render_issues` remains the general unsupported/incomplete/fatal gate.
- Certification reports collapse rows that differ only by the weight dimension omitted from certification v1, preserving existing closed-schema consumers.

## Validation

- `scripts/check.sh`: OK (fmt, clippy, workspace tests, PDF runner, structured corpus; local public-parity stage skipped on the known Poppler pin mismatch).
- `cargo test -p hwp-render fonts`: 5 passed.
- `cargo test -p hwp-cli render`: passed, including deterministic hashed render-report coverage.
- `python3 -m unittest tools.test_pdf_parity`: 22 passed.
- Private Hancom parity, content-free aggregate result:
  - pages remain 13 == oracle 13
  - `render_issues` now passes (unsupported/incomplete/fatal all zero)
  - `fonts` fails explicitly as intended: 8 substitutions and 3 resolved faces outside the pinned manifest set
  - text/raster/ROI remain open for the remaining epic work

## Remaining in epic #90

The private font inventory still lacks approved faces, so font parity remains ineligible until those assets are supplied and pinned. PR 8 remains: certification, documentation, and release gate.
