### PR TITLE
feat(certify): add preservation and Hancom-open evidence checks (#90 PR 8a)

### DIFF
--- a/crates/hwp-cli/src/certification.rs
+++ b/crates/hwp-cli/src/certification.rs
@@ -4,7 +4,7 @@
 //! diagnostic means only that this implementation's bounded algorithm did not observe a problem;
 //! it is not evidence of Hancom rendering parity.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -39,6 +39,10 @@ pub const MAX_ARTIFACT_TOTAL_BYTES: u64 = 512 * 1024 * 1024;
 pub const WINDOWS_CERTIFICATION_TREE_OVERHEAD_UTF16: usize = 101;
 pub const ORACLE_TIMEOUT: Duration = Duration::from_secs(120);
 const MAX_ORACLE_RESULT_BYTES: u64 = 64 * 1024;
+/// Bounded read limit for the optional preservation/hancom_open evidence artifacts.
+const MAX_EVIDENCE_ARTIFACT_BYTES: u64 = 64 * 1024;
+/// Mirrors `preservation-report-v1` `events.maxItems`.
+const MAX_PRESERVATION_EVENTS: usize = 1000;
 const MAX_LOG_BYTES_RECORDED: u64 = 64 * 1024;
 const MAX_PARSE_XML_DEPTH: usize = 128;
 const MAX_PARSE_XML_NODES: usize = 1_000_000;
@@ -83,6 +87,10 @@ pub struct DocumentPolicy {
     pub external_references: PresencePolicy,
     #[serde(default)]
     pub accessibility: AccessibilityPolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preservation: Option<PreservationPolicy>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hancom_open: Option<HancomOpenPolicy>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -185,6 +193,30 @@ pub struct AccessibilityPolicy {
     pub require_picture_descriptions: bool,
     #[serde(default)]
     pub require_shape_descriptions: bool,
+}
+
+/// Optional evidence check against a `preservation-report-v1` artifact produced by an earlier
+/// conversion run. The artifact carries only stable loss codes and counts, never content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PreservationPolicy {
+    /// Path to the preservation report JSON, relative to the policy file.
+    pub report: String,
+    /// Maximum tolerated loss total (sum of event counts). Defaults to zero.
+    #[serde(default)]
+    pub max_loss_codes: usize,
+}
+
+/// Optional evidence check against a `hancom-verification-receipt-v1` artifact attesting that
+/// Hancom Office opened the document without repair or damage warnings.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct HancomOpenPolicy {
+    /// Path to the verification receipt JSON, relative to the policy file.
+    pub receipt: String,
+    /// When true (default) the receipt result must be `pass`.
+    #[serde(default = "default_true")]
+    pub require_pass: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -327,6 +359,35 @@ pub struct CheckSet {
     pub package: CheckResult,
     pub repeat_import_consistency: CheckResult,
     pub rules: Vec<RuleResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preservation: Option<PreservationCheckReport>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hancom_open: Option<HancomOpenCheckReport>,
+}
+
+/// Outcome of the optional preservation evidence check. Content-free: only aggregated loss
+/// codes and counts, echoing the referenced `preservation-report-v1` artifact.
+#[derive(Debug, Clone, Serialize)]
+pub struct PreservationCheckReport {
+    pub status: CheckStatus,
+    pub reason_codes: Vec<String>,
+    pub loss_code_count: usize,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub loss_codes: Option<BTreeMap<String, usize>>,
+}
+
+/// Outcome of the optional Hancom open evidence check. Echoes only the receipt's content-free
+/// attestation fields; a missing or invalid receipt fails closed with no echo fields.
+#[derive(Debug, Clone, Serialize)]
+pub struct HancomOpenCheckReport {
+    pub status: CheckStatus,
+    pub reason_codes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub application: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verified_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verifier: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -676,10 +737,30 @@ pub fn execute(
         }
     }
 
+    // Optional evidence checks evaluate external artifacts pinned by the policy. They do not
+    // depend on native parsing and fail closed on missing or invalid artifacts.
+    let preservation_check = policy
+        .document
+        .preservation
+        .as_ref()
+        .map(|section| evaluate_preservation_evidence(section, policy_base));
+    let hancom_open_check = policy
+        .document
+        .hancom_open
+        .as_ref()
+        .map(|section| evaluate_hancom_open_evidence(section, policy_base));
+    let evidence_failed = preservation_check
+        .as_ref()
+        .is_some_and(|check| check.status != CheckStatus::Passed)
+        || hancom_open_check
+            .as_ref()
+            .is_some_and(|check| check.status != CheckStatus::Passed);
+
     let local_failed = package_check.status != CheckStatus::Passed
         || semantic_check.status != CheckStatus::Passed
         || rules.iter().any(|rule| rule.status == CheckStatus::Failed)
-        || render_report.status != CheckStatus::Passed;
+        || render_report.status != CheckStatus::Passed
+        || evidence_failed;
 
     let (oracle, mut oracle_artifacts) = if local_failed {
         (
@@ -731,6 +812,8 @@ pub fn execute(
             package: package_check,
             repeat_import_consistency: semantic_check,
             rules,
+            preservation: preservation_check,
+            hancom_open: hancom_open_check,
         },
         render: render_report,
         oracle,
@@ -745,6 +828,7 @@ pub fn execute(
     };
     validate_render_report_invariants(&report.render)?;
     validate_rule_composition(&report.checks.rules)?;
+    validate_evidence_check_invariants(&report)?;
     validate_report_artifact_invariants(&report)?;
 
     let report_bytes = with_final_newline(serde_json::to_vec_pretty(&report)?);
@@ -960,6 +1044,15 @@ fn validate_policy(policy: &CertificationPolicy) -> Result<()> {
         }
         (_, None) => anyhow::bail!("활성 oracle에는 configuration이 필요합니다"),
         (_, Some(config)) => validate_oracle_configuration(config)?,
+    }
+    if let Some(preservation) = &policy.document.preservation {
+        validate_relative_asset_path(&preservation.report)?;
+        if preservation.max_loss_codes > MAX_RULE_COUNT {
+            anyhow::bail!("preservation.max_loss_codes가 {MAX_RULE_COUNT} 상한을 초과합니다");
+        }
+    }
+    if let Some(hancom_open) = &policy.document.hancom_open {
+        validate_relative_asset_path(&hancom_open.receipt)?;
     }
     Ok(())
 }
@@ -1928,6 +2021,206 @@ fn validate_rule_composition(rules: &[RuleResult]) -> Result<()> {
                 .any(|(rule, expected)| rule.id != expected))
     {
         anyhow::bail!("certification rule composition invariant violated");
+    }
+    Ok(())
+}
+
+/// Content-free `hancom-verification-receipt-v1` artifact. Mirrors the closed receipt schema;
+/// validated field-by-field after parsing because the CLI never ships the schema at runtime.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HancomVerificationReceipt {
+    schema_version: String,
+    application: String,
+    result: String,
+    verified_at: String,
+    verifier: String,
+    #[serde(default)]
+    artifact_sha256: Option<String>,
+}
+
+fn valid_receipt_text(value: &str) -> bool {
+    !value.is_empty() && value.chars().count() <= 256 && !value.chars().any(char::is_control)
+}
+
+fn valid_receipt_timestamp(value: &str) -> bool {
+    fn digits(bytes: &[u8]) -> bool {
+        bytes.iter().all(u8::is_ascii_digit)
+    }
+    let bytes = value.as_bytes();
+    if !(20..=64).contains(&bytes.len())
+        || !digits(&bytes[0..4])
+        || bytes[4] != b'-'
+        || !digits(&bytes[5..7])
+        || bytes[7] != b'-'
+        || !digits(&bytes[8..10])
+        || bytes[10] != b'T'
+        || !digits(&bytes[11..13])
+        || bytes[13] != b':'
+        || !digits(&bytes[14..16])
+        || bytes[16] != b':'
+        || !digits(&bytes[17..19])
+    {
+        return false;
+    }
+    // Optional fractional seconds, then `Z` or a `±HH:MM` offset.
+    let mut tail = &value[19..];
+    if let Some(rest) = tail.strip_prefix('.') {
+        let Some(index) = rest.find(['Z', '+', '-']) else {
+            return false;
+        };
+        if index == 0 || !digits(&rest.as_bytes()[..index]) {
+            return false;
+        }
+        tail = &rest[index..];
+    }
+    if tail == "Z" {
+        return true;
+    }
+    let offset = tail.as_bytes();
+    offset.len() == 6
+        && matches!(offset[0], b'+' | b'-')
+        && digits(&offset[1..3])
+        && offset[3] == b':'
+        && digits(&offset[4..6])
+}
+
+fn valid_receipt(receipt: &HancomVerificationReceipt) -> bool {
+    receipt.schema_version == "1.0"
+        && matches!(receipt.result.as_str(), "pass" | "fail")
+        && valid_receipt_text(&receipt.application)
+        && valid_receipt_text(&receipt.verifier)
+        && valid_receipt_timestamp(&receipt.verified_at)
+        && receipt
+            .artifact_sha256
+            .as_ref()
+            .is_none_or(|value| validate_sha256(value, "receipt artifact sha256").is_ok())
+}
+
+/// The preservation evidence check loads the policy-pinned `preservation-report-v1` artifact
+/// and compares the aggregated loss total against the budget. Missing, oversized or malformed
+/// artifacts fail closed.
+fn evaluate_preservation_evidence(
+    policy: &PreservationPolicy,
+    policy_base: &Path,
+) -> PreservationCheckReport {
+    let invalid = || PreservationCheckReport {
+        status: CheckStatus::Failed,
+        reason_codes: vec!["preservation_report_invalid".to_string()],
+        loss_code_count: 0,
+        loss_codes: None,
+    };
+    let Ok(bytes) = read_bounded(
+        &policy_base.join(&policy.report),
+        MAX_EVIDENCE_ARTIFACT_BYTES,
+    ) else {
+        return invalid();
+    };
+    let Ok(report) = serde_json::from_slice::<hwp_model::preservation::PreservationReport>(&bytes)
+    else {
+        return invalid();
+    };
+    if report.contract != hwp_model::preservation::PRESERVATION_REPORT_CONTRACT
+        || report.events.len() > MAX_PRESERVATION_EVENTS
+        || report.events.iter().any(|event| event.count == 0)
+    {
+        return invalid();
+    }
+    let mut loss_codes: BTreeMap<String, usize> = BTreeMap::new();
+    for event in &report.events {
+        *loss_codes
+            .entry(event.code.as_str().to_string())
+            .or_default() += event.count;
+    }
+    let loss_code_count = loss_codes.values().sum();
+    let passed = loss_code_count <= policy.max_loss_codes;
+    PreservationCheckReport {
+        status: if passed {
+            CheckStatus::Passed
+        } else {
+            CheckStatus::Failed
+        },
+        reason_codes: if passed {
+            Vec::new()
+        } else {
+            vec!["preservation_loss_detected".to_string()]
+        },
+        loss_code_count,
+        loss_codes: (!loss_codes.is_empty()).then_some(loss_codes),
+    }
+}
+
+/// The Hancom open evidence check loads the policy-pinned receipt artifact and requires a
+/// `pass` result unless the policy relaxes it. Missing, oversized or malformed receipts fail
+/// closed and echo nothing.
+fn evaluate_hancom_open_evidence(
+    policy: &HancomOpenPolicy,
+    policy_base: &Path,
+) -> HancomOpenCheckReport {
+    let invalid = || HancomOpenCheckReport {
+        status: CheckStatus::Failed,
+        reason_codes: vec!["hancom_open_receipt_invalid".to_string()],
+        application: None,
+        verified_at: None,
+        verifier: None,
+    };
+    let Ok(bytes) = read_bounded(
+        &policy_base.join(&policy.receipt),
+        MAX_EVIDENCE_ARTIFACT_BYTES,
+    ) else {
+        return invalid();
+    };
+    let Ok(receipt) = serde_json::from_slice::<HancomVerificationReceipt>(&bytes) else {
+        return invalid();
+    };
+    if !valid_receipt(&receipt) {
+        return invalid();
+    }
+    let passed = !policy.require_pass || receipt.result == "pass";
+    HancomOpenCheckReport {
+        status: if passed {
+            CheckStatus::Passed
+        } else {
+            CheckStatus::Failed
+        },
+        reason_codes: if passed {
+            Vec::new()
+        } else {
+            vec!["hancom_open_not_attested".to_string()]
+        },
+        application: Some(receipt.application),
+        verified_at: Some(receipt.verified_at),
+        verifier: Some(receipt.verifier),
+    }
+}
+
+/// Post-build invariants for the optional evidence sections: status/reason consistency,
+/// aggregated preservation counts, and the overall-failure fold.
+fn validate_evidence_check_invariants(report: &CertificationReport) -> Result<()> {
+    let mut evidence_failed = false;
+    if let Some(check) = &report.checks.preservation {
+        if (check.status == CheckStatus::Passed) != check.reason_codes.is_empty() {
+            anyhow::bail!("preservation status/reason invariant violated");
+        }
+        if check
+            .loss_codes
+            .as_ref()
+            .is_some_and(|codes| codes.values().sum::<usize>() != check.loss_code_count)
+        {
+            anyhow::bail!("preservation loss count invariant violated");
+        }
+        evidence_failed |= check.status != CheckStatus::Passed;
+    }
+    if let Some(check) = &report.checks.hancom_open {
+        if (check.status == CheckStatus::Passed) != check.reason_codes.is_empty() {
+            anyhow::bail!("hancom_open status/reason invariant violated");
+        }
+        if check.status != CheckStatus::Passed {
+            evidence_failed = true;
+        }
+    }
+    if evidence_failed && report.overall != OverallStatus::Failed {
+        anyhow::bail!("evidence failure must fail the overall certification");
     }
     Ok(())
 }
@@ -4443,5 +4736,595 @@ exit 2"#,
         assert!(!serialized.contains("secret/team"));
         assert!(!serialized.contains(client));
         assert!(!serialized.contains(server));
+    }
+
+    fn evidence_scratch_dir(label: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "hwp-certify-evidence-{label}-{}-{}",
+            std::process::id(),
+            random_token().unwrap()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir(&path).unwrap();
+        path
+    }
+
+    fn evidence_policy_value() -> serde_json::Value {
+        let mut value = policy_json("disabled");
+        value["document"] = serde_json::json!({
+            "preservation": {"report": "preservation.json", "max_loss_codes": 2},
+            "hancom_open": {"receipt": "hancom-receipt.json", "require_pass": true}
+        });
+        value
+    }
+
+    fn policy_with_evidence() -> CertificationPolicy {
+        serde_json::from_value(evidence_policy_value()).unwrap()
+    }
+
+    #[test]
+    fn evidence_policy_sections_parse_and_validate() {
+        let policy = policy_with_evidence();
+        validate_policy(&policy).unwrap();
+        let preservation = policy.document.preservation.unwrap();
+        assert_eq!(preservation.report, "preservation.json");
+        assert_eq!(preservation.max_loss_codes, 2);
+        let hancom_open = policy.document.hancom_open.unwrap();
+        assert_eq!(hancom_open.receipt, "hancom-receipt.json");
+        assert!(hancom_open.require_pass);
+
+        // Defaults: max_loss_codes = 0, require_pass = true.
+        let mut value = policy_json("disabled");
+        value["document"] = serde_json::json!({
+            "preservation": {"report": "preservation.json"},
+            "hancom_open": {"receipt": "hancom-receipt.json"}
+        });
+        let policy: CertificationPolicy = serde_json::from_value(value).unwrap();
+        validate_policy(&policy).unwrap();
+        assert_eq!(policy.document.preservation.unwrap().max_loss_codes, 0);
+        assert!(policy.document.hancom_open.unwrap().require_pass);
+
+        // The sections stay closed and path-validated like the rest of the policy.
+        let mut value = policy_json("disabled");
+        value["document"] = serde_json::json!({
+            "preservation": {"report": "preservation.json", "bogus": true}
+        });
+        assert!(serde_json::from_value::<CertificationPolicy>(value).is_err());
+        let mut value = policy_json("disabled");
+        value["document"] = serde_json::json!({
+            "hancom_open": {"receipt": "../escape.json"}
+        });
+        let policy: CertificationPolicy = serde_json::from_value(value).unwrap();
+        assert!(validate_policy(&policy).is_err());
+    }
+
+    #[test]
+    fn evidence_policy_sections_match_the_policy_schema() {
+        let schema: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../schemas/certification-policy-v1.schema.json"
+        ))
+        .unwrap();
+        let validator = jsonschema::options()
+            .with_draft(jsonschema::Draft::Draft202012)
+            .build(&schema)
+            .unwrap();
+        let value = evidence_policy_value();
+        assert!(validator.is_valid(&value), "schema rejected {value}");
+
+        // A policy without the optional sections keeps its previous shape and stays valid.
+        let minimal = policy_json("disabled");
+        assert!(minimal.get("document").is_none());
+        assert!(validator.is_valid(&minimal), "schema rejected {minimal}");
+    }
+
+    #[test]
+    fn preservation_evidence_passes_within_the_loss_budget() {
+        let dir = evidence_scratch_dir("preservation-pass");
+        fs::write(
+            dir.join("preservation.json"),
+            serde_json::json!({
+                "contract": "hwp-preservation-report-v1",
+                "events": [
+                    {"code": "control_removed", "resource": "control", "disposition": "removed", "count": 2},
+                    {"code": "control_removed", "resource": "control", "disposition": "unrepresentable", "count": 1},
+                    {"code": "metadata_value_removed", "resource": "metadata", "disposition": "removed", "count": 3}
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let policy = PreservationPolicy {
+            report: "preservation.json".to_string(),
+            max_loss_codes: 6,
+        };
+        let check = evaluate_preservation_evidence(&policy, &dir);
+        assert_eq!(check.status, CheckStatus::Passed);
+        assert!(check.reason_codes.is_empty());
+        assert_eq!(check.loss_code_count, 6);
+        let codes = check.loss_codes.unwrap();
+        assert_eq!(codes["control_removed"], 3);
+        assert_eq!(codes["metadata_value_removed"], 3);
+        fs::remove_dir_all(&dir).unwrap();
+
+        // A lossless report passes the default zero budget and omits loss_codes.
+        let dir = evidence_scratch_dir("preservation-lossless");
+        fs::write(
+            dir.join("preservation.json"),
+            serde_json::json!({"contract": "hwp-preservation-report-v1", "events": []}).to_string(),
+        )
+        .unwrap();
+        let policy = PreservationPolicy {
+            report: "preservation.json".to_string(),
+            max_loss_codes: 0,
+        };
+        let check = evaluate_preservation_evidence(&policy, &dir);
+        assert_eq!(check.status, CheckStatus::Passed);
+        assert_eq!(check.loss_code_count, 0);
+        assert!(check.loss_codes.is_none());
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn preservation_evidence_fails_above_the_loss_budget() {
+        let dir = evidence_scratch_dir("preservation-loss");
+        fs::write(
+            dir.join("preservation.json"),
+            serde_json::json!({
+                "contract": "hwp-preservation-report-v1",
+                "events": [
+                    {"code": "picture_control_removed", "resource": "control", "disposition": "removed", "count": 2}
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let policy = PreservationPolicy {
+            report: "preservation.json".to_string(),
+            max_loss_codes: 1,
+        };
+        let check = evaluate_preservation_evidence(&policy, &dir);
+        assert_eq!(check.status, CheckStatus::Failed);
+        assert_eq!(check.reason_codes, ["preservation_loss_detected"]);
+        assert_eq!(check.loss_code_count, 2);
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn preservation_evidence_fails_closed_on_missing_or_invalid_artifacts() {
+        let dir = evidence_scratch_dir("preservation-invalid");
+        let policy = PreservationPolicy {
+            report: "preservation.json".to_string(),
+            max_loss_codes: 0,
+        };
+        let check = evaluate_preservation_evidence(&policy, &dir);
+        assert_eq!(check.status, CheckStatus::Failed);
+        assert_eq!(check.reason_codes, ["preservation_report_invalid"]);
+        assert!(check.loss_codes.is_none());
+
+        for (label, bytes) in [
+            ("malformed", b"{not json".to_vec()),
+            (
+                "wrong-contract",
+                serde_json::json!({"contract": "other", "events": []})
+                    .to_string()
+                    .into_bytes(),
+            ),
+            (
+                "zero-count",
+                serde_json::json!({
+                    "contract": "hwp-preservation-report-v1",
+                    "events": [
+                        {"code": "control_removed", "resource": "control", "disposition": "removed", "count": 0}
+                    ]
+                })
+                .to_string()
+                .into_bytes(),
+            ),
+        ] {
+            fs::write(dir.join("preservation.json"), bytes).unwrap();
+            let check = evaluate_preservation_evidence(&policy, &dir);
+            assert_eq!(check.status, CheckStatus::Failed, "{label}");
+            assert_eq!(check.reason_codes, ["preservation_report_invalid"], "{label}");
+        }
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    fn write_receipt(dir: &Path, receipt: serde_json::Value) {
+        fs::write(dir.join("hancom-receipt.json"), receipt.to_string()).unwrap();
+    }
+
+    fn valid_receipt_json() -> serde_json::Value {
+        serde_json::json!({
+            "schema_version": "1.0",
+            "application": "Hancom Office HWP",
+            "result": "pass",
+            "verified_at": "2026-08-15T12:00:00Z",
+            "verifier": "qa-operator-1",
+            "artifact_sha256": "0".repeat(64)
+        })
+    }
+
+    #[test]
+    fn hancom_open_evidence_passes_and_echoes_the_receipt() {
+        let dir = evidence_scratch_dir("hancom-pass");
+        write_receipt(&dir, valid_receipt_json());
+        let policy = HancomOpenPolicy {
+            receipt: "hancom-receipt.json".to_string(),
+            require_pass: true,
+        };
+        let check = evaluate_hancom_open_evidence(&policy, &dir);
+        assert_eq!(check.status, CheckStatus::Passed);
+        assert!(check.reason_codes.is_empty());
+        assert_eq!(check.application.as_deref(), Some("Hancom Office HWP"));
+        assert_eq!(check.verified_at.as_deref(), Some("2026-08-15T12:00:00Z"));
+        assert_eq!(check.verifier.as_deref(), Some("qa-operator-1"));
+
+        // require_pass=false accepts an explicit fail receipt as attested evidence.
+        let mut receipt = valid_receipt_json();
+        receipt["result"] = serde_json::json!("fail");
+        write_receipt(&dir, receipt);
+        let policy = HancomOpenPolicy {
+            require_pass: false,
+            ..policy
+        };
+        let check = evaluate_hancom_open_evidence(&policy, &dir);
+        assert_eq!(check.status, CheckStatus::Passed);
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn hancom_open_evidence_fails_when_not_attested() {
+        let dir = evidence_scratch_dir("hancom-fail");
+        let mut receipt = valid_receipt_json();
+        receipt["result"] = serde_json::json!("fail");
+        write_receipt(&dir, receipt);
+        let policy = HancomOpenPolicy {
+            receipt: "hancom-receipt.json".to_string(),
+            require_pass: true,
+        };
+        let check = evaluate_hancom_open_evidence(&policy, &dir);
+        assert_eq!(check.status, CheckStatus::Failed);
+        assert_eq!(check.reason_codes, ["hancom_open_not_attested"]);
+        assert_eq!(check.application.as_deref(), Some("Hancom Office HWP"));
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn hancom_open_evidence_fails_closed_on_missing_or_invalid_receipts() {
+        let dir = evidence_scratch_dir("hancom-invalid");
+        let policy = HancomOpenPolicy {
+            receipt: "hancom-receipt.json".to_string(),
+            require_pass: true,
+        };
+        let check = evaluate_hancom_open_evidence(&policy, &dir);
+        assert_eq!(check.status, CheckStatus::Failed);
+        assert_eq!(check.reason_codes, ["hancom_open_receipt_invalid"]);
+        assert!(check.application.is_none());
+        assert!(check.verified_at.is_none());
+        assert!(check.verifier.is_none());
+
+        for (label, mutate) in [
+            ("schema-version", "schema_version"),
+            ("result", "result"),
+            ("timestamp", "verified_at"),
+            ("hash", "artifact_sha256"),
+        ] {
+            let mut receipt = valid_receipt_json();
+            receipt[mutate] = serde_json::json!("bogus");
+            write_receipt(&dir, receipt);
+            let check = evaluate_hancom_open_evidence(&policy, &dir);
+            assert_eq!(check.status, CheckStatus::Failed, "{label}");
+            assert_eq!(
+                check.reason_codes,
+                ["hancom_open_receipt_invalid"],
+                "{label}"
+            );
+            assert!(check.application.is_none(), "{label}");
+        }
+        // Unknown fields are rejected by the closed contract.
+        let mut receipt = valid_receipt_json();
+        receipt["extra"] = serde_json::json!(true);
+        write_receipt(&dir, receipt);
+        let check = evaluate_hancom_open_evidence(&policy, &dir);
+        assert_eq!(check.status, CheckStatus::Failed);
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn receipt_timestamp_validation_matches_the_schema_shape() {
+        for valid in [
+            "2026-08-15T12:00:00Z",
+            "2026-08-15T12:00:00.123Z",
+            "2026-08-15T12:00:00+09:00",
+            "2026-08-15T12:00:00.5-05:30",
+        ] {
+            assert!(valid_receipt_timestamp(valid), "{valid}");
+        }
+        for invalid in [
+            "2026-08-15 12:00:00Z",
+            "2026-08-15T12:00:00",
+            "2026-08-15T12:00:00.Z",
+            "2026-08-15T12:00:00+0900",
+            "not-a-timestamp0000",
+        ] {
+            assert!(!valid_receipt_timestamp(invalid), "{invalid}");
+        }
+    }
+
+    #[test]
+    fn hancom_receipt_schema_pins_the_closed_contract() {
+        let schema: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../schemas/hancom-verification-receipt-v1.schema.json"
+        ))
+        .unwrap();
+        assert_eq!(schema["additionalProperties"], false);
+        assert_eq!(
+            schema["required"],
+            serde_json::json!([
+                "schema_version",
+                "application",
+                "result",
+                "verified_at",
+                "verifier"
+            ])
+        );
+        assert_eq!(schema["properties"]["schema_version"]["const"], "1.0");
+        assert_eq!(
+            schema["properties"]["result"]["enum"],
+            serde_json::json!(["pass", "fail"])
+        );
+
+        let validator = jsonschema::options()
+            .with_draft(jsonschema::Draft::Draft202012)
+            .build(&schema)
+            .unwrap();
+        assert!(validator.is_valid(&valid_receipt_json()));
+        let mut receipt = valid_receipt_json();
+        receipt["verifier"] = serde_json::json!("has\ncontrol");
+        assert!(!validator.is_valid(&receipt));
+    }
+
+    #[test]
+    fn report_schema_evidence_sections_mirror_the_preservation_codes() {
+        let schema: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../schemas/certification-report-v1.schema.json"
+        ))
+        .unwrap();
+        let checks = &schema["properties"]["checks"]["properties"];
+        assert!(checks.get("preservation").is_some());
+        assert!(checks.get("hancom_open").is_some());
+        let mut schema_codes: Vec<String> = schema["$defs"]["preservationLossCodes"]["properties"]
+            .as_object()
+            .unwrap()
+            .keys()
+            .cloned()
+            .collect();
+        schema_codes.sort();
+        let model_codes: Vec<&str> = [
+            hwp_model::preservation::PreservationCode::BinaryAssetRemoved,
+            hwp_model::preservation::PreservationCode::BinaryRelationshipRemoved,
+            hwp_model::preservation::PreservationCode::ControlMetadataUnrepresentable,
+            hwp_model::preservation::PreservationCode::ControlRemoved,
+            hwp_model::preservation::PreservationCode::GsoHeaderUnrepresentable,
+            hwp_model::preservation::PreservationCode::GsoShapeUnrepresentable,
+            hwp_model::preservation::PreservationCode::HwpContainerStorageRemoved,
+            hwp_model::preservation::PreservationCode::HwpContainerStreamRemoved,
+            hwp_model::preservation::PreservationCode::HwpOpaqueStreamChanged,
+            hwp_model::preservation::PreservationCode::HwpxOpaqueEntryChanged,
+            hwp_model::preservation::PreservationCode::HwpxPackageEntryRemoved,
+            hwp_model::preservation::PreservationCode::MetadataValueRemoved,
+            hwp_model::preservation::PreservationCode::OpaqueControlUnrepresentable,
+            hwp_model::preservation::PreservationCode::PictureControlRemoved,
+        ]
+        .into_iter()
+        .map(|code| code.as_str())
+        .collect();
+        assert_eq!(schema_codes, model_codes);
+        let reason_codes = schema["$defs"]["reasonCode"]["enum"].to_string();
+        for reason in [
+            "preservation_loss_detected",
+            "preservation_report_invalid",
+            "hancom_open_not_attested",
+            "hancom_open_receipt_invalid",
+        ] {
+            assert!(reason_codes.contains(reason), "{reason}");
+        }
+    }
+
+    #[test]
+    fn example_native_policy_and_evidence_artifacts_validate_against_their_schemas() {
+        let validator = |schema_path: &str| {
+            let schema: serde_json::Value = serde_json::from_str(schema_path).unwrap();
+            jsonschema::options()
+                .with_draft(jsonschema::Draft::Draft202012)
+                .build(&schema)
+                .unwrap()
+        };
+        let document = |path: &str| -> serde_json::Value { serde_json::from_str(path).unwrap() };
+        let policy = document(include_str!(
+            "../../../examples/certification-v1/native-policy.json"
+        ));
+        let schema = validator(include_str!(
+            "../../../schemas/certification-policy-v1.schema.json"
+        ));
+        assert!(schema.is_valid(&policy), "schema rejected {policy}");
+        let preservation = document(include_str!(
+            "../../../examples/certification-v1/preservation-report.json"
+        ));
+        let schema = validator(include_str!(
+            "../../../schemas/preservation-report-v1.schema.json"
+        ));
+        assert!(
+            schema.is_valid(&preservation),
+            "schema rejected {preservation}"
+        );
+        let receipt = document(include_str!(
+            "../../../examples/certification-v1/hancom-receipt.json"
+        ));
+        let schema = validator(include_str!(
+            "../../../schemas/hancom-verification-receipt-v1.schema.json"
+        ));
+        assert!(schema.is_valid(&receipt), "schema rejected {receipt}");
+
+        // The example policy also parses and validates through the runtime path.
+        let policy: CertificationPolicy = serde_json::from_value(policy).unwrap();
+        validate_policy(&policy).unwrap();
+    }
+
+    /// Build a fully passing native-only report value. Evidence sections are added by the
+    /// callers that need them; the baseline matches the pre-PR-8a wire shape.
+    fn passing_report_value() -> serde_json::Value {
+        let rules: Vec<RuleResult> = [
+            "defined_styles",
+            "used_styles",
+            "numbering.definitions",
+            "numbering.used",
+            "tables",
+            "links",
+            "metadata",
+            "macros",
+            "external_references",
+            "accessibility",
+            "unresolved_fields",
+            "fonts",
+        ]
+        .into_iter()
+        .map(|id| RuleResult {
+            id,
+            status: CheckStatus::Passed,
+            observed_count: 0,
+            reason_codes: Vec::new(),
+        })
+        .collect();
+        let mut render = empty_render_report(96.0);
+        render.status = CheckStatus::Passed;
+        render.reason_codes = Vec::new();
+        let report = CertificationReport {
+            schema_version: REPORT_SCHEMA_VERSION,
+            contract: "hwp-certification-report-v1",
+            overall: OverallStatus::Passed,
+            scope: "native_only",
+            input: InputReport {
+                format: "hwpx".to_string(),
+                bytes: 42,
+                sha256: "0".repeat(64),
+            },
+            policy_sha256: "1".repeat(64),
+            checks: CheckSet {
+                package: passed_check(),
+                repeat_import_consistency: passed_check(),
+                rules,
+                preservation: None,
+                hancom_open: None,
+            },
+            render,
+            oracle: OracleReport {
+                mode: OracleMode::Disabled,
+                status: OracleStatus::Disabled,
+                reason_code: None,
+                expected: None,
+                observed: None,
+                stdout: None,
+                stderr: None,
+                artifact_determinism: "not_applicable",
+            },
+            artifacts: Vec::new(),
+            limitations: vec![
+                "native_not_detected_is_algorithm_scoped",
+                "hancom_rendering_parity_not_claimed",
+                "oracle_artifact_determinism_not_claimed",
+                "oracle_page_count_not_host_verified",
+                "selected_pages_only_when_policy_selects_pages",
+            ],
+        };
+        validate_rule_composition(&report.checks.rules).unwrap();
+        validate_evidence_check_invariants(&report).unwrap();
+        serde_json::to_value(&report).unwrap()
+    }
+
+    /// The report schema cross-references the oracle-result schema by relative file ref;
+    /// inline that def so the test validator resolves every reference locally.
+    fn certification_report_validator() -> jsonschema::Validator {
+        let schema: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../schemas/certification-report-v1.schema.json"
+        ))
+        .unwrap();
+        let oracle: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../schemas/certification-oracle-result-v1.schema.json"
+        ))
+        .unwrap();
+        let mut rewritten = schema.to_string();
+        rewritten = rewritten.replace("certification-oracle-result-v1.schema.json#/", "#/");
+        let mut schema: serde_json::Value = serde_json::from_str(&rewritten).unwrap();
+        schema["$defs"]["attestation"] = oracle["$defs"]["attestation"].clone();
+        jsonschema::options()
+            .with_draft(jsonschema::Draft::Draft202012)
+            .build(&schema)
+            .unwrap()
+    }
+
+    #[test]
+    fn report_without_evidence_sections_still_validates_against_the_updated_schema() {
+        let value = passing_report_value();
+        assert!(value["checks"].get("preservation").is_none());
+        assert!(value["checks"].get("hancom_open").is_none());
+        let validator = certification_report_validator();
+        assert!(validator.is_valid(&value), "schema rejected {value}");
+    }
+
+    #[test]
+    fn report_with_passed_evidence_sections_validates_against_the_updated_schema() {
+        let mut value = passing_report_value();
+        value["checks"]["preservation"] = serde_json::json!({
+            "status": "passed",
+            "reason_codes": [],
+            "loss_code_count": 2,
+            "loss_codes": {"control_removed": 2}
+        });
+        value["checks"]["hancom_open"] = serde_json::json!({
+            "status": "passed",
+            "reason_codes": [],
+            "application": "Hancom Office HWP",
+            "verified_at": "2026-08-15T12:00:00Z",
+            "verifier": "qa-operator-1"
+        });
+        let validator = certification_report_validator();
+        assert!(validator.is_valid(&value), "schema rejected {value}");
+    }
+
+    #[test]
+    fn report_with_failed_evidence_requires_a_failed_overall() {
+        let validator = certification_report_validator();
+        let failed_preservation = serde_json::json!({
+            "status": "failed",
+            "reason_codes": ["preservation_loss_detected"],
+            "loss_code_count": 3,
+            "loss_codes": {"control_removed": 3}
+        });
+
+        // Failed evidence with an otherwise passing local composition: overall failed and the
+        // disabled oracle reports not_claimed (new oneOf branch).
+        let mut value = passing_report_value();
+        value["overall"] = serde_json::json!("failed");
+        value["oracle"]["artifact_determinism"] = serde_json::json!("not_claimed");
+        value["checks"]["preservation"] = failed_preservation.clone();
+        assert!(validator.is_valid(&value), "schema rejected {value}");
+
+        // Failed evidence can never compose with a passed or partial overall.
+        for overall in ["passed", "partial"] {
+            let mut value = passing_report_value();
+            value["overall"] = serde_json::json!(overall);
+            value["checks"]["preservation"] = failed_preservation.clone();
+            assert!(!validator.is_valid(&value), "schema accepted {value}");
+        }
+
+        // The echo fields and loss code names stay closed and content-free.
+        let mut value = passing_report_value();
+        value["overall"] = serde_json::json!("failed");
+        value["oracle"]["artifact_determinism"] = serde_json::json!("not_claimed");
+        let mut section = failed_preservation.clone();
+        section["loss_codes"] = serde_json::json!({"not_a_loss_code": 1});
+        value["checks"]["preservation"] = section;
+        assert!(!validator.is_valid(&value), "schema accepted {value}");
     }
 }

--- a/crates/hwp-cli/src/certification.rs
+++ b/crates/hwp-cli/src/certification.rs
@@ -43,6 +43,8 @@ const MAX_ORACLE_RESULT_BYTES: u64 = 64 * 1024;
 const MAX_EVIDENCE_ARTIFACT_BYTES: u64 = 64 * 1024;
 /// Mirrors `preservation-report-v1` `events.maxItems`.
 const MAX_PRESERVATION_EVENTS: usize = 1000;
+/// Per-event and per-code loss bound shared with the report schema's `lossCount`.
+const MAX_PRESERVATION_LOSS_COUNT: usize = 1_000_000;
 const MAX_LOG_BYTES_RECORDED: u64 = 64 * 1024;
 const MAX_PARSE_XML_DEPTH: usize = 128;
 const MAX_PARSE_XML_NODES: usize = 1_000_000;
@@ -744,11 +746,9 @@ pub fn execute(
         .preservation
         .as_ref()
         .map(|section| evaluate_preservation_evidence(section, policy_base));
-    let hancom_open_check = policy
-        .document
-        .hancom_open
-        .as_ref()
-        .map(|section| evaluate_hancom_open_evidence(section, policy_base));
+    let hancom_open_check = policy.document.hancom_open.as_ref().map(|section| {
+        evaluate_hancom_open_evidence(section, policy_base, &input_snapshot_report.sha256)
+    });
     let evidence_failed = preservation_check
         .as_ref()
         .is_some_and(|check| check.status != CheckStatus::Passed)
@@ -2085,16 +2085,26 @@ fn valid_receipt_timestamp(value: &str) -> bool {
         && digits(&offset[4..6])
 }
 
-fn valid_receipt(receipt: &HancomVerificationReceipt) -> bool {
+fn valid_receipt(receipt: &HancomVerificationReceipt, input_sha256: &str) -> bool {
     receipt.schema_version == "1.0"
         && matches!(receipt.result.as_str(), "pass" | "fail")
         && valid_receipt_text(&receipt.application)
         && valid_receipt_text(&receipt.verifier)
         && valid_receipt_timestamp(&receipt.verified_at)
-        && receipt
-            .artifact_sha256
-            .as_ref()
-            .is_none_or(|value| validate_sha256(value, "receipt artifact sha256").is_ok())
+        && receipt.artifact_sha256.as_ref().is_none_or(|value| {
+            // A supplied hash must be well-formed and bound to the certified input, so a
+            // receipt produced for a different document cannot be replayed.
+            validate_sha256(value, "receipt artifact sha256").is_ok() && value == input_sha256
+        })
+}
+
+/// `preservation-report-v1` artifact. Unlike the writer-side model type, both fields are
+/// required here so a malformed or stub artifact fails closed instead of reading as lossless.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PreservationReportArtifact {
+    contract: String,
+    events: Vec<hwp_model::preservation::PreservationEvent>,
 }
 
 /// The preservation evidence check loads the policy-pinned `preservation-report-v1` artifact
@@ -2116,23 +2126,37 @@ fn evaluate_preservation_evidence(
     ) else {
         return invalid();
     };
-    let Ok(report) = serde_json::from_slice::<hwp_model::preservation::PreservationReport>(&bytes)
-    else {
+    let Ok(report) = serde_json::from_slice::<PreservationReportArtifact>(&bytes) else {
         return invalid();
     };
+    // Per-event counts stay inside the report schema's lossCount range so a huge or wrapping
+    // artifact can never mint a schema-invalid section.
     if report.contract != hwp_model::preservation::PRESERVATION_REPORT_CONTRACT
         || report.events.len() > MAX_PRESERVATION_EVENTS
-        || report.events.iter().any(|event| event.count == 0)
+        || report
+            .events
+            .iter()
+            .any(|event| !(1..=MAX_PRESERVATION_LOSS_COUNT).contains(&event.count))
     {
         return invalid();
     }
     let mut loss_codes: BTreeMap<String, usize> = BTreeMap::new();
     for event in &report.events {
-        *loss_codes
+        let entry = loss_codes
             .entry(event.code.as_str().to_string())
-            .or_default() += event.count;
+            .or_insert(0);
+        let Some(total) = entry.checked_add(event.count) else {
+            return invalid();
+        };
+        *entry = total;
     }
-    let loss_code_count = loss_codes.values().sum();
+    let mut loss_code_count: usize = 0;
+    for count in loss_codes.values() {
+        let Some(total) = loss_code_count.checked_add(*count) else {
+            return invalid();
+        };
+        loss_code_count = total;
+    }
     let passed = loss_code_count <= policy.max_loss_codes;
     PreservationCheckReport {
         status: if passed {
@@ -2156,6 +2180,7 @@ fn evaluate_preservation_evidence(
 fn evaluate_hancom_open_evidence(
     policy: &HancomOpenPolicy,
     policy_base: &Path,
+    input_sha256: &str,
 ) -> HancomOpenCheckReport {
     let invalid = || HancomOpenCheckReport {
         status: CheckStatus::Failed,
@@ -2173,7 +2198,7 @@ fn evaluate_hancom_open_evidence(
     let Ok(receipt) = serde_json::from_slice::<HancomVerificationReceipt>(&bytes) else {
         return invalid();
     };
-    if !valid_receipt(&receipt) {
+    if !valid_receipt(&receipt, input_sha256) {
         return invalid();
     }
     let passed = !policy.require_pass || receipt.result == "pass";
@@ -4903,6 +4928,14 @@ exit 2"#,
 
         for (label, bytes) in [
             ("malformed", b"{not json".to_vec()),
+            // Required fields must be present; a stub must not read as a lossless report.
+            ("empty-object", serde_json::json!({}).to_string().into_bytes()),
+            (
+                "missing-events",
+                serde_json::json!({"contract": "hwp-preservation-report-v1"})
+                    .to_string()
+                    .into_bytes(),
+            ),
             (
                 "wrong-contract",
                 serde_json::json!({"contract": "other", "events": []})
@@ -4915,6 +4948,29 @@ exit 2"#,
                     "contract": "hwp-preservation-report-v1",
                     "events": [
                         {"code": "control_removed", "resource": "control", "disposition": "removed", "count": 0}
+                    ]
+                })
+                .to_string()
+                .into_bytes(),
+            ),
+            // Counts above the report schema's lossCount bound fail closed.
+            (
+                "oversized-count",
+                serde_json::json!({
+                    "contract": "hwp-preservation-report-v1",
+                    "events": [
+                        {"code": "control_removed", "resource": "control", "disposition": "removed", "count": 1_000_001}
+                    ]
+                })
+                .to_string()
+                .into_bytes(),
+            ),
+            (
+                "huge-count",
+                serde_json::json!({
+                    "contract": "hwp-preservation-report-v1",
+                    "events": [
+                        {"code": "control_removed", "resource": "control", "disposition": "removed", "count": 18_446_744_073_709_551_615_u64}
                     ]
                 })
                 .to_string()
@@ -4952,7 +5008,7 @@ exit 2"#,
             receipt: "hancom-receipt.json".to_string(),
             require_pass: true,
         };
-        let check = evaluate_hancom_open_evidence(&policy, &dir);
+        let check = evaluate_hancom_open_evidence(&policy, &dir, &"0".repeat(64));
         assert_eq!(check.status, CheckStatus::Passed);
         assert!(check.reason_codes.is_empty());
         assert_eq!(check.application.as_deref(), Some("Hancom Office HWP"));
@@ -4967,7 +5023,7 @@ exit 2"#,
             require_pass: false,
             ..policy
         };
-        let check = evaluate_hancom_open_evidence(&policy, &dir);
+        let check = evaluate_hancom_open_evidence(&policy, &dir, &"0".repeat(64));
         assert_eq!(check.status, CheckStatus::Passed);
         fs::remove_dir_all(&dir).unwrap();
     }
@@ -4982,7 +5038,7 @@ exit 2"#,
             receipt: "hancom-receipt.json".to_string(),
             require_pass: true,
         };
-        let check = evaluate_hancom_open_evidence(&policy, &dir);
+        let check = evaluate_hancom_open_evidence(&policy, &dir, &"0".repeat(64));
         assert_eq!(check.status, CheckStatus::Failed);
         assert_eq!(check.reason_codes, ["hancom_open_not_attested"]);
         assert_eq!(check.application.as_deref(), Some("Hancom Office HWP"));
@@ -4996,7 +5052,7 @@ exit 2"#,
             receipt: "hancom-receipt.json".to_string(),
             require_pass: true,
         };
-        let check = evaluate_hancom_open_evidence(&policy, &dir);
+        let check = evaluate_hancom_open_evidence(&policy, &dir, &"0".repeat(64));
         assert_eq!(check.status, CheckStatus::Failed);
         assert_eq!(check.reason_codes, ["hancom_open_receipt_invalid"]);
         assert!(check.application.is_none());
@@ -5012,7 +5068,7 @@ exit 2"#,
             let mut receipt = valid_receipt_json();
             receipt[mutate] = serde_json::json!("bogus");
             write_receipt(&dir, receipt);
-            let check = evaluate_hancom_open_evidence(&policy, &dir);
+            let check = evaluate_hancom_open_evidence(&policy, &dir, &"0".repeat(64));
             assert_eq!(check.status, CheckStatus::Failed, "{label}");
             assert_eq!(
                 check.reason_codes,
@@ -5025,8 +5081,35 @@ exit 2"#,
         let mut receipt = valid_receipt_json();
         receipt["extra"] = serde_json::json!(true);
         write_receipt(&dir, receipt);
-        let check = evaluate_hancom_open_evidence(&policy, &dir);
+        let check = evaluate_hancom_open_evidence(&policy, &dir, &"0".repeat(64));
         assert_eq!(check.status, CheckStatus::Failed);
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn hancom_open_receipt_hash_binds_to_the_certified_input() {
+        let dir = evidence_scratch_dir("hancom-hash");
+        let policy = HancomOpenPolicy {
+            receipt: "hancom-receipt.json".to_string(),
+            require_pass: true,
+        };
+        // The receipt hash matches the certified input.
+        write_receipt(&dir, valid_receipt_json());
+        let check = evaluate_hancom_open_evidence(&policy, &dir, &"0".repeat(64));
+        assert_eq!(check.status, CheckStatus::Passed);
+
+        // A receipt produced for a different document fails closed.
+        let check = evaluate_hancom_open_evidence(&policy, &dir, &"1".repeat(64));
+        assert_eq!(check.status, CheckStatus::Failed);
+        assert_eq!(check.reason_codes, ["hancom_open_receipt_invalid"]);
+        assert!(check.application.is_none());
+
+        // An omitted hash remains allowed; the field is optional in the schema.
+        let mut receipt = valid_receipt_json();
+        receipt.as_object_mut().unwrap().remove("artifact_sha256");
+        write_receipt(&dir, receipt);
+        let check = evaluate_hancom_open_evidence(&policy, &dir, &"1".repeat(64));
+        assert_eq!(check.status, CheckStatus::Passed);
         fs::remove_dir_all(&dir).unwrap();
     }
 

--- a/crates/hwp-cli/tests/certify.rs
+++ b/crates/hwp-cli/tests/certify.rs
@@ -180,6 +180,96 @@ fn mcp_certify_executes_the_same_atomic_contract() {
 }
 
 #[test]
+fn evidence_checks_fold_into_the_overall_result() {
+    fn run_case(
+        root: &Path,
+        input: &Path,
+        policy: &serde_json::Value,
+        receipt: Option<&serde_json::Value>,
+        label: &str,
+    ) -> serde_json::Value {
+        let receipt_path = root.join("hancom-receipt.json");
+        if let Some(receipt) = receipt {
+            fs::write(&receipt_path, receipt.to_string()).unwrap();
+        } else {
+            let _ = fs::remove_file(&receipt_path);
+        }
+        let policy_path = root.join("policy.json");
+        fs::write(&policy_path, serde_json::to_vec_pretty(policy).unwrap()).unwrap();
+        let report = root.join(format!("report-{label}"));
+        let status = Command::new(env!("CARGO_BIN_EXE_hwp"))
+            .arg("certify")
+            .arg(input)
+            .arg("--policy")
+            .arg(&policy_path)
+            .arg("--report")
+            .arg(&report)
+            .status()
+            .unwrap();
+        let value: serde_json::Value =
+            serde_json::from_slice(&fs::read(report.join("report.json")).unwrap()).unwrap();
+        assert_eq!(status.success(), value["overall"] == "passed");
+        value
+    }
+
+    let root = temp_dir("evidence");
+    let input = root.join("input.hwpx");
+    write_empty_hwpx(&input);
+    fs::write(
+        root.join("preservation.json"),
+        serde_json::json!({"contract": "hwp-preservation-report-v1", "events": []}).to_string(),
+    )
+    .unwrap();
+    let mut receipt = serde_json::json!({
+        "schema_version": "1.0",
+        "application": "Hancom Office HWP",
+        "result": "pass",
+        "verified_at": "2026-08-15T12:00:00Z",
+        "verifier": "qa-operator-1"
+    });
+    let mut policy = policy("disabled");
+    policy["document"]["preservation"] =
+        serde_json::json!({"report": "preservation.json", "max_loss_codes": 0});
+    policy["document"]["hancom_open"] =
+        serde_json::json!({"receipt": "hancom-receipt.json", "require_pass": true});
+
+    let passed = run_case(&root, &input, &policy, Some(&receipt), "pass");
+    assert_eq!(passed["overall"], "passed");
+    assert_eq!(passed["checks"]["preservation"]["status"], "passed");
+    assert_eq!(passed["checks"]["hancom_open"]["status"], "passed");
+    assert_eq!(
+        passed["checks"]["hancom_open"]["application"],
+        "Hancom Office HWP"
+    );
+
+    // A fail receipt with require_pass must fail the whole certification even though every
+    // native check passes.
+    receipt["result"] = serde_json::json!("fail");
+    let failed = run_case(&root, &input, &policy, Some(&receipt), "fail");
+    assert_eq!(failed["overall"], "failed");
+    assert_eq!(failed["checks"]["hancom_open"]["status"], "failed");
+    assert_eq!(
+        failed["checks"]["hancom_open"]["reason_codes"],
+        serde_json::json!(["hancom_open_not_attested"])
+    );
+
+    // A missing artifact fails closed.
+    let missing = run_case(&root, &input, &policy, None, "missing");
+    assert_eq!(missing["overall"], "failed");
+    assert_eq!(
+        missing["checks"]["hancom_open"]["reason_codes"],
+        serde_json::json!(["hancom_open_receipt_invalid"])
+    );
+    assert!(
+        missing["checks"]["hancom_open"]
+            .get("application")
+            .is_none()
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn repeated_native_certification_has_identical_artifacts_and_hashes() {
     let root = temp_dir("deterministic");
     let input = root.join("input.hwpx");

--- a/crates/hwp-cli/tests/certify.rs
+++ b/crates/hwp-cli/tests/certify.rs
@@ -266,6 +266,28 @@ fn evidence_checks_fold_into_the_overall_result() {
             .is_none()
     );
 
+    // A receipt hash pinned to the certified input passes; a hash from another document
+    // fails closed.
+    let input_sha256 = {
+        use sha2::Digest as _;
+        sha2::Sha256::digest(fs::read(&input).unwrap())
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>()
+    };
+    let mut pinned = receipt.clone();
+    pinned["result"] = serde_json::json!("pass");
+    pinned["artifact_sha256"] = serde_json::json!(input_sha256);
+    let bound = run_case(&root, &input, &policy, Some(&pinned), "hash-match");
+    assert_eq!(bound["overall"], "passed");
+    pinned["artifact_sha256"] = serde_json::json!("9".repeat(64));
+    let replayed = run_case(&root, &input, &policy, Some(&pinned), "hash-mismatch");
+    assert_eq!(replayed["overall"], "failed");
+    assert_eq!(
+        replayed["checks"]["hancom_open"]["reason_codes"],
+        serde_json::json!(["hancom_open_receipt_invalid"])
+    );
+
     fs::remove_dir_all(root).unwrap();
 }
 

--- a/docs/design/16-certification-v1.ko.md
+++ b/docs/design/16-certification-v1.ko.md
@@ -68,11 +68,33 @@ Dockerfile은 의도적으로 없다. 베이스 이미지와 LibreOffice 런타�
 명시적인 라이선스·대응 소스 처리가 필요하다. 이 공백이 메워지기 전까지 필수 오라클 모드는 부분
 구현으로 남는다.
 
+## 선택적 증거 검사
+
+문서 정책은 내용 없는(content-free) 선택적 증거 산출물 두 가지를 고정할 수 있다. 각각 정책
+파일 기준 상대 경로에서 64 KiB bounded read로 읽고, 닫힌 계약으로 파싱하며, 없거나 유효하지
+않으면 닫힌 실패(fail closed)를 반환한다. 섹션이 없으면 리포트는 기존 형태와 정확히 같고,
+섹션이 실패하면 `overall=failed`(및 미실행 오라클)가 된다. 리포트 스키마는 이를 전용
+`localPassed + evidenceFailed` 분기로 표현한다.
+
+- `document.preservation`: `preservation-report-v1` 산출물(예: `hwp convert --loss-report`
+  결과)을 읽는다. 집계 손실 합계(event count의 총합)가 `max_loss_codes`(기본 0) 이하이면
+  통과한다. 리포트는 코드별 집계 수만 `checks.preservation`으로 반영한다. 손실 초과 실패는
+  `preservation_loss_detected`, 산출물 누락·무효는 `preservation_report_invalid`를 쓴다.
+- `document.hancom_open`: 한컴오피스 애플리케이션이 복구·손상 경고 없이 문서를 열었다는
+  `hancom-verification-receipt-v1` 산출물을 읽는다. `require_pass`(기본 참)이면 receipt
+  결과가 `pass`여야 한다. 리포트는 receipt의 `application`, `verified_at`, `verifier`만
+  `checks.hancom_open`으로 반영한다. pass가 아닌 receipt는 `hancom_open_not_attested`,
+  누락·무효 receipt는 `hancom_open_receipt_invalid`를 쓰며 아무 필드도 반영하지 않는다.
+
+두 검사 모두 한컴 렌더링 동등성을 주장하지 않는다. 이름 붙인 외부 증거만 입증할 뿐이다.
+
 ## 스키마와 소비자
 
 - `schemas/certification-policy-v1.schema.json`
 - `schemas/certification-report-v1.schema.json`
 - `schemas/certification-oracle-result-v1.schema.json`
+- `schemas/preservation-report-v1.schema.json` (선택적 `preservation` 증거 입력)
+- `schemas/hancom-verification-receipt-v1.schema.json` (선택적 `hancom_open` 증거 입력)
 
 Maru 같은 소비자는 리포트 스키마를 검증한 뒤, JSON Schema로 표현할 수 없는 런타임 불변식을 직접
 확인해야 한다. typed issue 수·해시 재계산, 선택 쪽 진단과 쪽 산출물의 정확한 일치, 산출물 경로의

--- a/docs/design/16-certification-v1.md
+++ b/docs/design/16-certification-v1.md
@@ -75,11 +75,36 @@ dependency closure are not pinned, and no built image/runner attestation exists.
 also omits its GPL `COPYING` file, so future redistribution requires explicit license and
 corresponding-source handling. Required oracle mode remains partial until those gaps are closed.
 
+## Optional evidence checks
+
+The document policy may pin two optional, content-free evidence artifacts. Each is read with a
+64 KiB bounded read from a path relative to the policy file, parsed against its closed contract,
+and fails closed when missing or invalid. Absent sections produce exactly the pre-existing
+report shape; a failed section forces `overall=failed` (and an un-run oracle), which the report
+schema expresses through dedicated `localPassed + evidenceFailed` branches.
+
+- `document.preservation`: loads a `preservation-report-v1` artifact (for example from
+  `hwp convert --loss-report`). The check passes when the aggregated loss total — the sum of
+  event counts — is at most `max_loss_codes` (default 0). The report echoes only the aggregated
+  per-code counts as `checks.preservation`. Failures use `preservation_loss_detected`;
+  missing/invalid artifacts use `preservation_report_invalid`.
+- `document.hancom_open`: loads a `hancom-verification-receipt-v1` artifact attesting that a
+  Hancom Office application opened the document without repair or damage warnings. With
+  `require_pass` (default true) the receipt result must be `pass`. The report echoes only the
+  receipt's `application`, `verified_at`, and `verifier` as `checks.hancom_open`. A non-pass
+  receipt uses `hancom_open_not_attested`; missing/invalid receipts use
+  `hancom_open_receipt_invalid` and echo nothing.
+
+Neither check claims Hancom rendering parity; they attest only the specific external evidence
+they name.
+
 ## Schemas and consumers
 
 - `schemas/certification-policy-v1.schema.json`
 - `schemas/certification-report-v1.schema.json`
 - `schemas/certification-oracle-result-v1.schema.json`
+- `schemas/preservation-report-v1.schema.json` (optional `preservation` evidence input)
+- `schemas/hancom-verification-receipt-v1.schema.json` (optional `hancom_open` evidence input)
 
 Consumers such as Maru must validate the report schema and then verify the runtime invariants that
 JSON Schema cannot express: typed issue count/hash recomputation, exact selected-page diagnostics

--- a/examples/certification-v1/README.ko.md
+++ b/examples/certification-v1/README.ko.md
@@ -15,3 +15,17 @@ report 경로는 미리 존재하면 안 된다. 성공하면 `report.json`, `ma
 
 이 예제는 독립 LibreOffice 오라클을 의도적으로 비활성화한다. bounded hwp-cli 파서·렌더러 계약만
 인증하며 한컴 렌더 동등성을 주장하지 않는다.
+
+## 선택적 증거 검사
+
+이 정책은 내용 없는(content-free) 선택적 증거 섹션 두 가지도 함께 보여 준다.
+
+- `document.preservation`은 `preservation-report-v1` 산출물(예: `preservation-report.json`,
+  `hwp convert --loss-report`로 생성)을 읽어 손실 합계가 `max_loss_codes`를 넘으면 실패한다.
+- `document.hancom_open`은 한컴오피스가 복구·손상 경고 없이 문서를 열었다는
+  `hancom-verification-receipt-v1` 산출물(`hancom-receipt.json` 참고)을 읽고,
+  `require_pass`가 참일 때 receipt 결과가 `pass`가 아니면 실패한다.
+
+여기 포함된 두 동반 파일은 플레이스홀더다. 문서마다 다시 생성해야 하며, 산출물이 없거나
+유효하지 않으면 인증은 닫힌 실패(fail closed)를 반환한다. 정책에서 섹션을 빼면 검사를
+걸어넘고, 리포트는 이전 형태를 그대로 유지한다.

--- a/examples/certification-v1/README.md
+++ b/examples/certification-v1/README.md
@@ -15,3 +15,18 @@ The report path must not exist. A successful run atomically publishes `report.js
 
 This example intentionally disables the independent LibreOffice oracle. It certifies the
 bounded hwp-cli parser and renderer contract only; it does not claim Hancom rendering parity.
+
+## Optional evidence checks
+
+The policy also demonstrates the two optional, content-free evidence sections:
+
+- `document.preservation` loads a `preservation-report-v1` artifact (see
+  `preservation-report.json`, produced for example by `hwp convert --loss-report`) and fails
+  when the aggregated loss total exceeds `max_loss_codes`.
+- `document.hancom_open` loads a `hancom-verification-receipt-v1` artifact (see
+  `hancom-receipt.json`) attesting that Hancom Office opened the document without repair or
+  damage warnings, and fails when the receipt result is not `pass` while `require_pass` holds.
+
+Both companion files here are placeholders. Regenerate them per document: a missing or invalid
+artifact fails the certification closed. Omit either section from the policy to skip the check;
+reports then keep their previous shape.

--- a/examples/certification-v1/hancom-receipt.json
+++ b/examples/certification-v1/hancom-receipt.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "1.0",
+  "application": "Hancom Office HWP",
+  "result": "pass",
+  "verified_at": "2026-01-01T00:00:00Z",
+  "verifier": "example-verifier"
+}

--- a/examples/certification-v1/native-policy.json
+++ b/examples/certification-v1/native-policy.json
@@ -6,7 +6,15 @@
       "forbid_substitution": false
     },
     "macros": "deny",
-    "external_references": "deny"
+    "external_references": "deny",
+    "preservation": {
+      "report": "preservation-report.json",
+      "max_loss_codes": 0
+    },
+    "hancom_open": {
+      "receipt": "hancom-receipt.json",
+      "require_pass": true
+    }
   },
   "render": {
     "dpi": 96,

--- a/examples/certification-v1/preservation-report.json
+++ b/examples/certification-v1/preservation-report.json
@@ -1,0 +1,4 @@
+{
+  "contract": "hwp-preservation-report-v1",
+  "events": []
+}

--- a/schemas/certification-policy-v1.schema.json
+++ b/schemas/certification-policy-v1.schema.json
@@ -120,7 +120,33 @@
             "require_picture_descriptions": { "type": "boolean" },
             "require_shape_descriptions": { "type": "boolean" }
           }
-        }
+        },
+        "preservation": { "$ref": "#/$defs/preservationPolicy" },
+        "hancom_open": { "$ref": "#/$defs/hancomOpenPolicy" }
+      }
+    },
+    "evidencePath": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 4096,
+      "pattern": "^[^\\u0000-\\u001f\\u007f]+$"
+    },
+    "preservationPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["report"],
+      "properties": {
+        "report": { "$ref": "#/$defs/evidencePath" },
+        "max_loss_codes": { "type": "integer", "minimum": 0, "maximum": 1000000 }
+      }
+    },
+    "hancomOpenPolicy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["receipt"],
+      "properties": {
+        "receipt": { "$ref": "#/$defs/evidencePath" },
+        "require_pass": { "type": "boolean" }
       }
     },
     "metadataFields": {

--- a/schemas/certification-report-v1.schema.json
+++ b/schemas/certification-report-v1.schema.json
@@ -25,6 +25,8 @@
       "properties": {
         "package": { "$ref": "#/$defs/check" },
         "repeat_import_consistency": { "$ref": "#/$defs/check" },
+        "preservation": { "$ref": "#/$defs/preservationCheck" },
+        "hancom_open": { "$ref": "#/$defs/hancomOpenCheck" },
         "rules": {
           "type": "array", "maxItems": 32,
           "items": {
@@ -233,6 +235,32 @@
           }
         }
       ]
+    },
+    {
+      "allOf": [
+        { "$ref": "#/$defs/localPassed" },
+        { "$ref": "#/$defs/evidenceFailed" },
+        {
+          "properties": {
+            "overall": { "const": "failed" },
+            "scope": { "const": "native_only" },
+            "oracle": { "$ref": "#/$defs/oracleDisabledFailed" }
+          }
+        }
+      ]
+    },
+    {
+      "allOf": [
+        { "$ref": "#/$defs/localPassed" },
+        { "$ref": "#/$defs/evidenceFailed" },
+        {
+          "properties": {
+            "overall": { "const": "failed" },
+            "scope": { "const": "native_only" },
+            "oracle": { "$ref": "#/$defs/oracleNotRun" }
+          }
+        }
+      ]
     }
   ],
   "allOf": [
@@ -240,13 +268,96 @@
       "if": { "properties": { "scope": { "const": "native_plus_independent_import" } } },
       "then": { "properties": { "artifacts": { "contains": { "properties": { "path": { "const": "oracle/import.pdf" } }, "required": ["path"] }, "minContains": 1, "maxContains": 1 } } },
       "else": { "properties": { "artifacts": { "not": { "contains": { "properties": { "path": { "const": "oracle/import.pdf" } }, "required": ["path"] } } } } }
+    },
+    {
+      "not": {
+        "allOf": [
+          { "properties": { "overall": { "enum": ["passed", "partial"] } } },
+          { "$ref": "#/$defs/evidenceFailed" }
+        ]
+      }
     }
   ],
   "$defs": {
     "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
     "checkStatus": { "enum": ["passed", "failed", "skipped"] },
+    "lossCount": { "type": "integer", "minimum": 1, "maximum": 1000000 },
+    "preservationLossCodes": {
+      "type": "object",
+      "additionalProperties": false,
+      "minProperties": 1,
+      "maxProperties": 14,
+      "properties": {
+        "binary_asset_removed": { "$ref": "#/$defs/lossCount" },
+        "binary_relationship_removed": { "$ref": "#/$defs/lossCount" },
+        "control_metadata_unrepresentable": { "$ref": "#/$defs/lossCount" },
+        "control_removed": { "$ref": "#/$defs/lossCount" },
+        "gso_header_unrepresentable": { "$ref": "#/$defs/lossCount" },
+        "gso_shape_unrepresentable": { "$ref": "#/$defs/lossCount" },
+        "hwp_container_storage_removed": { "$ref": "#/$defs/lossCount" },
+        "hwp_container_stream_removed": { "$ref": "#/$defs/lossCount" },
+        "hwp_opaque_stream_changed": { "$ref": "#/$defs/lossCount" },
+        "hwpx_opaque_entry_changed": { "$ref": "#/$defs/lossCount" },
+        "hwpx_package_entry_removed": { "$ref": "#/$defs/lossCount" },
+        "metadata_value_removed": { "$ref": "#/$defs/lossCount" },
+        "opaque_control_unrepresentable": { "$ref": "#/$defs/lossCount" },
+        "picture_control_removed": { "$ref": "#/$defs/lossCount" }
+      }
+    },
+    "receiptShortString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^[^\\u0000-\\u001f\\u007f]+$"
+    },
+    "receiptTimestamp": {
+      "type": "string",
+      "maxLength": 64,
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$"
+    },
+    "preservationCheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "reason_codes", "loss_code_count"],
+      "properties": {
+        "status": { "$ref": "#/$defs/checkStatus" },
+        "reason_codes": { "$ref": "#/$defs/reasons" },
+        "loss_code_count": { "type": "integer", "minimum": 0, "maximum": 1000000 },
+        "loss_codes": { "$ref": "#/$defs/preservationLossCodes" }
+      },
+      "oneOf": [
+        { "properties": { "status": { "const": "passed" }, "reason_codes": { "maxItems": 0 } } },
+        { "properties": { "status": { "enum": ["failed", "skipped"] }, "reason_codes": { "minItems": 1 } } }
+      ]
+    },
+    "hancomOpenCheck": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "reason_codes"],
+      "properties": {
+        "status": { "$ref": "#/$defs/checkStatus" },
+        "reason_codes": { "$ref": "#/$defs/reasons" },
+        "application": { "$ref": "#/$defs/receiptShortString" },
+        "verified_at": { "$ref": "#/$defs/receiptTimestamp" },
+        "verifier": { "$ref": "#/$defs/receiptShortString" }
+      },
+      "oneOf": [
+        { "properties": { "status": { "const": "passed" }, "reason_codes": { "maxItems": 0 } } },
+        { "properties": { "status": { "enum": ["failed", "skipped"] }, "reason_codes": { "minItems": 1 } } }
+      ]
+    },
+    "evidenceFailed": {
+      "properties": {
+        "checks": {
+          "anyOf": [
+            { "properties": { "preservation": { "properties": { "status": { "enum": ["failed", "skipped"] } } } }, "required": ["preservation"] },
+            { "properties": { "hancom_open": { "properties": { "status": { "enum": ["failed", "skipped"] } } } }, "required": ["hancom_open"] }
+          ]
+        }
+      }
+    },
     "reasons": { "type": "array", "maxItems": 32, "uniqueItems": true, "items": { "$ref": "#/$defs/reasonCode" } },
-    "reasonCode": { "enum": ["package_validation_failed", "package_or_import_warnings", "document_parse_failed", "repeat_import_mismatch", "repeat_import_failed", "not_run", "parse_budget_exceeded", "render_policy_failed", "layout_budget_exceeded", "image_decode_budget_exceeded", "pagination_drift_detected", "font_manifest_or_resolution_failed", "render_page_scope_invalid", "render_execution_failed", "disallowed_value", "required_value_missing", "style_reference_out_of_range", "below_minimum", "above_maximum", "disallowed_definition_index", "required_definition_index_missing", "disallowed_scheme", "disallowed_field_present", "required_field_missing", "forbidden_field_present", "forbidden_present", "required_missing", "inspection_incomplete", "picture_description_missing", "shape_description_missing", "unresolved_field_binding", "requested_font_name_invalid", "disallowed_requested_font", "required_requested_font_missing", "font_or_glyph_missing", "font_substitution_forbidden", "font_resolution_report_incomplete", "resolved_font_outside_manifest", "font_resolution_not_run"] },
+    "reasonCode": { "enum": ["package_validation_failed", "package_or_import_warnings", "document_parse_failed", "repeat_import_mismatch", "repeat_import_failed", "not_run", "parse_budget_exceeded", "render_policy_failed", "layout_budget_exceeded", "image_decode_budget_exceeded", "pagination_drift_detected", "font_manifest_or_resolution_failed", "render_page_scope_invalid", "render_execution_failed", "disallowed_value", "required_value_missing", "style_reference_out_of_range", "below_minimum", "above_maximum", "disallowed_definition_index", "required_definition_index_missing", "disallowed_scheme", "disallowed_field_present", "required_field_missing", "forbidden_field_present", "forbidden_present", "required_missing", "inspection_incomplete", "picture_description_missing", "shape_description_missing", "unresolved_field_binding", "requested_font_name_invalid", "disallowed_requested_font", "required_requested_font_missing", "font_or_glyph_missing", "font_substitution_forbidden", "font_resolution_report_incomplete", "resolved_font_outside_manifest", "font_resolution_not_run", "preservation_loss_detected", "preservation_report_invalid", "hancom_open_not_attested", "hancom_open_receipt_invalid"] },
     "check": {
       "type": "object", "additionalProperties": false, "required": ["status", "reason_codes", "issue_count", "issue_sha256"],
       "properties": {

--- a/schemas/hancom-verification-receipt-v1.schema.json
+++ b/schemas/hancom-verification-receipt-v1.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hwp-cli.dev/schemas/hancom-verification-receipt-v1.schema.json",
+  "title": "hwp-hancom-verification-receipt-v1",
+  "description": "Content-free attestation that a Hancom Office application opened a document without repair or damage warnings. Carries only the application label, result, timestamp, verifier identity and an optional content hash — never document text, paths or payloads.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "application", "result", "verified_at", "verifier"],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "application": { "$ref": "#/$defs/shortString" },
+    "result": { "enum": ["pass", "fail"] },
+    "verified_at": { "$ref": "#/$defs/timestamp" },
+    "verifier": { "$ref": "#/$defs/shortString" },
+    "artifact_sha256": { "$ref": "#/$defs/sha256" }
+  },
+  "$defs": {
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "shortString": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256,
+      "pattern": "^[^\\u0000-\\u001f\\u007f]+$"
+    },
+    "timestamp": {
+      "type": "string",
+      "maxLength": 64,
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Epic #90 PR 8a: add the new preservation and Hancom-open checks to the certification policy and reports, additively — the pinned 12-rule composition, the 5 limitation consts, and every existing schema constraint stay byte-identical.

- **preservation** (optional policy section): ingest a `preservation-report-v1` artifact and require its aggregated loss-code count within budget (default 0). Content-free per-code counts echoed on failure.
- **hancom_open** (optional policy section): ingest a `hancom-verification-receipt-v1` attestation (new minimal closed schema: application/result/verified_at/verifier + optional artifact hash) and require `pass`.
- Both fail closed on missing/oversized/malformed artifacts; failed evidence forces `overall=failed` via two new top-level `oneOf` branches plus an `allOf not` guard. Reports without the new sections validate unchanged (regression test included).
- New additive reason codes: `preservation_loss_detected`, `preservation_report_invalid`, `hancom_open_not_attested`, `hancom_open_receipt_invalid`.
- Example policy + companion artifacts updated; `docs/design/16-certification-v1` EN/KO document the checks and the new schema.

## Verification

- `scripts/check.sh` OK (fmt/clippy/workspace tests/pdf-runner/structured-corpus; public parity skipped locally on the Poppler pin as usual).
- 11 new unit tests + 1 e2e CLI test (`certify.rs`) covering pass/fail/missing/invalid paths and schema-conformance pins.

Epic stays open; PR 8b (parity gate exclusion, gap analysis, release docs) follows.