### PR TITLE
chore(gitignore): ignore the local GSD .planning workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@
 target/diagnostic-corpus/
 tools/__pycache__/
 docs/spec/
+
+# GSD planning workspace is local-only agent working context, not a repo artifact.
+/.planning/


### PR DESCRIPTION
GSD (`@opengsd/gsd-core`) writes its codebase map, project brief, requirements, roadmap, and state under `.planning/`.

That directory is local agent working context, not a repo artifact — same category as `/fonts/` and `/docs/spec.txt`. Ignore it so it can never be staged.

One line plus a comment. No source, CI, or docs change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013iNeVLEihHUisev2fmNZNp