### PR TITLE
fix(convert,write): preserve gradient center/step and resolve picture BinRef to its own stream

### DIFF
--- a/crates/hwp-cli/tests/gradient_roundtrip.rs
+++ b/crates/hwp-cli/tests/gradient_roundtrip.rs
@@ -1,0 +1,88 @@
+//! FIDL-01 CLI-level check: an HWP5 file whose `BorderFill` gradient carries
+//! an explicit center/step survives `hwp convert --to hwpx` with those exact
+//! values on the emitted `hc:gradation` element, instead of the substituted
+//! constants (centerX="0" centerY="0" step="255").
+
+use std::io::Read as _;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn hwp() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_hwp"))
+}
+
+fn temp(name: &str) -> PathBuf {
+    let dir =
+        std::env::temp_dir().join(format!("hwp-cli-gradient-roundtrip-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir.join(name)
+}
+
+/// Raw HWP5 table-28 gradient block bytes matching the `GradientSpec` below:
+/// type(i16)=0 (linear), angle(i16)=90, centerX(i16)=25, centerY(i16)=75,
+/// spread(i16)=120, num(i16)=2, then two COLORREF u32 stops. This is exactly
+/// the byte shape a genuine Hangul-authored gradient BorderFill carries
+/// (`crates/hwp5/src/doc_info.rs::border_fill_tests::그러데이션_채움_파싱`).
+fn gradient_tail_bytes() -> Vec<u8> {
+    let mut d = Vec::new();
+    d.extend_from_slice(&0i16.to_le_bytes()); // type: LINEAR
+    d.extend_from_slice(&90i16.to_le_bytes()); // angle
+    d.extend_from_slice(&25i16.to_le_bytes()); // centerX
+    d.extend_from_slice(&75i16.to_le_bytes()); // centerY
+    d.extend_from_slice(&120i16.to_le_bytes()); // spread/step
+    d.extend_from_slice(&2i16.to_le_bytes()); // num
+    d.extend_from_slice(&0x0000_00FFu32.to_le_bytes());
+    d.extend_from_slice(&0x00FF_0000u32.to_le_bytes());
+    d
+}
+
+#[test]
+fn hwp5_gradient_center_and_step_survive_convert_to_hwpx() {
+    let mut doc = hwp_convert::from_markdown("그러데이션.\n");
+    doc.header.border_fills.push(hwp_model::BorderFill {
+        fill_type: 0x4,
+        // `tail` carries the raw table-28 bytes verbatim (the hwp5 write path
+        // re-emits a non-empty tail unchanged - see write.rs::emit_border_fill),
+        // so this is a faithful stand-in for a genuine Hangul-authored file.
+        tail: gradient_tail_bytes(),
+        gradient: Some(hwp_model::GradientSpec {
+            radial: false,
+            angle_deg: 90.0,
+            center_x: 25,
+            center_y: 75,
+            step: 120,
+            stops: vec![(0.0, 0x0000_00FF), (1.0, 0x00FF_0000)],
+        }),
+        ..hwp_model::BorderFill::default()
+    });
+
+    let input = temp("gradient_source.hwp");
+    hwp5::write_document(&doc, &input, &hwp5::WriteOptions::default()).unwrap();
+
+    let output = temp("gradient_output.hwpx");
+    let status = hwp()
+        .arg("convert")
+        .arg(&input)
+        .arg("--to")
+        .arg("hwpx")
+        .arg("-o")
+        .arg(&output)
+        .status()
+        .unwrap();
+    assert!(status.success(), "hwp5 -> hwpx convert 실패");
+
+    let bytes = std::fs::read(&output).unwrap();
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(bytes)).unwrap();
+    let mut xml = String::new();
+    zip.by_name("Contents/header.xml")
+        .unwrap()
+        .read_to_string(&mut xml)
+        .unwrap();
+
+    assert!(xml.contains(r#"centerX="25""#), "centerX=25 없음: {xml}");
+    assert!(xml.contains(r#"centerY="75""#), "centerY=75 없음: {xml}");
+    assert!(xml.contains(r#"step="120""#), "step=120 없음: {xml}");
+
+    std::fs::remove_file(&input).ok();
+    std::fs::remove_file(&output).ok();
+}

--- a/crates/hwp-cli/tests/gradient_roundtrip.rs
+++ b/crates/hwp-cli/tests/gradient_roundtrip.rs
@@ -18,19 +18,23 @@ fn temp(name: &str) -> PathBuf {
     dir.join(name)
 }
 
-/// Raw HWP5 table-28 gradient block bytes matching the `GradientSpec` below:
-/// type(i16)=0 (linear), angle(i16)=90, centerX(i16)=25, centerY(i16)=75,
-/// spread(i16)=120, num(i16)=2, then two COLORREF u32 stops. This is exactly
-/// the byte shape a genuine Hangul-authored gradient BorderFill carries
-/// (`crates/hwp5/src/doc_info.rs::border_fill_tests::그러데이션_채움_파싱`).
+/// Raw HWP5 gradation block bytes matching the `GradientSpec` below, in the field
+/// widths a genuine Hancom-saved file uses: type(u8)=0 (linear), angle(i32)=90,
+/// centerX(i32)=25, centerY(i32)=75, spread(i32)=120, num(i32)=2, then two COLORREF
+/// u32 stops.
+///
+/// The earlier version of this helper used i16 fields throughout and claimed to match
+/// a genuine file; it did not. A Hancom-saved HWP 5.1.1.0 reference document showed the
+/// real layout, and its exact bytes are now pinned by
+/// `hwp_model::control::gradient_spec_tests::gradient_spec_parse_hwp5_reads_a_genuine_hancom_block`.
 fn gradient_tail_bytes() -> Vec<u8> {
     let mut d = Vec::new();
-    d.extend_from_slice(&0i16.to_le_bytes()); // type: LINEAR
-    d.extend_from_slice(&90i16.to_le_bytes()); // angle
-    d.extend_from_slice(&25i16.to_le_bytes()); // centerX
-    d.extend_from_slice(&75i16.to_le_bytes()); // centerY
-    d.extend_from_slice(&120i16.to_le_bytes()); // spread/step
-    d.extend_from_slice(&2i16.to_le_bytes()); // num
+    d.push(0u8); // type: LINEAR
+    d.extend_from_slice(&90i32.to_le_bytes()); // angle
+    d.extend_from_slice(&25i32.to_le_bytes()); // centerX
+    d.extend_from_slice(&75i32.to_le_bytes()); // centerY
+    d.extend_from_slice(&120i32.to_le_bytes()); // spread/step
+    d.extend_from_slice(&2i32.to_le_bytes()); // num
     d.extend_from_slice(&0x0000_00FFu32.to_le_bytes());
     d.extend_from_slice(&0x00FF_0000u32.to_le_bytes());
     d

--- a/crates/hwp-convert/src/gso.rs
+++ b/crates/hwp-convert/src/gso.rs
@@ -229,7 +229,11 @@ fn parse_gradient(d: &[u8], fo: usize) -> Option<GradientSpec> {
     }
     stops.sort_by(|a, b| a.0.total_cmp(&b.0));
     Some(GradientSpec {
-        radial: gtype == 1,
+        // Type 1 is LINEAR - see the rationale on
+        // `hwp_model::GradientSpec::parse_hwp5`, established against a
+        // Hancom-saved reference document. Type 2 as radial is spec-derived and
+        // still unverified against a genuine file.
+        radial: gtype == 2,
         angle_deg: angle,
         center_x,
         center_y,
@@ -449,5 +453,7 @@ mod tests {
         assert_eq!(gr.center_x, 15);
         assert_eq!(gr.center_y, 85);
         assert_eq!(gr.step, 200);
+        // Type byte is 1 in the reference document and Hancom renders it linear.
+        assert!(!gr.radial, "genuine type 1 must be linear, not radial");
     }
 }

--- a/crates/hwp-convert/src/gso.rs
+++ b/crates/hwp-convert/src/gso.rs
@@ -193,19 +193,24 @@ fn hwp5_line_style(lt: u8) -> u8 {
     }
 }
 
-/// 그러데이션(Table 28): type(i16) 각(i16) cx cy spread num(i16),
-/// num>2면 INT32[num] 위치, 이어서 COLORREF[num].
+/// Gradation block: 1-byte type, then INT32 angle / centre-x / centre-y / spread /
+/// colour count; `INT32[num]` positions when `num > 2`; then `COLORREF[num]`.
+///
+/// Field widths verified against a genuine Hancom-saved HWP 5.1.1.0 file. Keep this
+/// in step with [`hwp_model::GradientSpec::parse_hwp5`], which parses the same block
+/// from the `BorderFill` side.
 fn parse_gradient(d: &[u8], fo: usize) -> Option<GradientSpec> {
-    let gtype = rd_u16(d, fo)? as i16;
-    let angle = rd_u16(d, fo + 2)? as i16 as f32;
-    let center_x = rd_u16(d, fo + 4)? as i16 as i32;
-    let center_y = rd_u16(d, fo + 6)? as i16 as i32;
-    let step = rd_u16(d, fo + 8)? as i16 as i32;
-    let num = rd_u16(d, fo + 10)? as usize;
+    let gtype = d.get(fo).copied()? as i16;
+    let angle = rd_i32(d, fo + 1)? as f32;
+    let center_x = rd_i32(d, fo + 5)?;
+    let center_y = rd_i32(d, fo + 9)?;
+    let step = rd_i32(d, fo + 13)?;
+    let num = rd_i32(d, fo + 17)?;
     if !(2..=16).contains(&num) {
         return None;
     }
-    let mut off = fo + 12;
+    let num = num as usize;
+    let mut off = fo + 21;
     let positions: Vec<f32> = if num > 2 {
         let mut v = Vec::with_capacity(num);
         for i in 0..num {
@@ -407,14 +412,14 @@ mod tests {
     /// Builds a minimal table-28 gradient block: type, angle, center_x,
     /// center_y, spread, num=2, then 2 COLORREFs (no position array since
     /// num <= 2).
-    fn table28_block(gtype: i16, angle: i16, cx: i16, cy: i16, spread: i16) -> Vec<u8> {
+    fn gradation_block(gtype: u8, angle: i32, cx: i32, cy: i32, spread: i32) -> Vec<u8> {
         let mut d = Vec::new();
-        d.extend_from_slice(&gtype.to_le_bytes());
+        d.push(gtype);
         d.extend_from_slice(&angle.to_le_bytes());
         d.extend_from_slice(&cx.to_le_bytes());
         d.extend_from_slice(&cy.to_le_bytes());
         d.extend_from_slice(&spread.to_le_bytes());
-        d.extend_from_slice(&2i16.to_le_bytes()); // num
+        d.extend_from_slice(&2i32.to_le_bytes()); // num
         d.extend_from_slice(&0xFF0000u32.to_le_bytes());
         d.extend_from_slice(&0x0000FFu32.to_le_bytes());
         d
@@ -422,10 +427,27 @@ mod tests {
 
     #[test]
     fn gradient_center_and_step_from_table28() {
-        let d = table28_block(0, 45, 30, 70, 120);
+        let d = gradation_block(0, 45, 30, 70, 120);
         let gr = parse_gradient(&d, 0).unwrap();
         assert_eq!(gr.center_x, 30);
         assert_eq!(gr.center_y, 70);
         assert_eq!(gr.step, 120);
+        assert_eq!(gr.angle_deg, 45.0);
+    }
+
+    /// The exact 35-byte gradation tail of a genuine Hancom-saved HWP 5.1.1.0
+    /// document. Before the layout was corrected this returned `None`.
+    #[test]
+    fn gradient_reads_a_genuine_hancom_block() {
+        let d: [u8; 35] = [
+            0x01, 0x5a, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x55, 0x00, 0x00, 0x00, 0xc8,
+            0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
+            0x00, 0x01, 0x00, 0x00, 0x00, 0x32, 0x00,
+        ];
+        let gr = parse_gradient(&d, 0).expect("genuine gradation must parse");
+        assert_eq!(gr.angle_deg, 90.0);
+        assert_eq!(gr.center_x, 15);
+        assert_eq!(gr.center_y, 85);
+        assert_eq!(gr.step, 200);
     }
 }

--- a/crates/hwp-convert/src/gso.rs
+++ b/crates/hwp-convert/src/gso.rs
@@ -198,6 +198,9 @@ fn hwp5_line_style(lt: u8) -> u8 {
 fn parse_gradient(d: &[u8], fo: usize) -> Option<GradientSpec> {
     let gtype = rd_u16(d, fo)? as i16;
     let angle = rd_u16(d, fo + 2)? as i16 as f32;
+    let center_x = rd_u16(d, fo + 4)? as i16 as i32;
+    let center_y = rd_u16(d, fo + 6)? as i16 as i32;
+    let step = rd_u16(d, fo + 8)? as i16 as i32;
     let num = rd_u16(d, fo + 10)? as usize;
     if !(2..=16).contains(&num) {
         return None;
@@ -223,6 +226,9 @@ fn parse_gradient(d: &[u8], fo: usize) -> Option<GradientSpec> {
     Some(GradientSpec {
         radial: gtype == 1,
         angle_deg: angle,
+        center_x,
+        center_y,
+        step,
         stops,
     })
 }
@@ -396,5 +402,30 @@ mod tests {
             children: Vec::new(),
         }];
         assert!(shapes_from_raw(&raw).is_empty());
+    }
+
+    /// Builds a minimal table-28 gradient block: type, angle, center_x,
+    /// center_y, spread, num=2, then 2 COLORREFs (no position array since
+    /// num <= 2).
+    fn table28_block(gtype: i16, angle: i16, cx: i16, cy: i16, spread: i16) -> Vec<u8> {
+        let mut d = Vec::new();
+        d.extend_from_slice(&gtype.to_le_bytes());
+        d.extend_from_slice(&angle.to_le_bytes());
+        d.extend_from_slice(&cx.to_le_bytes());
+        d.extend_from_slice(&cy.to_le_bytes());
+        d.extend_from_slice(&spread.to_le_bytes());
+        d.extend_from_slice(&2i16.to_le_bytes()); // num
+        d.extend_from_slice(&0xFF0000u32.to_le_bytes());
+        d.extend_from_slice(&0x0000FFu32.to_le_bytes());
+        d
+    }
+
+    #[test]
+    fn gradient_center_and_step_from_table28() {
+        let d = table28_block(0, 45, 30, 70, 120);
+        let gr = parse_gradient(&d, 0).unwrap();
+        assert_eq!(gr.center_x, 30);
+        assert_eq!(gr.center_y, 70);
+        assert_eq!(gr.step, 120);
     }
 }

--- a/crates/hwp-model/src/control.rs
+++ b/crates/hwp-model/src/control.rs
@@ -590,12 +590,19 @@ impl GradientSpec {
         }
         cur += num * 4;
         stops.sort_by(|a, b| a.0.total_cmp(&b.0));
-        // Preserve the established shape renderer mapping where type 1 is radial.
-        // Table 30 can be read as type 2 being radial; changing this requires
-        // comparison against a genuine Hangul-authored file.
+        // Gradation type 1 is LINEAR, not radial. Established by comparing a
+        // Hancom-saved reference document against our conversion of it: the
+        // reference renders a clean left-to-right fade in Hancom and its type
+        // byte is 1, while treating that as radial made the converted shape
+        // render as a corner-weighted blob. The same record also carries a
+        // meaningful `angle`, which only a linear gradient uses.
+        //
+        // Type 2 as radial follows the Table 30 reading and is NOT yet confirmed
+        // against a genuine file - no radial reference document exists in the
+        // fixture set. Any other type falls back to linear rather than guessing.
         Some((
             GradientSpec {
-                radial: gtype == 1,
+                radial: gtype == 2,
                 angle_deg: angle,
                 center_x,
                 center_y,
@@ -655,6 +662,8 @@ mod gradient_spec_tests {
         assert_eq!(gr.center_y, 85);
         assert_eq!(gr.step, 200);
         assert_eq!(gr.stops.len(), 2);
+        // Type byte is 1 in the reference document and Hancom renders it linear.
+        assert!(!gr.radial, "genuine type 1 must be linear, not radial");
     }
 
     #[test]

--- a/crates/hwp-model/src/control.rs
+++ b/crates/hwp-model/src/control.rs
@@ -522,8 +522,23 @@ fn is_false(v: &bool) -> bool {
 pub struct GradientSpec {
     pub radial: bool,
     pub angle_deg: f32,
+    /// HWP5 table-28 horizontal center (`cx`, `i16`) / OWPML `hc:gradation@centerX`.
+    #[serde(default)]
+    pub center_x: i32,
+    /// HWP5 table-28 vertical center (`cy`, `i16`) / OWPML `hc:gradation@centerY`.
+    #[serde(default)]
+    pub center_y: i32,
+    /// HWP5 table-28 spread (`i16`) / OWPML `hc:gradation@step`.
+    #[serde(default = "default_gradient_step")]
+    pub step: i32,
     /// (위치 0..1, COLORREF). 위치 오름차순.
     pub stops: Vec<(f32, u32)>,
+}
+
+/// Default `GradientSpec::step` (OWPML `hc:gradation@step`) when the source
+/// document genuinely carries no value for it.
+fn default_gradient_step() -> i32 {
+    255
 }
 
 impl GradientSpec {
@@ -544,6 +559,9 @@ impl GradientSpec {
         };
         let gtype = rd_u16(off)? as i16;
         let angle = rd_u16(off + 2)? as i16 as f32;
+        let center_x = rd_u16(off + 4)? as i16 as i32;
+        let center_y = rd_u16(off + 6)? as i16 as i32;
+        let step = rd_u16(off + 8)? as i16 as i32;
         let num = rd_u16(off + 10)? as usize;
         if !(1..=16).contains(&num) {
             return None;
@@ -576,10 +594,52 @@ impl GradientSpec {
             GradientSpec {
                 radial: gtype == 1,
                 angle_deg: angle,
+                center_x,
+                center_y,
+                step,
                 stops,
             },
             cur - off,
         ))
+    }
+}
+
+#[cfg(test)]
+mod gradient_spec_tests {
+    use super::GradientSpec;
+
+    /// Builds a minimal table-28 gradient block: type, angle, center_x,
+    /// center_y, spread, num=2, then 2 COLORREFs (no position array since
+    /// num <= 2).
+    fn table28_block(gtype: i16, angle: i16, cx: i16, cy: i16, spread: i16) -> Vec<u8> {
+        let mut d = Vec::new();
+        d.extend_from_slice(&gtype.to_le_bytes());
+        d.extend_from_slice(&angle.to_le_bytes());
+        d.extend_from_slice(&cx.to_le_bytes());
+        d.extend_from_slice(&cy.to_le_bytes());
+        d.extend_from_slice(&spread.to_le_bytes());
+        d.extend_from_slice(&2i16.to_le_bytes()); // num
+        d.extend_from_slice(&0xFF0000u32.to_le_bytes());
+        d.extend_from_slice(&0x0000FFu32.to_le_bytes());
+        d
+    }
+
+    #[test]
+    fn gradient_spec_parse_hwp5_reads_center_and_step() {
+        let d = table28_block(0, 45, 30, 70, 120);
+        let (gr, consumed) = GradientSpec::parse_hwp5(&d, 0).unwrap();
+        assert_eq!(gr.center_x, 30);
+        assert_eq!(gr.center_y, 70);
+        assert_eq!(gr.step, 120);
+        assert_eq!(consumed, d.len());
+    }
+
+    #[test]
+    fn gradient_spec_parse_hwp5_truncated_returns_none() {
+        let full = table28_block(0, 45, 30, 70, 120);
+        // Truncate inside the new center/spread region (after angle, before spread finishes).
+        let truncated = &full[..7];
+        assert!(GradientSpec::parse_hwp5(truncated, 0).is_none());
     }
 }
 

--- a/crates/hwp-model/src/control.rs
+++ b/crates/hwp-model/src/control.rs
@@ -543,12 +543,10 @@ fn default_gradient_step() -> i32 {
 
 impl GradientSpec {
     /// Parses an HWP5 table 28 gradient block: type, angle, horizontal center,
-    /// vertical center, spread, and color count as `i16`; positions as
-    /// `INT32[num]` when `num > 2`; then `COLORREF[num]`. Returns the parsed
-    /// specification and consumed byte count.
+    /// vertical center, spread, and color count; positions as `INT32[num]`
+    /// when `num > 2`; then `COLORREF[num]`. Returns the parsed specification
+    /// and consumed byte count.
     pub fn parse_hwp5(d: &[u8], off: usize) -> Option<(Self, usize)> {
-        let rd_u16 =
-            |o: usize| -> Option<u16> { d.get(o..o + 2).map(|b| u16::from_le_bytes([b[0], b[1]])) };
         let rd_i32 = |o: usize| -> Option<i32> {
             d.get(o..o + 4)
                 .map(|b| i32::from_le_bytes([b[0], b[1], b[2], b[3]]))
@@ -557,16 +555,21 @@ impl GradientSpec {
             d.get(o..o + 4)
                 .map(|b| u32::from_le_bytes([b[0], b[1], b[2], b[3]]))
         };
-        let gtype = rd_u16(off)? as i16;
-        let angle = rd_u16(off + 2)? as i16 as f32;
-        let center_x = rd_u16(off + 4)? as i16 as i32;
-        let center_y = rd_u16(off + 6)? as i16 as i32;
-        let step = rd_u16(off + 8)? as i16 as i32;
-        let num = rd_u16(off + 10)? as usize;
+        // Field widths verified against a genuine Hancom-saved HWP 5.1.1.0 file: a 1-byte
+        // gradation type followed by INT32 angle / centre-x / centre-y / step / colour count.
+        // The record is self-describing: for the reference file the 35-byte block decodes as
+        // 1 + 4*4 + 4 + 2*4 + 4 + 2, which is exactly its length.
+        let gtype = d.get(off).copied()? as i16;
+        let angle = rd_i32(off + 1)? as f32;
+        let center_x = rd_i32(off + 5)?;
+        let center_y = rd_i32(off + 9)?;
+        let step = rd_i32(off + 13)?;
+        let num = rd_i32(off + 17)?;
         if !(1..=16).contains(&num) {
             return None;
         }
-        let mut cur = off + 12;
+        let num = num as usize;
+        let mut cur = off + 21;
         let positions: Vec<f32> = if num > 2 {
             let mut v = Vec::with_capacity(num);
             for i in 0..num {
@@ -608,17 +611,17 @@ impl GradientSpec {
 mod gradient_spec_tests {
     use super::GradientSpec;
 
-    /// Builds a minimal table-28 gradient block: type, angle, center_x,
-    /// center_y, spread, num=2, then 2 COLORREFs (no position array since
-    /// num <= 2).
-    fn table28_block(gtype: i16, angle: i16, cx: i16, cy: i16, spread: i16) -> Vec<u8> {
+    /// Builds a gradation block in the layout a genuine Hancom-saved file uses:
+    /// 1-byte type, then INT32 angle / center_x / center_y / spread / num, then
+    /// `COLORREF[num]` (no position array since num <= 2).
+    fn gradation_block(gtype: u8, angle: i32, cx: i32, cy: i32, spread: i32) -> Vec<u8> {
         let mut d = Vec::new();
-        d.extend_from_slice(&gtype.to_le_bytes());
+        d.push(gtype);
         d.extend_from_slice(&angle.to_le_bytes());
         d.extend_from_slice(&cx.to_le_bytes());
         d.extend_from_slice(&cy.to_le_bytes());
         d.extend_from_slice(&spread.to_le_bytes());
-        d.extend_from_slice(&2i16.to_le_bytes()); // num
+        d.extend_from_slice(&2i32.to_le_bytes()); // num
         d.extend_from_slice(&0xFF0000u32.to_le_bytes());
         d.extend_from_slice(&0x0000FFu32.to_le_bytes());
         d
@@ -626,19 +629,39 @@ mod gradient_spec_tests {
 
     #[test]
     fn gradient_spec_parse_hwp5_reads_center_and_step() {
-        let d = table28_block(0, 45, 30, 70, 120);
+        let d = gradation_block(0, 45, 30, 70, 120);
         let (gr, consumed) = GradientSpec::parse_hwp5(&d, 0).unwrap();
         assert_eq!(gr.center_x, 30);
         assert_eq!(gr.center_y, 70);
         assert_eq!(gr.step, 120);
+        assert_eq!(gr.angle_deg, 45.0);
         assert_eq!(consumed, d.len());
+    }
+
+    /// The exact 35-byte gradation tail of a genuine Hancom-saved HWP 5.1.1.0
+    /// document (linear, 90 degrees, centre 15/85, spread 200, two colours).
+    /// Before this layout was corrected the parser read `num` as 0 here and
+    /// bailed, so every real gradient was silently dropped.
+    #[test]
+    fn gradient_spec_parse_hwp5_reads_a_genuine_hancom_block() {
+        let d: [u8; 35] = [
+            0x01, 0x5a, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x00, 0x00, 0x55, 0x00, 0x00, 0x00, 0xc8,
+            0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff,
+            0x00, 0x01, 0x00, 0x00, 0x00, 0x32, 0x00,
+        ];
+        let (gr, _) = GradientSpec::parse_hwp5(&d, 0).expect("genuine gradation must parse");
+        assert_eq!(gr.angle_deg, 90.0);
+        assert_eq!(gr.center_x, 15);
+        assert_eq!(gr.center_y, 85);
+        assert_eq!(gr.step, 200);
+        assert_eq!(gr.stops.len(), 2);
     }
 
     #[test]
     fn gradient_spec_parse_hwp5_truncated_returns_none() {
-        let full = table28_block(0, 45, 30, 70, 120);
-        // Truncate inside the new center/spread region (after angle, before spread finishes).
-        let truncated = &full[..7];
+        let full = gradation_block(0, 45, 30, 70, 120);
+        // Truncate inside the centre/spread region (past angle, before spread finishes).
+        let truncated = &full[..11];
         assert!(GradientSpec::parse_hwp5(truncated, 0).is_none());
     }
 }

--- a/crates/hwp-model/src/control.rs
+++ b/crates/hwp-model/src/control.rs
@@ -522,13 +522,13 @@ fn is_false(v: &bool) -> bool {
 pub struct GradientSpec {
     pub radial: bool,
     pub angle_deg: f32,
-    /// HWP5 table-28 horizontal center (`cx`, `i16`) / OWPML `hc:gradation@centerX`.
+    /// HWP5 gradation horizontal center (`cx`, `INT32`) / OWPML `hc:gradation@centerX`.
     #[serde(default)]
     pub center_x: i32,
-    /// HWP5 table-28 vertical center (`cy`, `i16`) / OWPML `hc:gradation@centerY`.
+    /// HWP5 gradation vertical center (`cy`, `INT32`) / OWPML `hc:gradation@centerY`.
     #[serde(default)]
     pub center_y: i32,
-    /// HWP5 table-28 spread (`i16`) / OWPML `hc:gradation@step`.
+    /// HWP5 gradation spread (`INT32`) / OWPML `hc:gradation@step`.
     #[serde(default = "default_gradient_step")]
     pub step: i32,
     /// (위치 0..1, COLORREF). 위치 오름차순.

--- a/crates/hwp-render/src/layout.rs
+++ b/crates/hwp-render/src/layout.rs
@@ -4710,12 +4710,34 @@ fn para_geometry(doc: &Document, para: &Paragraph) -> ParaGeom {
 
 fn items_width(items: &[InlineItem], tabs: &[TabStop]) -> f32 {
     let mut x = 0.0f32;
-    for item in items {
-        match item {
+    let mut idx = 0usize;
+    while idx < items.len() {
+        match &items[idx] {
             InlineItem::Run(run) => x += run.width_pt,
-            InlineItem::Tab => x = crate::tab::next_tab(tabs, x, TAB_INTERVAL_PT),
+            InlineItem::Tab => {
+                let (position, stop) = crate::tab::next_tab_at(tabs, x, TAB_INTERVAL_PT);
+                x = match stop {
+                    // Same kind-aware offset rule as place_wrapped, so estimation and
+                    // placement always agree (explicit_tab_stops_match_width_estimation_and_placement).
+                    Some(stop) => {
+                        let segment_width = tab_segment_width(items, idx + 1);
+                        let decimal_offset = (stop.kind == 3)
+                            .then(|| first_run_decimal_offset(items, idx + 1))
+                            .flatten();
+                        crate::tab::tab_segment_offset(
+                            stop.kind,
+                            stop.pos_pt,
+                            segment_width,
+                            decimal_offset,
+                        )
+                        .max(x)
+                    }
+                    None => position,
+                };
+            }
             InlineItem::LineBreak(_) => x = 0.0, // 새 줄 시작
         }
+        idx += 1;
     }
     x
 }
@@ -5074,7 +5096,7 @@ fn emphasis_mark(kind: u8, cx: f32, cy: f32, em: f32, color: u32) -> Vec<Item> {
 #[allow(clippy::too_many_arguments)]
 fn place_wrapped(
     page: &mut PageList,
-    items: Vec<InlineItem>,
+    mut items: Vec<InlineItem>,
     x0: f32,
     first_baseline_y: f32,
     max_width: f32,
@@ -5104,7 +5126,13 @@ fn place_wrapped(
         eprintln!("TRACE y={first_baseline_y:.1} x={x0:.1} wrap={max_width:.0} [{preview}]");
     }
 
-    for item in items {
+    // Index-based walk (rather than `for item in items`) so the tab arm can look ahead at
+    // the following segment via `tab_segment_width`/`first_run_decimal_offset`. Each slot is
+    // taken by value via `mem::replace`; the placeholder left behind is never read again since
+    // look-ahead only ever reads forward from `idx + 1`.
+    let mut idx = 0usize;
+    while idx < items.len() {
+        let item = std::mem::replace(&mut items[idx], InlineItem::Tab);
         match item {
             InlineItem::Run(run) => {
                 let sources = crate::shape::glyph_source_sequences(&run);
@@ -5115,6 +5143,7 @@ fn place_wrapped(
                         .is_some_and(|source| crate::shape::source_has_no_break_space(source));
                     push_run(page, x, y, run, border_fills, warnings);
                     x += w;
+                    idx += 1;
                     continue;
                 }
                 // CJK can wrap between glyph clusters except on either side of NB_SPACE.
@@ -5147,13 +5176,34 @@ fn place_wrapped(
                 } else {
                     x = piece_x;
                 }
+                idx += 1;
             }
             InlineItem::Tab => {
                 let (position, stop) = crate::tab::next_tab_at(tabs, x - x0, TAB_INTERVAL_PT);
-                let next_x = x0 + position;
+                let next_x = match stop {
+                    Some(stop) => {
+                        let segment_width = tab_segment_width(&items, idx + 1);
+                        let decimal_offset = (stop.kind == 3)
+                            .then(|| first_run_decimal_offset(&items, idx + 1))
+                            .flatten();
+                        // Clamp so a crafted stop position or an oversized segment can never
+                        // push text backwards — never before the current x (T-1-08).
+                        (x0 + crate::tab::tab_segment_offset(
+                            stop.kind,
+                            stop.pos_pt,
+                            segment_width,
+                            decimal_offset,
+                        ))
+                        .max(x)
+                    }
+                    // Default grid: no kind-aware placement, unchanged from before this plan.
+                    None => x0 + position,
+                };
                 // Leader line: only when the landed stop declares one (fill != 0). The fill
                 // code is HWPX leader numbering, not dash_pattern's — hwp5_line_style bridges
-                // the two families (see shape_draw.rs's own cross-reference comment).
+                // the two families (see shape_draw.rs's own cross-reference comment). The
+                // leader spans to `next_x`, the point where the following text actually
+                // begins — not to the raw stop position.
                 if let Some(stop) = stop
                     && stop.fill != 0
                     && warnings.charge_display_items(1)
@@ -5174,15 +5224,47 @@ fn place_wrapped(
                 }
                 x = next_x;
                 previous_no_break = false;
+                idx += 1;
             }
             InlineItem::LineBreak(_) => {
                 y += line_advance;
                 x = x0;
                 previous_no_break = false;
+                idx += 1;
             }
         }
     }
     y
+}
+
+/// Natural width of the inline items following a tab, up to but excluding the next
+/// `InlineItem::Tab` or `InlineItem::LineBreak` (or the end of `items`). Used so right,
+/// center and decimal placement can look ahead at the segment before it is placed. Zero when
+/// the segment is empty.
+fn tab_segment_width(items: &[InlineItem], from: usize) -> f32 {
+    items
+        .get(from..)
+        .unwrap_or(&[])
+        .iter()
+        .take_while(|item| !matches!(item, InlineItem::Tab | InlineItem::LineBreak(_)))
+        .map(|item| match item {
+            InlineItem::Run(run) => run.width_pt,
+            InlineItem::Tab | InlineItem::LineBreak(_) => 0.0,
+        })
+        .sum()
+}
+
+/// The accumulated `x_advance` up to (not including) the first glyph whose source contains a
+/// decimal separator (`.`), in the first run of the segment starting at `from`. `None` when
+/// that run has no separator, or the segment doesn't start with a run at all — the tab arm
+/// then falls back to right-tab placement, per a decimal tab with no decimal value.
+fn first_run_decimal_offset(items: &[InlineItem], from: usize) -> Option<f32> {
+    let InlineItem::Run(run) = items.get(from)? else {
+        return None;
+    };
+    let sources = crate::shape::glyph_source_sequences(run);
+    let dot_idx = sources.iter().position(|source| source.contains('.'))?;
+    Some(run.glyphs[..dot_idx].iter().map(|g| g.x_advance).sum())
 }
 
 #[cfg(test)]
@@ -6029,6 +6111,61 @@ mod tab_width_tests {
         item
     }
 
+    /// A glyph run with one glyph per `char` of `text`, each carrying the matching entry of
+    /// `glyph_widths` as its `x_advance` — for tests that need to know exactly where a
+    /// specific character (e.g. a decimal separator) starts. Font data stays empty so
+    /// `glyph_source_sequences`'s rustybuzz path fails closed to its byte-count fallback,
+    /// keeping the character-to-glyph mapping font-independent (see `distribute_source`).
+    fn dummy_glyph_run_with_widths(text: &str, glyph_widths: &[f32]) -> InlineItem {
+        let mut item = dummy_run(glyph_widths.iter().sum());
+        let InlineItem::Run(run) = &mut item else {
+            unreachable!();
+        };
+        run.text = text.to_string();
+        run.glyphs = glyph_widths
+            .iter()
+            .map(|&x_advance| Glyph {
+                id: 1,
+                x_advance,
+                x_offset: 0.0,
+                y_offset: 0.0,
+            })
+            .collect();
+        item
+    }
+
+    /// Places `items` at `x0 = 0.0`, `tabs`, and returns the x of each placed `Item::Glyphs`
+    /// entry in order, plus the page for further (e.g. leader-path) inspection.
+    fn place_at_origin(items: Vec<InlineItem>, tabs: &[TabStop]) -> (Vec<f32>, PageList) {
+        let mut page = PageList {
+            width_pt: 600.0,
+            height_pt: 800.0,
+            items: Vec::new(),
+        };
+        let mut warns = RenderIssueAccumulator::new();
+        place_wrapped(
+            &mut page,
+            items,
+            0.0,
+            100.0,
+            f32::INFINITY,
+            16.0,
+            tabs,
+            0.0,
+            &[],
+            &mut warns,
+        );
+        let xs = page
+            .items
+            .iter()
+            .filter_map(|it| match it {
+                Item::Glyphs { x, .. } => Some(*x),
+                _ => None,
+            })
+            .collect();
+        (xs, page)
+    }
+
     /// Explicit tab stops must advance to the same x position in width
     /// estimation and final placement.
     #[test]
@@ -6214,6 +6351,145 @@ mod tab_width_tests {
             .filter(|it| matches!(it, Item::Path { .. }))
             .count();
         assert_eq!(path_count, 0, "an unleadered tab must emit no path");
+    }
+
+    /// A right tab (kind 1) ends the following segment at the stop rather than starting
+    /// there. The leader (fill != 0) spans from the pre-tab x to where the text actually
+    /// begins — not to the raw stop position.
+    #[test]
+    fn right_tab_ends_the_segment_at_the_stop() {
+        let tabs = [TabStop {
+            pos_pt: 100.0,
+            kind: 1,
+            fill: 1,
+        }];
+        let items = vec![dummy_run(10.0), InlineItem::Tab, dummy_run(20.0)];
+        let (xs, page) = place_at_origin(items, &tabs);
+
+        assert_eq!(xs.len(), 2);
+        assert!((xs[1] - 80.0).abs() < 0.01, "segment start={}", xs[1]);
+
+        let leaders: Vec<(f32, f32)> = page
+            .items
+            .iter()
+            .filter_map(|it| match it {
+                Item::Path { commands, .. } => match commands.as_slice() {
+                    [PathCmd::MoveTo(x0, _), PathCmd::LineTo(x1, _)] => Some((*x0, *x1)),
+                    _ => None,
+                },
+                _ => None,
+            })
+            .collect();
+        assert_eq!(leaders.len(), 1, "expected one leader path: {leaders:?}");
+        assert!(
+            (leaders[0].0 - 10.0).abs() < 0.01,
+            "leader start={:?}",
+            leaders[0]
+        );
+        assert!(
+            (leaders[0].1 - 80.0).abs() < 0.01,
+            "leader must stop where the text begins (80.0), not at the stop (100.0): {:?}",
+            leaders[0]
+        );
+    }
+
+    /// A center tab (kind 2) centers the following segment on the stop, so it can extend
+    /// past the stop on the right just as far as it starts before it on the left.
+    #[test]
+    fn center_tab_centers_the_segment_on_the_stop() {
+        let tabs = [TabStop {
+            pos_pt: 100.0,
+            kind: 2,
+            fill: 0,
+        }];
+        let items = vec![dummy_run(10.0), InlineItem::Tab, dummy_run(20.0)];
+        let (xs, _page) = place_at_origin(items, &tabs);
+
+        assert_eq!(xs.len(), 2);
+        assert!((xs[1] - 90.0).abs() < 0.01, "segment start={}", xs[1]);
+    }
+
+    /// A decimal tab (kind 3) aligns the segment so its first decimal separator sits on the
+    /// stop, not the segment's start or end.
+    #[test]
+    fn decimal_tab_aligns_the_separator_on_the_stop() {
+        let tabs = [TabStop {
+            pos_pt: 100.0,
+            kind: 3,
+            fill: 0,
+        }];
+        let items = vec![
+            dummy_run(10.0),
+            InlineItem::Tab,
+            dummy_glyph_run_with_widths("12.5", &[5.0, 5.0, 5.0, 5.0]),
+        ];
+        let (xs, _page) = place_at_origin(items, &tabs);
+
+        assert_eq!(xs.len(), 2);
+        // The "." is the third character (glyph index 2); 5.0 + 5.0 = 10.0 of width precedes
+        // it, so the segment must start at 100.0 - 10.0 = 90.0 for the "." to land at 100.0.
+        assert!((xs[1] - 90.0).abs() < 0.01, "segment start={}", xs[1]);
+        assert!(
+            (xs[1] + 10.0 - 100.0).abs() < 0.01,
+            "the '.' glyph must sit on the stop"
+        );
+    }
+
+    /// A decimal tab whose segment carries no decimal separator behaves exactly like a right
+    /// tab — the whole segment ends at the stop.
+    #[test]
+    fn decimal_tab_without_a_separator_behaves_as_right_tab() {
+        let tabs = [TabStop {
+            pos_pt: 100.0,
+            kind: 3,
+            fill: 0,
+        }];
+        let items = vec![
+            dummy_run(10.0),
+            InlineItem::Tab,
+            dummy_glyph_run_with_widths("125", &[5.0, 5.0, 5.0]),
+        ];
+        let (xs, _page) = place_at_origin(items, &tabs);
+
+        assert_eq!(xs.len(), 2);
+        assert!((xs[1] - 85.0).abs() < 0.01, "segment start={}", xs[1]);
+    }
+
+    /// A left tab (kind 0) places the following segment starting at the stop, exactly as it
+    /// did before kind-aware placement existed.
+    #[test]
+    fn left_tab_placement_is_unchanged() {
+        let tabs = [TabStop {
+            pos_pt: 100.0,
+            kind: 0,
+            fill: 0,
+        }];
+        let items = vec![dummy_run(10.0), InlineItem::Tab, dummy_run(20.0)];
+        let (xs, _page) = place_at_origin(items, &tabs);
+
+        assert_eq!(xs.len(), 2);
+        assert!((xs[1] - 100.0).abs() < 0.01, "segment start={}", xs[1]);
+    }
+
+    /// A segment wider than the distance back to the stop cannot push text to a negative x
+    /// or behind the paragraph's left edge (T-1-08) — it falls back to the current x.
+    #[test]
+    fn oversized_segment_does_not_move_text_left_of_the_current_x() {
+        let tabs = [TabStop {
+            pos_pt: 100.0,
+            kind: 1,
+            fill: 0,
+        }];
+        let items = vec![dummy_run(10.0), InlineItem::Tab, dummy_run(200.0)];
+        let (xs, _page) = place_at_origin(items, &tabs);
+
+        assert_eq!(xs.len(), 2);
+        assert!(
+            (xs[1] - 10.0).abs() < 0.01,
+            "oversized segment must stay at the current x, got {}",
+            xs[1]
+        );
+        assert!(xs[1] >= 0.0);
     }
 }
 

--- a/crates/hwp-render/src/layout.rs
+++ b/crates/hwp-render/src/layout.rs
@@ -5900,6 +5900,9 @@ mod certification_budget_tests {
         gradient_shape.fill_gradient = Some(GradientSpec {
             radial: false,
             angle_deg: 0.0,
+            center_x: 0,
+            center_y: 0,
+            step: 255,
             stops: vec![(0.5, 0); 101],
         });
         stops_document.sections[0].paragraphs[0].controls =

--- a/crates/hwp-render/src/layout.rs
+++ b/crates/hwp-render/src/layout.rs
@@ -346,6 +346,24 @@ const COL_GAP_PT: f32 = 14.0;
 /// 반올림·잔여 advance 오차(줄당 0.1pt 수준)로 매 표마다 경고가 뜨지 않게 한다.
 const CELL_CONTENT_OVERFLOW_EPSILON_PT: f32 = 1.0;
 
+/// Pattern scale for tab-leader dashes, in pt.
+///
+/// `dash_pattern` scales its on/off run lengths by the stroke width, which is right for
+/// border lines (a thicker border wants proportionally longer dashes) but wrong for a tab
+/// leader: leader pitch is a typographic convention independent of how thin the mark is.
+/// Passing the 0.5pt stroke width produced a 1.5pt pitch - dense enough to read as a solid
+/// rule.
+///
+/// Measured against a Hancom-exported PDF of a dotted-leader table of contents (rasterised at
+/// 300dpi, long leader runs of 135-139 marks): mark 1.20pt, gap 1.92pt, pitch 3.12pt. The
+/// mark-to-gap ratio there is ~1:1.6, which `dash_pattern`'s `[1u, 2u]` dot style already
+/// matches; only the scale was wrong. `u = 1.04` reproduces that 3.12pt pitch.
+///
+/// Note this still differs from Hancom structurally: Hancom draws leaders as repeated glyph
+/// characters (a `TJ` run of the leader char), not as a stroked dash pattern. This constant
+/// matches the resulting rhythm, not the mechanism.
+const LEADER_DASH_SCALE: f32 = 1.04;
+
 /// lineseg가 1개뿐인 문단을 "불완전한 캐시"로 판정하는 초과 배율.
 ///
 /// 정품 줄은 seg 폭을 꽉 채우고, 우리 advance에는 한글과의 잔여 오차가 남아 조금 넘칠 수
@@ -5216,7 +5234,7 @@ fn place_wrapped(
                             width: 0.5,
                             dash: crate::shape_draw::dash_pattern(
                                 crate::shape_draw::hwp5_line_style(stop.fill),
-                                0.5,
+                                LEADER_DASH_SCALE,
                             ),
                         }),
                         rule: FillRule::NonZero,
@@ -6056,7 +6074,7 @@ mod certification_budget_tests {
 mod tab_width_tests {
     use std::sync::Arc;
 
-    use super::{items_width, place_wrapped};
+    use super::{LEADER_DASH_SCALE, items_width, place_wrapped};
     use crate::display::{Item, PageList, PathCmd};
     use crate::fonts::LoadedFont;
     use crate::issues::RenderIssueAccumulator;
@@ -6312,8 +6330,18 @@ mod tab_width_tests {
             other => panic!("unexpected leader path commands: {other:?}"),
         }
         assert!((width - 0.5).abs() < 0.01);
-        // hwp5_line_style(2) = 1 (dash) -> dash_pattern(1, 0.5) = [1.5, 1.0].
-        assert_eq!(dash, &vec![1.5, 1.0]);
+        // The mark stays a 0.5pt stroke, but the pattern is scaled by
+        // LEADER_DASH_SCALE (leader pitch is typographic, not stroke-proportional):
+        // hwp5_line_style(2) = 1 (dash) -> dash_pattern(1, 1.04) = [3.12, 2.08].
+        assert_eq!(dash.len(), 2);
+        assert!(
+            (dash[0] - 3.0 * LEADER_DASH_SCALE).abs() < 0.001,
+            "on={dash:?}"
+        );
+        assert!(
+            (dash[1] - 2.0 * LEADER_DASH_SCALE).abs() < 0.001,
+            "off={dash:?}"
+        );
     }
 
     /// A tab landing on a stop with fill=0 (NONE) emits no `Item::Path` at all.

--- a/crates/hwp-render/src/layout.rs
+++ b/crates/hwp-render/src/layout.rs
@@ -28,6 +28,7 @@ use crate::fonts::FontStore;
 use crate::footnote::{self, Note};
 use crate::issues::{RenderIssueAccumulator, RenderIssueCode};
 use crate::shape::{InlineItem, shape_range_page};
+use crate::tab::TabStop;
 
 /// 인증 렌더가 레이아웃 생성 전에 적용하는 작업/메모리 예산.
 pub const CERTIFICATION_MAX_PAGES: usize = 4_096;
@@ -4707,7 +4708,7 @@ fn para_geometry(doc: &Document, para: &Paragraph) -> ParaGeom {
     }
 }
 
-fn items_width(items: &[InlineItem], tabs: &[f32]) -> f32 {
+fn items_width(items: &[InlineItem], tabs: &[TabStop]) -> f32 {
     let mut x = 0.0f32;
     for item in items {
         match item {
@@ -5078,7 +5079,7 @@ fn place_wrapped(
     first_baseline_y: f32,
     max_width: f32,
     line_advance: f32,
-    tabs: &[f32],
+    tabs: &[TabStop],
     first_indent: f32,
     border_fills: &[BorderFill],
     warnings: &mut RenderIssueAccumulator,
@@ -5148,7 +5149,30 @@ fn place_wrapped(
                 }
             }
             InlineItem::Tab => {
-                x = x0 + crate::tab::next_tab(tabs, x - x0, TAB_INTERVAL_PT);
+                let (position, stop) = crate::tab::next_tab_at(tabs, x - x0, TAB_INTERVAL_PT);
+                let next_x = x0 + position;
+                // Leader line: only when the landed stop declares one (fill != 0). The fill
+                // code is HWPX leader numbering, not dash_pattern's — hwp5_line_style bridges
+                // the two families (see shape_draw.rs's own cross-reference comment).
+                if let Some(stop) = stop
+                    && stop.fill != 0
+                    && warnings.charge_display_items(1)
+                {
+                    page.items.push(Item::Path {
+                        commands: vec![PathCmd::MoveTo(x, y), PathCmd::LineTo(next_x, y)],
+                        fill: None,
+                        stroke: Some(Stroke {
+                            color: 0x0000_0000,
+                            width: 0.5,
+                            dash: crate::shape_draw::dash_pattern(
+                                crate::shape_draw::hwp5_line_style(stop.fill),
+                                0.5,
+                            ),
+                        }),
+                        rule: FillRule::NonZero,
+                    });
+                }
+                x = next_x;
                 previous_no_break = false;
             }
             InlineItem::LineBreak(_) => {
@@ -5951,10 +5975,11 @@ mod tab_width_tests {
     use std::sync::Arc;
 
     use super::{items_width, place_wrapped};
-    use crate::display::{Item, PageList};
+    use crate::display::{Item, PageList, PathCmd};
     use crate::fonts::LoadedFont;
     use crate::issues::RenderIssueAccumulator;
     use crate::shape::{Glyph, InlineItem, ShapedRun};
+    use crate::tab::TabStop;
 
     /// Creates a font-independent dummy run whose only meaningful field is width.
     fn dummy_run(width_pt: f32) -> InlineItem {
@@ -6008,7 +6033,11 @@ mod tab_width_tests {
     /// estimation and final placement.
     #[test]
     fn explicit_tab_stops_match_width_estimation_and_placement() {
-        let tabs = [150.0f32];
+        let tabs = [TabStop {
+            pos_pt: 150.0,
+            kind: 0,
+            fill: 0,
+        }];
         let make_items = || vec![dummy_run(10.0), InlineItem::Tab, dummy_run(20.0)];
 
         // Width estimate: 10 + tab to 150 + 20 = 170.
@@ -6086,6 +6115,105 @@ mod tab_width_tests {
             })
             .collect();
         assert_eq!(baselines, [100.0, 100.0, 100.0]);
+    }
+
+    /// A tab landing on a leadered stop emits exactly one dashed `Item::Path` between the
+    /// pre-tab and post-tab x positions at the run baseline. The leader style code passes
+    /// through `hwp5_line_style` before `dash_pattern` (fill=2 is HWPX DASH, which
+    /// `hwp5_line_style` maps to dash_pattern style 1).
+    #[test]
+    fn leadered_tab_emits_a_dashed_path_between_the_two_x_positions() {
+        let tabs = [TabStop {
+            pos_pt: 150.0,
+            kind: 0,
+            fill: 2,
+        }];
+        let items = vec![dummy_run(10.0), InlineItem::Tab, dummy_run(20.0)];
+
+        let mut page = PageList {
+            width_pt: 600.0,
+            height_pt: 800.0,
+            items: Vec::new(),
+        };
+        let mut warns = RenderIssueAccumulator::new();
+        place_wrapped(
+            &mut page,
+            items,
+            0.0,
+            100.0,
+            f32::INFINITY,
+            16.0,
+            &tabs,
+            0.0,
+            &[],
+            &mut warns,
+        );
+
+        let paths: Vec<(Vec<PathCmd>, f32, Vec<f32>)> = page
+            .items
+            .iter()
+            .filter_map(|it| match it {
+                Item::Path {
+                    commands,
+                    stroke: Some(stroke),
+                    ..
+                } => Some((commands.clone(), stroke.width, stroke.dash.clone())),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            paths.len(),
+            1,
+            "expected exactly one leader path: {paths:?}"
+        );
+        let (commands, width, dash) = &paths[0];
+        match commands.as_slice() {
+            [PathCmd::MoveTo(x0, _), PathCmd::LineTo(x1, _)] => {
+                assert!((x0 - 10.0).abs() < 0.01, "pre-tab x={x0}");
+                assert!((x1 - 150.0).abs() < 0.01, "post-tab x={x1}");
+            }
+            other => panic!("unexpected leader path commands: {other:?}"),
+        }
+        assert!((width - 0.5).abs() < 0.01);
+        // hwp5_line_style(2) = 1 (dash) -> dash_pattern(1, 0.5) = [1.5, 1.0].
+        assert_eq!(dash, &vec![1.5, 1.0]);
+    }
+
+    /// A tab landing on a stop with fill=0 (NONE) emits no `Item::Path` at all.
+    #[test]
+    fn tab_with_no_leader_emits_no_path() {
+        let tabs = [TabStop {
+            pos_pt: 150.0,
+            kind: 0,
+            fill: 0,
+        }];
+        let items = vec![dummy_run(10.0), InlineItem::Tab, dummy_run(20.0)];
+
+        let mut page = PageList {
+            width_pt: 600.0,
+            height_pt: 800.0,
+            items: Vec::new(),
+        };
+        let mut warns = RenderIssueAccumulator::new();
+        place_wrapped(
+            &mut page,
+            items,
+            0.0,
+            100.0,
+            f32::INFINITY,
+            16.0,
+            &tabs,
+            0.0,
+            &[],
+            &mut warns,
+        );
+
+        let path_count = page
+            .items
+            .iter()
+            .filter(|it| matches!(it, Item::Path { .. }))
+            .count();
+        assert_eq!(path_count, 0, "an unleadered tab must emit no path");
     }
 }
 

--- a/crates/hwp-render/src/shape_draw.rs
+++ b/crates/hwp-render/src/shape_draw.rs
@@ -99,7 +99,7 @@ pub fn draw_ir_shapes(
 }
 
 /// 선 종류 → 점선 패턴(on, off, …) pt. 0/그 외=실선(빈 벡터). 굵기 비례.
-fn dash_pattern(style: u8, width: f32) -> Vec<f32> {
+pub(crate) fn dash_pattern(style: u8, width: f32) -> Vec<f32> {
     let u = width.max(0.5);
     match style {
         1 => vec![3.0 * u, 2.0 * u],                                     // 파선
@@ -114,7 +114,7 @@ fn dash_pattern(style: u8, width: f32) -> Vec<f32> {
 /// Maps HWP5 border line types to `dash_pattern` style codes.
 ///
 /// Keep this mapping synchronized with `hwp-convert/src/gso.rs`.
-fn hwp5_line_style(lt: u8) -> u8 {
+pub(crate) fn hwp5_line_style(lt: u8) -> u8 {
     match lt {
         2 => 1,
         3 => 2,

--- a/crates/hwp-render/src/shape_draw.rs
+++ b/crates/hwp-render/src/shape_draw.rs
@@ -1042,6 +1042,9 @@ mod tests {
             fill_gradient: Some(GradientSpec {
                 radial: false,
                 angle_deg: 90.0,
+                center_x: 0,
+                center_y: 0,
+                step: 255,
                 stops: vec![(0.0, 0x0000_00FF), (1.0, 0x00FF_0000)],
             }),
             border_color: 0xFFFF_FFFF,

--- a/crates/hwp-render/src/shape_draw.rs
+++ b/crates/hwp-render/src/shape_draw.rs
@@ -936,12 +936,13 @@ mod tests {
 
     #[test]
     fn 그러데이션_2색_파싱() {
-        // fo=0: gtype=0(선형) angle=90 num=2, color0=red color1=blue.
-        let mut d = vec![0u8; 20];
-        d[2..4].copy_from_slice(&90u16.to_le_bytes());
-        d[10..12].copy_from_slice(&2u16.to_le_bytes());
-        d[12..16].copy_from_slice(&0x0000_00FFu32.to_le_bytes()); // R=FF
-        d[16..20].copy_from_slice(&0x00FF_0000u32.to_le_bytes()); // B=FF
+        // fo=0, genuine field widths: type(u8)=0(선형) angle(i32)=90 num(i32)=2,
+        // color0=red color1=blue.
+        let mut d = vec![0u8; 29];
+        d[1..5].copy_from_slice(&90i32.to_le_bytes());
+        d[17..21].copy_from_slice(&2i32.to_le_bytes());
+        d[21..25].copy_from_slice(&0x0000_00FFu32.to_le_bytes()); // R=FF
+        d[25..29].copy_from_slice(&0x00FF_0000u32.to_le_bytes()); // B=FF
         let g = parse_gradient(&d, 0).unwrap();
         assert!(!g.radial);
         assert_eq!(g.angle_deg, 90.0);

--- a/crates/hwp-render/src/tab.rs
+++ b/crates/hwp-render/src/tab.rs
@@ -168,4 +168,192 @@ mod tests {
         // No explicit stops -> default interval throughout.
         assert_eq!(next_tab(&[], 10.0, 40.0), 40.0);
     }
+
+    /// An HWPX-origin document (semantic tab_stops populated, tab_defs never touched) yields
+    /// its stops, kind and fill straight from the semantic model.
+    #[test]
+    fn hwpx_origin_tab_stops_are_read_from_the_semantic_model() {
+        let mut doc = Document::default();
+        doc.header.para_shapes.push(hwp_model::ParaShape::default());
+        doc.header.tab_stops.push(hwp_model::TabDef {
+            attr: 0,
+            items: vec![
+                hwp_model::TabItem {
+                    pos: 10000,
+                    kind: 1,
+                    fill: 2,
+                },
+                hwp_model::TabItem {
+                    pos: 20000,
+                    kind: 0,
+                    fill: 0,
+                },
+            ],
+        });
+        // tab_defs (hwp5-only raw) stays empty - the hwpx reader never populates it.
+        let para = Paragraph::default();
+
+        assert_eq!(
+            tab_stops(&doc, &para),
+            vec![
+                TabStop {
+                    pos_pt: 100.0,
+                    kind: 1,
+                    fill: 2
+                },
+                TabStop {
+                    pos_pt: 200.0,
+                    kind: 0,
+                    fill: 0
+                },
+            ]
+        );
+    }
+
+    /// An hwp5-origin document whose semantic parse failed (empty TabDef pushed to keep
+    /// tab_stops/tab_defs aligned) still yields its stops from the raw tab_defs bytes. Also
+    /// pins the DoS bound (T-1-06): a declared count wildly exceeding the actual data yields
+    /// only the entries the bytes actually contain, never panicking or over-allocating.
+    #[test]
+    fn hwp5_origin_falls_back_to_raw_tab_defs_when_semantic_is_empty() {
+        let mut doc = Document::default();
+        doc.header.para_shapes.push(hwp_model::ParaShape::default());
+        doc.header.tab_stops.push(hwp_model::TabDef::default());
+
+        let mut raw = Vec::new();
+        raw.extend_from_slice(&0u32.to_le_bytes()); // attr
+        raw.extend_from_slice(&1_000_000i32.to_le_bytes()); // count far exceeds the real data
+        for (pos, kind, fill) in [(5000i32, 0u8, 0u8), (15000, 1, 3)] {
+            raw.extend_from_slice(&pos.to_le_bytes());
+            raw.push(kind);
+            raw.push(fill);
+            raw.extend_from_slice(&0u16.to_le_bytes());
+        }
+        doc.header.tab_defs.push(hwp_model::RawEntry {
+            data: raw,
+            children: Vec::new(),
+        });
+        let para = Paragraph::default();
+
+        assert_eq!(
+            tab_stops(&doc, &para),
+            vec![
+                TabStop {
+                    pos_pt: 50.0,
+                    kind: 0,
+                    fill: 0
+                },
+                TabStop {
+                    pos_pt: 150.0,
+                    kind: 1,
+                    fill: 3
+                },
+            ]
+        );
+    }
+
+    /// Landing exactly on a stop does not select it - the next stop strictly greater wins,
+    /// falling back to the next stop or the default grid.
+    #[test]
+    fn tab_stop_exactly_at_current_x_is_not_selected() {
+        let stops = [
+            TabStop {
+                pos_pt: 100.0,
+                kind: 0,
+                fill: 0,
+            },
+            TabStop {
+                pos_pt: 150.0,
+                kind: 1,
+                fill: 2,
+            },
+        ];
+        let (position, stop) = next_tab_at(&stops, 100.0, 40.0);
+        assert_eq!(position, 150.0);
+        assert_eq!(
+            stop,
+            Some(TabStop {
+                pos_pt: 150.0,
+                kind: 1,
+                fill: 2
+            })
+        );
+
+        // With no further stop past it, falls through to the default grid.
+        let (position, stop) = next_tab_at(&stops[..1], 100.0, 40.0);
+        assert_eq!(position, 120.0); // floor(100/40)*40+40
+        assert!(stop.is_none());
+    }
+
+    /// A paragraph whose tab_def_id names no definition (in either tab_stops or tab_defs)
+    /// returns no explicit stops, so every tab falls back to the default grid.
+    #[test]
+    fn empty_tab_definition_uses_the_default_interval() {
+        let mut doc = Document::default();
+        doc.header.para_shapes.push(hwp_model::ParaShape {
+            tab_def_id: 5, // no definition at index 5 in either table
+            ..Default::default()
+        });
+        let para = Paragraph::default();
+
+        let stops = tab_stops(&doc, &para);
+        assert!(stops.is_empty());
+
+        let (position, stop) = next_tab_at(&stops, 10.0, 40.0);
+        assert_eq!(position, 40.0);
+        assert!(stop.is_none());
+    }
+
+    /// Two stops declared at the same position keep document order (stable sort, not
+    /// sort_unstable), and the one landed on is the first-declared.
+    #[test]
+    fn equal_position_tab_stops_keep_document_order() {
+        let mut doc = Document::default();
+        doc.header.para_shapes.push(hwp_model::ParaShape::default());
+        doc.header.tab_stops.push(hwp_model::TabDef {
+            attr: 0,
+            items: vec![
+                hwp_model::TabItem {
+                    pos: 10000,
+                    kind: 0,
+                    fill: 0,
+                },
+                hwp_model::TabItem {
+                    pos: 10000,
+                    kind: 2,
+                    fill: 2,
+                },
+            ],
+        });
+        let para = Paragraph::default();
+
+        let stops = tab_stops(&doc, &para);
+        assert_eq!(
+            stops,
+            vec![
+                TabStop {
+                    pos_pt: 100.0,
+                    kind: 0,
+                    fill: 0
+                },
+                TabStop {
+                    pos_pt: 100.0,
+                    kind: 2,
+                    fill: 2
+                },
+            ]
+        );
+
+        // Landing before the shared position selects the first-declared stop.
+        let (position, stop) = next_tab_at(&stops, 50.0, 40.0);
+        assert_eq!(position, 100.0);
+        assert_eq!(
+            stop,
+            Some(TabStop {
+                pos_pt: 100.0,
+                kind: 0,
+                fill: 0
+            })
+        );
+    }
 }

--- a/crates/hwp-render/src/tab.rs
+++ b/crates/hwp-render/src/tab.rs
@@ -1,24 +1,60 @@
-//! 탭 스톱 — TAB_DEF raw 바이트를 렌더 시점에 파싱한다(shape_draw가 도형 raw를
-//! 파싱하듯). v1은 왼쪽 탭 위치만 사용하고, 명시 스톱이 없으면 기본 간격으로 둔다.
+//! Tab stops — the semantic model (`DocHeader::tab_stops`) is the source of truth for a
+//! paragraph's explicit tab stops, since both the hwp5 and hwpx readers populate it. The raw
+//! `TAB_DEF` bytes (`DocHeader::tab_defs`, hwp5-only) are a fallback, used only when the semantic
+//! definition for the same `tab_def_id` is empty — the case where an hwp5 document's semantic
+//! parse (`hwp5::doc_info::parse_tab_def`) failed but the raw record still carries the data. Each
+//! stop carries its kind and leader (fill) code alongside its position.
 
 use hwp_model::{Document, Paragraph};
 
-/// 문단의 명시 탭 스톱 위치(pt, 오름차순). 정의가 없으면 빈 벡터(기본 간격 사용).
-pub fn tab_stops(doc: &Document, para: &Paragraph) -> Vec<f32> {
+/// One tab stop: position in points, tab kind, and leader (fill) code.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TabStop {
+    /// Tab position in points.
+    pub pos_pt: f32,
+    /// Tab kind: 0 left, 1 right, 2 center, 3 decimal.
+    pub kind: u8,
+    /// Leader/fill line-type code (border-line-style family). 0 means no leader.
+    pub fill: u8,
+}
+
+/// A paragraph's explicit tab stops (pt, ascending). Empty means "use the default interval".
+pub fn tab_stops(doc: &Document, para: &Paragraph) -> Vec<TabStop> {
     let pid = doc
         .header
         .para_shapes
         .get(para.para_shape.0 as usize)
         .map_or(0, |p| p.tab_def_id);
-    match doc.header.tab_defs.get(pid as usize) {
-        Some(entry) => parse_tab_stops(&entry.data),
-        None => Vec::new(),
-    }
+    let mut stops: Vec<TabStop> = match doc.header.tab_stops.get(pid as usize) {
+        Some(def) if !def.items.is_empty() => def
+            .items
+            .iter()
+            .filter(|item| item.pos > 0)
+            .map(|item| TabStop {
+                pos_pt: item.pos as f32 / 100.0,
+                kind: item.kind,
+                fill: item.fill,
+            })
+            .collect(),
+        // Semantic definition missing or empty: fall back to the raw hwp5 bytes for the same
+        // tab_def_id (covers an hwp5 document whose semantic parse produced an empty TabDef while
+        // tab_defs still carries the original bytes).
+        _ => match doc.header.tab_defs.get(pid as usize) {
+            Some(entry) => parse_tab_stops(&entry.data),
+            None => Vec::new(),
+        },
+    };
+    stops.sort_by(|a, b| {
+        a.pos_pt
+            .partial_cmp(&b.pos_pt)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    stops
 }
 
 /// TAB_DEF raw: `u32 attr, i32 count, count×(i32 pos HWPUNIT, u8 type, u8 fill, u16 resv)`.
-/// 왼쪽 탭(type 무관, v1) 위치만 pt로 모아 오름차순 정렬한다.
-fn parse_tab_stops(raw: &[u8]) -> Vec<f32> {
+/// Used only as the hwp5-origin fallback when the semantic parse produced an empty definition.
+fn parse_tab_stops(raw: &[u8]) -> Vec<TabStop> {
     if raw.len() < 8 {
         return Vec::new();
     }
@@ -30,28 +66,52 @@ fn parse_tab_stops(raw: &[u8]) -> Vec<f32> {
             break;
         }
         let pos = i32::from_le_bytes([raw[base], raw[base + 1], raw[base + 2], raw[base + 3]]);
-        if pos > 0 {
-            out.push(pos as f32 / 100.0);
+        if pos <= 0 {
+            continue;
         }
+        // The type/fill bytes are bounds-checked separately from the position; a truncated
+        // entry that has a valid position but no room for them just falls back to 0/0.
+        let (kind, fill) = if base + 6 <= raw.len() {
+            (raw[base + 4], raw[base + 5])
+        } else {
+            (0, 0)
+        };
+        out.push(TabStop {
+            pos_pt: pos as f32 / 100.0,
+            kind,
+            fill,
+        });
     }
-    out.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     out
 }
 
-/// 현재 위치 rel(줄 시작 기준 pt)에서 다음 탭 위치. 명시 스톱 우선, 없으면 기본 간격.
-pub fn next_tab(tabs: &[f32], rel: f32, default_interval: f32) -> f32 {
-    if let Some(&t) = tabs.iter().find(|&&t| t > rel + 0.01) {
-        t
+/// Current position `rel` (pt, relative to line start) -> next tab position, plus the stop
+/// landed on when it was an explicit one (`None` when the default grid interval was used).
+///
+/// Explicit stops win: the first stop strictly greater than `rel` (with the existing epsilon) is
+/// selected, so a tab landing exactly on a stop advances past it rather than standing still.
+pub fn next_tab_at(tabs: &[TabStop], rel: f32, default_interval: f32) -> (f32, Option<TabStop>) {
+    if let Some(&stop) = tabs.iter().find(|t| t.pos_pt > rel + 0.01) {
+        (stop.pos_pt, Some(stop))
     } else {
-        (rel / default_interval).floor() * default_interval + default_interval
+        (
+            (rel / default_interval).floor() * default_interval + default_interval,
+            None,
+        )
     }
+}
+
+/// Current position `rel` (pt, relative to line start) -> next tab position. Explicit stops win,
+/// falling back to the default grid interval.
+pub fn next_tab(tabs: &[TabStop], rel: f32, default_interval: f32) -> f32 {
+    next_tab_at(tabs, rel, default_interval).0
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// attr(4) + count=2 + (5000pt? no, HWPUNIT) 두 탭(100pt, 200pt).
+    /// attr(4) + count=2, two tabs (100pt left, 200pt center).
     #[test]
     fn 탭_파싱() {
         let mut raw = Vec::new();
@@ -64,23 +124,48 @@ mod tests {
             raw.extend_from_slice(&0u16.to_le_bytes()); // reserved
         }
         let stops = parse_tab_stops(&raw);
-        assert_eq!(stops, vec![100.0, 200.0]); // HWPUNIT/100 = pt
+        assert_eq!(
+            stops,
+            vec![
+                TabStop {
+                    pos_pt: 100.0,
+                    kind: 0,
+                    fill: 0
+                },
+                TabStop {
+                    pos_pt: 200.0,
+                    kind: 2,
+                    fill: 0
+                },
+            ]
+        ); // HWPUNIT/100 = pt
     }
 
     #[test]
     fn 빈_정의는_빈_스톱() {
         assert!(parse_tab_stops(&[]).is_empty());
-        assert!(parse_tab_stops(&0u32.to_le_bytes()).is_empty()); // 8바이트 미만
+        assert!(parse_tab_stops(&0u32.to_le_bytes()).is_empty()); // fewer than 8 bytes
     }
 
     #[test]
     fn next_tab_명시_우선_기본_폴백() {
-        let tabs = [100.0, 200.0];
-        assert_eq!(next_tab(&tabs, 50.0, 40.0), 100.0); // 다음 명시 스톱
+        let tabs = [
+            TabStop {
+                pos_pt: 100.0,
+                kind: 0,
+                fill: 0,
+            },
+            TabStop {
+                pos_pt: 200.0,
+                kind: 0,
+                fill: 0,
+            },
+        ];
+        assert_eq!(next_tab(&tabs, 50.0, 40.0), 100.0); // next explicit stop
         assert_eq!(next_tab(&tabs, 150.0, 40.0), 200.0);
-        // 마지막 스톱 너머 → 기본 간격.
+        // Past the last stop -> default interval.
         assert_eq!(next_tab(&tabs, 250.0, 40.0), 280.0); // floor(250/40)*40+40
-        // 명시 없음 → 전부 기본 간격.
+        // No explicit stops -> default interval throughout.
         assert_eq!(next_tab(&[], 10.0, 40.0), 40.0);
     }
 }

--- a/crates/hwp-render/src/tab.rs
+++ b/crates/hwp-render/src/tab.rs
@@ -107,6 +107,29 @@ pub fn next_tab(tabs: &[TabStop], rel: f32, default_interval: f32) -> f32 {
     next_tab_at(tabs, rel, default_interval).0
 }
 
+/// The x (relative to the same origin as `stop_pt`) at which a tab-following segment must
+/// start so it lands on `stop_pt` according to `kind`.
+///
+/// - kind 0 (left): the segment starts at the stop, unchanged from before kind-aware placement.
+/// - kind 1 (right): the segment ends at the stop.
+/// - kind 2 (center): the segment is centered on the stop.
+/// - kind 3 (decimal): `decimal_offset` (the width up to the first decimal separator) lands on
+///   the stop; with no separator (`None`) this behaves like a right tab.
+/// - any other kind: treated as left rather than dropping the tab.
+pub fn tab_segment_offset(
+    kind: u8,
+    stop_pt: f32,
+    segment_width: f32,
+    decimal_offset: Option<f32>,
+) -> f32 {
+    match kind {
+        1 => stop_pt - segment_width,
+        2 => stop_pt - segment_width / 2.0,
+        3 => stop_pt - decimal_offset.unwrap_or(segment_width),
+        _ => stop_pt,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/hwp-render/tests/tab_render.rs
+++ b/crates/hwp-render/tests/tab_render.rs
@@ -1,0 +1,116 @@
+//! Proves the tab leader `Item::Path` (added in 01-03, made kind-aware in 01-04) actually
+//! reaches all three render backends from a single layout-level emission — no change to
+//! `svg.rs`, `pdf.rs` or `png.rs` is needed or made by this test.
+//!
+//! Assertions stay at the structural level (SVG markup / PDF content-stream operators / "did
+//! the PNG render complete"), never on rendered letterforms, counted pages or pixels, since CI
+//! resolves text from whichever typefaces happen to be installed on each runner (repo
+//! CLAUDE.md's CI text-rendering-independence rule).
+
+use std::io::Read;
+
+use hwp_render::{RenderOptions, render_document, render_document_pdf, render_document_svg};
+
+/// A synthetic HWPX-origin document: one paragraph "A<TAB>B", with a single explicit tab stop
+/// carried the same way an hwpx reader populates it — `header.tab_stops[0]`, `header.tab_defs`
+/// left empty (hwpx never populates the raw hwp5-only fallback). The stop is a right tab
+/// (kind 1) with a DOT leader (fill 3), matching `hwpx::read::header`'s leader-attribute
+/// numbering that `tab.rs` already documents.
+fn document_with_leadered_tab() -> hwp_model::Document {
+    let mut doc = hwp_convert::from_markdown("AB");
+    // Splice a tab control between "A" and "B" directly on the IR rather than relying on a
+    // markdown parser to preserve a literal tab in inline text — the IR invariant (see
+    // `hwp_model::HwpChar::InlineCtrl`'s own doc comment) is what this test needs, not
+    // markdown's tab-handling behavior.
+    doc.sections[0].paragraphs[0].chars.insert(
+        1,
+        hwp_model::HwpChar::InlineCtrl {
+            code: hwp_model::ctrl_char::TAB,
+            payload: vec![0; 12],
+        },
+    );
+    doc.header.tab_stops = vec![hwp_model::TabDef {
+        attr: 0,
+        items: vec![hwp_model::TabItem {
+            pos: 30_000, // HWPUNIT/100 = 300pt — inside the page body, past "A".
+            kind: 1,
+            fill: 3,
+        }],
+    }];
+    doc
+}
+
+/// Scans raw PDF bytes for every `stream ... endstream` object, zlib-inflates each (all
+/// streams `pdf.rs` writes use `Filter::FlateDecode` — content, embedded typefaces and images
+/// alike — so no new dependency is needed: `flate2` is already a direct dependency of this
+/// crate, not a new one added for this test), and returns the ones that decoded successfully.
+fn flate_decoded_streams(pdf_bytes: &[u8]) -> Vec<Vec<u8>> {
+    let mut out = Vec::new();
+    let mut pos = 0usize;
+    while let Some(rel) = find(&pdf_bytes[pos..], b"stream") {
+        let mut data_start = pos + rel + b"stream".len();
+        // PDF spec: the stream keyword is followed by CRLF or a lone LF (never a lone CR).
+        if pdf_bytes.get(data_start) == Some(&b'\r') {
+            data_start += 1;
+        }
+        if pdf_bytes.get(data_start) == Some(&b'\n') {
+            data_start += 1;
+        }
+        let Some(end_rel) = find(&pdf_bytes[data_start..], b"endstream") else {
+            break;
+        };
+        let raw = &pdf_bytes[data_start..data_start + end_rel];
+        let raw = raw
+            .strip_suffix(b"\r\n")
+            .or_else(|| raw.strip_suffix(b"\n"))
+            .unwrap_or(raw);
+        let mut decoded = Vec::new();
+        if flate2::read::ZlibDecoder::new(raw)
+            .read_to_end(&mut decoded)
+            .is_ok()
+        {
+            out.push(decoded);
+        }
+        pos = data_start + end_rel + b"endstream".len();
+    }
+    out
+}
+
+fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+#[test]
+fn leader_dash_reaches_svg_and_pdf_backends() {
+    let doc = document_with_leadered_tab();
+    let opts = RenderOptions::default();
+
+    let svg = render_document_svg(&doc, &opts);
+    assert!(
+        svg.pages
+            .iter()
+            .any(|page| page.contains("stroke-dasharray")),
+        "leader dash must reach the SVG backend: {:?}",
+        svg.pages
+    );
+
+    let pdf = render_document_pdf(&doc, &opts, None).unwrap();
+    // The "d" operator (dash-pattern, PDF spec table 52) is the only single-letter content
+    // stream operator this codebase emits named exactly "d" — finding it as a standalone
+    // token in a decoded stream is an unambiguous signal the leader reached the PDF backend.
+    let dash_operator_found = flate_decoded_streams(&pdf.data).iter().any(|bytes| {
+        String::from_utf8_lossy(bytes)
+            .split_whitespace()
+            .any(|token| token == "d")
+    });
+    assert!(
+        dash_operator_found,
+        "leader dash ('d' operator) must reach a PDF content stream"
+    );
+
+    // Smoke check only: the pipeline completes and produces real page bytes. Never assert on
+    // rendered letterforms, pixel values or dimensions here — those depend on which typeface
+    // the runner resolves.
+    let png = render_document(&doc, &opts).unwrap();
+    assert!(!png.pages.is_empty(), "PNG render must complete");
+}

--- a/crates/hwp5/src/doc_info.rs
+++ b/crates/hwp5/src/doc_info.rs
@@ -648,11 +648,12 @@ mod border_fill_tests {
     #[test]
     fn 그러데이션_채움_파싱() {
         let mut d = prefix(0x4);
-        // Linear gradient at 90 degrees with two colors.
-        d.extend_from_slice(&0i16.to_le_bytes());
-        d.extend_from_slice(&90i16.to_le_bytes());
-        d.extend_from_slice(&[0u8; 6]); // cx cy spread
-        d.extend_from_slice(&2i16.to_le_bytes()); // num=2
+        // Linear gradient at 90 degrees with two colors, in the field widths a
+        // genuine Hancom-saved file uses: 1-byte type then INT32 fields.
+        d.push(0u8); // type
+        d.extend_from_slice(&90i32.to_le_bytes()); // angle
+        d.extend_from_slice(&[0u8; 12]); // cx cy spread
+        d.extend_from_slice(&2i32.to_le_bytes()); // num=2
         d.extend_from_slice(&0x0000_00FFu32.to_le_bytes()); // R=FF
         d.extend_from_slice(&0x00FF_0000u32.to_le_bytes()); // B=FF
         let bf = parse_border_fill(&d).unwrap();

--- a/crates/hwp5/src/write.rs
+++ b/crates/hwp5/src/write.rs
@@ -3951,6 +3951,165 @@ mod tests {
         std::fs::remove_file(output).unwrap();
     }
 
+    // --- FIDL-02 reproduction: bin_stream_index resolution (01-02-PLAN.md Task 1) ---
+    //
+    // All three scenarios below share a non-empty `bin_streams`/`header.bin_data` (two
+    // distinguishable streams, storage_id 1 and 2) - this is what distinguishes them from
+    // `typed_write_report_accounts_for_missing_picture_payload` above, which covers the
+    // genuinely-empty-payload case and must keep passing unchanged.
+
+    fn picture_report_path(label: &str) -> std::path::PathBuf {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("hwp5-{label}-{}-{unique}.hwp", std::process::id()))
+    }
+
+    /// Two bin streams with distinguishable payloads and two matching `BinDataItem`
+    /// entries (storage_id 1 and 2), so which stream the writer actually consumes for a
+    /// given `BinRef` is directly observable in the produced container.
+    fn picture_binref_repro_doc(bin_ref: hwp_model::BinRef) -> Document {
+        let mut doc = hwp_convert::from_markdown("picture report");
+        doc.bin_streams = vec![
+            hwp_model::BinStream {
+                name: "BIN0001.png".to_string(),
+                data: vec![1, 2, 3],
+            },
+            hwp_model::BinStream {
+                name: "BIN0002.png".to_string(),
+                data: vec![4, 5, 6],
+            },
+        ];
+        doc.header.bin_data = vec![
+            hwp_model::BinDataItem {
+                attr: 1,
+                storage_id: Some(1),
+                extension: Some("png".to_string()),
+                ..Default::default()
+            },
+            hwp_model::BinDataItem {
+                attr: 1,
+                storage_id: Some(2),
+                extension: Some("png".to_string()),
+                ..Default::default()
+            },
+        ];
+        doc.sections[0].paragraphs[0]
+            .controls
+            .push(Control::Picture(Picture {
+                common_data: Vec::new(),
+                width: hwp_model::HwpUnit(1000),
+                height: hwp_model::HwpUnit(500),
+                treat_as_char: true,
+                z_order: 0,
+                vert_offset: 0,
+                horz_offset: 0,
+                description: None,
+                crop: None,
+                flip: 0,
+                rotation: None,
+                brightness: 0,
+                contrast: 0,
+                effect_flags: 0,
+                effects_raw: Vec::new(),
+                caption: None,
+                bin_ref,
+                extras: Vec::new(),
+            }));
+        doc
+    }
+
+    /// The writer mints a fresh `storage_id` for a synthesized picture (`next_id` starts
+    /// one past the highest existing `storage_id`, here 2), so a resolved picture's bytes
+    /// always land at this fixed path regardless of which input stream fed it. `None`
+    /// means no synthesized stream was embedded at all.
+    fn synthesized_bin_stream_bytes(path: &Path) -> Option<Vec<u8>> {
+        let mut container = crate::Hwp5Container::open(path).unwrap();
+        let raw = container.read_stream_raw("/BinData/BIN0003.png").ok()?;
+        Some(decompress(&raw, "/BinData/BIN0003.png").unwrap())
+    }
+
+    #[test]
+    fn picture_binref_id_resolves_to_its_own_stream() {
+        // S1: BinRef::Id(2) names bin_streams[1] (storage_id 2) through header.bin_data,
+        // not bin_streams[0].
+        let doc = picture_binref_repro_doc(hwp_model::BinRef::Id(hwp_model::BinDataId(2)));
+        let output = picture_report_path("picture-binref-id");
+
+        let report = write_document_with_report(&doc, &output, &WriteOptions::default()).unwrap();
+
+        let bytes = synthesized_bin_stream_bytes(&output)
+            .expect("a resolvable BinRef::Id must still synthesize a picture stream");
+        assert_eq!(
+            bytes,
+            vec![4, 5, 6],
+            "BinRef::Id(2) names bin_streams[1] (storage_id 2); the writer must not fall \
+             back to bin_streams[0]. Preservation events: {:?}",
+            report.preservation.events
+        );
+        std::fs::remove_file(output).unwrap();
+    }
+
+    #[test]
+    fn picture_itemref_resolves_to_the_named_stream() {
+        // S3: BinRef::ItemRef("BIN0002.png") already matches the existing substring
+        // heuristic today - a regression guard, not a red-before-fix case.
+        let doc = picture_binref_repro_doc(hwp_model::BinRef::ItemRef("BIN0002.png".to_string()));
+        let output = picture_report_path("picture-itemref");
+
+        let report = write_document_with_report(&doc, &output, &WriteOptions::default()).unwrap();
+
+        let bytes = synthesized_bin_stream_bytes(&output)
+            .expect("a resolvable ItemRef must synthesize a picture stream");
+        assert_eq!(
+            bytes,
+            vec![4, 5, 6],
+            "ItemRef(\"BIN0002.png\") must consume bin_streams[1]. Preservation events: {:?}",
+            report.preservation.events
+        );
+        std::fs::remove_file(output).unwrap();
+    }
+
+    #[test]
+    fn picture_with_unresolvable_reference_reports_binary_asset_removed() {
+        // S2: BinRef::ItemRef names no existing stream. Today this silently falls back to
+        // bin_streams[0] instead of reporting a loss - the tangled defect this plan closes.
+        let doc = picture_binref_repro_doc(hwp_model::BinRef::ItemRef(
+            "not-in-this-document.png".to_string(),
+        ));
+        let output = picture_report_path("picture-unresolvable");
+
+        let report = write_document_with_report(&doc, &output, &WriteOptions::default()).unwrap();
+
+        assert!(
+            report.preservation.events.iter().any(|event| {
+                event.code == PreservationCode::BinaryAssetRemoved
+                    && event.resource == PreservationResourceKind::BinaryAsset
+                    && event.disposition == PreservationDisposition::Removed
+                    && event.count == 1
+            }),
+            "an unresolvable reference must be reported, not silently backfilled with \
+             bin_streams[0]: {:?}",
+            report.preservation.events
+        );
+        assert!(
+            report
+                .preservation
+                .events
+                .iter()
+                .any(|event| event.code == PreservationCode::PictureControlRemoved),
+            "the picture control itself still has no payload to write once its bin \
+             reference does not resolve: {:?}",
+            report.preservation.events
+        );
+        assert!(
+            synthesized_bin_stream_bytes(&output).is_none(),
+            "no picture stream should be synthesized for an unresolvable reference"
+        );
+        std::fs::remove_file(output).unwrap();
+    }
+
     fn synth_table(placement: Option<hwp_model::GsoPlacement>) -> Table {
         Table {
             common_data: Vec::new(),

--- a/crates/hwp5/src/write.rs
+++ b/crates/hwp5/src/write.rs
@@ -1438,12 +1438,51 @@ fn has_synthesizable_picture(doc: &Document) -> bool {
     doc.sections.iter().flat_map(|s| &s.paragraphs).any(in_para)
 }
 
+/// Resolves a `BinRef` to the index into `bin_names` (and the parallel `bin_streams`) it
+/// actually names. `BinRef::Id` mirrors `Document::resolve_bin`'s naming rule
+/// (`BIN{storage_id:04X}.{ext}` from `bin_data[id-1]`) and matches it against each name's
+/// trailing path component case-insensitively, since a stream name may or may not carry a
+/// `BinData/` prefix. `BinRef::ItemRef` first tries the same exact trailing-component match,
+/// then falls back to the substring match hwpx-origin documents rely on today. There is no
+/// index-0 fallback: an unresolvable reference returns `None`, which the caller reports as a
+/// typed loss instead of silently substituting an unrelated stream.
+fn bin_stream_index(
+    bin_names: &[String],
+    bin_data: &[hwp_model::BinDataItem],
+    bin_ref: &hwp_model::BinRef,
+) -> Option<usize> {
+    fn trailing(name: &str) -> &str {
+        name.rsplit('/').next().unwrap_or(name)
+    }
+    match bin_ref {
+        hwp_model::BinRef::Id(id) => {
+            let item = bin_data.get((id.0 as usize).checked_sub(1)?)?;
+            let storage_id = item.storage_id?;
+            let ext = item.extension.as_deref().unwrap_or("");
+            let name = format!("BIN{storage_id:04X}.{ext}");
+            bin_names
+                .iter()
+                .position(|n| trailing(n).eq_ignore_ascii_case(&name))
+        }
+        hwp_model::BinRef::ItemRef(s) if !s.is_empty() => bin_names
+            .iter()
+            .position(|n| trailing(n).eq_ignore_ascii_case(s))
+            .or_else(|| bin_names.iter().position(|n| n.contains(s.as_str()))),
+        _ => None,
+    }
+}
+
 /// 합성 문서의 hwpx 출신 이미지에 도형 레코드 + BIN_DATA 항목을 채운다.
 fn synthesize_pictures(doc: &mut Document, warnings: &mut WriteReport) {
     let bin_names: Vec<String> = doc.bin_streams.iter().map(|b| b.name.clone()).collect();
     if bin_names.is_empty() {
         return;
     }
+    // Snapshot header.bin_data before the mutable section walk below, so each
+    // picture's BinRef can be resolved against the BIN_DATA table it actually
+    // named without borrowing `doc` immutably and mutably at once.
+    let bin_data_snapshot = doc.header.bin_data.clone();
+    let bin_index = |r: &hwp_model::BinRef| bin_stream_index(&bin_names, &bin_data_snapshot, r);
     // 각 이미지의 원본 픽셀 크기(자르기·picture_effect의 자연 크기 산출용).
     let bin_dims: Vec<Option<(u32, u32)>> = doc
         .bin_streams
@@ -1490,6 +1529,7 @@ fn synthesize_pictures(doc: &mut Document, warnings: &mut WriteReport) {
                 para,
                 &bin_names,
                 &bin_dims,
+                &bin_index,
                 &mut assigned,
                 &mut next_id,
                 &mut inst,
@@ -1554,6 +1594,7 @@ fn synth_pictures_para(
     para: &mut Paragraph,
     bin_names: &[String],
     bin_dims: &[Option<(u32, u32)>],
+    bin_index: &dyn Fn(&hwp_model::BinRef) -> Option<usize>,
     assigned: &mut [Option<u16>],
     next_id: &mut u16,
     inst: &mut u32,
@@ -1564,16 +1605,12 @@ fn synth_pictures_para(
     for control in &mut para.controls {
         match control {
             Control::Picture(p) if p.extras.is_empty() => {
-                let item_ref = match &p.bin_ref {
-                    hwp_model::BinRef::ItemRef(s) => s.clone(),
-                    hwp_model::BinRef::Id(_) => String::new(),
-                };
-                // ItemRef가 파일명에 들어 있는 스트림, 없으면 첫 스트림. 같은
-                // 이미지를 여러 그림이 참조할 수 있으므로 배타 사용하지 않는다.
-                let pick = bin_names
-                    .iter()
-                    .position(|n| !item_ref.is_empty() && n.contains(&item_ref))
-                    .or(if bin_names.is_empty() { None } else { Some(0) });
+                // Resolve the stream this picture actually references: BinRef::Id
+                // through header.bin_data's storage_id naming, BinRef::ItemRef by
+                // exact name then substring. No index-0 fallback - an unresolvable
+                // reference is a reported loss below, never a silently substituted
+                // image (a different logo, seal, signature or photograph).
+                let pick = bin_index(&p.bin_ref);
                 let Some(idx) = pick else {
                     warnings.loss(
                         PreservationCode::BinaryAssetRemoved,
@@ -1675,8 +1712,8 @@ fn synth_pictures_para(
                 for cell in &mut t.cells {
                     for cp in &mut cell.paragraphs {
                         synth_pictures_para(
-                            cp, bin_names, bin_dims, assigned, next_id, inst, new_items, renames,
-                            warnings,
+                            cp, bin_names, bin_dims, bin_index, assigned, next_id, inst, new_items,
+                            renames, warnings,
                         );
                     }
                 }
@@ -1715,8 +1752,8 @@ fn synth_pictures_para(
                 for list in &mut g.paragraph_lists {
                     for lp in &mut list.paragraphs {
                         synth_pictures_para(
-                            lp, bin_names, bin_dims, assigned, next_id, inst, new_items, renames,
-                            warnings,
+                            lp, bin_names, bin_dims, bin_index, assigned, next_id, inst, new_items,
+                            renames, warnings,
                         );
                     }
                 }

--- a/crates/hwpx/src/read/header.rs
+++ b/crates/hwpx/src/read/header.rs
@@ -155,8 +155,9 @@ pub fn parse_header(xml: &str) -> Result<(DocHeader, Vec<String>)> {
     let mut numbering_ids: HashMap<u16, u16> = HashMap::new();
     let mut bullet_ids: HashMap<u16, u16> = HashMap::new();
     let mut current_tab: Option<hwp_model::TabDef> = None;
-    // Active hc:gradation state inside borderFill: radial flag, angle, colors.
-    let mut current_gradation: Option<(bool, f32, Vec<u32>)> = None;
+    // Active hc:gradation state inside borderFill: radial flag, angle,
+    // center_x, center_y, step, colors.
+    let mut current_gradation: Option<(bool, f32, i32, i32, i32, Vec<u32>)> = None;
     // 정품 tabItem은 hp:switch로 감싸 case(HwpUnitChar, unit=HWPUNIT, pos=X)와
     // default(unit 없음, pos=2X)를 함께 낸다. case만 취하고 default는 버리기 위해
     // hp:default 안에 있는 동안 tabItem 수집을 막는다(중복 방지). switch 없는 naked
@@ -665,11 +666,14 @@ pub fn parse_header(xml: &str) -> Result<(DocHeader, Vec<String>)> {
                         current_gradation = Some((
                             !gtype.eq_ignore_ascii_case("LINEAR"),
                             attr_i32(e, "angle").unwrap_or(0) as f32,
+                            attr_i32(e, "centerX").unwrap_or(0),
+                            attr_i32(e, "centerY").unwrap_or(0),
+                            attr_i32(e, "step").unwrap_or(255),
                             Vec::new(),
                         ));
                     }
                     b"color" => {
-                        if let Some((_, _, colors)) = &mut current_gradation
+                        if let Some((_, _, _, _, _, colors)) = &mut current_gradation
                             && let Some(v) = attr(e, "value")
                         {
                             colors.push(parse_color(&v));
@@ -707,7 +711,7 @@ pub fn parse_header(xml: &str) -> Result<(DocHeader, Vec<String>)> {
                     }
                 }
                 b"gradation" => {
-                    if let (Some(bf), Some((radial, angle_deg, colors))) =
+                    if let (Some(bf), Some((radial, angle_deg, center_x, center_y, step, colors))) =
                         (&mut current_border, current_gradation.take())
                         && colors.len() >= 2
                     {
@@ -721,11 +725,9 @@ pub fn parse_header(xml: &str) -> Result<(DocHeader, Vec<String>)> {
                         bf.gradient = Some(hwp_model::GradientSpec {
                             radial,
                             angle_deg,
-                            // TODO(Task 2 of this plan): thread centerX/centerY/step through
-                            // `current_gradation`'s stashed tuple instead of these placeholders.
-                            center_x: 0,
-                            center_y: 0,
-                            step: 255,
+                            center_x,
+                            center_y,
+                            step,
                             stops,
                         });
                     }

--- a/crates/hwpx/src/read/header.rs
+++ b/crates/hwpx/src/read/header.rs
@@ -721,6 +721,11 @@ pub fn parse_header(xml: &str) -> Result<(DocHeader, Vec<String>)> {
                         bf.gradient = Some(hwp_model::GradientSpec {
                             radial,
                             angle_deg,
+                            // TODO(Task 2 of this plan): thread centerX/centerY/step through
+                            // `current_gradation`'s stashed tuple instead of these placeholders.
+                            center_x: 0,
+                            center_y: 0,
+                            step: 255,
                             stops,
                         });
                     }

--- a/crates/hwpx/src/read/section.rs
+++ b/crates/hwpx/src/read/section.rs
@@ -1756,6 +1756,9 @@ fn parse_gradation(
     // LINEAR=선형, 그 외(RADIAL/CIRCLE/CONICAL/SQUARE)는 방사형 근사.
     let radial = !gtype.eq_ignore_ascii_case("LINEAR");
     let angle_deg = attr_i32(start, "angle").unwrap_or(0) as f32;
+    let center_x = attr_i32(start, "centerX").unwrap_or(0);
+    let center_y = attr_i32(start, "centerY").unwrap_or(0);
+    let step = attr_i32(start, "step").unwrap_or(255);
     let mut colors: Vec<u32> = Vec::new();
     loop {
         match next_event(reader)? {
@@ -1781,6 +1784,9 @@ fn parse_gradation(
     Ok(Some(GradientSpec {
         radial,
         angle_deg,
+        center_x,
+        center_y,
+        step,
         stops,
     }))
 }
@@ -1940,6 +1946,35 @@ mod page_ctrl_tests {
             1 + 8 + 1 + 1,
             "앞(1)+탭(8)+뒤(1)+끝(1) WCHAR"
         );
+    }
+
+    /// centerX/centerY/step round-trip: parse an `<hp:gradation>` carrying
+    /// explicit values, then re-emit via the same `hc:gradation` attribute
+    /// shape the section writer uses and confirm the values survive.
+    #[test]
+    fn gradation_center_and_step_round_trip() {
+        let g = run_gradation(
+            r##"<hp:gradation type="LINEAR" angle="90" centerX="30" centerY="70" step="120"><hp:color value="#FF0000"/><hp:color value="#0000FF"/></hp:gradation>"##,
+        )
+        .unwrap();
+        assert_eq!(g.center_x, 30);
+        assert_eq!(g.center_y, 70);
+        assert_eq!(g.step, 120);
+
+        // Re-emit with the writer's exact `hc:gradation` attribute shape and
+        // re-parse it to confirm the values survive the round trip.
+        let reemitted = format!(
+            r##"<hp:gradation type="{}" angle="{}" centerX="{}" centerY="{}" step="{}"><hp:color value="#FF0000"/><hp:color value="#0000FF"/></hp:gradation>"##,
+            if g.radial { "RADIAL" } else { "LINEAR" },
+            g.angle_deg.round() as i32,
+            g.center_x,
+            g.center_y,
+            g.step,
+        );
+        let g2 = run_gradation(&reemitted).unwrap();
+        assert_eq!(g2.center_x, g.center_x);
+        assert_eq!(g2.center_y, g.center_y);
+        assert_eq!(g2.step, g.step);
     }
 
     /// 색이 1개 이하면 그러데이션 없음(None).

--- a/crates/hwpx/src/write/header.rs
+++ b/crates/hwpx/src/write/header.rs
@@ -197,9 +197,12 @@ fn write_border_fills(out: &mut String, header: &DocHeader) {
             // GG-7 gradient fill in the same form emitted for shapes.
             let _ = write!(
                 out,
-                r##"<hc:fillBrush><hc:gradation type="{}" angle="{}" centerX="0" centerY="0" step="255" colorNum="{}" stepCenter="50" alpha="0">"##,
+                r##"<hc:fillBrush><hc:gradation type="{}" angle="{}" centerX="{}" centerY="{}" step="{}" colorNum="{}" stepCenter="50" alpha="0">"##,
                 if g.radial { "RADIAL" } else { "LINEAR" },
                 g.angle_deg.round() as i32,
+                g.center_x,
+                g.center_y,
+                g.step,
                 g.stops.len(),
             );
             for (_, c) in &g.stops {

--- a/crates/hwpx/src/write/section.rs
+++ b/crates/hwpx/src/write/section.rs
@@ -1431,9 +1431,12 @@ fn write_shape_element(
         // reader parse_gradation의 역: type/angle 속성 + color 자식들.
         let _ = write!(
             out,
-            r##"<hc:fillBrush><hc:gradation type="{}" angle="{}" centerX="0" centerY="0" step="255" colorNum="{}" stepCenter="50" alpha="0">"##,
+            r##"<hc:fillBrush><hc:gradation type="{}" angle="{}" centerX="{}" centerY="{}" step="{}" colorNum="{}" stepCenter="50" alpha="0">"##,
             if gr.radial { "RADIAL" } else { "LINEAR" },
             gr.angle_deg.round() as i32,
+            gr.center_x,
+            gr.center_y,
+            gr.step,
             gr.stops.len(),
         );
         for (_, c) in &gr.stops {

--- a/crates/hwpx/tests/read.rs
+++ b/crates/hwpx/tests/read.rs
@@ -777,6 +777,42 @@ fn 테두리채움_대각선_방향_파싱() {
     assert_ne!(bfs[2].attr & 0x20, 0, "backSlash on");
 }
 
+/// FIDL-01: a `<hc:gradation>` inside a `<hh:borderFill>` with explicit
+/// centerX/centerY/step attributes parses into a `BorderFill` whose
+/// `gradient` carries those three values; a gradation with no such
+/// attributes falls back to the documented default (0, 0, 255).
+#[test]
+fn border_fill_gradation_center_and_step() {
+    let xml = r##"<?xml version="1.0"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head" xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hh:refList>
+    <hh:borderFills itemCnt="2">
+      <hh:borderFill id="1" threeD="0" shadow="0">
+        <hc:fillBrush><hc:gradation type="LINEAR" angle="90" centerX="30" centerY="70" step="120" colorNum="2" stepCenter="50" alpha="0">
+          <hc:color value="#FF0000"/><hc:color value="#0000FF"/>
+        </hc:gradation></hc:fillBrush>
+      </hh:borderFill>
+      <hh:borderFill id="2" threeD="0" shadow="0">
+        <hc:fillBrush><hc:gradation type="LINEAR" angle="0" colorNum="2" stepCenter="50" alpha="0">
+          <hc:color value="#FF0000"/><hc:color value="#0000FF"/>
+        </hc:gradation></hc:fillBrush>
+      </hh:borderFill>
+    </hh:borderFills>
+  </hh:refList>
+</hh:head>"##;
+    let (header, _) = hwpx::read::header::parse_header(xml).unwrap();
+    let bfs = &header.border_fills;
+    assert_eq!(bfs.len(), 2);
+    let g1 = bfs[0].gradient.as_ref().expect("id=1 has a gradient");
+    assert_eq!(g1.center_x, 30);
+    assert_eq!(g1.center_y, 70);
+    assert_eq!(g1.step, 120);
+    let g2 = bfs[1].gradient.as_ref().expect("id=2 has a gradient");
+    assert_eq!(g2.center_x, 0);
+    assert_eq!(g2.center_y, 0);
+    assert_eq!(g2.step, 255);
+}
+
 /// GG-17 parses a `<hp:colLine>` child into `ColumnDef.divider`.
 #[test]
 fn parses_colpr_divider() {

--- a/crates/hwpx/tests/write.rs
+++ b/crates/hwpx/tests/write.rs
@@ -2940,6 +2940,9 @@ fn 셀배경_그러데이션_hwpx_왕복() {
         gradient: Some(hwp_model::GradientSpec {
             radial: false,
             angle_deg: 90.0,
+            center_x: 0,
+            center_y: 0,
+            step: 255,
             stops: vec![(0.0, 0x0000_00FF), (1.0, 0x00FF_0000)],
         }),
         ..hwp_model::BorderFill::default()


### PR DESCRIPTION
<!-- hwp-cli PR 체크리스트 — 지우지 말고 확인 후 체크 -->

## 요약

Closes two independent fidelity gaps that lose information on paths already working end to end:
**GE-α6** (gradient center and step) and **GE-2** (picture binary resolution). Both are
`docs/design/12-feature-gaps.md` §14.2 "independent, immediately actionable" items. No new
subsystem, no new dependency, no ground-truth corpus needed.

**Opened as a draft on purpose:** this touches the writer on both paths, so the checklist's Hancom
real-hardware verification applies and has **not run yet**. It is scheduled as the blocking
human-verify checkpoint later in this phase. Review is welcome now; do not merge until that
checkpoint is recorded.

### GE-α6 — gradient center and step (`hwp-model`, `hwp-convert`, `hwpx`)

Both HWP5 gradient parsers jumped from the angle field straight to the color count, skipping the
three `i16` fields between them (horizontal center, vertical center, spread), and both HWPX writers
then emitted the fixed constants `centerX="0" centerY="0" step="255"`. The information was present
in the source bytes and in the source XML; it was discarded in transit.

- `hwp_model::GradientSpec` gains three additive fields (`center_x`, `center_y`, `step`), all
  `#[serde(default)]`-compatible so existing JSON IR keeps deserializing.
- Both HWP5 parsers (`hwp-convert/src/gso.rs::parse_gradient` for gso shapes,
  `hwp-model/src/control.rs::GradientSpec::parse_hwp5` for `BorderFill`) read the previously
  skipped table-28 bytes through the **existing bounds-checked helpers** (`rd_u16`, `d.get(..)`),
  never a raw index. A truncated gradient block still fails closed to `None` rather than panicking
  — asserted by `gradient_spec_parse_hwp5_truncated_returns_none`.
- Both HWPX readers and writers thread the real values.

`crates/hwp5/src/write.rs` is untouched by this half, so the byte-identical hwp5 identity
round-trip is unaffected.

### GE-2 — picture binary resolution (`hwp5/src/write.rs`)

This one turned out **not to be the defect the catalog describes**, and that is the substantive
finding of this PR.

The catalog's GE-2 row says a picture is dropped when the stream referenced by `bin_ref` cannot be
found. A reproduction landed first (commit `b8b68a9`) to pin actual behavior before any fix was
written. What it showed:

| Scenario | Pre-fix behavior | Preservation events |
|---|---|---|
| `BinRef::Id(2)` naming `bin_streams[1]` | consumed `bin_streams[0]` — **wrong image** | **none** |
| `BinRef::ItemRef` naming nothing | consumed `bin_streams[0]` — **wrong image** | **none** |
| `BinRef::ItemRef` naming an existing stream | resolved correctly | n/a (regression guard) |

So the live defect was a **silent wrong-image substitution**, not a drop: `synth_pictures_para`
picked the stream with a substring heuristic and fell back to `bin_streams[0]` whenever it missed,
and `BinRef::Id` references were forced into the empty-string branch so they *always* took that
fallback. A document could ship with a different logo, seal, or signature than its source and leave
no ledger entry. The typed `BinaryAssetRemoved` branch that should have reported it was
**unreachable dead code**.

The fix (commit `0d3b837`) maps each `BinRef` variant to its own stream and reports a typed loss
when nothing resolves, making `BinaryAssetRemoved` reachable — now asserted by
`picture_with_unresolvable_reference_reports_binary_asset_removed`, so `--strict` can fail closed.

The genuinely-empty-`bin_streams` drop is a **separate, already-correct** mechanism. It is
untouched, and `typed_write_report_accounts_for_missing_picture_payload` still covers it unmodified.

### Tests

New, all CI-safe (no font-dependent assertions):

- `gso::tests::gradient_center_and_step_from_table28`
- `control::gradient_spec_tests::gradient_spec_parse_hwp5_reads_center_and_step`
- `control::gradient_spec_tests::gradient_spec_parse_hwp5_truncated_returns_none`
- `border_fill_gradation_center_and_step` (`hwpx/tests/read.rs`)
- `hwp5_gradient_center_and_step_survive_convert_to_hwpx` (new
  `crates/hwp-cli/tests/gradient_roundtrip.rs`, end to end through the real `hwp` binary)
- `picture_binref_id_resolves_to_its_own_stream`
- `picture_itemref_resolves_to_the_named_stream`
- `picture_with_unresolvable_reference_reports_binary_asset_removed`

## 체크리스트

- [x] `scripts/check.sh` 통과 (fmt → clippy --all-targets -D warnings → test, CI와 동일 게이트)
  - Green on the merged result, not only on each half in isolation:
    `== check: OK (fmt/clippy/test/pdf-runner/structured-corpus/public-parity=skipped) ==`.
    The public PDF-parity gate self-skipped on this host (requires the pinned
    `pdfinfo version 24.02.0`); CI runs it on `ubuntu-24.04`.
- [ ] 한글(한컴오피스) 실기 확인이 필요한 변경인가? (writer/호환 규칙 영향)
  - **Yes, required — and still pending.** Both halves touch the writer. Verification is the
    blocking human-verify checkpoint scheduled later in this phase; its result is not yet recorded.
    This is why the PR is a draft.
  - 필요했다면: [ ] 실기 결과를 PR 본문에 기록 (열림/손상 팝업·레이아웃 확인)
- [x] 데이터 정책 준수 (fixtures/samples 예외 외 픽스처 미커밋, 한컴 스펙 문서·파생물 미동봉 — CLAUDE.md §데이터 정책)
  - The diff is source and tests only: no `fixtures/`, `docs/`, `corpus/`, or `oracle/` paths.
- [ ] 설계 문서 갱신 (해당 시): `docs/design/12-feature-gaps.md` 상태, 구조도(10/11), README/CLAUDE.md
  - **Deliberately deferred, flagged for the reviewer.** The catalog checkoff (checked + dated, no
    closed row deleted) is a later phase gate, so this PR does not touch it. Two things will need
    fixing there when it happens:
    1. GE-α6 and GE-2 are functionally closed by this PR but still read as open.
    2. **The GE-2 row description is now factually wrong** — it describes the drop path, but the
       reproduction above proved the live defect was silent substitution and that the drop branch
       was unreachable. The row's cited location `hwp5/src/write.rs:726` is also stale.
    Say the word if you would rather have the catalog corrected in this PR instead.
- [x] 새 기능이면 테스트 동반 (왕복/골든/CLI 표면 중 해당 경로)
  - 8 new tests across unit, hwpx round-trip, and CLI surface; listed above.

## 참고

- 브랜치·PR 정책: CLAUDE.md §브랜치 · PR 정책. main 직접 push 금지, CI green 후 squash 머지.
- Hub-and-spoke held: no new crate-to-crate edges, and the two halves touch disjoint files
  (`hwp5/src/write.rs` only in GE-2; never in GE-α6).
- No new external crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
