### PR TITLE
ci: bound and retry the ubuntu font install so a hung mirror cannot eat the job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,30 @@ jobs:
       # Render smoke tests need a system Korean font. fonts-nanum ships glyf-outline TTFs;
       # the CFF-based fonts-noto-cjk made debug-build outline extraction ~100x slower
       # (that alone was a 15-minute ubuntu test step).
+      # Bounded and retried: a hung apt mirror used to consume the job's whole
+      # 30-minute budget in this one step, which cancelled the job before the
+      # toolchain, the cache and the Test step had run at all - so ubuntu reported
+      # a failure without a single test having executed. A normal install takes
+      # well under a minute; three bounded attempts fail fast and recover from a
+      # transient mirror, and the step still fails loudly if fonts genuinely
+      # cannot be installed (the render smoke tests need them).
       - name: Install Korean fonts (for rendering tests)
         if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y fonts-nanum
+        timeout-minutes: 5
+        run: |
+          set -euo pipefail
+          # Per-attempt `timeout` matters: the failure mode seen twice was a HANG,
+          # not a non-zero exit. Without it the first attempt never returns, the
+          # step-level timeout kills the whole step, and the retries never run.
+          for attempt in 1 2 3; do
+            if timeout 90 sudo apt-get update && timeout 90 sudo apt-get install -y fonts-nanum; then
+              exit 0
+            fi
+            echo "font install attempt ${attempt} failed or timed out; retrying" >&2
+            sleep 10
+          done
+          echo "fonts-nanum could not be installed after 3 attempts" >&2
+          exit 1
       - uses: dtolnay/rust-toolchain@1.93.0
       - uses: Swatinem/rust-cache@v2
       - name: Test


### PR DESCRIPTION
## 요약

`test (ubuntu-latest)` failed twice in a row at exactly 30 minutes, with every step after
`Install Korean fonts` reported as `skipped`.

The step had no timeout of its own, so a hung apt mirror consumed the job's entire 30-minute budget
and the job was cancelled **before the toolchain, the cache and the Test step ran at all**. Ubuntu
reported a failure without a single test having executed, while macOS, Windows and lint passed the
same commit in roughly three minutes each.

## Fix

Bound each apt invocation with `timeout 90` and retry three times.

The **per-attempt** timeout is the load-bearing part. The observed failure was a hang, not a non-zero
exit — so a retry loop alone would never get a second turn, because the first attempt never returns.
A step-level `timeout-minutes` alone has the same problem: it kills the step, not the attempt.

Both are present now: `timeout-minutes: 5` caps the step, `timeout 90` caps each attempt so the
retries can actually run.

## What this deliberately does not do

It does **not** make the step non-fatal. The render smoke tests need a system Korean font, so
continuing without one would trade a visible infrastructure failure for invisible test skips. If
fonts genuinely cannot be installed after three bounded attempts, the job still fails loudly.

## Evidence

- Run 32218083334, both the original and the re-run: step 3 `cancelled`, steps 4-6 (`rust-toolchain`,
  `rust-cache`, `Test`) `skipped`.
- Same commit on the other runners: `lint` 2m41s pass, `test (macos-latest)` 2m57s pass,
  `test (windows-latest)` 3m19s pass.
- `scripts/check.sh` green locally.

Found while verifying #116; kept separate so that PR stays scoped to its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)