### PR TITLE
ci: bound the pdf-parity poppler install and cover the font-install retry worst case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,28 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
+      # Same hung-mirror bound as the test job's font install: an unbounded
+      # apt-get here ate the whole 30-minute job budget on #117's own run,
+      # reporting "cancelled" without the oracle having run at all.
       - name: Install pinned Poppler tools
         shell: bash
+        # Worst case is 3 x (90s update + 90s install) + 2 x 10s sleep, ~9.5 min.
+        timeout-minutes: 12
         run: |
           set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends -y poppler-utils
+          installed=0
+          for attempt in 1 2 3; do
+            if timeout 90 sudo apt-get update && timeout 90 sudo apt-get install --no-install-recommends -y poppler-utils; then
+              installed=1
+              break
+            fi
+            echo "poppler install attempt ${attempt} failed or timed out; retrying" >&2
+            sleep 10
+          done
+          if [ "$installed" != 1 ]; then
+            echo "poppler-utils could not be installed after 3 attempts" >&2
+            exit 1
+          fi
           expected="$(python3 -c 'import json; print(json.load(open("fixtures/pdf-parity/public/manifest.json", encoding="utf-8"))["pins"]["poppler_version"])')"
           actual="$(pdfinfo -v 2>&1 | sed -n '1p')"
           echo "pdfinfo: $actual"
@@ -135,7 +151,9 @@ jobs:
       # cannot be installed (the render smoke tests need them).
       - name: Install Korean fonts (for rendering tests)
         if: runner.os == 'Linux'
-        timeout-minutes: 5
+        # Must exceed the retry loop's worst case (3 x (90s update + 90s install)
+        # + 2 x 10s sleep, ~9.5 min); a smaller budget can cut the last retry short.
+        timeout-minutes: 12
         run: |
           set -euo pipefail
           # Per-attempt `timeout` matters: the failure mode seen twice was a HANG,


### PR DESCRIPTION
Follow-up to #117.

- The same hung-mirror failure mode that #117 fixed for the test job's fonts-nanum install also applies to the pdf-parity job's poppler-utils install — on #117's own run it hung in `Install pinned Poppler tools` and ate the job's whole 30-minute budget, reporting "cancelled" without the oracle having run. This gives that step the same bounded, retried install (3 attempts, 90s per apt-get call) with a 12-minute step budget.
- Raises the test job's font-install step timeout from 5 to 12 minutes so it exceeds the retry loop's worst case (~9.5 min), addressing the review point left on #117.