### PR TITLE
feat(02-04): pin the input gate's CLI surface end to end (GATE-01/02)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+**Added**
+
+- Hancom distribution documents (배포용문서) are now read: `hwp cat`, `hwp convert` and
+  `hwp render` accept them, decrypting the ViewText streams and feeding the result through
+  the normal read path, with the unwrap announced on stderr
+  ([#116](https://github.com/STAIxBWLB/hwp-cli/pull/116)). Verified against 11 genuine
+  corpus documents at HWP 5.1.0.1 and 5.1.1.0. The source-preserving edit path
+  (`hwp edit`, `hwp fill`) still refuses these documents — their content lives in ViewText
+  streams rather than BodyText, so there is no source structure to rewrite against; convert
+  to an ordinary format first to edit.
+- Protected documents are refused by name instead of failing downstream
+  ([#116](https://github.com/STAIxBWLB/hwp-cli/pull/116)): password-encrypted,
+  certificate-encrypted, certificate-DRM, DRM-protected and digitally signed HWP5 documents,
+  and password-encrypted HWPX packages (which previously surfaced as an XML parse error),
+  each with a message naming the condition and suggesting a remedy. The certificate, DRM and
+  signature branches are **unverified against a genuine file** — no such document was
+  obtainable, so what is established is that the header bits are parsed and branched on, not
+  that Hancom sets them in the situations their labels name.
+
+**Changed**
+
+- Writing a formerly-distribution document out to a different format produces an
+  unprotected output, because the writer synthesizes a fixed attribute value for every
+  output; the tool now warns about this on stderr at read time
+  ([#116](https://github.com/STAIxBWLB/hwp-cli/pull/116)). A same-format
+  `hwp convert --to hwp` remains a byte-identical copy and keeps the protection bit.
+
+**Fixed**
+
+- Paragraph line-break settings (`breakSetting`) now survive hwp5 → hwpx conversion: the
+  hwpx writer derives them from the paragraph shape instead of emitting a fixed literal
+  ([#116](https://github.com/STAIxBWLB/hwp-cli/pull/116)).
+
 ## [0.8.6]
 
 **Changed**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,7 @@ name = "hwp-cli"
 version = "0.8.6"
 dependencies = [
  "anyhow",
+ "cfb",
  "clap",
  "flate2",
  "getrandom 0.3.4",

--- a/crates/hwp-cli/Cargo.toml
+++ b/crates/hwp-cli/Cargo.toml
@@ -45,3 +45,7 @@ windows-sys = { version = "0.61", features = [
 [dev-dependencies]
 zip = { workspace = true }
 jsonschema = { workspace = true }
+# 보호 비트 픽스처 합성 전용 (테스트에서 FileHeader 속성 DWORD를 패치). 이미
+# 워크스페이스 의존성이자 hwp5의 직접 의존성이라 트리에 새 코드가 추가되지 않고,
+# dev 전용이라 출시 바이너리에는 들어가지 않는다.
+cfb = { workspace = true }

--- a/crates/hwp-cli/src/commands/cat.rs
+++ b/crates/hwp-cli/src/commands/cat.rs
@@ -32,7 +32,22 @@ pub fn load_document(path: &Path) -> anyhow::Result<Document> {
                 eprintln!("경고: {w}");
             }
             if result.unwrapped_distribution {
-                eprintln!("정보: 배포용 문서를 해제했습니다");
+                // The hwp5 writer synthesizes a fixed attribute DWORD (0x1,
+                // compression only) for every IR-built output, so the
+                // distribution bit never survives a cross-format write. This is
+                // pre-existing writer behaviour GATE-01 made newly reachable,
+                // not a regression. Measured on a genuine dist-*.hwp
+                // (2026-08-20, plan 02-04 Task 0): full synthesis strips the
+                // bit; `convert --to hwp` is a pure byte copy that keeps it;
+                // the source-preserving edit path fails closed on a
+                // /ViewText-only document instead of writing anything. Hence
+                // the caveat names conversion only, and lives folded into this
+                // ONE line (D-10a) at load - the single choke point every
+                // command shares - because the write paths are many.
+                eprintln!(
+                    "정보: 배포용 문서를 해제했습니다 \
+                     (다른 형식으로 변환해 저장하면 배포용 보호는 유지되지 않습니다)"
+                );
             }
             Ok(result.document)
         }

--- a/crates/hwp-cli/tests/cli_surface.rs
+++ b/crates/hwp-cli/tests/cli_surface.rs
@@ -13,7 +13,7 @@
 //! page counts) here.
 
 use std::io::{BufRead, BufReader, Write as _};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
 fn hwp() -> Command {
@@ -367,5 +367,201 @@ fn hwp5_synthetic_identity_gate() {
         let ra = ca.read_stream_raw(name).unwrap();
         let rb = cb.read_stream_raw(name).unwrap();
         assert_eq!(ra, rb, "스트림 바이트 동일: {name}");
+    }
+}
+
+// --- GATE-02: 보호 문서 거부를 출시 바이너 end-to-end로 고정한다. ---
+
+/// hwp5 FileHeader 속성 비트 (36..40 DWORD) — crates/hwp5/src/file_header.rs의
+/// 비공개 `attr` 모듈과 동기화 유지. 라이브러리 쪽이 바뀌면 이 상수들도 바뀌어야
+/// 하는 게 맞다(테스트가 게이트의 실제 전선을 미러링).
+mod gate_bits {
+    pub const ENCRYPTED: u32 = 1 << 1;
+    pub const DRM: u32 = 1 << 4;
+    pub const HAS_SIGNATURE: u32 = 1 << 7;
+    pub const CERT_ENCRYPTED: u32 = 1 << 8;
+    pub const CERT_DRM: u32 = 1 << 10;
+}
+
+/// 보호 비트 픽스처 합성: 커밋된 hwpx 샘플을 hwp5로 변환한 뒤 FileHeader 스트림의
+/// 속성 DWORD(36..40, LE)에 `bits`를 OR해 다시 쓴다. 라이터가 항상 세우는 압축
+/// 비트는 보존된다. 새 거부 브랜치 추가 시 이 함수 한 번 호출로 픽스처 하나.
+fn protected_hwp5_fixture(dir: &Path, name: &str, bits: u32) -> PathBuf {
+    let base = dir.join(format!("{name}.hwp"));
+    let r = hwp()
+        .arg("convert")
+        .arg(fixture())
+        .arg("-o")
+        .arg(&base)
+        .output()
+        .unwrap();
+    assert!(
+        r.status.success(),
+        "기반 hwp5 합성: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+
+    let mut cfb = cfb::open_rw(&base).unwrap();
+    let mut header = Vec::new();
+    {
+        let mut stream = cfb.open_stream("/FileHeader").unwrap();
+        std::io::Read::read_to_end(&mut stream, &mut header).unwrap();
+    }
+    let attrs = u32::from_le_bytes(header[36..40].try_into().unwrap());
+    header[36..40].copy_from_slice(&(attrs | bits).to_le_bytes());
+    cfb.create_stream("/FileHeader")
+        .unwrap()
+        .write_all(&header)
+        .unwrap();
+    drop(cfb);
+    base
+}
+
+/// `hwp cat`이 거부로 실패하고, stderr가 그 조건을 이름 붙인 정확한 한국어 문장을
+/// 담는지 단언한다. 전체 문장(조건+해결 힌트)을 단언해 형제 변형과 구분되게 한다
+/// (D-06). stderr 전문을 반환해 호출자가 추가 단언을 얹을 수 있게 한다.
+fn assert_refusal_names_condition(file: &Path, sentence: &str) -> String {
+    let r = hwp().arg("cat").arg(file).output().unwrap();
+    assert!(!r.status.success(), "거부 기대: {}", file.display());
+    let stderr = String::from_utf8_lossy(&r.stderr).into_owned();
+    assert!(
+        stderr.contains(sentence),
+        "문장 {sentence:?} 부재. stderr: {stderr}"
+    );
+    stderr
+}
+
+#[test]
+fn password_encrypted_document_refuses_by_name() {
+    let dir = tmp_dir("refuse_password");
+    let f = protected_hwp5_fixture(&dir, "pw", gate_bits::ENCRYPTED);
+    assert_refusal_names_condition(
+        &f,
+        "암호화된 문서는 지원하지 않습니다. 한글에서 암호를 해제한 뒤 다시 저장하세요.",
+    );
+}
+
+#[test]
+fn certificate_encrypted_document_refuses_by_name() {
+    let dir = tmp_dir("refuse_cert_enc");
+    let f = protected_hwp5_fixture(&dir, "cert_enc", gate_bits::CERT_ENCRYPTED);
+    assert_refusal_names_condition(
+        &f,
+        "공인 인증서로 암호화된 문서는 지원하지 않습니다. 한글에서 인증서 암호화를 해제한 뒤 다시 저장하세요.",
+    );
+}
+
+#[test]
+fn certificate_drm_document_refuses_by_name() {
+    let dir = tmp_dir("refuse_cert_drm");
+    let f = protected_hwp5_fixture(&dir, "cert_drm", gate_bits::CERT_DRM);
+    assert_refusal_names_condition(
+        &f,
+        "공인 인증서 DRM으로 보호된 문서는 지원하지 않습니다. 한글에서 인증서 DRM 보안을 해제한 뒤 다시 저장하세요.",
+    );
+}
+
+#[test]
+fn drm_document_refuses_by_name() {
+    let dir = tmp_dir("refuse_drm");
+    let f = protected_hwp5_fixture(&dir, "drm", gate_bits::DRM);
+    assert_refusal_names_condition(
+        &f,
+        "DRM으로 보호된 문서는 지원하지 않습니다. 한글에서 DRM 보안을 해제한 뒤 다시 저장하세요.",
+    );
+}
+
+#[test]
+fn signed_document_refuses_by_name() {
+    let dir = tmp_dir("refuse_signed");
+    let f = protected_hwp5_fixture(&dir, "signed", gate_bits::HAS_SIGNATURE);
+    assert_refusal_names_condition(
+        &f,
+        "서명된 문서는 지원하지 않습니다. 한글에서 서명을 제거한 뒤 다시 저장하세요.",
+    );
+}
+
+/// hwpx 쪽 게이트: 커밋된 샘플의 매니페스트를 encryption-data를 담은 것으로
+/// 다시 써서 재포장(mimetype은 첫 엔트리·무압축 — OPC 규약)하면 암호화 거부가
+/// 뜨고, GATE-02 이전의 하류 XML 파싱 오류는 뜨지 않는다.
+#[test]
+fn encrypted_package_refuses_by_name() {
+    let dir = tmp_dir("refuse_encrypted_package");
+    let repacked = dir.join("encrypted.hwpx");
+
+    const ENCRYPTED_MANIFEST: &[u8] = br##"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?><odf:manifest xmlns:odf="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0"><odf:file-entry full-path="Contents/header.xml" media-type="application/xml" size="1"><odf:encryption-data checksum-type="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0#sha256-1k" checksum="AAAA"><odf:algorithm algorithm-name="http://www.w3.org/2001/04/xmlenc#aes256-cbc" initialisation-vector="AAAA"/><odf:key-derivation key-derivation-name="urn:oasis:names:tc:opendocument:xmlns:manifest:1.0#pbkdf2" key-size="32" iteration-count="1024" salt="AAAA"/><odf:start-key-generation start-key-generation-name="http://www.w3.org/2000/09/xmldsig#sha256" key-size="32"/></odf:encryption-data></odf:file-entry></odf:manifest>"##;
+
+    let mut archive = zip::ZipArchive::new(std::fs::File::open(fixture()).unwrap()).unwrap();
+    let mut writer = zip::ZipWriter::new(std::fs::File::create(&repacked).unwrap());
+    let mimetype_options =
+        zip::write::SimpleFileOptions::default().compression_method(zip::CompressionMethod::Stored);
+    writer.start_file("mimetype", mimetype_options).unwrap();
+    writer
+        .write_all(hwpx::package::MIMETYPE.as_bytes())
+        .unwrap();
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i).unwrap();
+        let name = entry.name().to_string();
+        if name == "mimetype" {
+            continue;
+        }
+        let mut data = Vec::new();
+        std::io::Read::read_to_end(&mut entry, &mut data).unwrap();
+        if name == "META-INF/manifest.xml" {
+            data = ENCRYPTED_MANIFEST.to_vec();
+        }
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        writer.start_file(&name, options).unwrap();
+        writer.write_all(&data).unwrap();
+    }
+    writer.finish().unwrap();
+
+    let stderr = assert_refusal_names_condition(
+        &repacked,
+        "암호화된 문서는 지원하지 않습니다. 한글에서 암호를 해제한 뒤 다시 저장하세요.",
+    );
+    assert!(
+        !stderr.contains("XML 파싱 오류"),
+        "하류 XML 파싱 오류로 떨어지면 안 됨: {stderr}"
+    );
+    assert!(
+        !stderr.contains("header.xml"),
+        "헤더 콘텐츠 파트 이름을 노출하면 안 됨: {stderr}"
+    );
+}
+
+/// 여섯 거부 모두 조건 문장 뒤에 해결 힌트 문장이 따라오는지(D-08) 구조로 단언한다
+/// — 힌트의 정확한 문구가 아니라 "둘째 문장이 존재한다"는 사실만 고정해, 문구 수정은
+/// 허용하되 힌트 삭제는 깨지게 한다.
+#[test]
+fn every_refusal_carries_a_remedy_hint() {
+    let dir = tmp_dir("refusal_hints");
+    let cases: Vec<(PathBuf, &str)> = [
+        ("pw", gate_bits::ENCRYPTED, "암호화된 문서는"),
+        (
+            "cert_enc",
+            gate_bits::CERT_ENCRYPTED,
+            "공인 인증서로 암호화된 문서는",
+        ),
+        (
+            "cert_drm",
+            gate_bits::CERT_DRM,
+            "공인 인증서 DRM으로 보호된 문서는",
+        ),
+        ("drm", gate_bits::DRM, "DRM으로 보호된 문서는"),
+        ("signed", gate_bits::HAS_SIGNATURE, "서명된 문서는"),
+    ]
+    .into_iter()
+    .map(|(name, bits, prefix)| (protected_hwp5_fixture(&dir, name, bits), prefix))
+    .collect();
+
+    for (file, prefix) in cases {
+        let stderr = assert_refusal_names_condition(&file, prefix);
+        let after_condition = stderr
+            .split_once("지원하지 않습니다. ")
+            .map(|(_, rest)| rest.trim())
+            .unwrap_or_else(|| panic!("조건 문장 종결 부재: {stderr}"));
+        assert!(!after_condition.is_empty(), "해결 힌트 문장 부재: {stderr}");
     }
 }

--- a/crates/hwp-cli/tests/input_gate.rs
+++ b/crates/hwp-cli/tests/input_gate.rs
@@ -1,0 +1,108 @@
+//! GATE-01 end-to-end: the distribution-document read path, corpus-gated.
+//!
+//! This suite CANNOT run in continuous integration: a genuine 배포용문서 cannot be
+//! synthesized (the unwrap key schedule is Hancom's), so every test here needs the
+//! ground-truth corpus, which lives outside the repository and is never committed.
+//! Run it locally with:
+//!
+//! ```text
+//! HWP_CORPUS_DIR=~/Documents/hwp_samples cargo test -p hwp-cli --test input_gate
+//! ```
+//!
+//! The no-skip contract of `cli_surface.rs` is why this is a separate file: CI-safe
+//! surface assertions go there, corpus-gated ones go here and skip cleanly.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+fn hwp() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_hwp"))
+}
+
+/// 첫 배포용 문서(dist-01*)를 반환. 코퍼스 변수가 없으면 None — 각 테스트는 그 경우
+/// 한국어 안내와 함께 조용히 스킵한다.
+fn first_distribution_document() -> Option<PathBuf> {
+    let dir = PathBuf::from(std::env::var_os("HWP_CORPUS_DIR")?);
+    if !dir.is_dir() {
+        return None;
+    }
+    let mut docs: Vec<PathBuf> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| {
+            let p = e.unwrap().path();
+            let name = p.file_name()?.to_string_lossy();
+            (name.starts_with("dist-") && name.ends_with(".hwp")).then_some(p)
+        })
+        .collect();
+    docs.sort();
+    docs.into_iter().next()
+}
+
+macro_rules! require_corpus {
+    () => {
+        match first_distribution_document() {
+            Some(doc) => doc,
+            None => {
+                eprintln!(
+                    "skip: HWP_CORPUS_DIR 미설정 — 배포용 문서 경로는 실물 코퍼스로만 검증 가능"
+                );
+                return;
+            }
+        }
+    };
+}
+
+const UNWRAP_NOTICE: &str = "배포용 문서를 해제했습니다";
+const WRITE_BACK_WARNING: &str = "배포용 보호는 유지되지 않습니다";
+
+/// stdout은 문서 텍스트만 담는다 — 안내·경고가 한 바이트라도 섞이면 파이프 소비자가
+/// 깨진다(D-03).
+#[test]
+fn distribution_document_text_goes_to_stdout_only() {
+    let doc = require_corpus!();
+    let r = hwp().arg("cat").arg(&doc).output().unwrap();
+    assert!(
+        r.status.success(),
+        "cat: {}",
+        String::from_utf8_lossy(&r.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&r.stdout);
+    assert!(!stdout.trim().is_empty(), "본문 텍스트가 비어 있으면 안 됨");
+    assert!(
+        !stdout.contains(UNWRAP_NOTICE),
+        "해제 안내가 stdout에 새어나감"
+    );
+    assert!(
+        !stdout.contains(WRITE_BACK_WARNING),
+        "쓰기 경고가 stdout에 새어나감"
+    );
+}
+
+/// 해제 사실은 stderr 한 줄로 알린다(D-10a: 경고까지 합친 정확히 한 줄).
+#[test]
+fn distribution_document_unwrap_is_announced_on_stderr() {
+    let doc = require_corpus!();
+    let r = hwp().arg("cat").arg(&doc).output().unwrap();
+    assert!(r.status.success());
+    let stderr = String::from_utf8_lossy(&r.stderr);
+    assert!(
+        stderr.contains(UNWRAP_NOTICE),
+        "해제 안내 부재. stderr: {stderr}"
+    );
+    let non_empty = stderr.lines().filter(|l| !l.trim().is_empty()).count();
+    assert_eq!(non_empty, 1, "stderr는 정확히 한 줄이어야 함: {stderr}");
+}
+
+/// 같은 한 줄에 쓰기 경고가 함께 실린다 — 다른 형식으로 변환해 저장하면 배포용
+/// 보호가 유지되지 않는다는 사실(02-04 Task 0 실측 기반 문구).
+#[test]
+fn distribution_document_write_back_is_warned_about() {
+    let doc = require_corpus!();
+    let r = hwp().arg("cat").arg(&doc).output().unwrap();
+    assert!(r.status.success());
+    let stderr = String::from_utf8_lossy(&r.stderr);
+    assert!(
+        stderr.contains(WRITE_BACK_WARNING),
+        "쓰기 경고 부재. stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
Phase 2 plan 02-04: puts the input gate's user-facing surface under end-to-end test and makes the release copy honest about what it establishes.

- **Write-back caveat, measured:** the distribution unwrap notice on stderr now carries the caveat in the same single line (D-10a). Wording follows a Task-0 measurement on a genuine corpus document: full synthesis strips the distribution bit, a no-edit `convert --to hwp` is a byte copy that keeps it, and the source-preserving edit path fails closed on `/ViewText`-only documents — so the caveat names conversion only.
- **End-to-end refusal assertions:** all six protected-document refusals (password, certificate-encrypted, certificate-DRM, DRM, signed on HWP5; encrypted package on HWPX) are pinned through the shipped binary on distinct full Korean sentences with remedy hints. Fixtures are synthesized in-test (header attribute DWORD patched via `cfb`, dev-dependency only — already in the workspace); no skips, no corpus needed.
- **Corpus-gated distribution suite:** new `tests/input_gate.rs` asserts stdout purity (no diagnostic byte on stdout) and the one-line stderr contract against a genuine 배포용문서; skips cleanly without `HWP_CORPUS_DIR`.
- **CHANGELOG:** the Unreleased entry states that the certificate, DRM and signature branches are unverified against a genuine file, and that writing a formerly-distribution document to another format drops the protection.

Local gates: `scripts/check.sh` OK; `cli_surface` 12/12; `input_gate` 3/3 with corpus set.
