### PR TITLE
chore(release): v0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ---
 
+## [Unreleased]
+
 ## [0.8.7]
 
 **Added**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ---
 
-## [Unreleased]
+## [0.8.7]
 
 **Added**
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-cli"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "anyhow",
  "cfb",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "hwp-model",
  "image",
@@ -722,14 +722,14 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "hwp-render"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "encoding_rs",
  "flate2",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "aes",
  "cfb",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "hwp-convert",
  "hwp-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.8.6"
+version = "0.8.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"


### PR DESCRIPTION
Release v0.8.7: close the CHANGELOG section and bump the workspace version (0.8.6 -> 0.8.7).

Contents (already on main): the input gate (GATE-01/02, #116/#119) — Hancom distribution document read support, named refusals for protected documents, and the write-back caveat; plus the CI apt mirror hardening (#120).

After merge: tag the merge commit once main CI is green, then push the tag to trigger release.yml:
```
git tag -a v0.8.7 -m v0.8.7 && git push origin v0.8.7
```