### PR TITLE
chore(release): v0.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,50 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.8.8]
+
+**Added**
+
+- A bundled bilingual Korean official-document skill tree with an authoring guide,
+  regulation reference, and eight Markdown templates
+  ([#126](https://github.com/STAIxBWLB/hwp-cli/pull/126)).
+- Evidence-backed eight-level official numbering for HWPX and native HWP5:
+  `1.`, `가.`, `1)`, `가)`, `(1)`, `(가)`, `①`, and `㉮`, including the
+  verified post-`하` continuation. Seven canonical profiles are available:
+  `official`, `report`, `plan`, `notice`, `minutes`, `gaejosik`, and
+  `press`.
+- Per-side `hwp new` margin overrides and matching `hwp_new` MCP fields. CLI and
+  MCP share canonical preset aliases, range/content-area validation, and atomic
+  no-publication behavior.
+
+**Changed**
+
+- Official authoring now fails closed before publication when native HWP5 input
+  requests an unproven list topology, non-default start, continuation range, or
+  depth. HWPX keeps its broader supported list-start semantics.
+- Official profile defaults now use A4 top/bottom/left/right margins of
+  20/10/20/20 mm, with profile-specific typography, header/footer bands, and
+  bottom-center `- N -` page numbering where enabled.
+
+**Fixed**
+
+- Native HWP5 paragraphs now persist the observed zero-based list-level binding
+  in `PARA_SHAPE`; without it Hancom displayed every nested level as decimal
+  level one despite valid numbering definitions.
+- Ordered-list start parsing no longer narrows values above `u32::MAX` or
+  overflows while formatting later markers. Nested table and materializable
+  control lists now share the same evidence-bound continuation checks.
+- The private Hancom verification-set generator is fail-fast, publishes its index
+  only after all fourteen documents validate, and rejects repository or
+  symlink-resolved repository destinations.
+
+**Verification**
+
+- The seven-profile HWP/HWPX matrix, code review, security audit, and CI passed.
+  Fourteen private artifacts were opened in genuine Hancom Office and passed
+  hash-bound certification. This is a bounded structural and application-
+  acceptance claim, not a pixel-parity claim.
+
 ## [0.8.7]
 
 **Added**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-cli"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "anyhow",
  "cfb",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "hwp-model",
  "image",
@@ -722,14 +722,14 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "hwp-render"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "encoding_rs",
  "flate2",
@@ -749,7 +749,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "aes",
  "cfb",
@@ -765,7 +765,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.8.7"
+version = "0.8.8"
 dependencies = [
  "hwp-convert",
  "hwp-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.8.7"
+version = "0.8.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"


### PR DESCRIPTION
## Summary

Prepare the v0.8.8 release for the official-document authoring layer merged in #126.

## Changes

- Add the v0.8.8 changelog section used verbatim by the GitHub Release workflow.
- Bump the workspace package version from 0.8.7 to 0.8.8.
- Refresh only workspace package versions in Cargo.lock with `--offline`.

## Verification

- [x] `scripts/release.sh --self-test`
- [x] `scripts/release_notes.sh v0.8.8`
- [x] `cargo +1.93.0 fmt --all --check`
- [x] `cargo +1.93.0 check --workspace`
- [x] Release diff limited to CHANGELOG.md, Cargo.toml, and Cargo.lock

After merge and green main CI, tag the squash merge commit as `v0.8.8` to trigger the release workflow.

Refs #121
