### PR TITLE
feat: hwp lint — official-document notation and structure rules (Phase 2.3, GN-3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,6 +714,7 @@ dependencies = [
  "libc",
  "pulldown-cmark",
  "quick-xml",
+ "regex",
  "resvg",
  "serde_json",
  "windows-sys",

--- a/crates/hwp-cli/src/cli.rs
+++ b/crates/hwp-cli/src/cli.rs
@@ -54,6 +54,13 @@ pub enum LangArg {
     Ko,
 }
 
+/// `hwp lint --profile` 값. `hwp_convert::lint::LintProfile`의 clap 미러.
+#[derive(Clone, Copy, ValueEnum)]
+pub enum LintProfileArg {
+    Gongmun,
+    Report,
+}
+
 #[derive(Subcommand)]
 // Edit 변형이 편집 플래그(Vec<String> 다수)로 커서 다른 변형과 크기차가 크다.
 // CLI 명령 enum은 시작 시 한 번만 파싱되므로 크기차는 무의미 — 박싱 대신 허용.
@@ -338,6 +345,22 @@ pub enum Cmd {
         /// Print as JSON
         #[arg(long)]
         json: bool,
+    },
+
+    /// Lint official-document notation and structure rules; advisory by default
+    /// (always exit 0) — --strict exits 1 only when an error-severity finding exists
+    Lint {
+        /// Target .md/.hwp/.hwpx file ("-" reads stdin as markdown)
+        file: PathBuf,
+        /// Lint profile: gongmun (default) or report; both run the same rule table in v1
+        #[arg(long, value_enum, default_value = "gongmun")]
+        profile: LintProfileArg,
+        /// Print the hwp-lint-report-v1 JSON report
+        #[arg(long)]
+        json: bool,
+        /// Exit 1 when an error-severity finding exists (default: always exit 0)
+        #[arg(long)]
+        strict: bool,
     },
 
     /// Certify package, semantics, native render and independent import under a versioned policy

--- a/crates/hwp-cli/src/cli.rs
+++ b/crates/hwp-cli/src/cli.rs
@@ -609,7 +609,7 @@ impl PresetArg {
 /// and deliberately stays silent: its stdout is a protocol channel.
 fn parse_preset_arg(value: &str) -> Result<PresetArg, String> {
     let preset = hwp_convert::OfficialPreset::parse(value).map(PresetArg)?;
-    if value.to_ascii_lowercase() == "gian" {
+    if value.eq_ignore_ascii_case("gian") {
         eprintln!("gian은 gongmun의 별칭입니다");
     }
     Ok(preset)

--- a/crates/hwp-cli/src/cli.rs
+++ b/crates/hwp-cli/src/cli.rs
@@ -599,8 +599,20 @@ impl PresetArg {
     }
 }
 
+/// Parse a `--preset` value through the shared alias registry. The deprecated
+/// Latin alias `gian` still resolves to the official preset but prints a
+/// one-time stderr deprecation note (D-03). The trigger compare lowercases
+/// first because `OfficialPreset::parse` lowercases before matching — without
+/// it, `--preset GIAN` would resolve silently and the note would never fire.
+/// Stderr only, never stdout (stdout carries command output). The MCP server's
+/// preset path (commands/mcp.rs) parses via `OfficialPreset::parse` directly
+/// and deliberately stays silent: its stdout is a protocol channel.
 fn parse_preset_arg(value: &str) -> Result<PresetArg, String> {
-    hwp_convert::OfficialPreset::parse(value).map(PresetArg)
+    let preset = hwp_convert::OfficialPreset::parse(value).map(PresetArg)?;
+    if value.to_ascii_lowercase() == "gian" {
+        eprintln!("gian은 gongmun의 별칭입니다");
+    }
+    Ok(preset)
 }
 
 #[derive(Clone, Copy, ValueEnum)]
@@ -742,6 +754,23 @@ mod tests {
         assert!(parse_preset_arg("unknown").is_err());
         for value in ["-1", "NaN", "inf", "201"] {
             assert!(parse_margin_mm(value).is_err(), "{value}");
+        }
+    }
+
+    #[test]
+    fn gian_alias_still_resolves_official_case_insensitively() {
+        use hwp_convert::OfficialPreset;
+
+        // D-03: the deprecated `gian` alias keeps resolving to the official
+        // canonical preset in any case — the deprecation note fires for each
+        // of these, so both the lowercase and uppercase forms take the same
+        // deprecation branch in parse_preset_arg (stderr pinned in tests/cli.rs).
+        for alias in ["gian", "GIAN", "Gian"] {
+            assert_eq!(
+                parse_preset_arg(alias).unwrap().canonical(),
+                OfficialPreset::Official,
+                "{alias} must keep resolving to the official preset"
+            );
         }
     }
 }

--- a/crates/hwp-cli/src/commands/lint.rs
+++ b/crates/hwp-cli/src/commands/lint.rs
@@ -71,9 +71,6 @@ fn report_json(file: &str, profile: LintProfile, findings: &[Finding]) -> Value 
 /// Lint result as a JSON object (shared CLI/MCP entry — no `process::exit`, no
 /// stdout). An unreadable or unsupported input is reported in the `error` field
 /// instead of panicking or exiting.
-// Wired up when the `hwp_lint` MCP tool lands (next plan); kept dead-code-allowed
-// until then so the shared entry ships with the tracer it belongs to.
-#[allow(dead_code)]
 pub fn lint_path_json(path: &Path, profile: LintProfile) -> Value {
     match read_markdown_input(path) {
         Ok(markdown) => {

--- a/crates/hwp-cli/src/commands/lint.rs
+++ b/crates/hwp-cli/src/commands/lint.rs
@@ -2,9 +2,9 @@
 //!
 //! Advisory by default: findings never affect the exit code unless `--strict` is
 //! given AND at least one error-severity finding exists (D-05). The JSON report
-//! follows the hwp-lint-report-v1 field set (D-06; the schema file itself lands
-//! with the contract-lock plan). Lint is read-only — the input file is never
-//! modified, created or deleted.
+//! follows the hwp-lint-report-v1 contract (D-06, published at
+//! `schemas/lint-report-v1.schema.json` — additive-only thereafter). Lint is
+//! read-only — the input file is never modified, created or deleted.
 
 use std::io::Read as _;
 use std::path::Path;
@@ -15,32 +15,72 @@ use serde_json::{Value, json};
 /// stdin read cap, mirroring the MCP `MAX_READ_BYTES` convention.
 const MAX_STDIN_BYTES: u64 = 16 * 1024 * 1024;
 
-/// Reads the lint input as markdown. `"-"` reads stdin (bounded, D-08); binary
-/// `.hwp`/`.hwpx` feeding is planned but not available yet — named explicitly.
-fn read_markdown_input(path: &Path) -> anyhow::Result<String> {
+/// D-02 note carried in every finding's `context` when the input reached the
+/// engine via markdown conversion from a binary .hwp/.hwpx. A fixed string,
+/// never content (T-02.3-04); it names the conversion path and the merged-cell
+/// HTML-block blind spot (RESEARCH Pitfall 3) so a conversion artifact is never
+/// mistaken for a source-document defect.
+const VIA_CONVERSION_NOTE: &str =
+    "markdown 변환 경유 입력입니다 — 병합 셀 표(HTML 블록) 안의 내용은 검사하지 않습니다";
+
+/// The lint input: markdown text plus whether it arrived via binary→markdown
+/// conversion (drives the D-02 `context` note in the JSON report).
+struct LintInput {
+    markdown: String,
+    via_conversion: bool,
+}
+
+/// Bounded UTF-8 read (D-08 / T-02.3-02): input beyond `cap` bytes is a Korean
+/// error naming the limit — never a silent truncation.
+fn read_bounded(reader: impl std::io::Read, cap: u64) -> anyhow::Result<String> {
+    let mut buf = String::new();
+    reader.take(cap + 1).read_to_string(&mut buf)?;
+    if buf.len() as u64 > cap {
+        anyhow::bail!("입력이 크기 제한({cap}바이트)을 초과했습니다");
+    }
+    Ok(buf)
+}
+
+/// Reads the lint input as markdown. `"-"` reads stdin (bounded, D-08 — never
+/// staged to a temp file, RESEARCH Pitfall 6); binary `.hwp`/`.hwpx` flows
+/// through the shared read path (`load_document` → `to_markdown_with`) into the
+/// SAME engine — one engine, two feeders (D-01). Read-only throughout: no
+/// writer is ever invoked on the input.
+fn read_lint_input(path: &Path) -> anyhow::Result<LintInput> {
     if path.as_os_str() == "-" {
-        let mut buf = String::new();
-        std::io::stdin()
-            .take(MAX_STDIN_BYTES)
-            .read_to_string(&mut buf)?;
-        return Ok(buf);
+        return Ok(LintInput {
+            markdown: read_bounded(std::io::stdin(), MAX_STDIN_BYTES)?,
+            via_conversion: false,
+        });
     }
     let ext = path
         .extension()
         .and_then(|e| e.to_str())
         .map(|e| e.to_ascii_lowercase());
     if matches!(ext.as_deref(), Some("hwp" | "hwpx")) {
-        anyhow::bail!(
-            "아직 지원하지 않는 입력입니다: {} — 바이너리(.hwp/.hwpx) 린트는 추후 지원 예정이며, 지금은 markdown(.md) 파일을 사용하세요",
-            path.display()
-        );
+        let doc = crate::commands::cat::load_document(path)?;
+        let markdown =
+            hwp_convert::to_markdown_with(&doc, &hwp_convert::MarkdownOptions::default())?;
+        return Ok(LintInput {
+            markdown,
+            via_conversion: true,
+        });
     }
-    Ok(std::fs::read_to_string(path)?)
+    Ok(LintInput {
+        markdown: std::fs::read_to_string(path)?,
+        via_conversion: false,
+    })
 }
 
 /// Builds the hwp-lint-report-v1 JSON object for already-computed findings (D-06
-/// field set; the profile is echoed per D-04).
-fn report_json(file: &str, profile: LintProfile, findings: &[Finding]) -> Value {
+/// field set; the profile is echoed per D-04). When the input arrived via
+/// binary→markdown conversion, every finding carries the D-02 `context` note.
+fn report_json(
+    file: &str,
+    profile: LintProfile,
+    findings: &[Finding],
+    via_conversion: bool,
+) -> Value {
     let error_count = findings
         .iter()
         .filter(|f| f.severity == Severity::Error)
@@ -53,13 +93,19 @@ fn report_json(file: &str, profile: LintProfile, findings: &[Finding]) -> Value 
         "profile": profile.name(),
         "findings": findings
             .iter()
-            .map(|f| json!({
-                "rule_id": f.rule_id,
-                "severity": f.severity.name(),
-                "line": f.line,
-                "col": f.col,
-                "message": f.message,
-            }))
+            .map(|f| {
+                let mut finding = json!({
+                    "rule_id": f.rule_id,
+                    "severity": f.severity.name(),
+                    "line": f.line,
+                    "col": f.col,
+                    "message": f.message,
+                });
+                if via_conversion {
+                    finding["context"] = json!(VIA_CONVERSION_NOTE);
+                }
+                finding
+            })
             .collect::<Vec<_>>(),
         "summary": {
             "error_count": error_count,
@@ -72,10 +118,15 @@ fn report_json(file: &str, profile: LintProfile, findings: &[Finding]) -> Value 
 /// stdout). An unreadable or unsupported input is reported in the `error` field
 /// instead of panicking or exiting.
 pub fn lint_path_json(path: &Path, profile: LintProfile) -> Value {
-    match read_markdown_input(path) {
-        Ok(markdown) => {
-            let findings = lint_markdown(&markdown, profile);
-            report_json(&path.display().to_string(), profile, &findings)
+    match read_lint_input(path) {
+        Ok(input) => {
+            let findings = lint_markdown(&input.markdown, profile);
+            report_json(
+                &path.display().to_string(),
+                profile,
+                &findings,
+                input.via_conversion,
+            )
         }
         Err(error) => json!({
             "schema_version": "1.0",
@@ -90,11 +141,16 @@ pub fn lint_path_json(path: &Path, profile: LintProfile) -> Value {
 }
 
 pub fn run(file: &Path, profile: LintProfile, json: bool, strict: bool) -> anyhow::Result<()> {
-    let markdown = read_markdown_input(file)?;
-    let findings = lint_markdown(&markdown, profile);
+    let input = read_lint_input(file)?;
+    let findings = lint_markdown(&input.markdown, profile);
 
     if json {
-        let report = report_json(&file.display().to_string(), profile, &findings);
+        let report = report_json(
+            &file.display().to_string(),
+            profile,
+            &findings,
+            input.via_conversion,
+        );
         println!("{}", serde_json::to_string_pretty(&report)?);
     } else {
         // D-07: one `{line}: {rule_id} — {message}` line per finding, ascending
@@ -110,4 +166,26 @@ pub fn run(file: &Path, profile: LintProfile, json: bool, strict: bool) -> anyho
         std::process::exit(1);
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bounded_read_accepts_input_within_the_cap() {
+        let text = read_bounded(std::io::Cursor::new("시행: 2020.7.8\n"), MAX_STDIN_BYTES).unwrap();
+        assert_eq!(text, "시행: 2020.7.8\n");
+    }
+
+    #[test]
+    fn bounded_read_rejects_over_cap_naming_the_limit() {
+        // A small stand-in cap keeps the test fast; the message must name it.
+        let err = read_bounded(std::io::Cursor::new(vec![b'a'; 65]), 64).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("64바이트"),
+            "error must name the limit: {message}"
+        );
+    }
 }

--- a/crates/hwp-cli/src/commands/lint.rs
+++ b/crates/hwp-cli/src/commands/lint.rs
@@ -188,4 +188,31 @@ mod tests {
             "error must name the limit: {message}"
         );
     }
+
+    #[test]
+    fn error_variant_report_matches_schema_v1() {
+        // WR-1: the MCP-facing failure report is a deliberate lint-report-v1
+        // variant (same contract, empty findings, optional `error` string) and
+        // must validate against the published schema.
+        let schema: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../../schemas/lint-report-v1.schema.json"
+        ))
+        .unwrap();
+        let validator = jsonschema::options()
+            .with_draft(jsonschema::Draft::Draft202012)
+            .build(&schema)
+            .unwrap();
+        let report = lint_path_json(
+            Path::new("/nonexistent/hwp-lint-wr1-does-not-exist.md"),
+            LintProfile::Gongmun,
+        );
+        assert!(
+            report.get("error").is_some(),
+            "unreadable input reports the error field: {report}"
+        );
+        assert!(
+            validator.is_valid(&report),
+            "schema rejected the error-variant report: {report}"
+        );
+    }
 }

--- a/crates/hwp-cli/src/commands/lint.rs
+++ b/crates/hwp-cli/src/commands/lint.rs
@@ -1,0 +1,116 @@
+//! `hwp lint` — official-document notation/structure lint (공문서 표기법·구조 검사).
+//!
+//! Advisory by default: findings never affect the exit code unless `--strict` is
+//! given AND at least one error-severity finding exists (D-05). The JSON report
+//! follows the hwp-lint-report-v1 field set (D-06; the schema file itself lands
+//! with the contract-lock plan). Lint is read-only — the input file is never
+//! modified, created or deleted.
+
+use std::io::Read as _;
+use std::path::Path;
+
+use hwp_convert::lint::{Finding, LintProfile, Severity, lint_markdown};
+use serde_json::{Value, json};
+
+/// stdin read cap, mirroring the MCP `MAX_READ_BYTES` convention.
+const MAX_STDIN_BYTES: u64 = 16 * 1024 * 1024;
+
+/// Reads the lint input as markdown. `"-"` reads stdin (bounded, D-08); binary
+/// `.hwp`/`.hwpx` feeding is planned but not available yet — named explicitly.
+fn read_markdown_input(path: &Path) -> anyhow::Result<String> {
+    if path.as_os_str() == "-" {
+        let mut buf = String::new();
+        std::io::stdin()
+            .take(MAX_STDIN_BYTES)
+            .read_to_string(&mut buf)?;
+        return Ok(buf);
+    }
+    let ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase());
+    if matches!(ext.as_deref(), Some("hwp" | "hwpx")) {
+        anyhow::bail!(
+            "아직 지원하지 않는 입력입니다: {} — 바이너리(.hwp/.hwpx) 린트는 추후 지원 예정이며, 지금은 markdown(.md) 파일을 사용하세요",
+            path.display()
+        );
+    }
+    Ok(std::fs::read_to_string(path)?)
+}
+
+/// Builds the hwp-lint-report-v1 JSON object for already-computed findings (D-06
+/// field set; the profile is echoed per D-04).
+fn report_json(file: &str, profile: LintProfile, findings: &[Finding]) -> Value {
+    let error_count = findings
+        .iter()
+        .filter(|f| f.severity == Severity::Error)
+        .count();
+    let warning_count = findings.len() - error_count;
+    json!({
+        "schema_version": "1.0",
+        "contract": "hwp-lint-report-v1",
+        "file": file,
+        "profile": profile.name(),
+        "findings": findings
+            .iter()
+            .map(|f| json!({
+                "rule_id": f.rule_id,
+                "severity": f.severity.name(),
+                "line": f.line,
+                "col": f.col,
+                "message": f.message,
+            }))
+            .collect::<Vec<_>>(),
+        "summary": {
+            "error_count": error_count,
+            "warning_count": warning_count,
+        },
+    })
+}
+
+/// Lint result as a JSON object (shared CLI/MCP entry — no `process::exit`, no
+/// stdout). An unreadable or unsupported input is reported in the `error` field
+/// instead of panicking or exiting.
+// Wired up when the `hwp_lint` MCP tool lands (next plan); kept dead-code-allowed
+// until then so the shared entry ships with the tracer it belongs to.
+#[allow(dead_code)]
+pub fn lint_path_json(path: &Path, profile: LintProfile) -> Value {
+    match read_markdown_input(path) {
+        Ok(markdown) => {
+            let findings = lint_markdown(&markdown, profile);
+            report_json(&path.display().to_string(), profile, &findings)
+        }
+        Err(error) => json!({
+            "schema_version": "1.0",
+            "contract": "hwp-lint-report-v1",
+            "file": path.display().to_string(),
+            "profile": profile.name(),
+            "error": error.to_string(),
+            "findings": [],
+            "summary": { "error_count": 0, "warning_count": 0 },
+        }),
+    }
+}
+
+pub fn run(file: &Path, profile: LintProfile, json: bool, strict: bool) -> anyhow::Result<()> {
+    let markdown = read_markdown_input(file)?;
+    let findings = lint_markdown(&markdown, profile);
+
+    if json {
+        let report = report_json(&file.display().to_string(), profile, &findings);
+        println!("{}", serde_json::to_string_pretty(&report)?);
+    } else {
+        // D-07: one `{line}: {rule_id} — {message}` line per finding, ascending
+        // line order — no headers, no context lines.
+        for f in &findings {
+            println!("{}: {} — {}", f.line, f.rule_id, f.message);
+        }
+    }
+
+    // D-05 exit policy: findings are advisory — the exit code stays 0 unless
+    // --strict is given AND an error-severity finding exists.
+    if strict && findings.iter().any(|f| f.severity == Severity::Error) {
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/crates/hwp-cli/src/commands/mcp.rs
+++ b/crates/hwp-cli/src/commands/mcp.rs
@@ -368,6 +368,7 @@ fn call_tool(name: &str, args: &Value, ctx: &Ctx) -> Value {
         "hwp_slots" => tool_slots(args, ctx),
         "hwp_fill" => tool_fill(args, ctx),
         "hwp_validate" => tool_validate(args, ctx),
+        "hwp_lint" => tool_lint(args, ctx),
         "hwp_certify" => tool_certify(args, ctx),
         other => Err(format!("알 수 없는 도구: {other}")),
     };
@@ -837,6 +838,20 @@ fn tool_validate(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
     let v = crate::commands::validate::validate_json(&path);
     Ok(vec![text_content(
         &serde_json::to_string_pretty(&v).unwrap_or_default(),
+    )])
+}
+
+/// `hwp_lint` — path-only (D-09): no inline text, no profile argument in v1.
+/// The path goes through the same canonicalize + root-containment sandbox as
+/// every other read tool (`checked_read_path`), then the shared lint entry —
+/// findings carry rule_id/severity/line/col/message only, no source excerpts
+/// (T-02.3-04).
+fn tool_lint(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
+    let path = checked_read_path(ctx, arg_str(args, "path")?)?;
+    let report =
+        crate::commands::lint::lint_path_json(&path, hwp_convert::lint::LintProfile::Gongmun);
+    Ok(vec![text_content(
+        &serde_json::to_string_pretty(&report).unwrap_or_default(),
     )])
 }
 
@@ -2078,6 +2093,13 @@ fn tool_defs() -> Vec<Value> {
             "description": "구조 검증(mimetype·필수 엔트리·XML 파싱). {valid, errors, warnings} 반환.",
             "inputSchema": {"type": "object", "properties": {
                 "path": {"type": "string"}
+            }, "required": ["path"]}
+        }),
+        json!({
+            "name": "hwp_lint",
+            "description": "공문서 표기법·구조 규칙 검사(markdown). 권고성 — hwp-lint-report-v1 형태의 findings JSON(rule_id·severity·line·col·message)을 반환하며 원문 발췌는 포함하지 않는다.",
+            "inputSchema": {"type": "object", "properties": {
+                "path": {"type": "string", "description": "검사할 markdown 파일 경로(--root 샌드박스 안)"}
             }, "required": ["path"]}
         }),
         json!({

--- a/crates/hwp-cli/src/commands/mod.rs
+++ b/crates/hwp-cli/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod fields;
 pub mod fill;
 pub mod grep;
 pub mod info;
+pub mod lint;
 pub mod mcp;
 pub mod new;
 pub(crate) mod output;

--- a/crates/hwp-cli/src/i18n.rs
+++ b/crates/hwp-cli/src/i18n.rs
@@ -543,6 +543,28 @@ pub const KO: &[(&str, &str, &str)] = &[
     ),
     ("validate", "file", "대상 HWP/HWPX 파일"),
     ("validate", "json", "JSON으로 출력"),
+    // lint
+    (
+        "lint",
+        "",
+        "공문서 표기법·구조 규칙 검사 — 기본은 권고(advisory)이며 항상 종료코드 0. --strict는 오류 심각도 지적이 있을 때만 종료코드 1",
+    ),
+    (
+        "lint",
+        "file",
+        "검사 대상 .md/.hwp/.hwpx 파일 (\"-\"는 stdin을 markdown으로 읽음)",
+    ),
+    (
+        "lint",
+        "profile",
+        "린트 프로필: gongmun(기본) 또는 report — v1에서는 같은 규칙 표 사용",
+    ),
+    ("lint", "json", "hwp-lint-report-v1 JSON 리포트로 출력"),
+    (
+        "lint",
+        "strict",
+        "오류 심각도 지적이 있으면 종료 코드 1 (기본: 항상 종료 코드 0)",
+    ),
     // certify
     (
         "certify",

--- a/crates/hwp-cli/src/main.rs
+++ b/crates/hwp-cli/src/main.rs
@@ -208,6 +208,18 @@ fn real_main() -> anyhow::Result<()> {
             allow_partial,
         } => commands::fill::run(&input, &output, &set, data.as_deref(), json, allow_partial),
         Cmd::Validate { file, json } => commands::validate::run(&file, json),
+        Cmd::Lint {
+            file,
+            profile,
+            json,
+            strict,
+        } => {
+            let profile = match profile {
+                hwp_cli::cli::LintProfileArg::Gongmun => hwp_convert::lint::LintProfile::Gongmun,
+                hwp_cli::cli::LintProfileArg::Report => hwp_convert::lint::LintProfile::Report,
+            };
+            commands::lint::run(&file, profile, json, strict)
+        }
         Cmd::Certify {
             input,
             policy,

--- a/crates/hwp-cli/tests/cli.rs
+++ b/crates/hwp-cli/tests/cli.rs
@@ -438,6 +438,71 @@ fn official_preset_aliases_and_margin_overrides() {
     }
 }
 
+#[test]
+fn gian_deprecation_note() {
+    const NOTE: &str = "gian은 gongmun의 별칭입니다";
+    let markdown = tmp("gian-deprecation.md");
+    std::fs::write(&markdown, "1. 항목\n").unwrap();
+    let gian_out = tmp("gian-deprecation-gian.hwpx");
+    let gian_upper_out = tmp("gian-deprecation-gian-upper.hwpx");
+    let silent_out = tmp("gian-deprecation-silent.hwpx");
+    for path in [&gian_out, &gian_upper_out, &silent_out] {
+        let _ = std::fs::remove_file(path);
+    }
+
+    // D-03: the deprecated Latin alias keeps working but prints the note to
+    // stderr exactly once — case-insensitively, because OfficialPreset::parse
+    // lowercases before matching, so `--preset GIAN` must take the same
+    // deprecation branch as `--preset gian`.
+    for (preset, output) in [("gian", &gian_out), ("GIAN", &gian_upper_out)] {
+        let result = hwp()
+            .args(["new", "--from"])
+            .arg(&markdown)
+            .args(["--preset", preset, "--output"])
+            .arg(output)
+            .output()
+            .unwrap();
+        assert!(
+            result.status.success(),
+            "{preset}: {}",
+            String::from_utf8_lossy(&result.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        assert_eq!(
+            stderr.matches(NOTE).count(),
+            1,
+            "{preset}: the deprecation note must print exactly once, got: {stderr}"
+        );
+    }
+
+    // The canonical name and the non-deprecated aliases stay silent.
+    for preset in ["official", "gongmun", "기안문"] {
+        let result = hwp()
+            .args(["new", "--from"])
+            .arg(&markdown)
+            .args(["--preset", preset, "--output"])
+            .arg(&silent_out)
+            .output()
+            .unwrap();
+        assert!(
+            result.status.success(),
+            "{preset}: {}",
+            String::from_utf8_lossy(&result.stderr)
+        );
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        assert!(
+            !stderr.contains(NOTE),
+            "{preset}: must not print the gian deprecation note, got: {stderr}"
+        );
+        let _ = std::fs::remove_file(&silent_out);
+    }
+
+    let _ = std::fs::remove_file(&markdown);
+    let _ = std::fs::remove_file(&gian_out);
+    let _ = std::fs::remove_file(&gian_upper_out);
+    let _ = std::fs::remove_file(&silent_out);
+}
+
 fn replace_zip_entry(path: &Path, target: &str, replacement: &[u8]) {
     let rewritten = path.with_extension("rewrite.hwpx");
     let input = std::fs::File::open(path).unwrap();

--- a/crates/hwp-cli/tests/cli_surface.rs
+++ b/crates/hwp-cli/tests/cli_surface.rs
@@ -275,6 +275,7 @@ fn mcp_stdio_session() {
         "hwp_fill",
         "hwp_grep",
         "hwp_info",
+        "hwp_lint",
         "hwp_list_bookmarks",
         "hwp_list_fields",
         "hwp_new",
@@ -287,7 +288,7 @@ fn mcp_stdio_session() {
     .iter()
     .map(|s| s.to_string())
     .collect();
-    assert_eq!(names, expect, "도구 16종");
+    assert_eq!(names, expect, "도구 17종");
 
     send(
         serde_json::json!({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{
@@ -299,7 +300,123 @@ fn mcp_stdio_session() {
     let v: serde_json::Value = serde_json::from_str(text).unwrap();
     assert_eq!(v["valid"], true, "hwp_validate 결과: {text}");
 
+    // hwp_lint: 루트 안 위반 markdown → findings 비어있지 않고 rule_id/line/message 보유.
+    let dir = tmp_dir("mcp_lint_call");
+    let violating = dir.join("violating.md");
+    std::fs::write(&violating, "시행일: 2020.7.8\n").unwrap();
+    send(
+        serde_json::json!({"jsonrpc":"2.0","id":4,"method":"tools/call","params":{
+        "name":"hwp_lint","arguments":{"path": violating.to_string_lossy()}}}),
+    );
+    let call = recv("tools/call");
+    assert_eq!(call["id"], 4);
+    assert_eq!(call["result"]["isError"], false, "hwp_lint 응답: {call}");
+    let text = call["result"]["content"][0]["text"].as_str().unwrap();
+    let report: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert_eq!(report["contract"], "hwp-lint-report-v1", "계약: {text}");
+    let findings = report["findings"].as_array().unwrap();
+    assert!(!findings.is_empty(), "위반 파일에 findings 없음: {text}");
+    for f in findings {
+        assert!(f["rule_id"].is_string(), "rule_id 누락: {f}");
+        assert!(f["line"].is_number(), "line 누락: {f}");
+        assert!(f["message"].is_string(), "message 누락: {f}");
+    }
+
     // stdin EOF = 종료 신호. try_wait 루프(최대 30s) 후 kill.
+    drop(stdin);
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            assert!(status.success(), "MCP 종료 코드: {status}");
+            break;
+        }
+        if Instant::now() > deadline {
+            let _ = child.kill();
+            panic!("MCP가 stdin EOF 후 30s 내 종료하지 않음");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// hwp_lint 샌드박스: --root 안의 파일은 검사되고, 루트 밖 경로는
+/// checked_read_path가 거부한다(isError=true). D-09/T-02.3-01 고정.
+#[test]
+fn mcp_hwp_lint_root_sandbox() {
+    use std::sync::mpsc;
+    use std::time::{Duration, Instant};
+
+    let dir = tmp_dir("mcp_lint_sandbox");
+    let in_root = dir.join("violating.md");
+    std::fs::write(&in_root, "시행일: 2020.7.8\n").unwrap();
+
+    let mut child = hwp()
+        .arg("mcp")
+        .arg("--root")
+        .arg(&dir)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("hwp mcp spawn");
+    let mut stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+
+    let (tx, rx) = mpsc::channel::<String>();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stdout).lines() {
+            let Ok(line) = line else { break };
+            if tx.send(line).is_err() {
+                break;
+            }
+        }
+    });
+    let recv = |what: &str| -> serde_json::Value {
+        let line = rx
+            .recv_timeout(Duration::from_secs(60))
+            .unwrap_or_else(|_| panic!("MCP 응답 타임아웃: {what}"));
+        serde_json::from_str(&line).unwrap_or_else(|_| panic!("JSON 파싱: {line}"))
+    };
+    let mut send = |v: serde_json::Value| {
+        stdin
+            .write_all(serde_json::to_string(&v).unwrap().as_bytes())
+            .unwrap();
+        stdin.write_all(b"\n").unwrap();
+        stdin.flush().unwrap();
+    };
+
+    send(
+        serde_json::json!({"jsonrpc":"2.0","id":1,"method":"initialize","params":{
+        "protocolVersion":"2024-11-05","capabilities":{},
+        "clientInfo":{"name":"cli_surface","version":"0"}}}),
+    );
+    recv("initialize");
+    send(serde_json::json!({"jsonrpc":"2.0","method":"notifications/initialized"}));
+
+    // 루트 안: findings가 돌아와야 한다.
+    send(
+        serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{
+        "name":"hwp_lint","arguments":{"path": in_root.to_string_lossy()}}}),
+    );
+    let call = recv("tools/call in-root");
+    assert_eq!(call["result"]["isError"], false, "in-root: {call}");
+    let text = call["result"]["content"][0]["text"].as_str().unwrap();
+    let report: serde_json::Value = serde_json::from_str(text).unwrap();
+    assert!(
+        !report["findings"].as_array().unwrap().is_empty(),
+        "in-root 위반 파일에 findings 없음: {text}"
+    );
+
+    // 루트 밖: checked_read_path 거부(isError=true).
+    send(
+        serde_json::json!({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{
+        "name":"hwp_lint","arguments":{"path": fixture().to_string_lossy()}}}),
+    );
+    let call = recv("tools/call out-of-root");
+    assert_eq!(
+        call["result"]["isError"], true,
+        "루트 밖 경로가 거부되지 않음: {call}"
+    );
+
     drop(stdin);
     let deadline = Instant::now() + Duration::from_secs(30);
     loop {

--- a/crates/hwp-cli/tests/lint.rs
+++ b/crates/hwp-cli/tests/lint.rs
@@ -1,0 +1,461 @@
+//! `hwp lint` integration suite — the ROADMAP SC1 acceptance harness (plan
+//! 02.3-04). Every SC1 clause gets a named test: the full 10-rule table fires
+//! on an all-violations fixture, the 8 embedded templates stay silent, exit
+//! codes follow D-05, human output follows D-07, `--json` validates against the
+//! published hwp-lint-report-v1 schema (D-06), stdin works (D-08), and binary
+//! .hwpx input flows through the same engine with the D-02 note (D-01/D-02).
+//!
+//! CI-safe by construction: text fixtures written to per-test tmp dirs, .hwpx
+//! inputs generated via `hwp new --from` — no committed fixtures, no fonts, no
+//! network.
+
+use std::collections::BTreeSet;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+fn hwp() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_hwp"))
+}
+
+fn repo(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(relative)
+}
+
+fn test_dir(name: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!("hwp-cli-lint-{}-{name}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&path);
+    std::fs::create_dir_all(&path).unwrap();
+    path
+}
+
+/// The full rule table (ROADMAP SC1 + D-05).
+const ALL_RULES: [&str; 10] = [
+    "notation-date",
+    "notation-time",
+    "notation-money",
+    "notation-attach-colon",
+    "notation-attach-number",
+    "notation-end-dot",
+    "notation-punctuation",
+    "ai-style-marks",
+    "struct-item-mark",
+    "struct-roman-heading",
+];
+
+/// One §6-derived violation per rule ID, plus the sanctioned counter-examples
+/// that must stay silent (adopted research Open Question 6: inline `const
+/// &str`, no committed data file). The ASCII roman numeral is a paragraph, not
+/// a `#` heading — a heading acquires the profile's auto-number prefix
+/// (`**1. …**`) on the markdown→IR→markdown round-trip, which would mask the
+/// numeral from `struct-roman-heading` on binary input.
+const ALL_VIOLATIONS: &str = r"I. 사업 개요
+
+시행: 2020.7.8
+
+회의는 오후 3시 20분에 열립니다.
+
+예산: 345천원
+
+기간: 4. 23.~6. 15.
+
+원장:김갑동
+
+■ 주요 지시 사항
+
+가. 항목 내용
+
+**가. 항목**
+
+□ 개최 결과
+○ 참석 현황
+
+# Ⅰ. 개요
+
+제3.01.호에 따라 v2.05.1 기준을 적용합니다.
+
+참고: https://example.com/2020.7.8/notice 및 [공지](https://example.com/1985.09.06/x)입니다.
+
+| 항목 | 내용 |
+| --- | --- |
+| 날짜 | 2020.7.8 |
+| 시각 | 오후 3시 20분 |
+
+```
+2020.7.8
+오후 3시 20분
+```
+
+붙임: 계획서
+
+붙임  1. 계획서 1부
+
+끝
+";
+
+/// A warnings-only input (a single notation-date violation, no 공문서 marker,
+/// no error-severity rule).
+const WARNINGS_ONLY: &str = "날짜: 2020.7.8\n";
+
+/// Parses D-07 human output lines `{line}: {rule_id} — {message}`.
+fn findings(stdout: &str) -> Vec<(u32, String)> {
+    stdout
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| {
+            let (line_no, rest) = line
+                .split_once(": ")
+                .unwrap_or_else(|| panic!("line-number prefix missing: {line}"));
+            let (rule, _message) = rest
+                .split_once(" — ")
+                .unwrap_or_else(|| panic!("em-dash rule separator missing: {line}"));
+            (
+                line_no.parse().expect("numeric line prefix"),
+                rule.to_owned(),
+            )
+        })
+        .collect()
+}
+
+fn rule_ids(stdout: &str) -> BTreeSet<String> {
+    findings(stdout).into_iter().map(|(_, rule)| rule).collect()
+}
+
+fn all_rules() -> BTreeSet<String> {
+    ALL_RULES.iter().map(|s| (*s).to_owned()).collect()
+}
+
+/// `hwp lint <file>`; asserts the run itself succeeded.
+fn lint_ok(path: &Path) -> Output {
+    let out = hwp().arg("lint").arg(path).output().expect("hwp lint");
+    assert!(
+        out.status.success(),
+        "hwp lint {}: {}",
+        path.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out
+}
+
+/// Writes `content` to `name` inside `dir` and returns the path.
+fn write_md(dir: &Path, name: &str, content: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, content).unwrap();
+    path
+}
+
+/// Generates a .hwpx from markdown via `hwp new --from` (the in-test document
+/// factory — no committed binary fixtures).
+fn new_hwpx(md: &Path, out: &Path) {
+    let made = hwp()
+        .args(["new", "--from"])
+        .arg(md)
+        .arg("-o")
+        .arg(out)
+        .output()
+        .expect("hwp new");
+    assert!(
+        made.status.success(),
+        "hwp new --from {}: {}",
+        md.display(),
+        String::from_utf8_lossy(&made.stderr)
+    );
+}
+
+/// The published hwp-lint-report-v1 schema as a compiled validator (D-06).
+fn lint_report_validator() -> jsonschema::Validator {
+    let schema: serde_json::Value =
+        serde_json::from_str(include_str!("../../../schemas/lint-report-v1.schema.json")).unwrap();
+    jsonschema::options()
+        .with_draft(jsonschema::Draft::Draft202012)
+        .build(&schema)
+        .unwrap()
+}
+
+#[test]
+fn fires_every_rule() {
+    let dir = test_dir("fires-every-rule");
+    let md = write_md(&dir, "all-violations.md", ALL_VIOLATIONS);
+
+    let out = lint_ok(&md);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        rule_ids(&stdout),
+        all_rules(),
+        "every rule in the table fires on the all-violations fixture:\n{stdout}"
+    );
+
+    // Per-rule counts pin the sanctioned counter-examples silent: the URLs
+    // (inline + bare), 제3.01.호, v2.05.1, the `| --- |` table and the fenced
+    // code block add nothing; the `□ `/`○ ` ladder and the U+2160 heading add
+    // nothing; the bold-wrapped `**가. 항목**` yields exactly one finding.
+    let mut counts: std::collections::BTreeMap<String, usize> = Default::default();
+    for (_, rule) in findings(&stdout) {
+        *counts.entry(rule).or_default() += 1;
+    }
+    let count = |rule: &str| counts.get(rule).copied().unwrap_or(0);
+    assert_eq!(count("notation-date"), 1, "URL/ho-citation/version masks");
+    assert_eq!(count("notation-time"), 1, "table/code blocks stay silent");
+    assert_eq!(count("notation-money"), 1);
+    assert_eq!(
+        count("notation-punctuation"),
+        2,
+        "tilde range + tight colon"
+    );
+    assert_eq!(count("ai-style-marks"), 1, "□ /○ ladder stays silent");
+    assert_eq!(
+        count("struct-item-mark"),
+        2,
+        "typed mark + exactly one bold-wrapped mark"
+    );
+    assert_eq!(
+        count("struct-roman-heading"),
+        1,
+        "U+2160 heading stays silent"
+    );
+    assert_eq!(count("notation-attach-colon"), 1);
+    assert_eq!(
+        count("notation-attach-number"),
+        2,
+        "typed `1.` + `1부` quantity"
+    );
+    assert_eq!(count("notation-end-dot"), 1);
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn silent_on_embedded_templates() {
+    let templates_dir = repo("skills/hwp/templates");
+    let mut templates: Vec<PathBuf> = std::fs::read_dir(&templates_dir)
+        .unwrap()
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "md"))
+        .collect();
+    templates.sort();
+    assert_eq!(
+        templates.len(),
+        8,
+        "the embedded template corpus is exactly 8 files: {templates:?}"
+    );
+    for template in templates {
+        let out = lint_ok(&template);
+        assert!(
+            out.stdout.is_empty(),
+            "{}: zero findings expected, got:\n{}",
+            template.display(),
+            String::from_utf8_lossy(&out.stdout)
+        );
+    }
+}
+
+#[test]
+fn exit_code_policy() {
+    let dir = test_dir("exit-code-policy");
+    let all = write_md(&dir, "all-violations.md", ALL_VIOLATIONS);
+    let warnings = write_md(&dir, "warnings-only.md", WARNINGS_ONLY);
+
+    // D-05: findings are advisory — the default run exits 0 even with
+    // error-severity findings present.
+    let default = hwp().arg("lint").arg(&all).output().unwrap();
+    assert!(
+        default.status.success(),
+        "default exits 0 with findings present: {}",
+        String::from_utf8_lossy(&default.stderr)
+    );
+
+    // --strict exits 1 only when an error-severity finding exists (the
+    // fixture carries struct-item-mark and struct-roman-heading).
+    let strict = hwp().args(["lint", "--strict"]).arg(&all).output().unwrap();
+    assert!(
+        !strict.status.success(),
+        "--strict exits 1 on error-severity findings"
+    );
+
+    // --strict with warnings only still exits 0.
+    let strict_warnings = hwp()
+        .args(["lint", "--strict"])
+        .arg(&warnings)
+        .output()
+        .unwrap();
+    assert!(
+        strict_warnings.status.success(),
+        "--strict exits 0 on warnings-only input: {}",
+        String::from_utf8_lossy(&strict_warnings.stderr)
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn json_matches_schema_v1() {
+    let dir = test_dir("json-schema");
+    let validator = lint_report_validator();
+
+    // Markdown input — findings carry no `context` (no conversion involved).
+    let md = write_md(&dir, "all-violations.md", ALL_VIOLATIONS);
+    let out = hwp()
+        .args(["lint", "--json"])
+        .arg(&md)
+        .output()
+        .expect("hwp lint --json");
+    assert!(out.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert!(
+        validator.is_valid(&value),
+        "schema rejected markdown report: {value}"
+    );
+    assert_eq!(value["contract"], "hwp-lint-report-v1");
+    assert_eq!(value["schema_version"], "1.0");
+    let md_findings = value["findings"].as_array().unwrap();
+    assert!(!md_findings.is_empty());
+    for finding in md_findings {
+        assert!(
+            finding.get("context").is_none(),
+            "markdown findings carry no context: {finding}"
+        );
+    }
+
+    // Generated .hwpx input — every finding carries the D-02 context note.
+    let hwpx = dir.join("all-violations.hwpx");
+    new_hwpx(&md, &hwpx);
+    let out = hwp()
+        .args(["lint", "--json"])
+        .arg(&hwpx)
+        .output()
+        .expect("hwp lint --json");
+    assert!(out.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert!(
+        validator.is_valid(&value),
+        "schema rejected binary report: {value}"
+    );
+    let bin_findings = value["findings"].as_array().unwrap();
+    assert!(!bin_findings.is_empty());
+    for finding in bin_findings {
+        assert!(
+            finding["context"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("markdown 변환 경유"),
+            "binary findings carry the D-02 note: {finding}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn human_output_format() {
+    let dir = test_dir("human-output-format");
+    let md = write_md(&dir, "all-violations.md", ALL_VIOLATIONS);
+
+    let out = lint_ok(&md);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(!stdout.is_empty(), "the fixture produces findings");
+
+    // D-07: every line is `{line}: {rule_id} — {message}`, line numbers
+    // ascending, no headers or context lines.
+    let mut previous = 0;
+    for line in stdout.lines() {
+        let (line_no, rest) = line
+            .split_once(": ")
+            .unwrap_or_else(|| panic!("line must start with `N: `: {line}"));
+        let number: u32 = line_no
+            .parse()
+            .unwrap_or_else(|_| panic!("numeric line prefix: {line}"));
+        let (rule, message) = rest
+            .split_once(" — ")
+            .unwrap_or_else(|| panic!("`rule — message` shape: {line}"));
+        assert!(
+            !rule.is_empty() && rule.bytes().all(|b| b.is_ascii_lowercase() || b == b'-'),
+            "kebab-case rule id: {line}"
+        );
+        assert!(!message.is_empty(), "non-empty message: {line}");
+        assert!(
+            number >= previous,
+            "ascending line order: {number} after {previous}"
+        );
+        previous = number;
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn stdin_markdown() {
+    let dir = test_dir("stdin-markdown");
+    let md = write_md(&dir, "all-violations.md", ALL_VIOLATIONS);
+
+    // D-08: `hwp lint -` lints piped stdin as markdown; the findings match
+    // the file run exactly (human output carries no file name).
+    let file_run = lint_ok(&md);
+    let mut child = hwp()
+        .args(["lint", "-"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("hwp lint -");
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(ALL_VIOLATIONS.as_bytes())
+        .unwrap();
+    let piped = child.wait_with_output().unwrap();
+    assert!(
+        piped.status.success(),
+        "stdin run exits 0: {}",
+        String::from_utf8_lossy(&piped.stderr)
+    );
+    assert_eq!(
+        piped.stdout, file_run.stdout,
+        "stdin findings match the file run"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
+fn binary_input_via_markdown() {
+    let dir = test_dir("binary-input");
+    let md = write_md(&dir, "all-violations.md", ALL_VIOLATIONS);
+    let hwpx = dir.join("all-violations.hwpx");
+    new_hwpx(&md, &hwpx);
+
+    // D-01: one engine, two feeders — the binary input fires the same rule
+    // table through the shared load_document → to_markdown_with read path.
+    let out = lint_ok(&hwpx);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(
+        rule_ids(&stdout),
+        all_rules(),
+        "binary input fires every rule via markdown conversion:\n{stdout}"
+    );
+
+    // D-02: every JSON finding carries the via-markdown-conversion context.
+    let out = hwp()
+        .args(["lint", "--json"])
+        .arg(&hwpx)
+        .output()
+        .expect("hwp lint --json");
+    assert!(out.status.success());
+    let value: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    let bin_findings = value["findings"].as_array().unwrap();
+    assert!(!bin_findings.is_empty());
+    for finding in bin_findings {
+        assert!(
+            finding["context"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("markdown 변환 경유"),
+            "D-02 context on every finding: {finding}"
+        );
+    }
+
+    let _ = std::fs::remove_dir_all(&dir);
+}

--- a/crates/hwp-convert/Cargo.toml
+++ b/crates/hwp-convert/Cargo.toml
@@ -11,6 +11,7 @@ hwp-model = { workspace = true }
 serde_json = { workspace = true }
 pulldown-cmark = { workspace = true }
 quick-xml = { workspace = true }
+regex = { workspace = true }
 resvg = { workspace = true }
 image = { workspace = true }
 zip = { workspace = true }

--- a/crates/hwp-convert/src/lib.rs
+++ b/crates/hwp-convert/src/lib.rs
@@ -12,6 +12,7 @@ pub mod from_markdown;
 pub mod gso;
 pub mod html;
 pub mod image;
+pub mod lint;
 pub mod markdown;
 pub mod merge;
 pub mod odt;

--- a/crates/hwp-convert/src/lint.rs
+++ b/crates/hwp-convert/src/lint.rs
@@ -228,4 +228,169 @@ mod tests {
             lint_markdown(md, LintProfile::Report)
         );
     }
+
+    // ---- Task 1: notation families + ai-style-marks + bare-URL mask ----
+
+    fn only_rule(md: &str, rule_id: &str) -> Vec<Finding> {
+        let findings = lint(md);
+        for f in &findings {
+            assert_eq!(f.rule_id, rule_id, "unexpected rule in {md:?}: {findings:?}");
+        }
+        findings
+    }
+
+    #[test]
+    fn notation_time_fires_on_meridiem_and_single_digit_hour() {
+        let findings = only_rule("일시: 오후 3시 20분\n", "notation-time");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(findings[0].severity, Severity::Warning);
+        let findings = only_rule("회의는 8:09에 시작합니다\n", "notation-time");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+    }
+
+    #[test]
+    fn notation_time_silent_on_canonical_24h_forms() {
+        for md in ["일시: 15:20\n", "일시: 08:09\n", "15:20∼17:00\n"] {
+            assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+        }
+    }
+
+    #[test]
+    fn notation_money_fires_on_abstract_thousand_and_missing_reading() {
+        let findings = only_rule("비용: 345천원\n", "notation-money");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        let findings = only_rule("금액은 금113,560원이다\n", "notation-money");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+    }
+
+    #[test]
+    fn notation_money_silent_on_canonical_amounts() {
+        for md in [
+            "금113,560원(금일십일만삼천오백육십원)\n",
+            "참석 50여 명\n",
+            "34만 5천 원\n",
+        ] {
+            assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+        }
+    }
+
+    #[test]
+    fn notation_attach_colon_fires_on_line_initial_colon() {
+        let findings = only_rule("붙임: 계획서 1부.  끝.\n", "notation-attach-colon");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(findings[0].line, 1);
+        assert_eq!(findings[0].col, 1);
+    }
+
+    #[test]
+    fn notation_attach_colon_silent_in_prose() {
+        for md in [
+            "자세한 내용은 붙임 파일을 참고하시기 바랍니다.\n",
+            "붙임  계획서 1부.  끝.\n",
+        ] {
+            assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+        }
+    }
+
+    #[test]
+    fn notation_attach_number_fires_on_single_number_and_missing_period() {
+        // One attachment must not carry the `1.` number (inline form).
+        let findings = only_rule("붙임  1. 계획서 1부.  끝.\n", "notation-attach-number");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        // One attachment in list form: the single-item ordered list is the
+        // typed `1.` number.
+        let findings = only_rule("붙임\n\n1. 계획서 1부.\n", "notation-attach-number");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        // Quantity missing the final period.
+        let findings = only_rule("붙임  계획서 1부\n", "notation-attach-number");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+    }
+
+    #[test]
+    fn notation_attach_number_silent_on_ladder_and_canonical_single() {
+        for md in [
+            // Two or more attachments keep the 1. 2. ladder.
+            "붙임  1. 계획서 1부.\n      2. 서류 1부.  끝.\n",
+            "붙임\n\n1. 계획서 1부.\n2. 서류 1부.\n",
+            // One attachment, unnumbered, quantity closed by a period.
+            "붙임  계획서 1부.  끝.\n",
+        ] {
+            assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+        }
+    }
+
+    #[test]
+    fn notation_end_dot_fires_when_gongmun_marker_present() {
+        let findings = only_rule("붙임  계획서 1부.  끝\n", "notation-end-dot");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        let findings = only_rule("수신  교육부장관\n\n협조하여 주시기 바랍니다.  끝\n", "notation-end-dot");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+    }
+
+    #[test]
+    fn notation_end_dot_silent_without_markers() {
+        for md in [
+            "메모: 오늘 회의 끝\n",
+            "붙임  계획서 1부.  끝.\n",
+            "회의가 끝나는 대로 공유\n",
+        ] {
+            assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+        }
+    }
+
+    #[test]
+    fn notation_punctuation_fires_on_keyboard_tilde_and_tight_colon() {
+        let findings = only_rule("기간: 2026. 4. 23.~2026. 6. 15.\n", "notation-punctuation");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        let findings = only_rule("원장:김갑동\n", "notation-punctuation");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+    }
+
+    #[test]
+    fn notation_punctuation_silent_on_canonical_forms() {
+        for md in ["기간: 2026. 4. 23.∼2026. 6. 15.\n", "원장: 김갑동\n"] {
+            assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+        }
+    }
+
+    #[test]
+    fn ai_style_marks_fires_on_decorative_leading_symbols() {
+        for md in ["■ 사업 개요\n", "▶ 추진 방향\n", "※ 참고 사항\n"] {
+            let findings = only_rule(md, "ai-style-marks");
+            assert_eq!(findings.len(), 1, "{md:?} -> {findings:?}");
+            assert_eq!(findings[0].severity, Severity::Warning);
+        }
+    }
+
+    #[test]
+    fn ai_style_marks_silent_on_sanctioned_marks() {
+        for md in [
+            "□ 회의 명칭\n\n○ 안건\n",
+            "★ 발의자 홍길동\n",
+            "- 목록 항목\n",
+        ] {
+            assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+        }
+    }
+
+    #[test]
+    fn fp_guard_url_bare() {
+        // A bare URL is plain Text (pulldown-cmark 0.13.4 has no GFM
+        // autolinking); the bounded mask keeps every rule silent on it.
+        let md = "참고: https://example.go.kr/2026.8.20/notice 입니다\n";
+        assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+        let md = "https://example.go.kr/2026.8.20/notice\n";
+        assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+    }
+
+    #[test]
+    fn fp_guard_url_inline() {
+        // Inline-link destinations and `<…>` autolinks are structurally safe.
+        for md in [
+            "[공고문](https://example.go.kr/2026.8.20/notice)\n",
+            "<https://example.go.kr/2026.8.20/notice>\n",
+        ] {
+            assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+        }
+    }
 }

--- a/crates/hwp-convert/src/lint.rs
+++ b/crates/hwp-convert/src/lint.rs
@@ -6,12 +6,22 @@
 //! line heuristics. Both lint profiles run the same rule table in v1 (D-04); the
 //! profile enum exists so calibration can diverge later without breaking the CLI.
 //!
-//! Findings carry rule id, severity, 1-based line and character-based column, and an
-//! advisory Korean message only — never source-text excerpts (T-02.3-04).
+//! Rule table (ROADMAP SC1 + D-05): `notation-date`, `notation-time`,
+//! `notation-money`, `notation-attach-colon`, `notation-attach-number`,
+//! `notation-end-dot`, `notation-punctuation` and `ai-style-marks` at warning
+//! severity; `struct-item-mark` and `struct-roman-heading` are the only two
+//! error-severity rules.
+//!
+//! Detection runs per text block (paragraph or heading): the block's Text events
+//! are concatenated with a source-offset map, so rules can anchor at line starts
+//! and still report exact positions. Findings carry rule id, severity, 1-based
+//! line and character-based column, and an advisory Korean message only — never
+//! source-text excerpts (T-02.3-04).
 
+use std::ops::Range;
 use std::sync::LazyLock;
 
-use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{Event, LinkType, Options, Parser, Tag, TagEnd};
 use regex::Regex;
 
 /// A lint profile (D-03). Both variants run the same rule table in v1 (D-04).
@@ -62,6 +72,27 @@ pub struct Finding {
     pub message: String,
 }
 
+// Rule IDs (kebab-case, stable — echoed into the hwp-lint-report-v1 JSON report).
+const RULE_NOTATION_DATE: &str = "notation-date";
+const RULE_NOTATION_TIME: &str = "notation-time";
+const RULE_NOTATION_MONEY: &str = "notation-money";
+const RULE_NOTATION_ATTACH_COLON: &str = "notation-attach-colon";
+const RULE_NOTATION_ATTACH_NUMBER: &str = "notation-attach-number";
+const RULE_NOTATION_END_DOT: &str = "notation-end-dot";
+const RULE_NOTATION_PUNCTUATION: &str = "notation-punctuation";
+const RULE_AI_STYLE_MARKS: &str = "ai-style-marks";
+const RULE_STRUCT_ITEM_MARK: &str = "struct-item-mark";
+const RULE_STRUCT_ROMAN_HEADING: &str = "struct-roman-heading";
+
+/// D-05 severity split: exactly the two structure rules are error-severity;
+/// every notation rule and ai-style-marks is a warning.
+fn severity_of(rule_id: &str) -> Severity {
+    match rule_id {
+        RULE_STRUCT_ITEM_MARK | RULE_STRUCT_ROMAN_HEADING => Severity::Error,
+        _ => Severity::Warning,
+    }
+}
+
 /// Candidate date span: `YYYY. M. D.` with optional spaces and optional final
 /// period. The canonical form is `YYYY. M. D.` (space after each period, mandatory
 /// final period, no leading zeros) per the 2020 행정업무운영 편람 표기법
@@ -70,9 +101,130 @@ pub struct Finding {
 static DATE_CANDIDATE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(\d{4})\. ?(\d{1,2})\. ?(\d{1,2})\.?").unwrap());
 
-/// Advisory message — cites the 편람 표기법, never statutory-violation wording and
-/// never a source-text excerpt (T-02.3-04).
+/// Bounded bare-URL mask — the single sanctioned textual exception to D-01's
+/// structural-only framing (adopted research Open Question 5). pulldown-cmark
+/// 0.13.4 does not GFM-autolink bare URLs, so they arrive as plain Text events
+/// and would otherwise fire the notation rules (`…/2026.8.20/…` dates,
+/// `http://…:8080` colons). Inline links and `<…>` autolinks are structurally
+/// safe (the destination is never a Text event; autolink text is skipped in the
+/// walk). `\S+` keeps the scan linear (T-02.3-03).
+static URL_MASK: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?:https?://|www\.)\S+").unwrap());
+
+/// `오전/오후 N시( N분)?` — the meridiem form must be rewritten as 24-hour
+/// `HH:MM` (§6 시각).
+static TIME_MERIDIEM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?:오전|오후)\s*\d{1,2}\s*시(?:\s*\d{1,2}\s*분)?").unwrap());
+/// `H:MM` candidate; the leading zero is mandatory (`08:09`), so only a bare
+/// single-digit hour fires. Two-digit hours are filtered after the match.
+static TIME_HM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(\d{1,2}):(\d{2})").unwrap());
+
+/// `345천원`-style abstract thousand-units (§6 금액).
+static MONEY_ABBR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\d+천원").unwrap());
+/// `금NNN,NNN원` candidate; silent only when the alteration-proof Korean reading
+/// `(금…원)` follows immediately (§6 금액).
+static MONEY_GEUM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"금\d[\d,]*원").unwrap());
+
+/// Line whose first token is `붙임` followed by a colon (must be `붙임∨∨`, §6
+/// 붙임). Anchored at line starts so prose mentions of 붙임 never fire.
+static ATTACH_COLON: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?m)^붙임[ \t]*:").unwrap());
+/// Paragraph opening an attachment block: first token `붙임` with no colon.
+static ATTACH_START: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^붙임(?:\s|$)").unwrap());
+/// Attachment quantity candidate; silent only when closed by a period (`1부.`).
+static ATTACH_QUANTITY: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\d+부").unwrap());
+/// The `끝` end-mark candidate; followed by `.` it is the canonical `끝.`.
+static END_MARK: LazyLock<Regex> = LazyLock::new(|| Regex::new("끝").unwrap());
+/// 공문서 markers that scope notation-end-dot (adopted research A5): a 붙임 line
+/// or a 수신/시행 line. Plain markdown notes never match, so they stay silent.
+static GONGMUN_MARKER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?:붙임|수신|시행)(?:[\s:]|$)").unwrap());
+/// 쌍점 candidate: a colon directly after a Hangul word. The rule requires one
+/// space after the colon (`원장: 김갑동`), so a non-space follower fires.
+static PUNCT_COLON: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[가-힣]:").unwrap());
+/// Minimal line-leading decorative set (adopted research A1). `□ `/`○ `
+/// paragraph starts are the sanctioned ladder (markdown contract §1,
+/// skills/hwp/templates/minutes.md) and `★` is statutory before 직위
+/// (시행규칙 제6조제1항), so neither is in the set.
+static AI_STYLE_MARK: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?m)^[■▶▲◆●※]").unwrap());
+
+/// Advisory messages — cite the rule source with its confidence tag, never
+/// statutory-violation wording beyond the tag and never a source-text excerpt
+/// (T-02.3-04).
 const NOTATION_DATE_MESSAGE: &str = "날짜는 `2026. 6. 19.`처럼 표기합니다 (마침표 뒤 한 칸, 마지막 마침표 필수, 앞자리 0 제거) — 행정업무운영 편람 표기법";
+const NOTATION_TIME_MESSAGE: &str = "시각은 `15:20`처럼 24시간제 `HH:MM`으로 표기합니다 (한 자리 시간도 `08:09`처럼 0을 채웁니다) — 행정업무운영 편람 표기법";
+const NOTATION_MONEY_ABBR_MESSAGE: &str = "`345천원` 같은 천 단위 표기는 `345,000원` 또는 `34만 5천 원`처럼 표기합니다 — 행정업무운영 편람 표기법";
+const NOTATION_MONEY_READING_MESSAGE: &str = "금액은 `금113,560원(금일십일만삼천오백육십원)`처럼 한글 금액을 괄호 안에 병기합니다 — 행정업무운영 편람 표기법";
+const NOTATION_ATTACH_COLON_MESSAGE: &str =
+    "`붙임` 뒤에는 쌍점(:)을 붙이지 않고 두 칸을 띄워 씁니다 — 행정업무운영 편람 표기법";
+const NOTATION_ATTACH_NUMBER_MESSAGE: &str =
+    "붙임이 하나일 때는 번호 `1.`을 붙이지 않습니다 — 행정업무운영 편람 표기법";
+const NOTATION_ATTACH_QUANTITY_MESSAGE: &str =
+    "붙임 수량은 `1부.`처럼 마침표로 닫습니다 — 행정업무운영 편람 표기법";
+const NOTATION_END_DOT_MESSAGE: &str =
+    "공문서 끝에는 `끝.`처럼 마침표를 붙입니다 — 행정업무운영 편람 표기법";
+const NOTATION_PUNCT_TILDE_MESSAGE: &str =
+    "범위에는 키보드 `~` 대신 물결표 `∼`를 사용합니다 — 행정업무운영 편람 표기법";
+const NOTATION_PUNCT_COLON_MESSAGE: &str =
+    "쌍점(:)은 앞말에 붙이고 뒤에 한 칸을 띄웁니다 (`원장: 김갑동`) — 행정업무운영 편람 표기법";
+const AI_STYLE_MARKS_MESSAGE: &str =
+    "장식 기호(■ ▶ ▲ ◆ ● ※)로 항목을 시작하지 말고 공문서 항목 기호(□ ○)나 중첩 목록을 사용합니다";
+
+/// One linted text block: a paragraph or heading at structural depth 0, with
+/// its Text events concatenated (`text`), a per-segment source-offset map
+/// (`segs`: concat byte offset → source byte offset) and the masked URL spans
+/// (`masked`, concat byte ranges) that notation rules must skip.
+struct Para {
+    text: String,
+    segs: Vec<(usize, usize)>,
+    masked: Vec<Range<usize>>,
+    in_heading: bool,
+    /// Inside a 붙임 block: the 붙임 paragraph itself or an item of the
+    /// attachment list that immediately follows it.
+    attach_entry: bool,
+}
+
+impl Para {
+    fn new(in_heading: bool) -> Self {
+        Self {
+            text: String::new(),
+            segs: Vec::new(),
+            masked: Vec::new(),
+            in_heading,
+            attach_entry: false,
+        }
+    }
+
+    /// Append one Text event, masking bare-URL spans (the bounded D-01
+    /// exception — see `URL_MASK`).
+    fn push_text(&mut self, text: &str, source_start: usize) {
+        let base = self.text.len();
+        for m in URL_MASK.find_iter(text) {
+            self.masked.push((base + m.start())..(base + m.end()));
+        }
+        self.segs.push((base, source_start));
+        self.text.push_str(text);
+    }
+
+    /// Append a synthetic line break for a soft/hard break so rules can anchor
+    /// at line starts within a paragraph.
+    fn push_break(&mut self, source_start: usize) {
+        self.segs.push((self.text.len(), source_start));
+        self.text.push('\n');
+    }
+
+    /// Map a concat byte offset back to a source byte offset.
+    fn source_offset(&self, concat_idx: usize) -> usize {
+        let i = self
+            .segs
+            .partition_point(|&(concat_start, _)| concat_start <= concat_idx);
+        let (concat_start, source_start) = self.segs[i - 1];
+        source_start + (concat_idx - concat_start)
+    }
+
+    /// True when the `[start, end)` concat span intersects a masked URL span.
+    fn masked_overlap(&self, start: usize, end: usize) -> bool {
+        self.masked.iter().any(|m| m.start < end && start < m.end)
+    }
+}
 
 /// Lint markdown text and return findings in ascending source order.
 ///
@@ -98,38 +250,274 @@ pub fn lint_markdown(markdown: &str, profile: LintProfile) -> Vec<Finding> {
         (idx as u32, col)
     };
 
+    let (paras, single_attach_lists) = collect_paras(markdown, options);
+
+    // notation-end-dot scope (adopted research A5): fire only in documents
+    // carrying a 공문서 marker (a 붙임 line or a 수신/시행 line) so plain
+    // markdown notes stay silent.
+    let has_gongmun_marker = paras.iter().any(|p| is_gongmun_marker(&p.text));
+
     let mut findings = Vec::new();
-    // Structural skip depth (D-01): Text inside code blocks, tables and HTML blocks
-    // is never linted; InlineHtml events are skipped outright.
+    for para in &paras {
+        if para.text.is_empty() {
+            continue;
+        }
+        lint_notation_date(para, &locate, &mut findings);
+        lint_notation_time(para, &locate, &mut findings);
+        lint_notation_money(para, &locate, &mut findings);
+        lint_notation_punctuation(para, &locate, &mut findings);
+        if has_gongmun_marker {
+            lint_notation_end_dot(para, &locate, &mut findings);
+        }
+        if !para.in_heading {
+            lint_notation_attach_colon(para, &locate, &mut findings);
+            lint_notation_attach_number(para, &locate, &mut findings);
+            lint_ai_style_marks(para, &locate, &mut findings);
+        }
+        if para.attach_entry {
+            lint_attach_quantity(para, &locate, &mut findings);
+        }
+    }
+    // A single-item ordered list right after a 붙임 paragraph is the typed `1.`
+    // number the rule forbids for a lone attachment.
+    for idx in single_attach_lists {
+        let para = &paras[idx];
+        push(
+            &mut findings,
+            RULE_NOTATION_ATTACH_NUMBER,
+            &locate,
+            para.source_offset(0),
+            NOTATION_ATTACH_NUMBER_MESSAGE,
+        );
+    }
+    // D-07: ascending source order regardless of rule evaluation order.
+    findings.sort_by_key(|f| (f.line, f.col));
+    findings
+}
+
+/// Walk the pulldown-cmark AST and collect the lintable text blocks plus the
+/// paragraph indices of single-item ordered attachment lists (the typed `1.`
+/// number forbidden for a lone attachment).
+fn collect_paras(markdown: &str, options: Options) -> (Vec<Para>, Vec<usize>) {
+    let mut paras: Vec<Para> = Vec::new();
+    let mut single_attach_lists: Vec<usize> = Vec::new();
+    // Structural skip depth (D-01): Text inside code blocks, tables and HTML
+    // blocks is never linted; InlineHtml events never reach a block's text.
     let mut skip_depth: u32 = 0;
+    let mut item_depth: u32 = 0;
+    let mut list_depth: u32 = 0;
+    // `<…>` autolinks and `<addr>` email autolinks carry their URL as the link
+    // text; that text is never prose, so it is skipped structurally.
+    let mut autolink_depth: u32 = 0;
+    let mut link_stack: Vec<bool> = Vec::new();
+    let mut cur: Option<Para> = None;
+    // 붙임 block tracking: a paragraph opening with the `붙임` token starts an
+    // attachment block; a list immediately following it is the attachment
+    // ladder and its items are linted for quantity periods and counted for the
+    // single-attachment number rule.
+    let mut pending_attach = false;
+    let mut attach_list = false;
+    let mut attach_list_depth: u32 = 0;
+    let mut attach_item_level: u32 = 0;
+    let mut attach_item_count: u32 = 0;
+    let mut attach_list_ordered = false;
+    let mut expect_first_attach_para = false;
+    let mut first_attach_para: Option<usize> = None;
+    // Tight list items carry their Text directly under the Item tag with no
+    // Paragraph wrapper; that text is collected in this implicit block and
+    // flushed at the next block boundary.
+    let mut implicit: Option<Para> = None;
+
     for (event, range) in Parser::new_ext(markdown, options).into_offset_iter() {
         match event {
             Event::Start(Tag::CodeBlock(_) | Tag::Table(_) | Tag::HtmlBlock) => {
+                flush_implicit(&mut implicit, &mut paras, &mut pending_attach);
                 skip_depth += 1;
+                pending_attach = false;
             }
             Event::End(TagEnd::CodeBlock | TagEnd::Table | TagEnd::HtmlBlock) => {
                 skip_depth = skip_depth.saturating_sub(1);
             }
-            Event::Text(text) if skip_depth == 0 => {
-                lint_notation_date(&text, range.start, &locate, &mut findings);
+            Event::Start(Tag::BlockQuote(_)) => {
+                flush_implicit(&mut implicit, &mut paras, &mut pending_attach);
+                pending_attach = false;
+            }
+            Event::Start(Tag::Heading { .. }) => {
+                flush_implicit(&mut implicit, &mut paras, &mut pending_attach);
+                pending_attach = false;
+                if skip_depth == 0 {
+                    cur = Some(Para::new(true));
+                }
+            }
+            Event::End(TagEnd::Heading(_)) => {
+                if let Some(para) = cur.take() {
+                    paras.push(para);
+                }
+            }
+            Event::Start(Tag::List(start)) => {
+                flush_implicit(&mut implicit, &mut paras, &mut pending_attach);
+                list_depth += 1;
+                if pending_attach {
+                    attach_list = true;
+                    attach_list_depth = list_depth;
+                    attach_item_level = item_depth + 1;
+                    attach_item_count = 0;
+                    attach_list_ordered = start.is_some();
+                    first_attach_para = None;
+                    pending_attach = false;
+                }
+            }
+            Event::End(TagEnd::List(_)) => {
+                if attach_list && list_depth == attach_list_depth {
+                    if attach_list_ordered
+                        && attach_item_count == 1
+                        && let Some(idx) = first_attach_para
+                    {
+                        single_attach_lists.push(idx);
+                    }
+                    attach_list = false;
+                }
+                list_depth = list_depth.saturating_sub(1);
+            }
+            Event::Start(Tag::Item) => {
+                flush_implicit(&mut implicit, &mut paras, &mut pending_attach);
+                item_depth += 1;
+                if attach_list && item_depth == attach_item_level {
+                    attach_item_count += 1;
+                    expect_first_attach_para = attach_item_count == 1;
+                }
+            }
+            Event::End(TagEnd::Item) => {
+                flush_implicit(&mut implicit, &mut paras, &mut pending_attach);
+                item_depth = item_depth.saturating_sub(1);
+            }
+            Event::Start(Tag::Paragraph) => {
+                flush_implicit(&mut implicit, &mut paras, &mut pending_attach);
+                // A non-list block after the 붙임 paragraph closes the block.
+                pending_attach = false;
+                if skip_depth == 0 {
+                    let mut para = Para::new(false);
+                    if attach_list && item_depth == attach_item_level {
+                        para.attach_entry = true;
+                        if expect_first_attach_para {
+                            first_attach_para = Some(paras.len());
+                            expect_first_attach_para = false;
+                        }
+                    }
+                    cur = Some(para);
+                }
+            }
+            Event::End(TagEnd::Paragraph) => {
+                if let Some(mut para) = cur.take() {
+                    if is_attach_start(&para.text) {
+                        para.attach_entry = true;
+                        pending_attach = true;
+                    }
+                    paras.push(para);
+                }
+            }
+            Event::Start(Tag::Link { link_type, .. }) => {
+                let autolink = matches!(link_type, LinkType::Autolink | LinkType::Email);
+                if autolink {
+                    autolink_depth += 1;
+                }
+                link_stack.push(autolink);
+            }
+            Event::End(TagEnd::Link) => {
+                if link_stack.pop().unwrap_or(false) {
+                    autolink_depth = autolink_depth.saturating_sub(1);
+                }
+            }
+            Event::Text(text) => {
+                if skip_depth == 0 && autolink_depth == 0 {
+                    // Tight list items carry their Text directly under the Item
+                    // (no Paragraph wrapper) — collect it in an implicit block.
+                    if cur.is_none() && item_depth > 0 && implicit.is_none() {
+                        let mut para = Para::new(false);
+                        if attach_list && item_depth == attach_item_level {
+                            para.attach_entry = true;
+                            if expect_first_attach_para {
+                                first_attach_para = Some(paras.len());
+                                expect_first_attach_para = false;
+                            }
+                        }
+                        implicit = Some(para);
+                    }
+                    if let Some(para) = cur.as_mut().or(implicit.as_mut()) {
+                        para.push_text(&text, range.start);
+                    }
+                }
+            }
+            Event::SoftBreak | Event::HardBreak => {
+                if skip_depth == 0
+                    && let Some(para) = cur.as_mut().or(implicit.as_mut())
+                {
+                    para.push_break(range.start);
+                }
             }
             _ => {}
         }
     }
-    findings
+    (paras, single_attach_lists)
+}
+
+/// Push a collected tight-list-item block, applying the same 붙임-block
+/// classification as a real paragraph end.
+fn flush_implicit(implicit: &mut Option<Para>, paras: &mut Vec<Para>, pending_attach: &mut bool) {
+    if let Some(mut para) = implicit.take() {
+        if is_attach_start(&para.text) {
+            para.attach_entry = true;
+            *pending_attach = true;
+        }
+        paras.push(para);
+    }
+}
+
+/// Paragraph opening an attachment block (first token `붙임`, no colon).
+fn is_attach_start(text: &str) -> bool {
+    ATTACH_START.is_match(text)
+}
+/// Document-level 공문서 marker scoping notation-end-dot (adopted A5).
+fn is_gongmun_marker(text: &str) -> bool {
+    GONGMUN_MARKER.is_match(text)
+}
+
+fn is_hangul_syllable(c: char) -> bool {
+    ('가'..='힣').contains(&c)
+}
+
+/// Append one finding, deriving severity from the rule id (D-05).
+fn push(
+    findings: &mut Vec<Finding>,
+    rule_id: &'static str,
+    locate: &impl Fn(usize) -> (u32, u32),
+    source_offset: usize,
+    message: &str,
+) {
+    let (line, col) = locate(source_offset);
+    findings.push(Finding {
+        rule_id,
+        severity: severity_of(rule_id),
+        line,
+        col,
+        message: message.to_string(),
+    });
 }
 
 /// `notation-date` (warning): flag any date-like span that deviates from the
 /// canonical `YYYY. M. D.` form — missing spaces (`2020.7.8`), a missing final
 /// period (`2026. 8. 20`), or leading zeros (`1985.09.06.`).
 fn lint_notation_date(
-    text: &str,
-    base: usize,
+    para: &Para,
     locate: &impl Fn(usize) -> (u32, u32),
     findings: &mut Vec<Finding>,
 ) {
+    let text = &para.text;
     for caps in DATE_CANDIDATE.captures_iter(text) {
         let whole = caps.get(0).unwrap();
+        if para.masked_overlap(whole.start(), whole.end()) {
+            continue;
+        }
         // Guard: a digit on either side means a longer numeric run (e.g. the
         // `12026. 8. 20.` prefix or the `2020.7.8.1` 4-part version), not a date.
         let before = text[..whole.start()].bytes().next_back();
@@ -144,14 +532,276 @@ fn lint_notation_date(
         if whole.as_str() == canonical {
             continue;
         }
-        let (line, col) = locate(base + whole.start());
-        findings.push(Finding {
-            rule_id: "notation-date",
-            severity: Severity::Warning,
-            line,
-            col,
-            message: NOTATION_DATE_MESSAGE.to_string(),
-        });
+        push(
+            findings,
+            RULE_NOTATION_DATE,
+            locate,
+            para.source_offset(whole.start()),
+            NOTATION_DATE_MESSAGE,
+        );
+    }
+}
+
+/// `notation-time` (warning): meridiem forms (`오후 3시 20분`) and bare
+/// single-digit hours (`8:09`) must be rewritten as 24-hour `HH:MM` (`15:20`,
+/// `08:09`).
+fn lint_notation_time(
+    para: &Para,
+    locate: &impl Fn(usize) -> (u32, u32),
+    findings: &mut Vec<Finding>,
+) {
+    let text = &para.text;
+    for m in TIME_MERIDIEM.find_iter(text) {
+        if para.masked_overlap(m.start(), m.end()) {
+            continue;
+        }
+        push(
+            findings,
+            RULE_NOTATION_TIME,
+            locate,
+            para.source_offset(m.start()),
+            NOTATION_TIME_MESSAGE,
+        );
+    }
+    for caps in TIME_HM.captures_iter(text) {
+        let whole = caps.get(0).unwrap();
+        // Canonical `HH:MM` keeps the leading zero; only a bare single-digit
+        // hour violates the form.
+        if caps[1].len() != 1 || para.masked_overlap(whole.start(), whole.end()) {
+            continue;
+        }
+        // Guard: digits or colons on either side mean a longer numeric/time
+        // run, not an `H:MM` time.
+        let before = text[..whole.start()].bytes().next_back();
+        let after = text[whole.end()..].bytes().next();
+        if before.is_some_and(|b| b.is_ascii_digit() || b == b':')
+            || after.is_some_and(|b| b.is_ascii_digit() || b == b':')
+        {
+            continue;
+        }
+        push(
+            findings,
+            RULE_NOTATION_TIME,
+            locate,
+            para.source_offset(whole.start()),
+            NOTATION_TIME_MESSAGE,
+        );
+    }
+}
+
+/// `notation-money` (warning): abstract thousand-units (`345천원` → `345,000원`
+/// or `34만 5천 원`) and `금NNN,NNN원` without the alteration-proof Korean
+/// reading `(금…원)` in parentheses.
+fn lint_notation_money(
+    para: &Para,
+    locate: &impl Fn(usize) -> (u32, u32),
+    findings: &mut Vec<Finding>,
+) {
+    let text = &para.text;
+    for m in MONEY_ABBR.find_iter(text) {
+        if para.masked_overlap(m.start(), m.end()) {
+            continue;
+        }
+        push(
+            findings,
+            RULE_NOTATION_MONEY,
+            locate,
+            para.source_offset(m.start()),
+            NOTATION_MONEY_ABBR_MESSAGE,
+        );
+    }
+    for m in MONEY_GEUM.find_iter(text) {
+        if para.masked_overlap(m.start(), m.end()) {
+            continue;
+        }
+        // Silent only when the Korean reading follows immediately.
+        if text[m.end()..].starts_with("(금") {
+            continue;
+        }
+        push(
+            findings,
+            RULE_NOTATION_MONEY,
+            locate,
+            para.source_offset(m.start()),
+            NOTATION_MONEY_READING_MESSAGE,
+        );
+    }
+}
+
+/// `notation-attach-colon` (warning): a line whose first token is `붙임` must
+/// not carry a colon. Line-start anchoring keeps prose mentions of 붙임 silent.
+fn lint_notation_attach_colon(
+    para: &Para,
+    locate: &impl Fn(usize) -> (u32, u32),
+    findings: &mut Vec<Finding>,
+) {
+    for m in ATTACH_COLON.find_iter(&para.text) {
+        push(
+            findings,
+            RULE_NOTATION_ATTACH_COLON,
+            locate,
+            para.source_offset(m.start()),
+            NOTATION_ATTACH_COLON_MESSAGE,
+        );
+    }
+}
+
+/// `notation-attach-number` (warning), paragraph form: a 붙임 block with
+/// exactly one entry must not carry the `1.` number (two or more keep the
+/// `1. 2.` ladder). Conservative by design — only the unambiguous single-entry
+/// case fires. The list form is detected in `collect_paras`.
+fn lint_notation_attach_number(
+    para: &Para,
+    locate: &impl Fn(usize) -> (u32, u32),
+    findings: &mut Vec<Finding>,
+) {
+    if !is_attach_start(&para.text) {
+        return;
+    }
+    let mut lines = para.text.split('\n');
+    let first = lines.next().unwrap_or_default();
+    let rest = first["붙임".len()..].trim();
+    let mut entries = vec![rest];
+    for line in lines {
+        let t = line.trim();
+        if !t.is_empty() {
+            entries.push(t);
+        }
+    }
+    entries.retain(|e| !e.is_empty());
+    if entries.len() == 1
+        && entries[0].starts_with("1.")
+        && let Some(idx) = para.text.find("1.")
+    {
+        push(
+            findings,
+            RULE_NOTATION_ATTACH_NUMBER,
+            locate,
+            para.source_offset(idx),
+            NOTATION_ATTACH_NUMBER_MESSAGE,
+        );
+    }
+}
+
+/// `notation-attach-number` (warning), quantity form: inside a 붙임 block the
+/// quantity must be closed by a period (`1부.`).
+fn lint_attach_quantity(
+    para: &Para,
+    locate: &impl Fn(usize) -> (u32, u32),
+    findings: &mut Vec<Finding>,
+) {
+    for m in ATTACH_QUANTITY.find_iter(&para.text) {
+        if para.masked_overlap(m.start(), m.end()) {
+            continue;
+        }
+        if para.text[m.end()..].starts_with('.') {
+            continue;
+        }
+        push(
+            findings,
+            RULE_NOTATION_ATTACH_NUMBER,
+            locate,
+            para.source_offset(m.start()),
+            NOTATION_ATTACH_QUANTITY_MESSAGE,
+        );
+    }
+}
+
+/// `notation-end-dot` (warning): a `끝` end mark without its period. Runs only
+/// in documents carrying a 공문서 marker (adopted research A5).
+fn lint_notation_end_dot(
+    para: &Para,
+    locate: &impl Fn(usize) -> (u32, u32),
+    findings: &mut Vec<Finding>,
+) {
+    for m in END_MARK.find_iter(&para.text) {
+        if para.masked_overlap(m.start(), m.end()) {
+            continue;
+        }
+        match para.text[m.end()..].chars().next() {
+            // Canonical `끝.`.
+            Some('.') => {}
+            // Part of a longer word (끝내다, 끝까지) — not the end mark.
+            Some(c) if is_hangul_syllable(c) => {}
+            _ => push(
+                findings,
+                RULE_NOTATION_END_DOT,
+                locate,
+                para.source_offset(m.start()),
+                NOTATION_END_DOT_MESSAGE,
+            ),
+        }
+    }
+}
+
+/// `notation-punctuation` (warning): keyboard `~` inside a date/number range
+/// (the 물결표 `∼` is correct) and a 쌍점 without the required following space
+/// (`원장:김갑동` → `원장: 김갑동`).
+fn lint_notation_punctuation(
+    para: &Para,
+    locate: &impl Fn(usize) -> (u32, u32),
+    findings: &mut Vec<Finding>,
+) {
+    let text = &para.text;
+    for (idx, _) in text.match_indices('~') {
+        if para.masked_overlap(idx, idx + 1) {
+            continue;
+        }
+        // Fire only inside a date/number range — a digit or period on both
+        // sides. Strikethrough markers never reach Text events, and `~` with
+        // spaces or at a boundary is not a range.
+        let range_edge = |c: Option<char>| c.is_some_and(|c| c.is_ascii_digit() || c == '.');
+        let prev = text[..idx].chars().next_back();
+        let next = text[idx + 1..].chars().next();
+        if range_edge(prev) && range_edge(next) {
+            push(
+                findings,
+                RULE_NOTATION_PUNCTUATION,
+                locate,
+                para.source_offset(idx),
+                NOTATION_PUNCT_TILDE_MESSAGE,
+            );
+        }
+    }
+    for m in PUNCT_COLON.find_iter(text) {
+        if para.masked_overlap(m.start(), m.end()) {
+            continue;
+        }
+        // 쌍점: attached to the preceding word, one space after. A Hangul-word
+        // colon directly followed by a non-space character fires; ASCII
+        // scheme-like colons (`http:`) never match the Hangul anchor.
+        if text[m.end()..]
+            .chars()
+            .next()
+            .is_some_and(|c| !c.is_whitespace())
+        {
+            push(
+                findings,
+                RULE_NOTATION_PUNCTUATION,
+                locate,
+                para.source_offset(m.start()),
+                NOTATION_PUNCT_COLON_MESSAGE,
+            );
+        }
+    }
+}
+
+/// `ai-style-marks` (warning): paragraph/item text starting with a decorative
+/// line-leading symbol (■ ▶ ▲ ◆ ● ※) — the AI-generation tell. The sanctioned
+/// `□ `/`○ ` ladder and the statutory `★` are not in the set.
+fn lint_ai_style_marks(
+    para: &Para,
+    locate: &impl Fn(usize) -> (u32, u32),
+    findings: &mut Vec<Finding>,
+) {
+    for m in AI_STYLE_MARK.find_iter(&para.text) {
+        push(
+            findings,
+            RULE_AI_STYLE_MARKS,
+            locate,
+            para.source_offset(m.start()),
+            AI_STYLE_MARKS_MESSAGE,
+        );
     }
 }
 
@@ -234,7 +884,10 @@ mod tests {
     fn only_rule(md: &str, rule_id: &str) -> Vec<Finding> {
         let findings = lint(md);
         for f in &findings {
-            assert_eq!(f.rule_id, rule_id, "unexpected rule in {md:?}: {findings:?}");
+            assert_eq!(
+                f.rule_id, rule_id,
+                "unexpected rule in {md:?}: {findings:?}"
+            );
         }
         findings
     }
@@ -323,7 +976,10 @@ mod tests {
     fn notation_end_dot_fires_when_gongmun_marker_present() {
         let findings = only_rule("붙임  계획서 1부.  끝\n", "notation-end-dot");
         assert_eq!(findings.len(), 1, "{findings:?}");
-        let findings = only_rule("수신  교육부장관\n\n협조하여 주시기 바랍니다.  끝\n", "notation-end-dot");
+        let findings = only_rule(
+            "수신  교육부장관\n\n협조하여 주시기 바랍니다.  끝\n",
+            "notation-end-dot",
+        );
         assert_eq!(findings.len(), 1, "{findings:?}");
     }
 

--- a/crates/hwp-convert/src/lint.rs
+++ b/crates/hwp-convert/src/lint.rs
@@ -1,0 +1,231 @@
+//! Official-document lint engine (표기법·구조 규칙 검사).
+//!
+//! Pure, IO-free module colocated with `official.rs` (the official-document policy
+//! home). Markdown input is parsed with the pulldown-cmark AST (D-01): fenced code
+//! blocks, GFM tables and HTML blocks are skipped structurally via event depth, not
+//! line heuristics. Both lint profiles run the same rule table in v1 (D-04); the
+//! profile enum exists so calibration can diverge later without breaking the CLI.
+//!
+//! Findings carry rule id, severity, 1-based line and character-based column, and an
+//! advisory Korean message only — never source-text excerpts (T-02.3-04).
+
+use std::sync::LazyLock;
+
+use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+use regex::Regex;
+
+/// A lint profile (D-03). Both variants run the same rule table in v1 (D-04).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub enum LintProfile {
+    /// Statutory 공문서 rules (default).
+    #[default]
+    Gongmun,
+    /// 보고서 conventions (reserved for later calibration).
+    Report,
+}
+
+impl LintProfile {
+    /// Stable canonical CLI/report name (echoed into the JSON report per D-04).
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Gongmun => "gongmun",
+            Self::Report => "report",
+        }
+    }
+}
+
+/// Finding severity (D-05). Only `Error` affects the `--strict` exit code.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Severity {
+    Error,
+    Warning,
+}
+
+impl Severity {
+    /// Lowercase report spelling (D-06).
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warning => "warning",
+        }
+    }
+}
+
+/// One lint finding. `line` is 1-based; `col` is character-based (Korean is 3
+/// bytes/char in UTF-8, so byte columns would drift).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Finding {
+    pub rule_id: &'static str,
+    pub severity: Severity,
+    pub line: u32,
+    pub col: u32,
+    pub message: String,
+}
+
+/// Candidate date span: `YYYY. M. D.` with optional spaces and optional final
+/// period. The canonical form is `YYYY. M. D.` (space after each period, mandatory
+/// final period, no leading zeros) per the 2020 행정업무운영 편람 표기법
+/// (skills/hwp/references/korean-official-format.md §6 날짜). A 4-digit year is
+/// required so `제3.01.호` and `v2.05.1` can never match.
+static DATE_CANDIDATE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(\d{4})\. ?(\d{1,2})\. ?(\d{1,2})\.?").unwrap());
+
+/// Advisory message — cites the 편람 표기법, never statutory-violation wording and
+/// never a source-text excerpt (T-02.3-04).
+const NOTATION_DATE_MESSAGE: &str = "날짜는 `2026. 6. 19.`처럼 표기합니다 (마침표 뒤 한 칸, 마지막 마침표 필수, 앞자리 0 제거) — 행정업무운영 편람 표기법";
+
+/// Lint markdown text and return findings in ascending source order.
+///
+/// The profile is recorded by callers (report echo, D-04) but selects no rules in
+/// v1 — both profiles share one rule table.
+pub fn lint_markdown(markdown: &str, profile: LintProfile) -> Vec<Finding> {
+    let _ = profile; // Same rule table for every profile in v1 (D-04).
+
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_TABLES);
+    // Parses strikethrough (`~~`) and footnotes (`[^N]`). Task lists (TASKLISTS) are excluded — no corresponding IR meaning.
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+    options.insert(Options::ENABLE_FOOTNOTES);
+
+    // 1-based line index: byte offset of each line start, for binary search.
+    let line_starts: Vec<usize> = std::iter::once(0)
+        .chain(markdown.match_indices('\n').map(|(i, _)| i + 1))
+        .collect();
+    let locate = |offset: usize| -> (u32, u32) {
+        let idx = line_starts.partition_point(|&start| start <= offset);
+        let line_start = line_starts[idx - 1];
+        let col = markdown[line_start..offset].chars().count() as u32 + 1;
+        (idx as u32, col)
+    };
+
+    let mut findings = Vec::new();
+    // Structural skip depth (D-01): Text inside code blocks, tables and HTML blocks
+    // is never linted; InlineHtml events are skipped outright.
+    let mut skip_depth: u32 = 0;
+    for (event, range) in Parser::new_ext(markdown, options).into_offset_iter() {
+        match event {
+            Event::Start(Tag::CodeBlock(_) | Tag::Table(_) | Tag::HtmlBlock) => {
+                skip_depth += 1;
+            }
+            Event::End(TagEnd::CodeBlock | TagEnd::Table | TagEnd::HtmlBlock) => {
+                skip_depth = skip_depth.saturating_sub(1);
+            }
+            Event::Text(text) if skip_depth == 0 => {
+                lint_notation_date(&text, range.start, &locate, &mut findings);
+            }
+            _ => {}
+        }
+    }
+    findings
+}
+
+/// `notation-date` (warning): flag any date-like span that deviates from the
+/// canonical `YYYY. M. D.` form — missing spaces (`2020.7.8`), a missing final
+/// period (`2026. 8. 20`), or leading zeros (`1985.09.06.`).
+fn lint_notation_date(
+    text: &str,
+    base: usize,
+    locate: &impl Fn(usize) -> (u32, u32),
+    findings: &mut Vec<Finding>,
+) {
+    for caps in DATE_CANDIDATE.captures_iter(text) {
+        let whole = caps.get(0).unwrap();
+        // Guard: a digit on either side means a longer numeric run (e.g. the
+        // `12026. 8. 20.` prefix or the `2020.7.8.1` 4-part version), not a date.
+        let before = text[..whole.start()].bytes().next_back();
+        let after = text[whole.end()..].bytes().next();
+        if before.is_some_and(|b| b.is_ascii_digit()) || after.is_some_and(|b| b.is_ascii_digit()) {
+            continue;
+        }
+        let year: u32 = caps[1].parse().unwrap();
+        let month: u32 = caps[2].parse().unwrap();
+        let day: u32 = caps[3].parse().unwrap();
+        let canonical = format!("{year}. {month}. {day}.");
+        if whole.as_str() == canonical {
+            continue;
+        }
+        let (line, col) = locate(base + whole.start());
+        findings.push(Finding {
+            rule_id: "notation-date",
+            severity: Severity::Warning,
+            line,
+            col,
+            message: NOTATION_DATE_MESSAGE.to_string(),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lint(md: &str) -> Vec<Finding> {
+        lint_markdown(md, LintProfile::Gongmun)
+    }
+
+    #[test]
+    fn notation_date_fires_on_each_wrong_form() {
+        for (md, why) in [
+            ("시행: 2020.7.8\n", "missing spaces and final period"),
+            ("시행: 2026. 8. 20\n", "missing final period"),
+            ("시행: 1985.09.06.\n", "leading zeros and missing spaces"),
+            ("시행: 2020. 7. 8\n", "missing final period only"),
+        ] {
+            let findings = lint(md);
+            assert_eq!(findings.len(), 1, "{why}: {md:?} -> {findings:?}");
+            assert_eq!(findings[0].rule_id, "notation-date");
+            assert_eq!(findings[0].severity, Severity::Warning);
+        }
+    }
+
+    #[test]
+    fn notation_date_silent_on_correct_forms() {
+        for md in [
+            "시행: 2020. 7. 8.\n",
+            "시행일: 2026. 6. 19.\n",
+            "2023. 11. 11.(토) 개최\n",
+            "기간: 2026. 4. 23.∼2026. 6. 15.\n",
+        ] {
+            assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+        }
+    }
+
+    #[test]
+    fn notation_date_never_matches_non_date_numeric_runs() {
+        for md in [
+            "제3.01.호 참조\n",  // no 4-digit year
+            "버전 v2.05.1\n",    // no 4-digit year
+            "버전 2020.7.8.1\n", // 4-part version: digit after the span
+        ] {
+            assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+        }
+    }
+
+    #[test]
+    fn structural_skips_code_table_and_html_blocks() {
+        let md = "```\n2020.7.8\n```\n\n| 날짜 |\n|------|\n| 2020.7.8 |\n\n<div>\n2020.7.8\n</div>\n\n시행: 2020.7.8\n";
+        let findings = lint(md);
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(findings[0].line, 13);
+    }
+
+    #[test]
+    fn line_and_col_are_1_based_and_character_based() {
+        // Korean text before the date: byte cols would drift (3 bytes/char).
+        let md = "본문입니다.\n\n시행: 2020.7.8\n";
+        let findings = lint(md);
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(findings[0].line, 3);
+        // "시행: " is 4 characters, so the date starts at column 5.
+        assert_eq!(findings[0].col, 5);
+    }
+
+    #[test]
+    fn report_profile_runs_the_same_rule_table_v1() {
+        let md = "시행: 2020.7.8\n";
+        assert_eq!(
+            lint_markdown(md, LintProfile::Gongmun),
+            lint_markdown(md, LintProfile::Report)
+        );
+    }
+}

--- a/crates/hwp-convert/src/lint.rs
+++ b/crates/hwp-convert/src/lint.rs
@@ -315,6 +315,11 @@ pub fn lint_markdown(markdown: &str, profile: LintProfile) -> Vec<Finding> {
     // number the rule forbids for a lone attachment.
     for idx in single_attach_lists {
         let para = &paras[idx];
+        if para.text.is_empty() {
+            // An empty first block (e.g. an image-only paragraph) carries no
+            // typed `1.` text position — skip it like the main rule loop does.
+            continue;
+        }
         push(
             &mut findings,
             RULE_NOTATION_ATTACH_NUMBER,
@@ -1065,6 +1070,22 @@ mod tests {
         // Quantity missing the final period.
         let findings = only_rule("붙임  계획서 1부\n", "notation-attach-number");
         assert_eq!(findings.len(), 1, "{findings:?}");
+    }
+
+    #[test]
+    fn single_attach_list_with_empty_first_paragraph_does_not_panic() {
+        // CR-1 regression: a loose single-item ordered list after a 붙임
+        // paragraph whose first block carries no Text events (an image-only
+        // paragraph) used to underflow `Para::source_offset` (exit 101). The
+        // empty block carries no typed `1.` position, so it is skipped.
+        let md = "붙임\n\n1. ![](x.png)\n\n   추가 설명 문단\n";
+        let findings = lint(md);
+        assert!(
+            findings
+                .iter()
+                .all(|f| f.rule_id != "notation-attach-number"),
+            "{findings:?}"
+        );
     }
 
     #[test]

--- a/crates/hwp-convert/src/lint.rs
+++ b/crates/hwp-convert/src/lint.rs
@@ -1049,4 +1049,119 @@ mod tests {
             assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
         }
     }
+
+    // ---- Task 2: error-severity structure rules + the five FP-guard pins ----
+
+    #[test]
+    fn struct_item_mark_fires_on_typed_ladder_marks() {
+        for md in [
+            "가. 항목입니다\n",
+            "1) 항목입니다\n",
+            "가) 항목입니다\n",
+            "(1) 항목입니다\n",
+            "(가) 항목입니다\n",
+            "① 항목입니다\n",
+            "㉮ 항목입니다\n",
+            "· 항목입니다\n",
+            "ㆍ 항목입니다\n",
+            "\\- 항목입니다\n",
+        ] {
+            let findings = only_rule(md, "struct-item-mark");
+            assert_eq!(findings.len(), 1, "{md:?} -> {findings:?}");
+            assert_eq!(findings[0].severity, Severity::Error);
+        }
+    }
+
+    #[test]
+    fn struct_item_mark_silent_on_sanctioned_forms() {
+        // The literal □/○ ladder is the sanctioned authoring form (markdown
+        // contract §1); minutes.md uses it and must stay silent (SC1). Nested
+        // list markup carries the numbered path.
+        let minutes_style = "{{회의명}} 회의록\n\n작성: {{작성자}}\n\n□ 회의 명칭\n\n○○ 회의\n\n□ 상정 안건\n\n1. 첫째 안건\n2. 둘째 안건\n\n□ 결정 사항\n\n○ 결정 1\n";
+        assert!(lint(minutes_style).is_empty(), "{:?}", lint(minutes_style));
+        for md in ["□ 회의 명칭\n", "○ 안건\n", "- 목록 항목\n"] {
+            assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+        }
+    }
+
+    #[test]
+    fn struct_item_mark_fires_on_double_mark_in_list_item() {
+        // A rung mark at the start of a list item's own text double-numbers
+        // next to the engine-assigned mark.
+        for md in ["- 가. 항목입니다\n", "1. (1) 항목입니다\n", "- · 항목입니다\n"] {
+            let findings = only_rule(md, "struct-item-mark");
+            assert_eq!(findings.len(), 1, "{md:?} -> {findings:?}");
+            assert_eq!(findings[0].severity, Severity::Error);
+        }
+    }
+
+    #[test]
+    fn struct_roman_heading_fires_on_ascii_numerals() {
+        for md in ["# I. 사업 개요\n", "## III. 추진 계획\n", "I. 사업 개요\n"] {
+            let findings = only_rule(md, "struct-roman-heading");
+            assert_eq!(findings.len(), 1, "{md:?} -> {findings:?}");
+            assert_eq!(findings[0].severity, Severity::Error);
+        }
+    }
+
+    #[test]
+    fn struct_roman_heading_silent_on_fullwidth_and_english() {
+        for md in ["## Ⅰ. 사업 개요\n", "Ⅻ. 기타 사항\n", "I. Introduction\n"] {
+            assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+        }
+    }
+
+    #[test]
+    fn fp_guard_ho_citation() {
+        let md = "제3.01.호를 참조하시기 바랍니다.\n";
+        assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+    }
+
+    #[test]
+    fn fp_guard_version_string() {
+        let md = "버전 v2.05.1 기준으로 작성\n";
+        assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+    }
+
+    #[test]
+    fn fp_guard_table_rule_row() {
+        let md = "| 구분 | 내용 |\n| --- | --- |\n| 날짜 | 2020.7.8 |\n";
+        assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+    }
+
+    #[test]
+    fn fp_guard_bold_wrapped_mark() {
+        // Adopted research A3 (bold-x2 guard): a Strong-wrapped hand-typed
+        // mark yields exactly one finding — not zero and not two.
+        let findings = only_rule("**가. 항목입니다**\n", "struct-item-mark");
+        assert_eq!(findings.len(), 1, "{findings:?}");
+        assert_eq!(findings[0].severity, Severity::Error);
+    }
+
+    #[test]
+    fn skips_code_and_tables() {
+        let md = "```\n가. 항목\n오후 3시 20분\n345천원\n붙임: 계획서 1부\n2020.7.8\nI. 사업 개요\n■ 참고\n```\n\n| 규칙 |\n| --- |\n| 가. 항목 |\n\n평범한 문단입니다.\n";
+        assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
+    }
+
+    #[test]
+    fn severity_split_matches_d05() {
+        // D-05: exactly the two structure rules are error-severity; every
+        // notation rule and ai-style-marks is a warning.
+        let md = "시행: 2020.7.8\n\n일시: 오후 3시 20분\n\n비용: 345천원\n\n붙임: 계획서 1부.  끝.\n\n원장:김갑동\n\n기간: 10~20\n\n■ 참고\n\n가. 항목입니다\n\n# I. 개요\n\n붙임  1. 계획서 1부.  끝.\n\n끝\n";
+        let findings = lint(md);
+        let mut seen = std::collections::HashMap::new();
+        for f in &findings {
+            seen.insert(f.rule_id, f.severity);
+        }
+        assert_eq!(seen.len(), 10, "{findings:?}");
+        for (rule, severity) in &seen {
+            let expected = if matches!(*rule, "struct-item-mark" | "struct-roman-heading") {
+                Severity::Error
+            } else {
+                Severity::Warning
+            };
+            assert_eq!(*severity, expected, "{rule}");
+        }
+    }
 }

--- a/crates/hwp-convert/src/lint.rs
+++ b/crates/hwp-convert/src/lint.rs
@@ -348,6 +348,10 @@ fn collect_paras(markdown: &str, options: Options) -> (Vec<Para>, Vec<usize>) {
     // text; that text is never prose, so it is skipped structurally.
     let mut autolink_depth: u32 = 0;
     let mut link_stack: Vec<bool> = Vec::new();
+    // Image alt text is an attribute of an embedded resource, not document
+    // prose (D-01); it arrives as ordinary Text inside the Image span and is
+    // skipped structurally like autolink text.
+    let mut image_depth: u32 = 0;
     // Strong-span depth — records whether a block's first text is bold-wrapped
     // (the A3 bold-x2 guard; detection itself stays paragraph-level).
     let mut strong_depth: u32 = 0;
@@ -475,8 +479,14 @@ fn collect_paras(markdown: &str, options: Options) -> (Vec<Para>, Vec<usize>) {
                     autolink_depth = autolink_depth.saturating_sub(1);
                 }
             }
+            Event::Start(Tag::Image { .. }) => {
+                image_depth += 1;
+            }
+            Event::End(TagEnd::Image) => {
+                image_depth = image_depth.saturating_sub(1);
+            }
             Event::Text(text) => {
-                if skip_depth == 0 && autolink_depth == 0 {
+                if skip_depth == 0 && autolink_depth == 0 && image_depth == 0 {
                     // Tight list items carry their Text directly under the Item
                     // (no Paragraph wrapper) — collect it in an implicit block.
                     if cur.is_none() && item_depth > 0 && implicit.is_none() {
@@ -1177,6 +1187,15 @@ mod tests {
         ] {
             assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
         }
+    }
+
+    #[test]
+    fn fp_guard_image_alt_text() {
+        // WR-2: image alt text is an attribute of an embedded resource, not
+        // document prose — a date-like string in the alt produces no finding
+        // (D-01 structural skip, consistent with autolink text).
+        let md = "참고 ![2020.7.8 캡처](x.png) 입니다\n";
+        assert!(lint(md).is_empty(), "{md:?} -> {:?}", lint(md));
     }
 
     // ---- Task 2: error-severity structure rules + the five FP-guard pins ----

--- a/crates/hwp-convert/src/lint.rs
+++ b/crates/hwp-convert/src/lint.rs
@@ -97,9 +97,13 @@ fn severity_of(rule_id: &str) -> Severity {
 /// period. The canonical form is `YYYY. M. D.` (space after each period, mandatory
 /// final period, no leading zeros) per the 2020 행정업무운영 편람 표기법
 /// (skills/hwp/references/korean-official-format.md §6 날짜). A 4-digit year is
-/// required so `제3.01.호` and `v2.05.1` can never match.
+/// required so `제3.01.호` and `v2.05.1` can never match. Digit classes are ASCII
+/// (`[0-9]`, never `\d`): the regex crate's `\d` is Unicode-aware and would match
+/// full-width `２０２６`, which then fails `parse::<u32>()` and panics the whole
+/// lint run. Every notation rule here concerns 아라비아 숫자 (편람 §6 표기법), so
+/// ASCII is also the semantically correct class.
 static DATE_CANDIDATE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(\d{4})\. ?(\d{1,2})\. ?(\d{1,2})\.?").unwrap());
+    LazyLock::new(|| Regex::new(r"([0-9]{4})\. ?([0-9]{1,2})\. ?([0-9]{1,2})\.?").unwrap());
 
 /// Bounded bare-URL mask — the single sanctioned textual exception to D-01's
 /// structural-only framing (adopted research Open Question 5). pulldown-cmark
@@ -112,17 +116,18 @@ static URL_MASK: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?:https?://|ww
 
 /// `오전/오후 N시( N분)?` — the meridiem form must be rewritten as 24-hour
 /// `HH:MM` (§6 시각).
-static TIME_MERIDIEM: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?:오전|오후)\s*\d{1,2}\s*시(?:\s*\d{1,2}\s*분)?").unwrap());
+static TIME_MERIDIEM: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?:오전|오후)\s*[0-9]{1,2}\s*시(?:\s*[0-9]{1,2}\s*분)?").unwrap()
+});
 /// `H:MM` candidate; the leading zero is mandatory (`08:09`), so only a bare
 /// single-digit hour fires. Two-digit hours are filtered after the match.
-static TIME_HM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(\d{1,2}):(\d{2})").unwrap());
+static TIME_HM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"([0-9]{1,2}):([0-9]{2})").unwrap());
 
 /// `345천원`-style abstract thousand-units (§6 금액).
-static MONEY_ABBR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\d+천원").unwrap());
+static MONEY_ABBR: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[0-9]+천원").unwrap());
 /// `금NNN,NNN원` candidate; silent only when the alteration-proof Korean reading
 /// `(금…원)` follows immediately (§6 금액).
-static MONEY_GEUM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"금\d[\d,]*원").unwrap());
+static MONEY_GEUM: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"금[0-9][0-9,]*원").unwrap());
 
 /// Line whose first token is `붙임` followed by a colon (must be `붙임∨∨`, §6
 /// 붙임). Anchored at line starts so prose mentions of 붙임 never fire.
@@ -130,7 +135,11 @@ static ATTACH_COLON: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?m)^붙임
 /// Paragraph opening an attachment block: first token `붙임` with no colon.
 static ATTACH_START: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^붙임(?:\s|$)").unwrap());
 /// Attachment quantity candidate; silent only when closed by a period (`1부.`).
-static ATTACH_QUANTITY: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\d+부").unwrap());
+static ATTACH_QUANTITY: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[0-9]+부").unwrap());
+
+/// A complete parenthetical Korean amount reading, anchored at the position just
+/// after `금NNN,NNN원`: `(금` … `원)` on one line (§6 금액).
+static MONEY_READING: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^\(금[^)\n]*원\)").unwrap());
 /// The `끝` end-mark candidate; followed by `.` it is the canonical `끝.`.
 static END_MARK: LazyLock<Regex> = LazyLock::new(|| Regex::new("끝").unwrap());
 /// 공문서 markers that scope notation-end-dot (adopted research A5): a 붙임 line
@@ -671,8 +680,10 @@ fn lint_notation_money(
         if para.masked_overlap(m.start(), m.end()) {
             continue;
         }
-        // Silent only when the Korean reading follows immediately.
-        if text[m.end()..].starts_with("(금") {
+        // Silent only when a *complete* Korean reading follows immediately.
+        // A prefix test would accept the truncated `금113,560원(금` and a reading
+        // that never closes; §6 requires the whole `(금…원)` parenthetical.
+        if MONEY_READING.is_match(&text[m.end()..]) {
             continue;
         }
         push(
@@ -1317,5 +1328,44 @@ mod tests {
             };
             assert_eq!(*severity, expected, "{rule}");
         }
+    }
+
+    #[test]
+    fn full_width_digits_do_not_panic() {
+        // Regression: the regex crate's `\d` is Unicode-aware, so full-width
+        // digits matched the date candidate and then panicked in
+        // `parse::<u32>()`, killing the CLI and the MCP server on user input.
+        // ASCII digit classes keep them out of the span entirely.
+        for md in [
+            "２０２６. ８. ２０.\n",
+            "일시: 오후 ３시\n",
+            "비용: ３４５천원\n",
+        ] {
+            let _ = lint(md);
+        }
+    }
+
+    #[test]
+    fn money_reading_must_close() {
+        // A prefix-only `(금` test accepted a truncated or unterminated reading;
+        // §6 requires the whole `(금…원)` parenthetical.
+        let money = |md: &str| {
+            lint(md)
+                .into_iter()
+                .filter(|f| f.rule_id == "notation-money")
+                .count()
+        };
+        assert_eq!(
+            money("금13,500원(금일만삼천오백원)\n"),
+            0,
+            "complete reading is silent"
+        );
+        assert_eq!(money("금113,560원(금\n"), 1, "truncated reading fires");
+        assert_eq!(
+            money("금113,560원(금일십일만\n"),
+            1,
+            "unterminated reading fires"
+        );
+        assert_eq!(money("금99,000원\n"), 1, "missing reading fires");
     }
 }

--- a/crates/hwp-convert/src/lint.rs
+++ b/crates/hwp-convert/src/lint.rs
@@ -145,6 +145,22 @@ static PUNCT_COLON: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"[가-힣]:")
 /// skills/hwp/templates/minutes.md) and `★` is statutory before 직위
 /// (시행규칙 제6조제1항), so neither is in the set.
 static AI_STYLE_MARK: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"(?m)^[■▶▲◆●※]").unwrap());
+/// Hand-typed item marks at a line start (adopted research A2): statutory
+/// ladder marks (`가.`, `1)`, `가)`, `(1)`, `(가)`, circled digits/letters) that
+/// must come from nested-list depth, and the `-`/`·`/`ㆍ` rung symbols. The
+/// Hangul class is the exact 14-letter ladder so prose like `밥. 먹자` stays
+/// silent. Literal `□ `/`○ ` is the sanctioned ladder and is never in the set.
+static ITEM_MARK: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"(?m)^(?:[가나다라마바사아자차카타파하][.)]|\d{1,2}\)|\(\d{1,2}\)|\([가나다라마바사아자차카타파하]\)|[①-⑳㉑-㉟㉮-㉻]|[-·ㆍ])(?:\s|$)",
+    )
+    .unwrap()
+});
+/// ASCII roman-numeral heading start (`I.`, `II.`, … `XII.`). The full-width
+/// forms `Ⅰ`-`Ⅻ` (U+2160…) are the correct form and never match. Longer
+/// numerals come first so alternation preference cannot truncate a match.
+static ROMAN_START: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?:VIII|XII|VII|III|XI|IX|VI|IV|II|X|V|I)\.").unwrap());
 
 /// Advisory messages — cite the rule source with its confidence tag, never
 /// statutory-violation wording beyond the tag and never a source-text excerpt
@@ -167,6 +183,10 @@ const NOTATION_PUNCT_COLON_MESSAGE: &str =
     "쌍점(:)은 앞말에 붙이고 뒤에 한 칸을 띄웁니다 (`원장: 김갑동`) — 행정업무운영 편람 표기법";
 const AI_STYLE_MARKS_MESSAGE: &str =
     "장식 기호(■ ▶ ▲ ◆ ● ※)로 항목을 시작하지 말고 공문서 항목 기호(□ ○)나 중첩 목록을 사용합니다";
+const STRUCT_ITEM_MARK_MESSAGE: &str = "항목 부호(`가.`, `(1)`, `①` 등)는 직접 입력하지 말고 중첩 목록 들여쓰기로 표현합니다 — 공문서 마크다운 계약";
+const STRUCT_ITEM_MARK_DOUBLE_MESSAGE: &str = "목록 항목 앞에 부호를 직접 입력하면 엔진이 부여하는 부호와 겹칩니다 (직접 입력한 부호를 지웁니다) — 공문서 마크다운 계약";
+const STRUCT_ROMAN_HEADING_MESSAGE: &str =
+    "머리글 로마 숫자는 ASCII `I.` 대신 전각 `Ⅰ.`(U+2160)을 사용합니다 — 공문서 마크다운 계약";
 
 /// One linted text block: a paragraph or heading at structural depth 0, with
 /// its Text events concatenated (`text`), a per-segment source-offset map
@@ -177,25 +197,36 @@ struct Para {
     segs: Vec<(usize, usize)>,
     masked: Vec<Range<usize>>,
     in_heading: bool,
+    /// Inside a list item — drives the double-mark guard's message.
+    in_item: bool,
+    /// The block's first Text event arrived inside a Strong span — records the
+    /// bold-wrapped case behind the A3 exactly-one-finding guard (see
+    /// `lint_struct_item_mark`).
+    first_text_in_strong: bool,
     /// Inside a 붙임 block: the 붙임 paragraph itself or an item of the
     /// attachment list that immediately follows it.
     attach_entry: bool,
 }
 
 impl Para {
-    fn new(in_heading: bool) -> Self {
+    fn new(in_heading: bool, in_item: bool) -> Self {
         Self {
             text: String::new(),
             segs: Vec::new(),
             masked: Vec::new(),
             in_heading,
+            in_item,
+            first_text_in_strong: false,
             attach_entry: false,
         }
     }
 
     /// Append one Text event, masking bare-URL spans (the bounded D-01
     /// exception — see `URL_MASK`).
-    fn push_text(&mut self, text: &str, source_start: usize) {
+    fn push_text(&mut self, text: &str, source_start: usize, in_strong: bool) {
+        if self.segs.is_empty() {
+            self.first_text_in_strong = in_strong;
+        }
         let base = self.text.len();
         for m in URL_MASK.find_iter(text) {
             self.masked.push((base + m.start())..(base + m.end()));
@@ -273,7 +304,9 @@ pub fn lint_markdown(markdown: &str, profile: LintProfile) -> Vec<Finding> {
             lint_notation_attach_colon(para, &locate, &mut findings);
             lint_notation_attach_number(para, &locate, &mut findings);
             lint_ai_style_marks(para, &locate, &mut findings);
+            lint_struct_item_mark(para, &locate, &mut findings);
         }
+        lint_struct_roman_heading(para, &locate, &mut findings);
         if para.attach_entry {
             lint_attach_quantity(para, &locate, &mut findings);
         }
@@ -310,6 +343,9 @@ fn collect_paras(markdown: &str, options: Options) -> (Vec<Para>, Vec<usize>) {
     // text; that text is never prose, so it is skipped structurally.
     let mut autolink_depth: u32 = 0;
     let mut link_stack: Vec<bool> = Vec::new();
+    // Strong-span depth — records whether a block's first text is bold-wrapped
+    // (the A3 bold-x2 guard; detection itself stays paragraph-level).
+    let mut strong_depth: u32 = 0;
     let mut cur: Option<Para> = None;
     // 붙임 block tracking: a paragraph opening with the `붙임` token starts an
     // attachment block; a list immediately following it is the attachment
@@ -346,7 +382,7 @@ fn collect_paras(markdown: &str, options: Options) -> (Vec<Para>, Vec<usize>) {
                 flush_implicit(&mut implicit, &mut paras, &mut pending_attach);
                 pending_attach = false;
                 if skip_depth == 0 {
-                    cur = Some(Para::new(true));
+                    cur = Some(Para::new(true, item_depth > 0));
                 }
             }
             Event::End(TagEnd::Heading(_)) => {
@@ -396,7 +432,7 @@ fn collect_paras(markdown: &str, options: Options) -> (Vec<Para>, Vec<usize>) {
                 // A non-list block after the 붙임 paragraph closes the block.
                 pending_attach = false;
                 if skip_depth == 0 {
-                    let mut para = Para::new(false);
+                    let mut para = Para::new(false, item_depth > 0);
                     if attach_list && item_depth == attach_item_level {
                         para.attach_entry = true;
                         if expect_first_attach_para {
@@ -416,6 +452,12 @@ fn collect_paras(markdown: &str, options: Options) -> (Vec<Para>, Vec<usize>) {
                     paras.push(para);
                 }
             }
+            Event::Start(Tag::Strong) => {
+                strong_depth += 1;
+            }
+            Event::End(TagEnd::Strong) => {
+                strong_depth = strong_depth.saturating_sub(1);
+            }
             Event::Start(Tag::Link { link_type, .. }) => {
                 let autolink = matches!(link_type, LinkType::Autolink | LinkType::Email);
                 if autolink {
@@ -433,7 +475,7 @@ fn collect_paras(markdown: &str, options: Options) -> (Vec<Para>, Vec<usize>) {
                     // Tight list items carry their Text directly under the Item
                     // (no Paragraph wrapper) — collect it in an implicit block.
                     if cur.is_none() && item_depth > 0 && implicit.is_none() {
-                        let mut para = Para::new(false);
+                        let mut para = Para::new(false, true);
                         if attach_list && item_depth == attach_item_level {
                             para.attach_entry = true;
                             if expect_first_attach_para {
@@ -444,7 +486,7 @@ fn collect_paras(markdown: &str, options: Options) -> (Vec<Para>, Vec<usize>) {
                         implicit = Some(para);
                     }
                     if let Some(para) = cur.as_mut().or(implicit.as_mut()) {
-                        para.push_text(&text, range.start);
+                        para.push_text(&text, range.start, strong_depth > 0);
                     }
                 }
             }
@@ -805,6 +847,72 @@ fn lint_ai_style_marks(
     }
 }
 
+/// `struct-item-mark` (error, D-05): hand-typed item marks where the markdown
+/// contract requires nested-list depth — statutory ladder marks (`가.`, `1)`,
+/// `가)`, `(1)`, `(가)`, circled digits/letters) and the `-`/`·`/`ㆍ` rung
+/// symbols at a line start, plus any rung mark at the start of a list item's
+/// own text (the double-mark case). Paragraph-initial literal `□ `/`○ ` is the
+/// sanctioned ladder (contract §1, minutes.md) and is never flagged.
+fn lint_struct_item_mark(
+    para: &Para,
+    locate: &impl Fn(usize) -> (u32, u32),
+    findings: &mut Vec<Finding>,
+) {
+    // Adopted research A3 (the SC1 bold-x2 guard): detection is anchored at
+    // line starts and emits once per position, so a Strong-wrapped mark
+    // (`**가. 항목**`) yields exactly one finding — never zero (the bold span
+    // is not a skip) and never two (no per-span re-emission).
+    let _strong_wrapped = para.first_text_in_strong;
+    for m in ITEM_MARK.find_iter(&para.text) {
+        let message = if para.in_item {
+            STRUCT_ITEM_MARK_DOUBLE_MESSAGE
+        } else {
+            STRUCT_ITEM_MARK_MESSAGE
+        };
+        push(
+            findings,
+            RULE_STRUCT_ITEM_MARK,
+            locate,
+            para.source_offset(m.start()),
+            message,
+        );
+    }
+}
+
+/// `struct-roman-heading` (error, D-05): ASCII roman numerals (`I.`, `II.`, …)
+/// where the contract requires the full-width forms (`Ⅰ.` U+2160). Inside a
+/// `#` heading the numeral alone fires; in a paragraph the numeral must be
+/// followed by `. ` + Hangul content so ordinary English sentences
+/// ("I. Introduction") stay silent.
+fn lint_struct_roman_heading(
+    para: &Para,
+    locate: &impl Fn(usize) -> (u32, u32),
+    findings: &mut Vec<Finding>,
+) {
+    let Some(m) = ROMAN_START.find(&para.text) else {
+        return;
+    };
+    let after = &para.text[m.end()..];
+    let fires = if para.in_heading {
+        after.chars().next().is_none_or(|c| c.is_whitespace())
+    } else {
+        after
+            .trim_start()
+            .chars()
+            .next()
+            .is_some_and(is_hangul_syllable)
+    };
+    if fires {
+        push(
+            findings,
+            RULE_STRUCT_ROMAN_HEADING,
+            locate,
+            para.source_offset(m.start()),
+            STRUCT_ROMAN_HEADING_MESSAGE,
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1056,7 +1164,9 @@ mod tests {
     fn struct_item_mark_fires_on_typed_ladder_marks() {
         for md in [
             "가. 항목입니다\n",
-            "1) 항목입니다\n",
+            // `1)` at line start is an ordered-list marker in CommonMark;
+            // the literal mark only reaches text when escaped.
+            "1\\) 항목입니다\n",
             "가) 항목입니다\n",
             "(1) 항목입니다\n",
             "(가) 항목입니다\n",
@@ -1088,7 +1198,11 @@ mod tests {
     fn struct_item_mark_fires_on_double_mark_in_list_item() {
         // A rung mark at the start of a list item's own text double-numbers
         // next to the engine-assigned mark.
-        for md in ["- 가. 항목입니다\n", "1. (1) 항목입니다\n", "- · 항목입니다\n"] {
+        for md in [
+            "- 가. 항목입니다\n",
+            "1. (1) 항목입니다\n",
+            "- · 항목입니다\n",
+        ] {
             let findings = only_rule(md, "struct-item-mark");
             assert_eq!(findings.len(), 1, "{md:?} -> {findings:?}");
             assert_eq!(findings[0].severity, Severity::Error);

--- a/docs/design/20-remote-mcp.ko.md
+++ b/docs/design/20-remote-mcp.ko.md
@@ -13,7 +13,7 @@
 
 ### 1.1 범위
 
-- `hwp mcp` stdio를 기본 local transport로 유지하고 16개 tool 동작의 호환성을 보존.
+- `hwp mcp` stdio를 기본 local transport로 유지하고 17개 tool 동작의 호환성을 보존.
 - hosted deployment용 Streamable HTTP mode를 명시적 별도 설정으로 추가.
 - 두 adapter가 하나의 transport-independent JSON-RPC/tool dispatch core를 공유.
 - 모든 remote request 인증 및 tenant, principal, session별 workspace 격리.
@@ -225,13 +225,13 @@ maintained protocol/HTTP primitive를 우선한다. no tokio/no SDK 유지는 un
 
 ## 9. 단계별 follow-up backlog
 
-1. **Core extraction:** typed JSON-RPC value와 authority context 도입. stdio output과 16개 tool의
+1. **Core extraction:** typed JSON-RPC value와 authority context 도입. stdio output과 17개 tool의
    byte/behavior compatibility 유지.
 2. **Artifact model:** network listener 없이 tenant-owned upload, immutable output, remote-safe
    schema, quota, cleanup 구현.
 3. **Transport/auth:** 선택한 HTTP adapter, protocol header, SSE/session lifecycle, OAuth resource
    server validation, proxy boundary, audit event를 명시적 build/deployment mode 뒤에 추가.
-4. **Quick Web pilot:** non-production connector 등록. 16개 tool의 remote-safe parity, upload,
+4. **Quick Web pilot:** non-production connector 등록. 17개 tool의 remote-safe parity, upload,
    edit, render, convert, download, expiry, reconnect 검증.
 5. **Security gate:** cross-tenant, rebinding, proxy bypass, archive bomb, race, timeout,
    cancellation, load test 완료. General availability 전 independent review.
@@ -242,7 +242,7 @@ maintained protocol/HTTP primitive를 우선한다. no tokio/no SDK 유지는 un
 
 Remote MCP 구현은 다음을 모두 입증해야 통과한다.
 
-- stdio가 기본값으로 남고 기존 process test가 정확히 16개 tool을 계속 노출;
+- stdio가 기본값으로 남고 기존 process test가 정확히 17개 tool을 계속 노출;
 - HTTP conformance가 `POST`, `GET`, `DELETE`, 두 response media type, version negotiation,
   notification, session 생성/종료, reconnect, disconnect를 검증;
 - invalid origin, host, content type, protocol version, token, scope, session, artifact ownership이
@@ -254,7 +254,7 @@ Remote MCP 구현은 다음을 모두 입증해야 통과한다.
 - worker termination 뒤 published partial artifact나 reusable authority가 남지 않음;
 - log/error에 token, document content, client-local path, server filesystem path가 없음;
 - TLS/trusted proxy/host-origin check/OAuth validation을 우회해 application backend에 접근 불가;
-- tenant-isolated test environment에서 Quick Web이 initialize, 의도한 16개 remote-safe tool list,
+- tenant-isolated test environment에서 Quick Web이 initialize, 의도한 17개 remote-safe tool list,
   upload-to-download edit workflow를 완료.
 
 어느 기준이든 미검증이면 release gate 실패다. HTTP가 unrestricted `hwp mcp`를 단순 shell-out하거나,

--- a/docs/design/20-remote-mcp.md
+++ b/docs/design/20-remote-mcp.md
@@ -13,7 +13,7 @@ process. Amazon Quick Web is the first concrete consumer. Implementation remains
 
 ### 1.1 Scope
 
-- Preserve `hwp mcp` stdio as the default local transport and keep its 16-tool behavior compatible.
+- Preserve `hwp mcp` stdio as the default local transport and keep its 17-tool behavior compatible.
 - Add an explicit, separately configured Streamable HTTP mode for hosted deployments.
 - Reuse one transport-independent JSON-RPC and tool-dispatch core from both adapters.
 - Authenticate every remote request and isolate workspaces by tenant, principal, and session.
@@ -236,14 +236,14 @@ security tests pass without recreating an unsafe framework.
 ## 9. Phased follow-up backlog
 
 1. **Core extraction:** introduce typed JSON-RPC values and authority contexts; keep stdio output and
-   all 16 tools byte/behavior compatible.
+   all 17 tools byte/behavior compatible.
 2. **Artifact model:** implement tenant-owned uploads, immutable outputs, remote-safe schemas, quotas,
    and cleanup without opening a network listener.
 3. **Transport and auth:** add the selected HTTP adapter, protocol headers, SSE/session lifecycle,
    OAuth resource-server validation, proxy boundary, and audit events behind an explicit build or
    deployment mode.
 4. **Quick Web pilot:** register a non-production connector, verify initialization and remote-safe
-   parity for all 16 tools, then test upload, edit, render, convert, download, expiry, and reconnect.
+   parity for all 17 tools, then test upload, edit, render, convert, download, expiry, and reconnect.
 5. **Security gate:** complete cross-tenant, rebinding, proxy-bypass, archive-bomb, race, timeout,
    cancellation, and load tests; obtain an independent review before general availability.
 6. **Operations:** define SLOs, capacity, key rotation, incident response, deletion verification,
@@ -253,7 +253,7 @@ security tests pass without recreating an unsafe framework.
 
 A Remote MCP implementation is acceptable only when all of the following are demonstrated:
 
-- stdio remains the default and its existing process test still exposes exactly 16 tools;
+- stdio remains the default and its existing process test still exposes exactly 17 tools;
 - HTTP conformance covers `POST`, `GET`, `DELETE`, both response media types, version negotiation,
   notifications, session creation/termination, reconnect, and disconnect behavior;
 - invalid origin, host, content type, protocol version, token, scope, session, or artifact ownership
@@ -266,7 +266,7 @@ A Remote MCP implementation is acceptable only when all of the following are dem
 - logs and errors contain no tokens, document content, client-local paths, or server filesystem paths;
 - the application backend cannot be reached by bypassing TLS, the trusted proxy, host/origin checks,
   or OAuth validation;
-- Quick Web completes initialize, lists the intended 16 remote-safe tools, and performs an
+- Quick Web completes initialize, lists the intended 17 remote-safe tools, and performs an
   upload-to-download edit workflow in a tenant-isolated test environment.
 
 The implementation fails the release gate if any criterion is unverified, if HTTP merely shells out

--- a/docs/manual/cli-reference.ko.md
+++ b/docs/manual/cli-reference.ko.md
@@ -23,6 +23,7 @@
 - [`hwp slots`](#hwp-slots)
 - [`hwp fill`](#hwp-fill)
 - [`hwp validate`](#hwp-validate)
+- [`hwp lint`](#hwp-lint)
 - [`hwp certify`](#hwp-certify)
 - [`hwp corpus`](#hwp-corpus)
 - [`hwp mcp`](#hwp-mcp)
@@ -272,6 +273,19 @@ TemplateSpec/Data v1에서 typed native HWP/HWPX 생성
 |---|---|---|---|
 | `<FILE>` |  |  | 대상 HWP/HWPX 파일 |
 | `--json` |  |  | JSON으로 출력 |
+
+## `hwp lint`
+
+공문서 표기법·구조 규칙 검사 — 기본은 권고(advisory)이며 항상 종료코드 0. --strict는 오류 심각도 지적이 있을 때만 종료코드 1
+
+**사용법:** `hwp lint [OPTIONS] <FILE>`
+
+| 인자/플래그 | 값 | 기본값 | 설명 |
+|---|---|---|---|
+| `<FILE>` |  |  | 검사 대상 .md/.hwp/.hwpx 파일 ("-"는 stdin을 markdown으로 읽음) |
+| `--profile` | `gongmun` \| `report` | `gongmun` | 린트 프로필: gongmun(기본) 또는 report — v1에서는 같은 규칙 표 사용 |
+| `--json` |  |  | hwp-lint-report-v1 JSON 리포트로 출력 |
+| `--strict` |  |  | 오류 심각도 지적이 있으면 종료 코드 1 (기본: 항상 종료 코드 0) |
 
 ## `hwp certify`
 

--- a/docs/manual/cli-reference.md
+++ b/docs/manual/cli-reference.md
@@ -23,6 +23,7 @@ This document is generated from the clap definitions of the `hwp` CLI. Do not ed
 - [`hwp slots`](#hwp-slots)
 - [`hwp fill`](#hwp-fill)
 - [`hwp validate`](#hwp-validate)
+- [`hwp lint`](#hwp-lint)
 - [`hwp certify`](#hwp-certify)
 - [`hwp corpus`](#hwp-corpus)
 - [`hwp mcp`](#hwp-mcp)
@@ -272,6 +273,19 @@ Structural validation (mimetype, required entries, XML parsing); exit code 0 whe
 |---|---|---|---|
 | `<FILE>` |  |  | Target HWP/HWPX file |
 | `--json` |  |  | Print as JSON |
+
+## `hwp lint`
+
+Lint official-document notation and structure rules; advisory by default (always exit 0) — --strict exits 1 only when an error-severity finding exists
+
+**Usage:** `hwp lint [OPTIONS] <FILE>`
+
+| Argument/flag | Value | Default | Description |
+|---|---|---|---|
+| `<FILE>` |  |  | Target .md/.hwp/.hwpx file ("-" reads stdin as markdown) |
+| `--profile` | `gongmun` \| `report` | `gongmun` | Lint profile: gongmun (default) or report; both run the same rule table in v1 |
+| `--json` |  |  | Print the hwp-lint-report-v1 JSON report |
+| `--strict` |  |  | Exit 1 when an error-severity finding exists (default: always exit 0) |
 
 ## `hwp certify`
 

--- a/schemas/lint-report-v1.schema.json
+++ b/schemas/lint-report-v1.schema.json
@@ -22,7 +22,8 @@
         "error_count": { "type": "integer", "minimum": 0 },
         "warning_count": { "type": "integer", "minimum": 0 }
       }
-    }
+    },
+    "error": { "type": "string" }
   },
   "$defs": {
     "lintFinding": {

--- a/schemas/lint-report-v1.schema.json
+++ b/schemas/lint-report-v1.schema.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hwp-cli.dev/schemas/lint-report-v1.schema.json",
+  "title": "hwp-lint-report-v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "contract", "file", "profile", "findings", "summary"],
+  "properties": {
+    "schema_version": { "const": "1.0" },
+    "contract": { "const": "hwp-lint-report-v1" },
+    "file": { "type": "string" },
+    "profile": { "enum": ["gongmun", "report"] },
+    "findings": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/lintFinding" }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["error_count", "warning_count"],
+      "properties": {
+        "error_count": { "type": "integer", "minimum": 0 },
+        "warning_count": { "type": "integer", "minimum": 0 }
+      }
+    }
+  },
+  "$defs": {
+    "lintFinding": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["rule_id", "severity", "line", "col", "message"],
+      "properties": {
+        "rule_id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+        "severity": { "enum": ["error", "warning"] },
+        "line": { "type": "integer", "minimum": 1 },
+        "col": { "type": "integer", "minimum": 1 },
+        "message": { "type": "string" },
+        "context": { "type": "string" }
+      }
+    }
+  }
+}

--- a/skills/hwp/SKILL.ko.md
+++ b/skills/hwp/SKILL.ko.md
@@ -45,7 +45,7 @@ HWPX 형식을 읽고 쓰며, docx, pdf, html, markdown, json, odt, txt, csv로 
   또는 JSON IR을 가져옵니다 (생략 시 빈 문서); `--set-meta key=value` (title/author/
   subject/keywords, 반복 가능); `--preset official|report|plan|notice|minutes|press`
   (한국 공문서 프로필, 마크다운 입력 전용); `gian`과 문서화된 호환 별칭은 표준 프로필로
-  정규화합니다. 변별 여백은 mm 단위 `--margin-top`, `--margin-bottom`, `--margin-left`,
+  정규화합니다 — `gian` 별칭은 계속 동작하지만 한 번의 지원 중단 안내를 출력합니다. 변별 여백은 mm 단위 `--margin-top`, `--margin-bottom`, `--margin-left`,
   `--margin-right`로 지정합니다. `--strict`는 마크다운 가져오기가 내용을 유실하면 실패합니다.
 - `hwp edit {input} -o {output} [flags...]` — 기존 문서 편집; 이미지, 서식, 미파싱
   레코드는 보존합니다. 문자열 플래그 (모두 반복 가능): `--replace "find=>repl"`,
@@ -97,7 +97,8 @@ HWPX 형식을 읽고 쓰며, docx, pdf, html, markdown, json, odt, txt, csv로 
 하나씩 `official`(기안문), `report`(보고서), `plan`(계획서), `notice`(공고문),
 `minutes`(회의록), `press`(보도자료) 여섯 가지입니다. 표준 공문서 프로필은 `gian`,
 `gongmun`을 의미상 호환 별칭으로 받습니다. 별칭은 같은 프로필을 선택할 뿐 raw-byte
-동일성을 약속하지 않습니다. 한국어 별칭도 사용할 수 있습니다. 각 유형을 마크다운 골격으로
+동일성을 약속하지 않으며, `gian` 별칭은 계속 동작하지만 한 번의 지원 중단 안내를
+출력합니다. 한국어 별칭도 사용할 수 있습니다. 각 유형을 마크다운 골격으로
 작성하고, `hwp new --from ... --preset official`(또는 맞는 프로필)로 생성한 뒤 `hwp fill`로
 채웁니다.
 
@@ -178,7 +179,7 @@ Quick의 로컬 폴터 권한에 추가된 폴터는 내장 읽기/검색 도구
 
 Quick 설정을 도와줄 때는 JSON 임포트를 선호하고, 인수 안에 셸 인용 문자를 넣지 마세요.
 세 계층을 순서대로 검증하세요: 정확한 절대 경로 바이너리가 버전을 반환하는지; Quick이
-16개 도구를 보고하고 새로고침 후에도 활성 상태인지; 마지막으로 `hwp_new`와 이어진
+17개 도구를 보고하고 새로고침 후에도 활성 상태인지; 마지막으로 `hwp_new`와 이어진
 `hwp_validate`가 설정된 LocalLow 루트 아래 절대 경로에서 성공하는지 (예:
 `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\quick-hwp-smoke.hwpx`).
 디스커버리만으로 파일 접근이 증명된다고 주장하지 마세요.
@@ -187,7 +188,7 @@ Quick 설정을 도와줄 때는 JSON 임포트를 선호하고, 인수 안에 �
 복사-붙여넣기 운영자 및 AI 런북:
 `https://github.com/STAIxBWLB/hwp-cli/blob/main/docs/manual/amazon-quick-desktop.md`.
 
-도구 (16):
+도구 (17):
 
 | 도구 | 필수 인수 | 용도 |
 |---|---|---|
@@ -205,6 +206,7 @@ Quick 설정을 도와줄 때는 JSON 임포트를 선호하고, 인수 안에 �
 | `hwp_template` | `output`, `template` (+`data`) | TemplateSpec/Data v1의 한정된 확장 |
 | `hwp_fill` | `input`, `output`, `values` | hwpx 템플릿의 `{{name}}` 채우기 (패키지 보존) |
 | `hwp_validate` | `path` | 구조 검증, `{valid, errors, warnings}` |
+| `hwp_lint` | `path` | 마크다운 파일의 공문서 표기법·구조 규칙 검사 (권고성; 경로만, `--root` 샌드박스 적용); hwp-lint-report-v1 findings JSON (`rule_id`/`severity`/`line`/`col`/`message`) 반환 |
 | `hwp_certify` | `input`, `policy`, `report` | 인증 실행 후 보고서를 원자적으로 발행 |
 | `hwp_diff` | `input`, `ref` | 한 페이지를 렌더링해 참조 PNG와 비교 |
 

--- a/skills/hwp/SKILL.md
+++ b/skills/hwp/SKILL.md
@@ -45,7 +45,8 @@ syntax (used by `fill`, `slots` and the template tools).
   markdown or a JSON IR (empty document when omitted); `--set-meta key=value` (title/author/
   subject/keywords, repeatable); `--preset official|report|plan|notice|minutes|press`
   (Korean official-document profiles, markdown input only); `gian` and other documented
-  compatibility aliases normalize to a canonical profile. Per-side overrides are
+  compatibility aliases normalize to a canonical profile — the `gian` alias still works but
+  prints a one-time deprecation note. Per-side overrides are
   `--margin-top`, `--margin-bottom`, `--margin-left` and `--margin-right` in millimetres.
   `--strict` fails when markdown import drops content.
 - `hwp edit {input} -o {output} [flags...]` — edit an existing document; images, formatting
@@ -98,7 +99,8 @@ syntax (used by `fill`, `slots` and the template tools).
 one per document type: `official` (기안문), `report` (보고서), `plan` (계획서), `notice`
 (공고문), `minutes` (회의록) and `press` (보도자료). The canonical official profile accepts
 `gian` and `gongmun` as semantic compatibility aliases; aliases select the same profile, not a
-raw-byte identity promise. Korean aliases are also accepted. Each type is authored as a markdown
+raw-byte identity promise, and the `gian` alias still works but prints a one-time deprecation
+note. Korean aliases are also accepted. Each type is authored as a markdown
 skeleton, created with `hwp new --from ... --preset official` (or its matching profile), and
 filled with `hwp fill`.
 
@@ -179,7 +181,7 @@ of it, and re-enable the connector if repeated startup failures caused Quick to 
 
 When helping someone configure Quick, prefer JSON import and never put shell quote characters
 inside an argument. Verify three layers in order: the exact absolute binary returns a version;
-Quick reports 16 tools and stays enabled after refresh; then `hwp_new` followed by `hwp_validate`
+Quick reports 17 tools and stays enabled after refresh; then `hwp_new` followed by `hwp_validate`
 succeeds on an absolute path under the configured LocalLow root (for example
 `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\quick-hwp-smoke.hwpx`). Do not claim
 that discovery alone proves file access.
@@ -187,7 +189,7 @@ After a connector edit, refresh or start a new chat instead of reusing an old ge
 The copy-paste operator and AI runbook is:
 `https://github.com/STAIxBWLB/hwp-cli/blob/main/docs/manual/amazon-quick-desktop.md`.
 
-Tools (16):
+Tools (17):
 
 | Tool | Required arguments | Purpose |
 |---|---|---|
@@ -205,6 +207,7 @@ Tools (16):
 | `hwp_template` | `output`, `template` (+`data`) | Bounded expansion of TemplateSpec/Data v1 |
 | `hwp_fill` | `input`, `output`, `values` | Fill `{{name}}` in an hwpx template (package preserved) |
 | `hwp_validate` | `path` | Structural validation, `{valid, errors, warnings}` |
+| `hwp_lint` | `path` | Advisory official-document notation/structure lint on a markdown file (path only, `--root` sandboxed); returns the hwp-lint-report-v1 findings JSON (`rule_id`/`severity`/`line`/`col`/`message`) |
 | `hwp_certify` | `input`, `policy`, `report` | Run certification and publish the report atomically |
 | `hwp_diff` | `input`, `ref` | Render one page and compare it to a reference PNG |
 

--- a/skills/hwp/official-documents.ko.md
+++ b/skills/hwp/official-documents.ko.md
@@ -63,7 +63,7 @@
 
 | 문서 유형 | 오늘의 프리셋 | 템플릿 골격 | 비고 |
 |---|---|---|---|
-| 기안문 | `official` (맑은 고딕 12pt/160%; `gian` 호환 별칭) | `gian-internal.md` (내부결재), `gian-external.md` (대외시행) | `gongmun-basic.md`는 순수 대외 공문 기본형 (접수번호/접수일자 없음) |
+| 기안문 | `official` (맑은 고딕 12pt/160%; `gian` 호환 별칭 — 계속 동작하며 한 번의 지원 중단 안내 출력) | `gian-internal.md` (내부결재), `gian-external.md` (대외시행) | `gongmun-basic.md`는 순수 대외 공문 기본형 (접수번호/접수일자 없음) |
 | 보고서 | `report` (HCR 바탕 15pt/160%) | `report.md` | 머리말/꼬리말 15 mm, `- N -` 쪽 번호; 배경 → 내용 → 계획 → 행정사항 골격 |
 | 계획서 | `plan` (HCR 바탕 15pt/160%) | `plan.md` | 머리말/꼬리말 15 mm, `- N -` 쪽 번호; 9개 절 사업계획서 골격 |
 | 회의록 | `minutes` (HCR 바탕 14pt/130%) | `minutes.md` | 머리말/꼬리말 여백과 쪽 번호 없음; 공공기록물 관리에 관한 법률 시행령 제18조의 9가지 법정 요소 (D-19) |
@@ -76,7 +76,8 @@
 여섯 프로필 모두 시작 여백은 위/아래/왼쪽/오른쪽 20/10/20/20 mm입니다. 변별 여백은
 `--margin-top`, `--margin-bottom`, `--margin-left`, `--margin-right`로만 명시합니다. 표준
 이름은 `official`, `report`, `plan`, `notice`, `minutes`, `press`이며, `gian`, `gongmun`과
-문서화된 한국어 이름은 하나의 표준 프로필로 정규화됩니다.
+문서화된 한국어 이름은 하나의 표준 프로필로 정규화됩니다. `gian` 별칭은 계속 동작하지만
+한 번의 지원 중단 안내를 출력합니다.
 
 모든 레시피가 공유하는 관례:
 
@@ -189,9 +190,21 @@ hwp render out.hwpx -o page1.png --pages 1 --font-dir fonts/
 
 위의 모든 레시피는 `hwp`가 MCP stdio 서버로 실행될 때 MCP 도구와 일대일로 대응됩니다:
 `hwp new` → `hwp_new`, `hwp fill` → `hwp_fill`, `hwp render` → `hwp_render`,
-`hwp validate` → `hwp_validate`. 규정 린터 (`hwp_lint`)는 2.3 단계에서 도입됩니다.
-서버는 항상 최소 하나의 `--root`를 지정해 시작해 도구가 샌드박스 작업 공간만 접근하게
-하세요. 도구 상세, 샌드박스 의미, 클라이언트 설정은 SKILL.md의 MCP 절에 있습니다.
+`hwp validate` → `hwp_validate`, 그리고 `hwp lint` → `hwp_lint`. 서버는 항상 최소
+하나의 `--root`를 지정해 시작해 도구가 샌드박스 작업 공간만 접근하게 하세요. 도구
+상세, 샌드박스 의미, 클라이언트 설정은 SKILL.md의 MCP 절에 있습니다.
+
+### 생성 전 린트
+
+`hwp_lint`는 마크다운 파일 `path` 하나만 받고(인라인 텍스트 없음) 서버의 `--root`
+샌드박스를 따릅니다. 반환값은 권고성 hwp-lint-report-v1 findings JSON — finding마다
+`rule_id`/`severity`/`line`/`col`/`message`, 원문 발췌 없음 — 입니다. CLI 쌍은
+`hwp lint <file.md> [--profile gongmun|report] [--json] [--strict]`입니다.
+
+`hwp new --from` 전에 마크다운 골격을 린트하세요. 오류 심각도 구조 finding
+(`struct-item-mark`, `struct-roman-heading`)을 먼저 고치세요 — `--strict`에서는 이들이
+명령을 실패시킵니다. 표기법 경고는 수동으로 적용하는 권고로 다루세요. 린트는 파일을
+다시 쓰지 않습니다.
 
 ## 7. 한컴 오피스 최종 확인
 

--- a/skills/hwp/official-documents.md
+++ b/skills/hwp/official-documents.md
@@ -67,7 +67,7 @@ present-day path.
 
 | Document type | Preset today | Template skeleton | Notes |
 |---|---|---|---|
-| 기안문 (draft) | `official` (Malgun Gothic 12pt/160%; `gian` compatibility alias) | `gian-internal.md` (내부결재), `gian-external.md` (대외시행) | `gongmun-basic.md` covers the plain external official letter (no 접수번호/접수일자) |
+| 기안문 (draft) | `official` (Malgun Gothic 12pt/160%; `gian` compatibility alias — still works, prints a one-time deprecation note) | `gian-internal.md` (내부결재), `gian-external.md` (대외시행) | `gongmun-basic.md` covers the plain external official letter (no 접수번호/접수일자) |
 | 보고서 (report) | `report` (HCR Batang 15pt/160%) | `report.md` | 15 mm header/footer, `- N -` page number; 배경 → 내용 → 계획 → 행정사항 skeleton |
 | 계획서 (plan) | `plan` (HCR Batang 15pt/160%) | `plan.md` | 15 mm header/footer, `- N -` page number; 9-section 사업계획서 skeleton |
 | 회의록 (minutes) | `minutes` (HCR Batang 14pt/130%) | `minutes.md` | No header/footer margin or page number; 9 statutory elements of 공공기록물 관리에 관한 법률 시행령 제18조 (D-19) |
@@ -81,7 +81,8 @@ type and apply the style in the body text. All six profiles start with top/botto
 margins of 20/10/20/20 mm; use `--margin-top`, `--margin-bottom`, `--margin-left` or
 `--margin-right` only for an explicit per-side override. Canonical names are `official`,
 `report`, `plan`, `notice`, `minutes` and `press`; `gian`, `gongmun` and the documented Korean
-names normalize to one of them.
+names normalize to one of them. The `gian` alias still works but prints a one-time deprecation
+note.
 
 Conventions every recipe shares:
 
@@ -196,9 +197,21 @@ so the recipe above is unaffected.
 
 Every recipe above maps one-to-one onto the MCP tools when `hwp` runs as an MCP stdio
 server: `hwp new` → `hwp_new`, `hwp fill` → `hwp_fill`, `hwp render` → `hwp_render`,
-`hwp validate` → `hwp_validate`. A regulation linter (`hwp_lint`) arrives in Phase 2.3.
-Always start the server with at least one `--root` so the tools can only touch the sandboxed
-workspace; tool details, sandbox semantics and client setup stay in SKILL.md's MCP section.
+`hwp validate` → `hwp_validate`, and `hwp lint` → `hwp_lint`. Always start the server
+with at least one `--root` so the tools can only touch the sandboxed workspace; tool
+details, sandbox semantics and client setup stay in SKILL.md's MCP section.
+
+### Lint before you generate
+
+`hwp_lint` takes a markdown file `path` only (no inline text), honors the server's
+`--root` sandbox, and returns the advisory hwp-lint-report-v1 findings JSON —
+`rule_id`/`severity`/`line`/`col`/`message` per finding, with no source-text excerpts.
+The CLI twin is `hwp lint <file.md> [--profile gongmun|report] [--json] [--strict]`.
+
+Lint the markdown skeleton before `hwp new --from`. Fix error-severity structure
+findings (`struct-item-mark`, `struct-roman-heading`) first — under `--strict` they
+fail the command — and treat the notation warnings as advisory guidance to apply by
+hand; lint never rewrites the file.
 
 ## 7. Final check in Hancom Office
 


### PR DESCRIPTION
Phase 2.3 (GN-3). Adds `hwp lint`, its rule engine, the `hwp-lint-report-v1` contract, and
`hwp_lint` as the 17th MCP tool.

## Why this is a PR and not already on main

These seventeen commits were made directly on local `main`, which the repo policy forbids
("Features, fixes, docs — all work happens on a branch. No direct pushes to main"). They were
never pushed. I moved them onto this branch and reset local `main` back to `origin/main`; no
history was rewritten and no commit was dropped.

That detour was not bookkeeping. Because the work never passed a gate, it carried a CI-breaking
defect — see below.

## What ships

`hwp lint <file>` — markdown, `.hwp`, `.hwpx`, or `-` for stdin.

- `--profile gongmun|report` (default `gongmun`; one rule table for both in v1)
- `--json` emits `hwp-lint-report-v1` (`schemas/lint-report-v1.schema.json`)
- `--strict` exits 1 only on an error-severity finding; advisory and exit 0 otherwise

Ten rules across three families:

```
notation-date  notation-time  notation-money  notation-punctuation
notation-attach-colon  notation-attach-number  notation-end-dot
struct-item-mark  struct-roman-heading
ai-style-marks
```

Findings carry `line`, `col`, `rule_id`, `severity`, `message`. MCP goes 16 → 17 tools, with the
count guard and the Remote MCP acceptance text updated in the same change (EN + KO).

## The defect the missing gate hid

`crates/hwp-cli/src/cli.rs` used `value.to_ascii_lowercase() == "gian"`, which
`clippy::manual_ignore_case_cmp` rejects at deny level under the pinned 1.93.0 toolchain. The
branch failed `scripts/check.sh` on arrival and would have failed CI. Fixed in the last commit
with `eq_ignore_ascii_case` — the ASCII-insensitive compare the doc comment already described, so
behaviour is unchanged and `--preset GIAN` still fires the note.

## Open question — the deprecation note names an alias, not the canonical name

`parse_preset_arg` prints `gian은 gongmun의 별칭입니다`. But `gongmun` is not the preset's name:

```rust
"official" | "gian" | "gongmun" => Ok(Self::Official),
```

The canonical name is `official` — that is what `OfficialPreset::name()` returns, and what the
`--preset` help and `docs/manual/cli-reference{,.ko}.md` advertise. The note therefore steers a
user off one alias and onto another.

The cause is inside D-03 itself. `02.3-CONTEXT.md` asserts "`gongmun` is the official-document
preset name and `gian` is a hidden alias", while the same decision also records "no preset key
rename" — so `official` stayed canonical and the premise never became true.

Left as-is deliberately: it is a recorded decision and `5726a6b` pins the exact string in a
binary-level test, so changing it is a decision plus a test update, not a typo fix. Two ways out
if it should change:

1. Point the note at the canonical name — `gian은 official의 별칭입니다` — and update the test.
2. Keep the wording and make the premise true by renaming the canonical key to `gongmun`, which
   D-03 explicitly declined.

## Verification

`scripts/check.sh` green under the pinned 1.93.0 toolchain: fmt, clippy `-D warnings`, 45 test
binaries with zero failures, PDF-runner tests, and the structured-corpus gate. Public PDF parity
skipped — this host lacks the pinned `pdfinfo 24.02.0`; CI runs it on ubuntu-24.04.

Refs #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NP1tBbckiBLFFBGBa4bWr