### PR TITLE
chore(brew): formula v0.9.0

### DIFF
--- a/Formula/hwp.rb
+++ b/Formula/hwp.rb
@@ -10,24 +10,24 @@ class Hwp < Formula
   # brew style: desc 는 formula 이름(hwp)으로 시작하면 안 된다.
   desc "한글 문서(HWP 5.0·HWPX) 읽기·변환·렌더·편집 단일 바이너리"
   homepage "https://github.com/STAIxBWLB/hwp-cli"
-  version "0.8.8"
+  version "0.9.0"
   license any_of: ["MIT", "Apache-2.0"]
 
   on_macos do
     on_arm do
       url "https://github.com/STAIxBWLB/hwp-cli/releases/download/v#{version}/hwp-v#{version}-aarch64-apple-darwin.tar.gz"
-      sha256 "9a279a04fa30513025a1fd6df991299e17cbf95456e0f396b906cf76d44e7e62"
+      sha256 "f5f6552d395ebab477a044279adbeac847ebb3c9a6172f16b58ab7413d178c8d"
     end
     on_intel do
       url "https://github.com/STAIxBWLB/hwp-cli/releases/download/v#{version}/hwp-v#{version}-x86_64-apple-darwin.tar.gz"
-      sha256 "445deec250df4f65f1934c805d784d28ebb8b917f891f5692204a74cb4dd0f53"
+      sha256 "83ef31abe859dd535c3dad1dcc25e6ca856148dd4733024737aedb070312309a"
     end
   end
 
   on_linux do
     on_intel do
       url "https://github.com/STAIxBWLB/hwp-cli/releases/download/v#{version}/hwp-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
-      sha256 "2a8342e7b68c398d5b3d62f851352a8405986c379fcfd85c40584c8b33080963"
+      sha256 "d7ecab0639c704a25e3a3eb032a5e751fcbd0151962eaba6a9bb42593ea0816b"
     end
   end
 


### PR DESCRIPTION
Points the tap at the v0.9.0 release artifacts.

Checksums are the ones the release workflow published, not recomputed by hand:

| Target | sha256 |
|---|---|
| aarch64-apple-darwin | `f5f6552d395ebab477a044279adbeac847ebb3c9a6172f16b58ab7413d178c8d` |
| x86_64-apple-darwin | `83ef31abe859dd535c3dad1dcc25e6ca856148dd4733024737aedb070312309a` |
| x86_64-unknown-linux-gnu | `d7ecab0639c704a25e3a3eb032a5e751fcbd0151962eaba6a9bb42593ea0816b` |

Verified rather than assumed: the arm64 archive was downloaded from the release and its computed
sha256 matches the value declared here, and the extracted binary runs.

```
$ ./hwp --version
hwp 0.9.0
$ ./hwp new --list-templates | head -3
gian-internal	기안문-내부결재
gian-external	기안문-대외시행
gongmun-basic	공문서-기본
$ printf '2025.1.6 회의\n' > t.md && ./hwp lint t.md
1: notation-date — 날짜는 `2026. 6. 19.`처럼 표기합니다 …
```

Both surfaces new in 0.9.0 (`--list-templates`, `hwp lint`) are present in the shipped binary, so
the release is not just tagged but actually carries the work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NP1tBbckiBLFFBGBa4bWr