### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.10.0]
+
 **Added**
 
 - `--doc-foot 수신자=…` (MCP `doc_foot`) adds the multi-recipient list to the 결문. It is the one

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "cfb",
@@ -707,7 +707,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "hwp-model",
  "image",
@@ -723,14 +723,14 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "hwp-render"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "encoding_rs",
  "flate2",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "aes",
  "cfb",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "hwp-convert",
  "hwp-model",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"


### PR DESCRIPTION
Bumps the workspace to 0.10.0 and closes the `[Unreleased]` CHANGELOG section, which `scripts/release_notes.sh 0.10.0` extracts verbatim as the GitHub Release body (36 lines, verified).

Minor bump rather than patch: this release adds a frame key and changes what `hwp new --template` produces, including one slot-name contract change.

## What ships since 0.9.0

**Added** — `--doc-foot 수신자=…` (MCP `doc_foot`) carries the multi-recipient list in the 결문. It is the one conditional 결문 row, so a document that never names it keeps the exact bytes it had before the key existed (#142).

**Changed** — `hwp new --template <slug>` now produces a finished, framed document on its own (#140). A template brings the canonical profile it is written for and its native 두문/결문 frames, whose values default to its own `{{slot}}` tokens, so the one-command form yields real 두문/결문 **tables** instead of loose paragraphs and every field stays fillable. `--preset` and the frame flags override one template default each instead of being refused.

**Fixed** — `gongmun-basic` is modelled as the multi-recipient 공문서 it is named for: 두문 reads the fixed `수신자 참조`, 결문 carries the `{{수신자}}` list (#142). Before this it generated a document byte-identical to `gian-external`. Two bundled-guide claims that contradicted the binary are corrected (#140).

### Upgrade note

`gongmun-basic`'s `{{수신}}` slot is replaced by `{{수신자}}`. Callers filling that template by name need to rename the key in their `--set` list; `hwp fill` fails closed, so the mismatch surfaces as an error rather than an empty field.

## Verification

Phase 2.4 closed at 12/12 must-haves. All eight `--template` outputs were opened in genuine Hancom Office HWP 12.30.0 build 6446 (macOS 26.6.2 build 25G83) with no repair or corruption dialog; twenty private receipts are bound to the rebuilt sha256 index and are 20/20 schema-valid. Receipts and artifacts stay outside the repository.

## Known issue

`hwp lint` reports false `struct-item-mark` findings on any preset document containing nested ordered lists ([#141](https://github.com/STAIxBWLB/hwp-cli/issues/141)). Pre-existing on main; reachable through `--template report`/`plan` since a template now implies its preset.

## After merge

Tag the merge commit on main and push the tag to trigger `release.yml`, which verifies the tagged commit's green CI before building and then opens the Homebrew formula bump.