### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.11.0]
+
 **Added**
 
 - Password-protected HWP5 and HWPX input now enters the normal read, convert and render paths when
@@ -52,6 +54,31 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
   line with the catalog.
 
 **Fixed**
+
+- Non-ASCII passwords saved by Hangul now authenticate with the observed CP949 byte derivation,
+  while UTF-8 remains the first candidate and ASCII behavior is unchanged. The independent corpus
+  probe confirms the genuine Korean-password HWPX under CP949 and rejects the tested alternative
+  encodings; HWP5 uses the same closed candidate list but remains marked as inference until a
+  genuine non-ASCII HWP5 is measured.
+
+- Protected native conversion is snapshot-bound and publishes only after source identity,
+  container preservation and semantic reread checks agree. This applies to single files, batches,
+  Markdown media sidecars and HWP/HWPX output. Batch preloading shares crypto budgets across
+  encoding candidates, avoids duplicate decryptions, and enforces format-specific memory bounds.
+
+- HWPX manifest attributes now decode XML entities, and password-unlocked rewrites remove only
+  encryption metadata while preserving ordinary manifest registrations for opaque parts. HWP5
+  multi-section and distribution ViewText streams are authenticated and parsed rather than being
+  limited to `BodyText/Section0`.
+
+- Password handling now bounds HWP5 and HWPX preview reads, aggregate HWP5 CFB1 work, aggregate
+  HWPX PBKDF2 work, ciphertext allocation and password stdin. MCP notifications scrub parsed
+  passwords before returning, and wrong/absent corpus receipts require the exact stable refusal
+  code.
+
+- Owner corpus fixtures, receipt directories and receipt-producing source paths are canonicalized
+  before repository-isolation checks, preventing external-looking symlinks from certifying files or
+  writing evidence inside the checkout.
 
 - Password-unlocked HWPX entries remain available for every read during one package invocation,
   including the second `version.xml` access. Rewriting a decrypted document also replaces the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hwp-model",
  "image",
@@ -749,14 +749,14 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "hwp-render"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "encoding_rs",
  "flate2",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aes",
  "cfb",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"

--- a/README.ko.md
+++ b/README.ko.md
@@ -108,7 +108,7 @@ curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/inst
 기본 위치는 `~/.local/bin`이다(PATH에 없으면 안내를 출력한다). 위치·버전은 인자나 환경변수로 바꾼다:
 
 ```sh
-curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.10.0
+curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.11.0
 HWP_INSTALL_DIR=~/bin sh scripts/install.sh
 ```
 
@@ -149,7 +149,7 @@ RHEL/CentOS 7+ 및 그 이후 배포판에서 그대로 돌아간다. 빌드 러
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
-  | sh -s -- --tag v0.10.0 --dir ./bin
+  | sh -s -- --tag v0.11.0 --dir ./bin
 ```
 
 플랫폼이 배포 번들을 수집하기 전에 바이너리가 있어야 하므로(Vercel `includeFiles`, Next.js

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The default location is `~/.local/bin` (if it is not on PATH, the script says so
 location or version with arguments or environment variables:
 
 ```sh
-curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.10.0
+curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.11.0
 HWP_INSTALL_DIR=~/bin sh scripts/install.sh
 ```
 
@@ -165,7 +165,7 @@ to bump:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
-  | sh -s -- --tag v0.10.0 --dir ./bin
+  | sh -s -- --tag v0.11.0 --dir ./bin
 ```
 
 Run this from the build command (or a `prebuild` script) so the binary exists before the platform


### PR DESCRIPTION
## Summary
- close the password-protected HWP5/HWPX implementation notes as v0.11.0
- document genuine non-ASCII Hangul password compatibility and the final security/resource hardening
- bump all workspace crates and Cargo.lock from 0.10.0 to 0.11.0
- update pinned install examples to v0.11.0

## Verification
- `scripts/release.sh --self-test`
- `scripts/release_notes.sh 0.11.0`
- `cargo +1.93.0 test -p hwp-cli --test cli_reference`
- feature merge main CI: https://github.com/STAIxBWLB/hwp-cli/actions/runs/32972855434
- exact feature HEAD genuine gate: 7 receipts, HWP5/HWPX/non-ASCII direct reads, wrong/absent stable refusal

## Release sequence
After squash merge and green main CI, create annotated tag `v0.11.0` on the exact release merge SHA and verify release assets, checksums, Homebrew, installed binary, and active skill runtime.
