### PR TITLE
feat: add native label-form fill and editing recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+**Added**
+
+- `hwp edit --set-cell-by-label "label=value"` fills a uniquely resolved adjacent or header-row
+  form value cell. The operation is atomic by default, rejects ambiguous and duplicate targets,
+  supports `--label-table` for recursive-table scope, and is available through the typed MCP edit
+  surface.
+
+- The bundled `hwp` skill now exports a bilingual native editing crosswalk for inspection,
+  anchor-based paragraph editing, data-driven table fill, label-value forms, and the
+  validate-plus-render guard workflow. It records explicit limits for section-index, raw-ZIP, and
+  structural XML-drift operations rather than claiming unsupported parity.
+
+**Changed**
+
+- These merged source changes are a prerequisite for retiring the old `hwpx` skill, not
+  replacement evidence by themselves. The separate release plan must publish and record the
+  first supported tag, verify its exported skill tree and old-template compatibility, and only
+  then allow the retirement gate to proceed.
+
 ## [0.11.0]
 
 **Added**

--- a/crates/hwp-cli/src/cli.rs
+++ b/crates/hwp-cli/src/cli.rs
@@ -493,6 +493,12 @@ pub struct EditArgs {
     /// Set a table cell, "table:row:col=value" (repeatable; 0-based indices)
     #[arg(long = "set-cell")]
     pub set_cell: Vec<String>,
+    /// Fill the value cell immediately right of a form label, "label=value" (repeatable)
+    #[arg(long = "set-cell-by-label")]
+    pub set_cell_by_label: Vec<String>,
+    /// Restrict every --set-cell-by-label request to this zero-based recursive table index
+    #[arg(long = "label-table", requires = "set_cell_by_label")]
+    pub label_table: Option<usize>,
     /// Fill a field, "name=value" (repeatable; list names with hwp fields)
     #[arg(long = "set-field")]
     pub set_field: Vec<String>,

--- a/crates/hwp-cli/src/commands/edit.rs
+++ b/crates/hwp-cli/src/commands/edit.rs
@@ -6,7 +6,7 @@
 //! 패키지 외과 수술 경로(`hwpx::patch::rewrite_document_staged`)로, 편집된
 //! 콘텐츠 엔트리만 재직렬화하고 나머지 엔트리는 raw 복사로 바이트 보존한다.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::Path;
 
@@ -67,6 +67,11 @@ pub(crate) enum TypedEditOperation {
         row: u16,
         col: u16,
         text: String,
+    },
+    SetCellByLabel {
+        label: String,
+        text: String,
+        table: Option<usize>,
     },
     CreateField {
         anchor: String,
@@ -268,6 +273,18 @@ struct ResolvedLabelEdit {
     text: String,
     candidate: hwp_convert::FormCellCandidate,
     request: String,
+}
+
+struct LabelEditRequest {
+    label: String,
+    text: String,
+    table: Option<usize>,
+    request: String,
+}
+
+struct LabelPreflight {
+    resolved: Vec<Option<ResolvedLabelEdit>>,
+    unapplied: Vec<String>,
 }
 
 #[derive(Debug)]
@@ -609,9 +626,16 @@ pub fn execute(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<E
     let original_doc = doc.clone();
     // Label lookup is a preflight, not another mutation primitive: every request
     // observes the original document and errors before a staged output exists.
-    let mut resolved_label_edits = preflight_cli_label_edits(plan, &mut doc)?.into_iter();
+    let label_preflight = preflight_label_edits(plan, &mut doc)?;
+    if !label_preflight.unapplied.is_empty() && !plan.allow_partial {
+        anyhow::bail!(
+            "적용되지 않은 편집 요청이 있습니다: {} (--allow-partial로 일치한 요청만 적용 가능)",
+            label_preflight.unapplied.join(", ")
+        );
+    }
+    let mut resolved_label_edits = label_preflight.resolved.into_iter();
     let mut edits = 0usize;
-    let mut unapplied = Vec::new();
+    let mut unapplied = label_preflight.unapplied;
     // 구조 편집(문단/행 추가·삭제·이미지 삽입)은 합성 경로로 써야 한다 — 삽입 문단/행
     // 불변식 + 그림 도형 레코드 합성(빈-extras Picture)이 적용되도록.
     let structural = plan.operations.iter().any(EditOperation::is_structural)
@@ -686,6 +710,9 @@ pub fn execute(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<E
                     let resolved = resolved_label_edits
                         .next()
                         .expect("label edits are resolved during preflight");
+                    let Some(resolved) = resolved else {
+                        continue;
+                    };
                     let before = doc.clone();
                     hwp_convert::set_cell(
                         &mut doc,
@@ -1155,7 +1182,13 @@ pub fn execute(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<E
         }
     }
     for operation in &plan.typed_operations {
-        apply_typed_operation(operation, &mut doc, &mut edits, &mut unapplied)?;
+        apply_typed_operation(
+            operation,
+            &mut doc,
+            &mut edits,
+            &mut unapplied,
+            &mut resolved_label_edits,
+        )?;
     }
 
     if !unapplied.is_empty() && !plan.allow_partial {
@@ -1240,11 +1273,11 @@ pub fn execute(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<E
     })
 }
 
-fn preflight_cli_label_edits(
+fn preflight_label_edits(
     plan: &EditPlan,
     doc: &mut hwp_model::Document,
-) -> anyhow::Result<Vec<ResolvedLabelEdit>> {
-    let mut resolved = Vec::new();
+) -> anyhow::Result<LabelPreflight> {
+    let mut requests = Vec::new();
     for operation in &plan.operations {
         let EditOperation::SetCellByLabel { specs, table } = operation else {
             continue;
@@ -1257,28 +1290,76 @@ fn preflight_cli_label_edits(
             if normalized.is_empty() {
                 anyhow::bail!("--set-cell-by-label 레이블은 비어 있을 수 없습니다");
             }
-            let candidates = hwp_convert::find_form_cells_by_label(doc, &normalized, *table);
-            match candidates.as_slice() {
-                [] => anyhow::bail!("양식 레이블에 해당하는 셀을 찾지 못했습니다"),
-                [candidate] => resolved.push(ResolvedLabelEdit {
-                    text: text.to_string(),
-                    candidate: *candidate,
-                    request: format!("--set-cell-by-label {spec:?}"),
-                }),
-                many => anyhow::bail!(
-                    "양식 레이블 대상이 모호합니다: {}",
-                    many.iter()
-                        .map(|candidate| format!(
-                            "표{} ({},{})",
-                            candidate.table, candidate.row, candidate.col
-                        ))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ),
-            }
+            requests.push(LabelEditRequest {
+                label: normalized,
+                text: text.to_string(),
+                table: *table,
+                request: "set_cell_by_label".to_string(),
+            });
         }
     }
-    Ok(resolved)
+    for operation in &plan.typed_operations {
+        let TypedEditOperation::SetCellByLabel { label, text, table } = operation else {
+            continue;
+        };
+        let normalized = hwp_convert::normalize_form_label(label);
+        if normalized.is_empty() {
+            anyhow::bail!("set_cell_by_label 레이블은 비어 있을 수 없습니다");
+        }
+        requests.push(LabelEditRequest {
+            label: normalized,
+            text: text.clone(),
+            table: *table,
+            request: "set_cell_by_label".to_string(),
+        });
+    }
+
+    let mut resolved = Vec::with_capacity(requests.len());
+    let mut unapplied = Vec::new();
+    let mut targeted = BTreeSet::new();
+    for request in requests {
+        if let Some(table) = request.table {
+            if hwp_convert::table_dims(doc, table).is_none() {
+                anyhow::bail!("set_cell_by_label의 table 범위가 유효하지 않습니다");
+            }
+        }
+        let candidates = hwp_convert::find_form_cells_by_label(doc, &request.label, request.table);
+        match candidates.as_slice() {
+            [] => {
+                unapplied.push(request.request);
+                resolved.push(None);
+            }
+            [candidate] => {
+                if !targeted.insert(*candidate) {
+                    anyhow::bail!(
+                        "양식 레이블 대상이 중복됩니다: 표{} ({},{})",
+                        candidate.table,
+                        candidate.row,
+                        candidate.col
+                    );
+                }
+                resolved.push(Some(ResolvedLabelEdit {
+                    text: request.text,
+                    candidate: *candidate,
+                    request: "set_cell_by_label".to_string(),
+                }));
+            }
+            many => anyhow::bail!(
+                "양식 레이블 대상이 모호합니다: {}",
+                many.iter()
+                    .map(|candidate| format!(
+                        "표{} ({},{})",
+                        candidate.table, candidate.row, candidate.col
+                    ))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        }
+    }
+    Ok(LabelPreflight {
+        resolved,
+        unapplied,
+    })
 }
 
 struct PatchReport {
@@ -1383,6 +1464,7 @@ fn apply_typed_operation(
     doc: &mut hwp_model::Document,
     edits: &mut usize,
     unapplied: &mut Vec<String>,
+    resolved_label_edits: &mut dyn Iterator<Item = Option<ResolvedLabelEdit>>,
 ) -> anyhow::Result<()> {
     match operation {
         TypedEditOperation::Replace { from, to } => {
@@ -1418,6 +1500,28 @@ fn apply_typed_operation(
                 edits,
                 unapplied,
             );
+        }
+        TypedEditOperation::SetCellByLabel { .. } => {
+            let resolved = resolved_label_edits
+                .next()
+                .expect("label edits are resolved during preflight");
+            let Some(resolved) = resolved else {
+                return Ok(());
+            };
+            let before = doc.clone();
+            hwp_convert::set_cell(
+                doc,
+                resolved.candidate.table,
+                resolved.candidate.row,
+                resolved.candidate.col,
+                &resolved.text,
+            )
+            .map_err(|error| anyhow::anyhow!(error))?;
+            eprintln!(
+                "양식 셀 설정: 표{} ({},{})",
+                resolved.candidate.table, resolved.candidate.row, resolved.candidate.col
+            );
+            record_effect(&before, doc, resolved.request, edits, unapplied);
         }
         TypedEditOperation::CreateField {
             anchor,

--- a/crates/hwp-cli/src/commands/edit.rs
+++ b/crates/hwp-cli/src/commands/edit.rs
@@ -20,6 +20,10 @@ use crate::commands::cat::load_document;
 enum EditOperation {
     Replace(Vec<String>),
     SetCell(Vec<String>),
+    SetCellByLabel {
+        specs: Vec<String>,
+        table: Option<usize>,
+    },
     CreateField(Vec<String>),
     CreateBookmark(Vec<String>),
     CreateHyperlink(Vec<String>),
@@ -234,6 +238,7 @@ impl EditOperation {
             | Self::DeleteBookmark(_) => true,
             Self::Replace(_)
             | Self::SetCell(_)
+            | Self::SetCellByLabel { .. }
             | Self::CreateField(_)
             | Self::CreateBookmark(_)
             | Self::CreateHyperlink(_)
@@ -257,6 +262,12 @@ pub struct EditPlan {
     typed_operations: Vec<TypedEditOperation>,
     verify: bool,
     allow_partial: bool,
+}
+
+struct ResolvedLabelEdit {
+    text: String,
+    candidate: hwp_convert::FormCellCandidate,
+    request: String,
 }
 
 #[derive(Debug)]
@@ -303,6 +314,8 @@ impl EditPlan {
             output,
             replace,
             set_cell,
+            set_cell_by_label,
+            label_table,
             set_field,
             set_meta,
             create_field,
@@ -344,6 +357,12 @@ impl EditPlan {
         }
         add!(Replace, replace);
         add!(SetCell, set_cell);
+        if !set_cell_by_label.is_empty() {
+            operations.push(EditOperation::SetCellByLabel {
+                specs: set_cell_by_label,
+                table: label_table,
+            });
+        }
         add!(CreateField, create_field);
         add!(CreateBookmark, create_bookmark);
         add!(CreateHyperlink, create_hyperlink);
@@ -588,6 +607,9 @@ pub fn execute(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<E
 
     let mut doc = load_document(input)?;
     let original_doc = doc.clone();
+    // Label lookup is a preflight, not another mutation primitive: every request
+    // observes the original document and errors before a staged output exists.
+    let mut resolved_label_edits = preflight_cli_label_edits(plan, &mut doc)?.into_iter();
     let mut edits = 0usize;
     let mut unapplied = Vec::new();
     // 구조 편집(문단/행 추가·삭제·이미지 삽입)은 합성 경로로 써야 한다 — 삽입 문단/행
@@ -657,6 +679,27 @@ pub fn execute(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<E
                         &mut edits,
                         &mut unapplied,
                     );
+                }
+            }
+            EditOperation::SetCellByLabel { specs, .. } => {
+                for _ in specs {
+                    let resolved = resolved_label_edits
+                        .next()
+                        .expect("label edits are resolved during preflight");
+                    let before = doc.clone();
+                    hwp_convert::set_cell(
+                        &mut doc,
+                        resolved.candidate.table,
+                        resolved.candidate.row,
+                        resolved.candidate.col,
+                        &resolved.text,
+                    )
+                    .map_err(|error| anyhow::anyhow!(error))?;
+                    eprintln!(
+                        "양식 셀 설정: 표{} ({},{})",
+                        resolved.candidate.table, resolved.candidate.row, resolved.candidate.col
+                    );
+                    record_effect(&before, &doc, resolved.request, &mut edits, &mut unapplied);
                 }
             }
             // 누름틀 생성은 set_field보다 먼저 — 같은 호출에서 생성한 필드를 바로 채울 수 있게.
@@ -1195,6 +1238,47 @@ pub fn execute(input: &Path, output: &Path, plan: &EditPlan) -> anyhow::Result<E
         warnings,
         preservation: writer_report.preservation,
     })
+}
+
+fn preflight_cli_label_edits(
+    plan: &EditPlan,
+    doc: &mut hwp_model::Document,
+) -> anyhow::Result<Vec<ResolvedLabelEdit>> {
+    let mut resolved = Vec::new();
+    for operation in &plan.operations {
+        let EditOperation::SetCellByLabel { specs, table } = operation else {
+            continue;
+        };
+        for spec in specs {
+            let (label, text) = spec.split_once('=').with_context(|| {
+                format!("--set-cell-by-label 형식은 \"레이블=값\" 입니다: {spec:?}")
+            })?;
+            let normalized = hwp_convert::normalize_form_label(label);
+            if normalized.is_empty() {
+                anyhow::bail!("--set-cell-by-label 레이블은 비어 있을 수 없습니다");
+            }
+            let candidates = hwp_convert::find_form_cells_by_label(doc, &normalized, *table);
+            match candidates.as_slice() {
+                [] => anyhow::bail!("양식 레이블에 해당하는 셀을 찾지 못했습니다"),
+                [candidate] => resolved.push(ResolvedLabelEdit {
+                    text: text.to_string(),
+                    candidate: *candidate,
+                    request: format!("--set-cell-by-label {spec:?}"),
+                }),
+                many => anyhow::bail!(
+                    "양식 레이블 대상이 모호합니다: {}",
+                    many.iter()
+                        .map(|candidate| format!(
+                            "표{} ({},{})",
+                            candidate.table, candidate.row, candidate.col
+                        ))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ),
+            }
+        }
+    }
+    Ok(resolved)
 }
 
 struct PatchReport {

--- a/crates/hwp-cli/src/commands/edit.rs
+++ b/crates/hwp-cli/src/commands/edit.rs
@@ -1318,10 +1318,10 @@ fn preflight_label_edits(
     let mut unapplied = Vec::new();
     let mut targeted = BTreeSet::new();
     for request in requests {
-        if let Some(table) = request.table {
-            if hwp_convert::table_dims(doc, table).is_none() {
-                anyhow::bail!("set_cell_by_label의 table 범위가 유효하지 않습니다");
-            }
+        if let Some(table) = request.table
+            && hwp_convert::table_dims(doc, table).is_none()
+        {
+            anyhow::bail!("set_cell_by_label의 table 범위가 유효하지 않습니다");
         }
         let candidates = hwp_convert::find_form_cells_by_label(doc, &request.label, request.table);
         match candidates.as_slice() {

--- a/crates/hwp-cli/src/commands/mcp.rs
+++ b/crates/hwp-cli/src/commands/mcp.rs
@@ -1263,6 +1263,13 @@ fn tool_edit(args: &Value, ctx: &Ctx) -> Result<Vec<Value>, String> {
             text: required_item_str(item, "set_cell", "text")?.to_string(),
         });
     }
+    for item in arg_array(args, "set_cell_by_label")? {
+        operations.push(Op::SetCellByLabel {
+            label: required_item_str(item, "set_cell_by_label", "label")?.to_string(),
+            text: required_item_str(item, "set_cell_by_label", "text")?.to_string(),
+            table: optional_item_usize(item, "set_cell_by_label", "table")?,
+        });
+    }
     for item in arg_array(args, "set_field")? {
         operations.push(Op::SetField {
             name: required_item_str(item, "set_field", "name")?.to_string(),
@@ -2187,6 +2194,10 @@ fn tool_defs() -> Vec<Value> {
                     "table": {"type": "integer"}, "row": {"type": "integer"},
                     "col": {"type": "integer"}, "text": {"type": "string"}},
                     "required": ["table", "row", "col", "text"]}, "description": "표 셀 설정(0-기반)"},
+                "set_cell_by_label": {"type": "array", "items": {"type": "object", "additionalProperties": false, "properties": {
+                    "label": {"type": "string"}, "text": {"type": "string"},
+                    "table": {"type": "integer", "minimum": 0}},
+                    "required": ["label", "text"]}, "description": "양식 레이블의 인접 또는 첫 데이터 행 셀 설정(선택 table은 0-기반 재귀 표 범위)"},
                 "set_field": {"type": "array", "items": {"type": "object", "properties": {
                     "name": {"type": "string"}, "value": {"type": "string"}},
                     "required": ["name", "value"]}, "description": "필드/누름틀 채우기(이름으로)"},
@@ -4123,6 +4134,51 @@ mod tests {
         // set_page is a single object; the rest are arrays.
         assert_eq!(properties["set_page"]["type"], "object");
         assert_eq!(properties["add_table"]["type"], "array");
+    }
+
+    #[test]
+    fn mcp_set_cell_by_label_uses_shared_preflight_and_closed_item_schema() {
+        let tools = tool_defs();
+        let edit = tools
+            .iter()
+            .find(|tool| tool["name"] == "hwp_edit")
+            .unwrap();
+        let item = &edit["inputSchema"]["properties"]["set_cell_by_label"]["items"];
+        assert_eq!(item["additionalProperties"], false);
+        assert_eq!(item["properties"]["table"]["minimum"], 0);
+
+        let source = temp_file("set-cell-by-label-mcp-source.hwpx");
+        let output = temp_file("set-cell-by-label-mcp-out.hwpx");
+        create_hwpx(&source, "| 성명 | |\n|---|---|\n");
+        tool_edit(
+            &json!({
+                "input": source,
+                "output": output,
+                "set_cell_by_label": [{"label": " 성명：", "text": "MCP홍길동"}]
+            }),
+            &ctx(),
+        )
+        .expect("MCP label edit");
+        assert!(
+            load_document(&output)
+                .unwrap()
+                .plain_text()
+                .contains("MCP홍길동")
+        );
+
+        let missing = tool_edit(
+            &json!({
+                "input": source,
+                "output": output,
+                "set_cell_by_label": [{"label": null, "text": "MCP홍길동"}]
+            }),
+            &ctx(),
+        )
+        .unwrap_err();
+        assert!(missing.contains("label 필요"), "{missing}");
+        for path in [&source, &output] {
+            let _ = std::fs::remove_file(path);
+        }
     }
 
     #[test]

--- a/crates/hwp-cli/src/commands/skill.rs
+++ b/crates/hwp-cli/src/commands/skill.rs
@@ -78,6 +78,14 @@ pub const SKILL_FILES: &[EmbeddedFile] = &[
         contents: include_str!("../../../../skills/hwp/references/korean-official-format.ko.md"),
     },
     EmbeddedFile {
+        rel: "references/editing-recipes.md",
+        contents: include_str!("../../../../skills/hwp/references/editing-recipes.md"),
+    },
+    EmbeddedFile {
+        rel: "references/editing-recipes.ko.md",
+        contents: include_str!("../../../../skills/hwp/references/editing-recipes.ko.md"),
+    },
+    EmbeddedFile {
         rel: "templates/gian-internal.md",
         contents: include_str!("../../../../skills/hwp/templates/gian-internal.md"),
     },

--- a/crates/hwp-cli/src/i18n.rs
+++ b/crates/hwp-cli/src/i18n.rs
@@ -412,6 +412,16 @@ pub const KO: &[(&str, &str, &str)] = &[
     ),
     (
         "edit",
+        "set_cell_by_label",
+        "양식 레이블의 값 셀 설정 \"레이블=값\" (반복 가능, 정확 일치)",
+    ),
+    (
+        "edit",
+        "label_table",
+        "모든 --set-cell-by-label 요청을 이 0-기반 재귀 표 인덱스로 제한",
+    ),
+    (
+        "edit",
         "set_field",
         "필드/누름틀 채우기 \"이름=값\" (반복 가능 — hwp fields로 이름 확인)",
     ),

--- a/crates/hwp-cli/tests/table_edit.rs
+++ b/crates/hwp-cli/tests/table_edit.rs
@@ -98,6 +98,26 @@ fn set_cell_by_label_fills_unique_adjacent_cell_and_validates() {
 }
 
 #[test]
+fn set_cell_by_label_fills_first_data_row_below_a_header_label() {
+    let source = label_form("label_header", "| 성명 |\n|---|\n| |\n");
+    let output = tmp("label_header_out.hwpx");
+    let result = hwp()
+        .arg("edit")
+        .arg(&source)
+        .arg("-o")
+        .arg(&output)
+        .args(["--set-cell-by-label", "성명=홍길동"])
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "header fill: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert!(cat(&output).contains("홍길동"), "filled value is visible");
+}
+
+#[test]
 fn set_cell_by_label_uses_exact_normalized_matching_only() {
     let source = label_form("label_exact", "| 성명: | |\n|---|---|\n");
     for (case, request) in [
@@ -147,6 +167,98 @@ fn set_cell_by_label_rejects_empty_or_missing_without_changing_files() {
             "destination unchanged"
         );
     }
+}
+
+#[test]
+fn set_cell_by_label_requires_scope_for_ambiguity_and_rejects_duplicates() {
+    let source = label_form(
+        "label_ambiguous",
+        "| 성명 | |\n|---|---|\n\n| 성명 | |\n|---|---|\n",
+    );
+    for (case, args) in [
+        (
+            "ambiguous",
+            vec!["--set-cell-by-label", "성명=홍길동", "--allow-partial"],
+        ),
+        (
+            "duplicate",
+            vec![
+                "--set-cell-by-label",
+                "성명=홍길동",
+                "--set-cell-by-label",
+                " 성명：=김철수",
+            ],
+        ),
+    ] {
+        let output = tmp(&format!("label_{case}_out.hwpx"));
+        let sentinel = format!("sentinel-{case}").into_bytes();
+        std::fs::write(&output, &sentinel).unwrap();
+        let result = hwp()
+            .arg("edit")
+            .arg(&source)
+            .arg("-o")
+            .arg(&output)
+            .args(args)
+            .output()
+            .unwrap();
+        assert!(!result.status.success(), "{case} must fail");
+        assert_eq!(std::fs::read(output).unwrap(), sentinel, "{case} is atomic");
+        let stderr = String::from_utf8_lossy(&result.stderr);
+        assert!(
+            !stderr.contains("홍길동"),
+            "{case} must not disclose values"
+        );
+    }
+}
+
+#[test]
+fn set_cell_by_label_partial_and_table_scope_are_deterministic() {
+    let source = label_form(
+        "label_partial_scope",
+        "| 성명 | |\n|---|---|\n\n| 성명 | |\n|---|---|\n",
+    );
+    let default_output = tmp("label_partial_default.hwpx");
+    let sentinel = b"default-sentinel";
+    std::fs::write(&default_output, sentinel).unwrap();
+    let default_result = hwp()
+        .arg("edit")
+        .arg(&source)
+        .arg("-o")
+        .arg(&default_output)
+        .args([
+            "--set-cell-by-label",
+            "성명=홍길동",
+            "--set-cell-by-label",
+            "주소=제주",
+        ])
+        .output()
+        .unwrap();
+    assert!(!default_result.status.success());
+    assert_eq!(std::fs::read(&default_output).unwrap(), sentinel);
+
+    let scoped_output = tmp("label_scope_out.hwpx");
+    let scoped_result = hwp()
+        .arg("edit")
+        .arg(&source)
+        .arg("-o")
+        .arg(&scoped_output)
+        .args([
+            "--set-cell-by-label",
+            "성명=홍길동",
+            "--set-cell-by-label",
+            "주소=제주",
+            "--label-table",
+            "1",
+            "--allow-partial",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        scoped_result.status.success(),
+        "scoped partial: {}",
+        String::from_utf8_lossy(&scoped_result.stderr)
+    );
+    assert!(cat(&scoped_output).contains("홍길동"));
 }
 
 /// 픽스처 자체가 유효해야 한다(익명화 후에도 한컴 규격 충족).

--- a/crates/hwp-cli/tests/table_edit.rs
+++ b/crates/hwp-cli/tests/table_edit.rs
@@ -26,6 +26,26 @@ fn tmp(name: &str) -> PathBuf {
     dir.join(name)
 }
 
+/// Generate a compact form table for label-fill tests without depending on private fixtures.
+fn label_form(name: &str, markdown: &str) -> PathBuf {
+    let source = tmp(&format!("{name}.md"));
+    std::fs::write(&source, markdown).unwrap();
+    let form = tmp(&format!("{name}.hwpx"));
+    let result = hwp()
+        .args(["new", "--from"])
+        .arg(&source)
+        .arg("-o")
+        .arg(&form)
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "form generation: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    form
+}
+
 /// 픽스처를 임시 사본으로 복사해 편집한다(원본 불변).
 fn copy_fixture(name: &str) -> PathBuf {
     let dst = tmp(name);
@@ -43,6 +63,90 @@ fn read_zip_entry(path: &PathBuf, name: &str) -> Vec<u8> {
     let mut buf = Vec::new();
     zip.by_name(name).unwrap().read_to_end(&mut buf).unwrap();
     buf
+}
+
+#[test]
+fn set_cell_by_label_fills_unique_adjacent_cell_and_validates() {
+    let source = label_form(
+        "label_adjacent",
+        "| 성명： | |\n|---|---|\n| 소울별 | 이름 |\n",
+    );
+    let output = tmp("label_adjacent_out.hwpx");
+    let result = hwp()
+        .arg("edit")
+        .arg(&source)
+        .arg("-o")
+        .arg(&output)
+        .args(["--set-cell-by-label", "  성명：=홍길동", "--verify"])
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "label fill: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert!(cat(&output).contains("홍길동"), "filled value is visible");
+    assert!(
+        hwp()
+            .arg("validate")
+            .arg(&output)
+            .status()
+            .unwrap()
+            .success(),
+        "label fill output validates"
+    );
+}
+
+#[test]
+fn set_cell_by_label_uses_exact_normalized_matching_only() {
+    let source = label_form("label_exact", "| 성명: | |\n|---|---|\n");
+    for (case, request) in [
+        ("different_label", "성명A=값이"),
+        ("substring", "성=김"),
+        ("nfd", "가=김"),
+    ] {
+        let output = tmp(&format!("label_exact_{case}.hwpx"));
+        let result = hwp()
+            .arg("edit")
+            .arg(&source)
+            .arg("-o")
+            .arg(&output)
+            .args(["--set-cell-by-label", request])
+            .output()
+            .unwrap();
+        assert!(!result.status.success(), "{case} must not match");
+        assert!(!output.exists(), "{case} must not publish an output");
+    }
+}
+
+#[test]
+fn set_cell_by_label_rejects_empty_or_missing_without_changing_files() {
+    let source = label_form("label_atomic", "| 성명 | |\n|---|---|\n");
+    let source_before = std::fs::read(&source).unwrap();
+    for (case, request) in [("empty", " ：=홍길동"), ("missing", "주소=제주")] {
+        let output = tmp(&format!("label_atomic_{case}.hwpx"));
+        let existing = format!("sentinel-{case}").into_bytes();
+        std::fs::write(&output, &existing).unwrap();
+        let result = hwp()
+            .arg("edit")
+            .arg(&source)
+            .arg("-o")
+            .arg(&output)
+            .args(["--set-cell-by-label", request])
+            .output()
+            .unwrap();
+        assert!(!result.status.success(), "{case} must fail");
+        assert_eq!(
+            std::fs::read(&source).unwrap(),
+            source_before,
+            "source unchanged"
+        );
+        assert_eq!(
+            std::fs::read(&output).unwrap(),
+            existing,
+            "destination unchanged"
+        );
+    }
 }
 
 /// 픽스처 자체가 유효해야 한다(익명화 후에도 한컴 규격 충족).

--- a/crates/hwp-cli/tests/table_edit.rs
+++ b/crates/hwp-cli/tests/table_edit.rs
@@ -118,6 +118,29 @@ fn set_cell_by_label_fills_first_data_row_below_a_header_label() {
 }
 
 #[test]
+fn set_cell_by_label_fills_below_a_multicolumn_header_without_ambiguity() {
+    let source = label_form(
+        "label_multicolumn_header",
+        "| 성명 | 소속 |\n|---|---|\n| | |\n",
+    );
+    let output = tmp("label_multicolumn_header_out.hwpx");
+    let result = hwp()
+        .arg("edit")
+        .arg(&source)
+        .arg("-o")
+        .arg(&output)
+        .args(["--set-cell-by-label", "성명=홍길동", "--verify"])
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "multi-column header fill: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    assert!(cat(&output).contains("홍길동"), "filled value is visible");
+}
+
+#[test]
 fn set_cell_by_label_uses_exact_normalized_matching_only() {
     let source = label_form("label_exact", "| 성명: | |\n|---|---|\n");
     for (case, request) in [

--- a/crates/hwp-convert/src/edit.rs
+++ b/crates/hwp-convert/src/edit.rs
@@ -29,11 +29,13 @@ pub fn normalize_form_label(label: &str) -> String {
         .to_string()
 }
 
-/// Find cells immediately to the right of a matching form label.
+/// Find writable form cells for a matching label.
 ///
 /// Table indices use the same recursive document order as [`set_cell`]. This
 /// intentionally calls the readonly table walker so discovery cannot clear
-/// opaque HWPX XML or otherwise mutate the document.
+/// opaque HWPX XML or otherwise mutate the document. A label may address the
+/// immediately adjacent cell, or the first data cell directly below a label in
+/// the table's first row.
 pub fn find_form_cells_by_label(
     doc: &mut Document,
     label: &str,
@@ -52,6 +54,22 @@ pub fn find_form_cells_by_label(
                 return Vec::new();
             }
             let mut matches = Vec::new();
+            let header_is_complete =
+                current
+                    .cells
+                    .iter()
+                    .filter(|cell| cell.row == 0)
+                    .all(|cell| {
+                        !normalize_form_label(
+                            &cell
+                                .paragraphs
+                                .iter()
+                                .map(Paragraph::plain_text)
+                                .collect::<Vec<_>>()
+                                .join("\n"),
+                        )
+                        .is_empty()
+                    });
             for label_cell in &current.cells {
                 let visible = label_cell
                     .paragraphs
@@ -73,6 +91,21 @@ pub fn find_form_cells_by_label(
                         row: target.row,
                         col: target.col,
                     });
+                }
+
+                if header_is_complete && label_cell.row == 0 {
+                    let first_data_row = label_cell.row.saturating_add(label_cell.row_span);
+                    if let Some(target) = current
+                        .cells
+                        .iter()
+                        .find(|cell| cell.row == first_data_row && cell.col == label_cell.col)
+                    {
+                        matches.push(FormCellCandidate {
+                            table: table_index,
+                            row: target.row,
+                            col: target.col,
+                        });
+                    }
                 }
             }
             matches

--- a/crates/hwp-convert/src/edit.rs
+++ b/crates/hwp-convert/src/edit.rs
@@ -9,6 +9,85 @@
 
 use hwp_model::{CharShapeId, Control, Document, HwpChar, Paragraph};
 
+/// A writable form-cell coordinate discovered without changing the document.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct FormCellCandidate {
+    pub table: usize,
+    pub row: u16,
+    pub col: u16,
+}
+
+/// Normalise a form label for the deliberately narrow label-fill contract.
+///
+/// Only surrounding Unicode whitespace and terminal ASCII/full-width colons are
+/// removed. In particular, this does not case-fold or Unicode-normalise input.
+pub fn normalize_form_label(label: &str) -> String {
+    label
+        .trim()
+        .trim_end_matches([':', '：'])
+        .trim_end()
+        .to_string()
+}
+
+/// Find cells immediately to the right of a matching form label.
+///
+/// Table indices use the same recursive document order as [`set_cell`]. This
+/// intentionally calls the readonly table walker so discovery cannot clear
+/// opaque HWPX XML or otherwise mutate the document.
+pub fn find_form_cells_by_label(
+    doc: &mut Document,
+    label: &str,
+    table: Option<usize>,
+) -> Vec<FormCellCandidate> {
+    let wanted = normalize_form_label(label);
+    if wanted.is_empty() {
+        return Vec::new();
+    }
+
+    let mut candidates = Vec::new();
+    let mut table_index = 0usize;
+    loop {
+        let found = with_nth_table_readonly(doc, table_index, |current| {
+            if table.is_some_and(|scope| scope != table_index) {
+                return Vec::new();
+            }
+            let mut matches = Vec::new();
+            for label_cell in &current.cells {
+                let visible = label_cell
+                    .paragraphs
+                    .iter()
+                    .map(Paragraph::plain_text)
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                if normalize_form_label(&visible) != wanted {
+                    continue;
+                }
+                let right_col = label_cell.col.saturating_add(label_cell.col_span);
+                if let Some(target) = current
+                    .cells
+                    .iter()
+                    .find(|cell| cell.row == label_cell.row && cell.col == right_col)
+                {
+                    matches.push(FormCellCandidate {
+                        table: table_index,
+                        row: target.row,
+                        col: target.col,
+                    });
+                }
+            }
+            matches
+        });
+        let Some(found) = found else {
+            break;
+        };
+        candidates.extend(found);
+        table_index += 1;
+    }
+    candidates.sort_unstable();
+    candidates.dedup();
+    candidates
+}
+
 /// 문서 전체에서 `from`을 `to`로 치환한다(본문·표 셀·글상자 문단 재귀).
 /// `all`이 거짓이면 첫 1건만 바꾼다. 반환값은 치환 횟수.
 ///

--- a/crates/hwp-convert/src/edit.rs
+++ b/crates/hwp-convert/src/edit.rs
@@ -80,25 +80,25 @@ pub fn find_form_cells_by_label(
                 if normalize_form_label(&visible) != wanted {
                     continue;
                 }
-                let right_col = label_cell.col.saturating_add(label_cell.col_span);
-                if let Some(target) = current
-                    .cells
-                    .iter()
-                    .find(|cell| cell.row == label_cell.row && cell.col == right_col)
-                {
-                    matches.push(FormCellCandidate {
-                        table: table_index,
-                        row: target.row,
-                        col: target.col,
-                    });
-                }
-
                 if header_is_complete && label_cell.row == 0 {
                     let first_data_row = label_cell.row.saturating_add(label_cell.row_span);
                     if let Some(target) = current
                         .cells
                         .iter()
                         .find(|cell| cell.row == first_data_row && cell.col == label_cell.col)
+                    {
+                        matches.push(FormCellCandidate {
+                            table: table_index,
+                            row: target.row,
+                            col: target.col,
+                        });
+                    }
+                } else {
+                    let right_col = label_cell.col.saturating_add(label_cell.col_span);
+                    if let Some(target) = current
+                        .cells
+                        .iter()
+                        .find(|cell| cell.row == label_cell.row && cell.col == right_col)
                     {
                         matches.push(FormCellCandidate {
                             table: table_index,

--- a/crates/hwp-convert/src/lib.rs
+++ b/crates/hwp-convert/src/lib.rs
@@ -30,9 +30,10 @@ pub use bookmark::{
 pub use csv::to_csv;
 pub use docx::to_docx;
 pub use edit::{
-    CloneTextMode, ObjectKind, add_col, add_rows, add_rows_at, add_table, add_table_column,
-    add_table_columns, apply_meta, clone_table, delete_object, delete_table_column,
-    delete_table_row, merge_cells, replace_text, set_cell, split_cell, table_dims,
+    CloneTextMode, FormCellCandidate, ObjectKind, add_col, add_rows, add_rows_at, add_table,
+    add_table_column, add_table_columns, apply_meta, clone_table, delete_object,
+    delete_table_column, delete_table_row, find_form_cells_by_label, merge_cells,
+    normalize_form_label, replace_text, set_cell, split_cell, table_dims,
 };
 pub use field::{
     FieldInfo, PlaceholderInfo, create_field, create_hyperlink, hyperlink_url, list_fields,

--- a/docs/manual/cli-reference.ko.md
+++ b/docs/manual/cli-reference.ko.md
@@ -199,6 +199,8 @@ TemplateSpec/Data v1에서 typed native HWP/HWPX 생성
 | `-o, --output` | `<OUTPUT>` |  | 출력 파일 경로 |
 | `--replace` | `<REPLACE>` |  | 텍스트 치환 "찾기=>바꾸기" (반복 가능, 모든 일치 치환) |
 | `--set-cell` | `<SET_CELL>` |  | 표 셀 설정 "표:행:열=값" (반복 가능, 0-기반 인덱스) |
+| `--set-cell-by-label` | `<SET_CELL_BY_LABEL>` |  | 양식 레이블의 값 셀 설정 "레이블=값" (반복 가능, 정확 일치) |
+| `--label-table` | `<LABEL_TABLE>` |  | 모든 --set-cell-by-label 요청을 이 0-기반 재귀 표 인덱스로 제한 |
 | `--set-field` | `<SET_FIELD>` |  | 필드/누름틀 채우기 "이름=값" (반복 가능 — hwp fields로 이름 확인) |
 | `--set-meta` | `<SET_META>` |  | 메타데이터 설정 "키=값" (키: title\|author\|subject\|keywords, 반복 가능) |
 | `--create-field` | `<CREATE_FIELD>` |  | 누름틀 생성 "앵커=>이름" 또는 "앵커=>이름=값" — 앵커 텍스트 뒤에 %clk 필드 삽입 (반복 가능) |

--- a/docs/manual/cli-reference.md
+++ b/docs/manual/cli-reference.md
@@ -199,6 +199,8 @@ Edit an existing document (text replacement, table cells); images and formatting
 | `-o, --output` | `<OUTPUT>` |  | Output file path |
 | `--replace` | `<REPLACE>` |  | Replace text, "find=>replace" (repeatable; replaces every match) |
 | `--set-cell` | `<SET_CELL>` |  | Set a table cell, "table:row:col=value" (repeatable; 0-based indices) |
+| `--set-cell-by-label` | `<SET_CELL_BY_LABEL>` |  | Fill the value cell immediately right of a form label, "label=value" (repeatable) |
+| `--label-table` | `<LABEL_TABLE>` |  | Restrict every --set-cell-by-label request to this zero-based recursive table index |
 | `--set-field` | `<SET_FIELD>` |  | Fill a field, "name=value" (repeatable; list names with hwp fields) |
 | `--set-meta` | `<SET_META>` |  | Set metadata, "key=value" (keys: title\|author\|subject\|keywords; repeatable) |
 | `--create-field` | `<CREATE_FIELD>` |  | Create a field, "anchor=>name" or "anchor=>name=value": insert a %clk field after the anchor text (repeatable) |

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -25,7 +25,8 @@ run $CARGO clippy --workspace --all-targets -- -D warnings
 run $CARGO test --workspace
 run python3 -m unittest tools/test_pdf_parity.py
 run bash scripts/check-structured-corpus.sh
-run target/debug/examples/validate_structured_corpus \
+target_dir="${CARGO_TARGET_DIR:-target}"
+run "$target_dir/debug/examples/validate_structured_corpus" \
     schemas/pdf-parity-history-v1.schema.json \
     fixtures/pdf-parity/public/scoreboard/history.json
 

--- a/skills/hwp/SKILL.ko.md
+++ b/skills/hwp/SKILL.ko.md
@@ -139,6 +139,12 @@ report·plan·notice·press에는 `- N -` 쪽 번호를 넣고 official·minutes
 `official-documents.md` (이 파일 옆에 납출됨)에, 규정 배경은
 `references/korean-official-format.md`에 있습니다.
 
+## Editing recipes (편집 레시피)
+
+retired `hwpx` 워크플로우의 정직한 한계를 포함한 이중 언어 네이티브 편집 마이그레이션 대조표는
+[references/editing-recipes.ko.md](references/editing-recipes.ko.md)에 있습니다. 분석, anchor 기반
+문단 편집, 데이터 기반 표 채우기, label-value 양식, validate-plus-render guard 순서에 사용하십시오.
+
 ## MCP 서버
 
 `hwp mcp`는 stdio 위에서 동기 JSON-RPC 2.0을 사용합니다 (줄 구분; stdout이 프로토콜을

--- a/skills/hwp/SKILL.md
+++ b/skills/hwp/SKILL.md
@@ -141,6 +141,13 @@ Per-document recipes, slot tables, the Korean alias table, fill/validate workflo
 Hancom final check live in `official-documents.md` (exported next to this file); regulation
 background lives in `references/korean-official-format.md`.
 
+## Editing recipes
+
+The bilingual native editing migration crosswalk, including honest limits for retired `hwpx`
+workflows, lives in [references/editing-recipes.md](references/editing-recipes.md). Use it for
+analysis, anchor-based paragraph edits, data-driven table fill, label-value forms, and the
+validate-plus-render guard sequence.
+
 ## MCP server
 
 `hwp mcp` speaks synchronous JSON-RPC 2.0 over stdio (line-delimited; stdout carries the

--- a/skills/hwp/references/editing-recipes.ko.md
+++ b/skills/hwp/references/editing-recipes.ko.md
@@ -1,0 +1,138 @@
+[한국어](editing-recipes.ko.md) · [English](editing-recipes.md)
+
+# 네이티브 편집 레시피와 이전 `hwpx` 마이그레이션 대조표
+
+이 레시피는 하나의 번들 `hwp` 스킬에서 사용합니다. 이전 별도 `hwpx` 스킬의 편집 안내를
+대체하지만 래퍼, 보조 스크립트, 실행 레시피, 바이너리 템플릿을 추가하지 않습니다. 로컬
+체크아웃이 아니라 배포된 `hwp` 바이너리에서 모든 명령을 실행하십시오.
+
+## 범위와 릴리스 경계
+
+첫 Phase 2.5 릴리스 태그는 태그 생성 전에 지원 최소 `hwp` 버전을 채웁니다. 그 전까지 이
+원본 레시피 쌍은 명령 계약만 설명합니다. 로컬 빌드, 버전 없는 `PATH` 바이너리, 병합 전 브랜치는
+retirement 또는 replacement 근거가 아닙니다.
+
+`templates/` 아래의 마크다운 8개는 번들 템플릿 SSOT로 유지합니다. 이전 바이너리 템플릿 6개는
+읽기 전용 retirement 호환성 코퍼스이며, 복사, 보관, 편집하지 않습니다.
+
+## 네이티브 마이그레이션 대조표
+
+### 상태 용어
+
+- **exact**: 네이티브 명령이 이전 동작 그 자체입니다.
+- **composed**: 둘 이상의 네이티브 명령으로 유용한 워크플로우를 만듭니다.
+- **limited**: 네이티브 명령이 명시한 안전 경로를 지원하지만 이전 의미를 재현하지 않습니다.
+- **intentionally retired**: raw package 수술이나 비네이티브 폴백에는 대체 경로가 없습니다.
+
+| 이전 추론 동작 | 네이티브 명령 순서 | 상태 | 알려진 제한 | 실행 가능한 검증 |
+|---|---|---|---|---|
+| `summary` | `hwp info form.hwpx --json` 다음 `hwp cat form.hwpx --format json > form.json` | composed | 이전 pretty summary 또는 XML section-index map은 없습니다. | `test -s form.json && hwp validate form.hwpx` |
+| `unpack` | unpack하지 말고 `hwp edit form.hwpx -o edited.hwpx --replace "old=>new" --verify`를 사용합니다. | intentionally retired | 지원되는 raw-ZIP 추출 워크플로우는 없습니다. | `hwp validate edited.hwpx` |
+| `repack` | repack하지 말고 `hwp edit form.hwpx -o edited.hwpx --replace "old=>new" --verify`를 사용합니다. | intentionally retired | 네이티브 writer가 package layout을 맡으며 수동 manifest 변경은 지원하지 않습니다. | `hwp validate edited.hwpx` |
+| `edit`의 run-spanning find/replace | `hwp edit form.hwpx -o edited.hwpx --replace "old=>new" --verify` | limited | 네이티브 replace는 임의 XML text run에 걸쳐 분할된 찾기 문자열의 일치를 보장하지 않습니다. | `hwp validate edited.hwpx && hwp cat edited.hwpx --format plain` |
+| `fill`의 run-spanning `{{slot}}` | `hwp slots template.hwpx --json` 다음 `hwp fill template.hwpx -o filled.hwpx --set "name=value" --json` | limited | 슬롯은 서식 run을 넘을 수 있지만 줄바꿈이나 문단 경계를 넘을 수는 없습니다. | `hwp slots template.hwpx --json && hwp validate filled.hwpx` |
+| `fill-table` | `hwp fill template.hwpx -o filled.hwpx --data tables.json --json` | exact | `tables.json`은 네이티브 `tables` 데이터 계약을 따르고 기존 표를 대상으로 해야 합니다. | `hwp validate filled.hwpx` |
+| `fill-form` | `hwp edit form.hwpx -o filled.hwpx --set-cell-by-label "성명=홍길동" --set-cell-by-label "소속=AI센터" --verify` | limited | 정규화된 각 레이블은 인접 또는 header-row value cell 하나로만 해석되어야 합니다. 모호성이나 중복 대상은 발행을 거부합니다. 재귀 표 범위는 `--label-table N`으로 제한합니다. | `hwp validate filled.hwpx && hwp cat filled.hwpx --format plain` |
+| `analyze` | `hwp info form.hwpx --json` 다음 `hwp cat form.hwpx --format json > form.json` | composed | JSON IR은 텍스트, 표, anchor에 유용하지만 이전 raw `sec` child index나 XML style ID를 내보내지 않습니다. | `test -s form.json && hwp validate form.hwpx` |
+| `edit-section` | `hwp cat form.hwpx --format json > form.json`, 다음 `hwp edit form.hwpx -o edited.hwpx --delete-para "old paragraph" --insert-para "anchor=>replacement paragraph" --verify` | limited | anchor/문단 동작은 raw `[start:end)` section-index 수술이 아니며 XML 문단 스타일을 인덱스로 복제하지 않습니다. | `hwp validate edited.hwpx && hwp cat edited.hwpx --format json > edited.json` |
+| 편집 시 `linesegarray` 정리 | `hwp edit form.hwpx -o edited.hwpx --replace "old=>new" --verify` | composed | writer가 layout record를 내부 관리하며 사용자 표시 `linesegarray` 스위치나 XML 수준 보고서는 없습니다. | `hwp validate edited.hwpx` |
+| sec-index section 편집 | `hwp cat form.hwpx --format json > form.json`, 다음 `hwp edit ... --delete-para ... --insert-para ... --verify` | limited | 네이티브 표면은 안정적인 `sec` child index 계약을 의도적으로 제공하지 않습니다. | `hwp validate edited.hwpx` |
+| mimetype-first STORED repack | `hwp edit form.hwpx -o edited.hwpx --replace "old=>new" --verify` | intentionally retired | writer는 유효한 package 구성을 보존하지만 일반 raw-ZIP repack API를 노출하지 않습니다. | `hwp validate edited.hwpx` |
+| `guard` / `page_guard` 구조 드리프트 지표 | `hwp validate edited.hwpx`, 다음 `hwp render reference.hwpx -o reference.png --report reference.render.json`, `hwp render edited.hwpx -o edited.png --report edited.render.json` | composed | validation과 render report는 XML 문단/표/텍스트 변화율 임계값을 재현하지 않습니다. layout이 중요하면 report 페이지 수를 비교하고 렌더 결과를 검토하십시오. | `hwp validate edited.hwpx && test -s reference.render.json && test -s edited.render.json` |
+
+## 편집 전 확인
+
+### 편집 가능한 맵 만들기
+
+네이티브 metadata와 IR 출력으로 시작합니다. JSON에서 안정적인 표시 텍스트, 표 내용 또는
+field/bookmark 이름을 anchor로 찾고, 이전 XML index를 추론하지 마십시오.
+
+```bash
+hwp info form.hwpx --json
+hwp cat form.hwpx --format json > form.json
+hwp fields form.hwpx --json
+hwp bookmarks form.hwpx --json
+```
+
+### 확인 검증
+
+```bash
+test -s form.json
+hwp validate form.hwpx
+```
+
+## 네이티브 placeholder와 양식 채우기
+
+### 템플릿 또는 표 채우기
+
+placeholder 작업은 `hwp fill` 전에 `hwp slots`를 사용합니다. 데이터 기반 표 행에는 `--data`를
+사용하며, 이것이 이전 `fill-table` 명령의 네이티브 대체입니다.
+
+```bash
+hwp slots template.hwpx --json
+hwp fill template.hwpx -o filled.hwpx --set "title=2026 Plan" --json
+hwp fill table-template.hwpx -o table-filled.hwpx --data tables.json --json
+hwp validate filled.hwpx
+hwp validate table-filled.hwpx
+```
+
+### label-value 양식 채우기
+
+`--set-cell-by-label`은 `label=value`를 받고 인접 `label | value` 및 header/data-row
+레이아웃을 찾으며 기본값으로 atomic입니다. 모호하거나 중복된 레이블을 우회하려고
+`--allow-partial`을 사용하지 마십시오.
+
+```bash
+hwp edit form.hwpx -o form-filled.hwpx \
+  --set-cell-by-label "성명=홍길동" \
+  --set-cell-by-label "소속=AI센터" \
+  --verify
+hwp validate form-filled.hwpx
+```
+
+## anchor를 통한 내용 편집
+
+### 문단 치환 또는 재구성
+
+지원되는 in-place match에는 `--replace`를 사용합니다. section 형태 변경에는 기존 text anchor와
+문단 동작을 사용합니다. validation과 검토를 통과할 때까지 원본은 바꾸지 말고 새 output에
+작성합니다.
+
+```bash
+hwp edit form.hwpx -o revised.hwpx \
+  --replace "2025 Plan=>2026 Plan" \
+  --delete-para "old body paragraph" \
+  --insert-para "body heading=>replacement paragraph" \
+  --verify
+hwp validate revised.hwpx
+```
+
+### 경계 이해하기
+
+네이티브 raw `sec` index editor, XML 문단 스타일 복제 동작, unpack/repack 경로, Python helper는
+없습니다. 의도한 편집이 그 의미에 의존하면 이 레시피를 exact migration으로 취급하지 말고
+원본 문서를 그대로 보존하십시오.
+
+## 완성 출력 지키기
+
+### 검증하고 렌더하기
+
+validation은 package 구조를 확인합니다. render report는 페이지 수와 renderer 진단을 제공하지만
+이전 structural XML-drift 임계값의 대체는 아닙니다.
+
+```bash
+hwp validate revised.hwpx
+hwp render form.hwpx -o reference.png --report reference.render.json
+hwp render revised.hwpx -o revised.png --report revised.render.json
+```
+
+### 증거 검토
+
+두 render report 파일을 확인하고 layout이 중요할 때 페이지 이미지를 점검합니다. 페이지 수 변화나
+눈에 보이는 overflow는 validation을 약화할 근거가 아니라 내용을 고칠 이유입니다.
+
+## 안전과 비목표
+
+위의 모든 쓰기 명령은 `hwp validate`로 끝납니다. 네이티브 edit와 fill은 atomic publication을
+사용하며, 필요한 변경이 실패하면 기존 output을 그대로 둡니다. 이 레시피는 retired wrapper,
+Python XML helper, 실행 가능한 recipe 파일, 이전 바이너리 template을 의도적으로 복원하지 않습니다.

--- a/skills/hwp/references/editing-recipes.md
+++ b/skills/hwp/references/editing-recipes.md
@@ -1,0 +1,138 @@
+[한국어](editing-recipes.ko.md) · [English](editing-recipes.md)
+
+# Native editing recipes and old `hwpx` migration crosswalk
+
+This is the canonical editing guide in the one bundled `hwp` skill. It replaces old `hwpx`
+guidance without adding a wrapper, helper script, executable recipe, or binary template. Run the
+commands with a released `hwp` binary, not a local checkout.
+
+## Scope and release boundary
+
+The first Phase 2.5 release tag will populate the minimum supported `hwp` version before that
+release is tagged. Until then this source pair documents only the command contract: a local build,
+an unversioned `PATH` binary, or an unmerged branch is not retirement or replacement evidence.
+
+The eight Markdown files under `templates/` remain the bundled template SSOT. The six old binary
+templates are a read-only retirement compatibility corpus; do not copy, archive, or edit them.
+
+## Native migration crosswalk
+
+### Status words
+
+- **exact**: the native command is the old operation itself.
+- **composed**: more than one native command provides the useful workflow.
+- **limited**: native commands cover the stated safe path but do not reproduce the old semantic.
+- **intentionally retired**: raw package surgery or a non-native fallback has no replacement.
+
+| Old inferred operation | Native command sequence | Status | Known limitation | Runnable verification |
+|---|---|---|---|---|
+| `summary` | `hwp info form.hwpx --json` then `hwp cat form.hwpx --format json > form.json` | composed | No legacy pretty summary or XML section-index map. | `test -s form.json && hwp validate form.hwpx` |
+| `unpack` | Do not unpack; use `hwp edit form.hwpx -o edited.hwpx --replace "old=>new" --verify`. | intentionally retired | No supported raw-ZIP extraction workflow. | `hwp validate edited.hwpx` |
+| `repack` | Do not repack; use `hwp edit form.hwpx -o edited.hwpx --replace "old=>new" --verify`. | intentionally retired | Native writers own package layout; manual manifest changes are unsupported. | `hwp validate edited.hwpx` |
+| `edit` run-spanning find/replace | `hwp edit form.hwpx -o edited.hwpx --replace "old=>new" --verify` | limited | Does not promise matching a find string split across arbitrary XML text runs. | `hwp validate edited.hwpx && hwp cat edited.hwpx --format plain` |
+| `fill` run-spanning `{{slot}}` | `hwp slots template.hwpx --json` then `hwp fill template.hwpx -o filled.hwpx --set "name=value" --json` | limited | A slot may span formatting runs, but never a line break or paragraph boundary. | `hwp slots template.hwpx --json && hwp validate filled.hwpx` |
+| `fill-table` | `hwp fill template.hwpx -o filled.hwpx --data tables.json --json` | exact | `tables.json` must follow the native `tables` data contract and target an existing table. | `hwp validate filled.hwpx` |
+| `fill-form` | `hwp edit form.hwpx -o filled.hwpx --set-cell-by-label "성명=홍길동" --set-cell-by-label "소속=AI센터" --verify` | limited | Each normalized label must resolve to exactly one adjacent or header-row value cell; ambiguity and duplicate targets refuse publication. Use `--label-table N` to scope recursive tables. | `hwp validate filled.hwpx && hwp cat filled.hwpx --format plain` |
+| `analyze` | `hwp info form.hwpx --json` then `hwp cat form.hwpx --format json > form.json` | composed | JSON IR is useful for text, tables, and anchors, but exposes no old raw `sec` child indices or XML style IDs. | `test -s form.json && hwp validate form.hwpx` |
+| `edit-section` | `hwp cat form.hwpx --format json > form.json`, then `hwp edit form.hwpx -o edited.hwpx --delete-para "old paragraph" --insert-para "anchor=>replacement paragraph" --verify` | limited | Anchor and paragraph operations are not raw `[start:end)` section-index surgery and do not clone an XML paragraph style by index. | `hwp validate edited.hwpx && hwp cat edited.hwpx --format json > edited.json` |
+| `linesegarray` clearing on edit | `hwp edit form.hwpx -o edited.hwpx --replace "old=>new" --verify` | composed | The writer manages layout records internally; there is no user-visible `linesegarray` switch or XML-level report. | `hwp validate edited.hwpx` |
+| sec-index section edits | `hwp cat form.hwpx --format json > form.json`, then `hwp edit ... --delete-para ... --insert-para ... --verify` | limited | The native surface deliberately has no stable `sec` child index contract. | `hwp validate edited.hwpx` |
+| mimetype-first STORED repack | `hwp edit form.hwpx -o edited.hwpx --replace "old=>new" --verify` | intentionally retired | The writer preserves valid package construction but exposes no general raw-ZIP repack API. | `hwp validate edited.hwpx` |
+| `guard` / `page_guard` structural drift metric | `hwp validate edited.hwpx`, then `hwp render reference.hwpx -o reference.png --report reference.render.json` and `hwp render edited.hwpx -o edited.png --report edited.render.json` | composed | Validation and render reports do not reproduce XML paragraph/table/text-delta thresholds. Compare report page counts and review rendered output when layout matters. | `hwp validate edited.hwpx && test -s reference.render.json && test -s edited.render.json` |
+
+## Inspect before editing
+
+### Build an editable map
+
+Start with native metadata and IR output. Search the JSON for stable visible text, table content,
+or a field/bookmark name that can serve as an anchor; do not infer an old XML index from it.
+
+```bash
+hwp info form.hwpx --json
+hwp cat form.hwpx --format json > form.json
+hwp fields form.hwpx --json
+hwp bookmarks form.hwpx --json
+```
+
+### Verify the inspection
+
+```bash
+test -s form.json
+hwp validate form.hwpx
+```
+
+## Fill native placeholders and forms
+
+### Fill a template or table
+
+Use `hwp slots` before `hwp fill` for placeholders. Use `--data` for data-driven table rows; it
+is the native `fill-table` replacement.
+
+```bash
+hwp slots template.hwpx --json
+hwp fill template.hwpx -o filled.hwpx --set "title=2026 Plan" --json
+hwp fill table-template.hwpx -o table-filled.hwpx --data tables.json --json
+hwp validate filled.hwpx
+hwp validate table-filled.hwpx
+```
+
+### Fill a label-value form
+
+`--set-cell-by-label` accepts `label=value`, finds adjacent `label | value` and header/data-row
+layouts, and is atomic by default. Do not use `--allow-partial` to bypass an ambiguous or duplicate
+label.
+
+```bash
+hwp edit form.hwpx -o form-filled.hwpx \
+  --set-cell-by-label "성명=홍길동" \
+  --set-cell-by-label "소속=AI센터" \
+  --verify
+hwp validate form-filled.hwpx
+```
+
+## Edit content through anchors
+
+### Replace or reshape a paragraph
+
+Use `--replace` for a supported in-place match. For a section-shaped change, use an existing text
+anchor with paragraph operations. Keep the source unchanged and write to a new output until the
+result has passed validation and review.
+
+```bash
+hwp edit form.hwpx -o revised.hwpx \
+  --replace "2025 Plan=>2026 Plan" \
+  --delete-para "old body paragraph" \
+  --insert-para "body heading=>replacement paragraph" \
+  --verify
+hwp validate revised.hwpx
+```
+
+### Understand the boundary
+
+There is no native raw `sec` index editor, XML paragraph-style cloning operation, unpack/repack
+route, or Python helper. If the intended edit depends on those semantics, stop and keep the source
+document intact rather than treating this recipe as an exact migration.
+
+## Guard a completed output
+
+### Validate and render
+
+Validation confirms package structure. Render reports give page counts and renderer diagnostics;
+they are not a replacement for the old structural XML-drift thresholds.
+
+```bash
+hwp validate revised.hwpx
+hwp render form.hwpx -o reference.png --report reference.render.json
+hwp render revised.hwpx -o revised.png --report revised.render.json
+```
+
+### Review the evidence
+
+Check both render report files and inspect the page images when layout is material. A changed page
+count or visible overflow is a reason to revise the content, not to weaken validation.
+
+## Safety and non-goals
+
+Every writing command above ends with `hwp validate`. Native edits and fills publish atomically;
+failed required changes leave the existing output untouched. These recipes intentionally do not
+restore the retired wrapper, a Python XML helper, executable recipe files, or old binary templates.


### PR DESCRIPTION
# Summary

- Add deterministic native label-to-cell form filling for CLI and MCP, including adjacent and header-row layouts, recursive-table scoping, and atomic ambiguity and duplicate rejection.
- Embed the canonical English/Korean native editing migration crosswalk in the exported hwp skill tree.
- Document that a merged source branch is not release or retirement evidence until the separate tagged-release and old-template compatibility gates complete.

## Acceptance evidence

- EDIT-01: filtered label and MCP integration coverage in crates/hwp-cli/tests/table_edit.rs and crates/hwp-cli/src/commands/mcp.rs passes.
- Skill export: embedded_table_matches_skill_tree_on_disk and en_ko_pairs_have_identical_structure pass, preserving byte-exact exported recipes and matching Markdown structure.
- Generated CLI references are current: docs/manual/cli-reference.md and docs/manual/cli-reference.ko.md are verified by cli_reference_up_to_date.
- Full local CI mirror passes on this head with CARGO_TARGET_DIR=/tmp/hwp-cli-phase-02.5-target.JvN9W0, CARGO_INCREMENTAL=0, CARGO_BUILD_JOBS=1, and scripts/check.sh.

## Release boundary

This PR intentionally does not create a release tag or claim that its local or branch binary replaces the retiring skill. The subsequent release plan must publish the tagged binary, verify exported-tree and old-template compatibility, and record the minimum supported version before skills retirement can merge.

Closes #121
