### PR TITLE
fix: harden label fill and skill export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.12.1]
+
+**Fixed**
+
+- Label-form fill now preserves explicit adjacent `{{label}}` value-cell precedence even when a
+  following data row makes the first row look like a complete table header. Complete multi-column
+  headers still resolve below the selected header, and the existing atomic ambiguity, duplicate,
+  scope and redacted-diagnostic guarantees remain covered by regression tests.
+
+- `hwp skill export` now rejects symlinked destination components and files for regular exports,
+  including the fixed Codex and Claude install targets. It stages a complete regular-file tree and
+  publishes it as one directory replacement, restoring the prior tree if publication fails so an
+  interrupted export cannot leave a mixed-version skill tree.
+
 ## [0.12.0]
 
 **Added**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-cli"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "hwp-model",
  "image",
@@ -749,14 +749,14 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "hwp-render"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "encoding_rs",
  "flate2",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "aes",
  "cfb",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"

--- a/crates/hwp-cli/src/commands/skill.rs
+++ b/crates/hwp-cli/src/commands/skill.rs
@@ -1136,10 +1136,7 @@ mod tests {
 
         let error = publish_staged_tree_with(&dir, &staged, |source, destination| {
             if source == staged {
-                return Err(std::io::Error::new(
-                    ErrorKind::Other,
-                    "forced staged publish failure",
-                ));
+                return Err(std::io::Error::other("forced staged publish failure"));
             }
             fs::rename(source, destination)
         })

--- a/crates/hwp-cli/src/commands/skill.rs
+++ b/crates/hwp-cli/src/commands/skill.rs
@@ -582,10 +582,7 @@ fn home_dir() -> anyhow::Result<PathBuf> {
 /// `SKILL_FILES` are retained, while all path components and files are checked
 /// with `symlink_metadata` before anything is written.
 fn export(dir: &Path) -> anyhow::Result<PathBuf> {
-    let parent = dir
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .context("스킬 디렉터리의 상위 경로가 없습니다")?;
+    let parent = parent_or_current(dir);
     ensure_regular_directory(parent)?;
     let staged = create_private_directory(parent, "hwp-export-stage")?;
     let result = (|| {
@@ -599,7 +596,15 @@ fn export(dir: &Path) -> anyhow::Result<PathBuf> {
             Ok(metadata) if !metadata.is_dir() => {
                 anyhow::bail!("스킬 경로가 디렉터리가 아닙니다: {}", dir.display())
             }
-            Ok(_) => copy_regular_tree(dir, &staged)?,
+            Ok(metadata) => {
+                fs::set_permissions(&staged, metadata.permissions()).with_context(|| {
+                    format!(
+                        "스킬 스테이징 디렉터리 권한을 설정할 수 없습니다: {}",
+                        staged.display()
+                    )
+                })?;
+                copy_regular_tree(dir, &staged)?;
+            }
             Err(error) if error.kind() == ErrorKind::NotFound => {}
             Err(error) => {
                 return Err(error)
@@ -624,6 +629,12 @@ fn export(dir: &Path) -> anyhow::Result<PathBuf> {
     Ok(dir.to_path_buf())
 }
 
+fn parent_or_current(path: &Path) -> &Path {
+    path.parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."))
+}
+
 fn ensure_regular_directory(path: &Path) -> anyhow::Result<()> {
     match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.file_type().is_symlink() => {
@@ -635,11 +646,7 @@ fn ensure_regular_directory(path: &Path) -> anyhow::Result<()> {
         Ok(metadata) if metadata.is_dir() => Ok(()),
         Ok(_) => anyhow::bail!("스킬 경로가 디렉터리가 아닙니다: {}", path.display()),
         Err(error) if error.kind() == ErrorKind::NotFound => {
-            let parent = path
-                .parent()
-                .filter(|parent| !parent.as_os_str().is_empty())
-                .context("스킬 디렉터리의 상위 경로가 없습니다")?;
-            ensure_regular_directory(parent)?;
+            ensure_regular_directory(parent_or_current(path))?;
             match fs::create_dir(path) {
                 Ok(()) => {}
                 Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
@@ -720,6 +727,12 @@ fn copy_regular_tree(source: &Path, destination: &Path) -> anyhow::Result<()> {
                     destination_path.display()
                 )
             })?;
+            fs::set_permissions(&destination_path, metadata.permissions()).with_context(|| {
+                format!(
+                    "스킬 스테이징 디렉터리 권한을 설정할 수 없습니다: {}",
+                    destination_path.display()
+                )
+            })?;
             copy_regular_tree(&source_path, &destination_path)?;
         } else if metadata.is_file() {
             fs::copy(&source_path, &destination_path).with_context(|| {
@@ -771,10 +784,7 @@ fn publish_staged_tree_with<F>(dir: &Path, staged: &Path, mut rename: F) -> anyh
 where
     F: FnMut(&Path, &Path) -> std::io::Result<()>,
 {
-    let parent = dir
-        .parent()
-        .filter(|parent| !parent.as_os_str().is_empty())
-        .context("스킬 디렉터리의 상위 경로가 없습니다")?;
+    let parent = parent_or_current(dir);
     let existing = match fs::symlink_metadata(dir) {
         Ok(metadata) => {
             if metadata.file_type().is_symlink() || !metadata.is_dir() {
@@ -811,7 +821,10 @@ where
             )),
         };
     }
-    remove_regular_tree(&backup)
+    if let Err(error) = remove_regular_tree(&backup) {
+        eprintln!("스킬 이전 버전 백업을 정리하지 못했습니다: {error}");
+    }
+    Ok(())
 }
 
 fn remove_regular_tree(path: &Path) -> anyhow::Result<()> {
@@ -1029,6 +1042,12 @@ mod tests {
             );
         }
         let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn bare_relative_export_uses_the_current_directory_as_its_parent() {
+        assert_eq!(parent_or_current(Path::new("hwp")), Path::new("."));
+        assert_eq!(parent_or_current(Path::new("./hwp")), Path::new("."));
     }
 
     #[test]

--- a/crates/hwp-cli/src/commands/skill.rs
+++ b/crates/hwp-cli/src/commands/skill.rs
@@ -23,6 +23,7 @@
 use std::fs;
 use std::io::{ErrorKind, Write as _};
 use std::path::{Component, Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Context as _;
 use serde::Deserialize;
@@ -574,23 +575,278 @@ fn home_dir() -> anyhow::Result<PathBuf> {
         .with_context(|| format!("홈 디렉터리 환경변수 ${VAR} 가 설정되어 있지 않습니다"))
 }
 
-/// Writes the embedded skill tree under `dir` (creating parent directories
-/// as needed) and returns `dir`. Files in `dir` that are not listed in
-/// `SKILL_FILES` are left untouched — export never deletes.
+/// Writes the embedded skill tree under `dir` and returns `dir`.
+///
+/// A complete replacement tree is built in a private sibling staging
+/// directory and atomically published. Existing regular files outside
+/// `SKILL_FILES` are retained, while all path components and files are checked
+/// with `symlink_metadata` before anything is written.
 fn export(dir: &Path) -> anyhow::Result<PathBuf> {
-    fs::create_dir_all(dir)
-        .with_context(|| format!("스킬 디렉터리를 만들 수 없습니다: {}", dir.display()))?;
-    for file in SKILL_FILES {
-        let path = dir.join(file.rel);
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!("스킬 디렉터리를 만들 수 없습니다: {}", parent.display())
-            })?;
+    let parent = dir
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .context("스킬 디렉터리의 상위 경로가 없습니다")?;
+    ensure_regular_directory(parent)?;
+    let staged = create_private_directory(parent, "hwp-export-stage")?;
+    let result = (|| {
+        match fs::symlink_metadata(dir) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                anyhow::bail!(
+                    "스킬 경로의 심볼릭 링크를 사용할 수 없습니다: {}",
+                    dir.display()
+                )
+            }
+            Ok(metadata) if !metadata.is_dir() => {
+                anyhow::bail!("스킬 경로가 디렉터리가 아닙니다: {}", dir.display())
+            }
+            Ok(_) => copy_regular_tree(dir, &staged)?,
+            Err(error) if error.kind() == ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("스킬 경로를 확인할 수 없습니다: {}", dir.display()));
+            }
         }
-        fs::write(&path, file.contents)
-            .with_context(|| format!("{}를 쓸 수 없습니다: {}", file.rel, path.display()))?;
+
+        for file in SKILL_FILES {
+            let path = staged.join(file.rel);
+            if let Some(parent) = path.parent() {
+                ensure_regular_directory(parent)?;
+            }
+            write_regular_file(&path, file.contents)
+                .with_context(|| format!("{}를 쓸 수 없습니다: {}", file.rel, path.display()))?;
+        }
+        publish_staged_tree(dir, &staged)
+    })();
+    if result.is_err() && staged.exists() {
+        remove_regular_tree(&staged)?;
     }
+    result?;
     Ok(dir.to_path_buf())
+}
+
+fn ensure_regular_directory(path: &Path) -> anyhow::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => {
+            anyhow::bail!(
+                "스킬 경로의 심볼릭 링크를 사용할 수 없습니다: {}",
+                path.display()
+            )
+        }
+        Ok(metadata) if metadata.is_dir() => Ok(()),
+        Ok(_) => anyhow::bail!("스킬 경로가 디렉터리가 아닙니다: {}", path.display()),
+        Err(error) if error.kind() == ErrorKind::NotFound => {
+            let parent = path
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .context("스킬 디렉터리의 상위 경로가 없습니다")?;
+            ensure_regular_directory(parent)?;
+            match fs::create_dir(path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {}
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("스킬 디렉터리를 만들 수 없습니다: {}", path.display())
+                    });
+                }
+            }
+            let metadata = fs::symlink_metadata(path).with_context(|| {
+                format!("스킬 디렉터리를 확인할 수 없습니다: {}", path.display())
+            })?;
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                anyhow::bail!("스킬 디렉터리가 안전하지 않습니다: {}", path.display());
+            }
+            Ok(())
+        }
+        Err(error) => Err(error)
+            .with_context(|| format!("스킬 디렉터리를 확인할 수 없습니다: {}", path.display())),
+    }
+}
+
+fn create_private_directory(parent: &Path, prefix: &str) -> anyhow::Result<PathBuf> {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock")
+        .as_nanos();
+    for attempt in 0..32 {
+        let path = parent.join(format!(
+            ".{prefix}-{}-{nonce}-{attempt}",
+            std::process::id()
+        ));
+        match fs::create_dir(&path) {
+            Ok(()) => return Ok(path),
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "스킬 스테이징 디렉터리를 만들 수 없습니다: {}",
+                        path.display()
+                    )
+                });
+            }
+        }
+    }
+    anyhow::bail!("고유한 스킬 스테이징 디렉터리를 만들 수 없습니다")
+}
+
+fn copy_regular_tree(source: &Path, destination: &Path) -> anyhow::Result<()> {
+    let metadata = fs::symlink_metadata(source)
+        .with_context(|| format!("스킬 경로를 확인할 수 없습니다: {}", source.display()))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        anyhow::bail!(
+            "스킬 경로가 안전한 디렉터리가 아닙니다: {}",
+            source.display()
+        );
+    }
+    for entry in fs::read_dir(source)
+        .with_context(|| format!("스킬 디렉터리를 읽을 수 없습니다: {}", source.display()))?
+    {
+        let entry = entry
+            .with_context(|| format!("스킬 디렉터리를 읽을 수 없습니다: {}", source.display()))?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let metadata = fs::symlink_metadata(&source_path).with_context(|| {
+            format!("스킬 경로를 확인할 수 없습니다: {}", source_path.display())
+        })?;
+        if metadata.file_type().is_symlink() {
+            anyhow::bail!(
+                "스킬 경로의 심볼릭 링크를 사용할 수 없습니다: {}",
+                source_path.display()
+            );
+        }
+        if metadata.is_dir() {
+            fs::create_dir(&destination_path).with_context(|| {
+                format!(
+                    "스킬 스테이징 디렉터리를 만들 수 없습니다: {}",
+                    destination_path.display()
+                )
+            })?;
+            copy_regular_tree(&source_path, &destination_path)?;
+        } else if metadata.is_file() {
+            fs::copy(&source_path, &destination_path).with_context(|| {
+                format!(
+                    "스킬 파일을 스테이징할 수 없습니다: {}",
+                    source_path.display()
+                )
+            })?;
+        } else {
+            anyhow::bail!(
+                "스킬 경로가 일반 파일이 아닙니다: {}",
+                source_path.display()
+            );
+        }
+    }
+    Ok(())
+}
+
+fn write_regular_file(path: &Path, contents: &str) -> anyhow::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            anyhow::bail!("스킬 파일 경로가 안전하지 않습니다: {}", path.display())
+        }
+        Ok(_) => fs::remove_file(path)
+            .with_context(|| format!("기존 스킬 파일을 제거할 수 없습니다: {}", path.display()))?,
+        Err(error) if error.kind() == ErrorKind::NotFound => {}
+        Err(error) => {
+            return Err(error).with_context(|| {
+                format!("스킬 파일 경로를 확인할 수 없습니다: {}", path.display())
+            });
+        }
+    }
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .with_context(|| format!("스킬 파일을 쓸 수 없습니다: {}", path.display()))?;
+    file.write_all(contents.as_bytes())
+        .with_context(|| format!("스킬 파일을 쓸 수 없습니다: {}", path.display()))
+}
+
+fn publish_staged_tree(dir: &Path, staged: &Path) -> anyhow::Result<()> {
+    publish_staged_tree_with(dir, staged, |source, destination| {
+        fs::rename(source, destination)
+    })
+}
+
+fn publish_staged_tree_with<F>(dir: &Path, staged: &Path, mut rename: F) -> anyhow::Result<()>
+where
+    F: FnMut(&Path, &Path) -> std::io::Result<()>,
+{
+    let parent = dir
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .context("스킬 디렉터리의 상위 경로가 없습니다")?;
+    let existing = match fs::symlink_metadata(dir) {
+        Ok(metadata) => {
+            if metadata.file_type().is_symlink() || !metadata.is_dir() {
+                anyhow::bail!("스킬 경로가 안전한 디렉터리가 아닙니다: {}", dir.display());
+            }
+            true
+        }
+        Err(error) if error.kind() == ErrorKind::NotFound => false,
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("스킬 경로를 확인할 수 없습니다: {}", dir.display()));
+        }
+    };
+    if !existing {
+        return rename(staged, dir)
+            .with_context(|| format!("스킬 트리를 게시할 수 없습니다: {}", dir.display()));
+    }
+
+    let backup = create_private_directory(parent, "hwp-export-backup")?;
+    fs::remove_dir(&backup)
+        .with_context(|| format!("스킬 백업 경로를 준비할 수 없습니다: {}", backup.display()))?;
+    rename(dir, &backup)
+        .with_context(|| format!("기존 스킬 트리를 백업할 수 없습니다: {}", dir.display()))?;
+    if let Err(error) = rename(staged, dir) {
+        return match rename(&backup, dir) {
+            Ok(()) => Err(error).with_context(|| {
+                format!(
+                    "스킬 트리를 게시할 수 없어 기존 버전을 복원했습니다: {}",
+                    dir.display()
+                )
+            }),
+            Err(restore_error) => Err(anyhow::anyhow!(
+                "스킬 트리 게시과 기존 버전 복원에 모두 실패했습니다: publish={error}; restore={restore_error}"
+            )),
+        };
+    }
+    remove_regular_tree(&backup)
+}
+
+fn remove_regular_tree(path: &Path) -> anyhow::Result<()> {
+    let metadata = fs::symlink_metadata(path)
+        .with_context(|| format!("스킬 임시 경로를 확인할 수 없습니다: {}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        anyhow::bail!(
+            "스킬 임시 경로의 심볼릭 링크를 제거할 수 없습니다: {}",
+            path.display()
+        );
+    }
+    if metadata.is_file() {
+        return fs::remove_file(path)
+            .with_context(|| format!("스킬 임시 파일을 제거할 수 없습니다: {}", path.display()));
+    }
+    if !metadata.is_dir() {
+        anyhow::bail!(
+            "스킬 임시 경로가 일반 파일이나 디렉터리가 아닙니다: {}",
+            path.display()
+        );
+    }
+    for entry in fs::read_dir(path)
+        .with_context(|| format!("스킬 임시 디렉터리를 읽을 수 없습니다: {}", path.display()))?
+    {
+        let entry = entry.with_context(|| {
+            format!("스킬 임시 디렉터리를 읽을 수 없습니다: {}", path.display())
+        })?;
+        remove_regular_tree(&entry.path())?;
+    }
+    fs::remove_dir(path).with_context(|| {
+        format!(
+            "스킬 임시 디렉터리를 제거할 수 없습니다: {}",
+            path.display()
+        )
+    })
 }
 
 /// Writes `skills/hwp/SKILL.md` under an already-resolved canonical Quick
@@ -824,6 +1080,79 @@ mod tests {
             }
             let _ = fs::remove_dir_all(&home);
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fixed_codex_export_rejects_symlinked_components_and_files() {
+        use std::os::unix::fs::symlink;
+
+        let home = temp_dir("skill-export-codex-symlink");
+        let outside = home.join("outside");
+        fs::create_dir_all(&outside).expect("create outside");
+        let dir = match install_target_under(InstallTarget::Codex, &home, None).expect("target") {
+            ExportTarget::Plain(dir) => dir,
+            ExportTarget::QuickProfile(_) => panic!("codex resolves to a plain directory"),
+        };
+
+        symlink(&outside, home.join(".codex")).expect("symlink component");
+        assert!(
+            export(&dir).is_err(),
+            "a Codex path component symlink is rejected"
+        );
+        assert!(
+            !outside.join("skills/hwp/SKILL.md").exists(),
+            "the component symlink target must not receive exported files"
+        );
+        fs::remove_file(home.join(".codex")).expect("remove component symlink");
+
+        fs::create_dir_all(dir.join("references")).expect("create regular target");
+        symlink(&outside, dir.join("references/link")).expect("symlink nested component");
+        assert!(
+            export(&dir).is_err(),
+            "a nested Codex path component symlink is rejected"
+        );
+        fs::remove_file(dir.join("references/link")).expect("remove nested component symlink");
+
+        let outside_file = outside.join("editing-recipes.md");
+        fs::write(&outside_file, b"keep").expect("seed outside file");
+        symlink(&outside_file, dir.join("references/editing-recipes.md"))
+            .expect("symlink exported file");
+        assert!(export(&dir).is_err(), "a Codex file symlink is rejected");
+        assert_eq!(fs::read(&outside_file).unwrap(), b"keep");
+        fs::remove_file(dir.join("references/editing-recipes.md")).expect("remove file symlink");
+        remove_regular_tree(&home).expect("clean regular test root");
+    }
+
+    #[test]
+    fn staged_export_rolls_back_the_whole_tree_when_publish_fails() {
+        let root = temp_dir("skill-export-rollback");
+        let dir = root.join("hwp");
+        fs::create_dir_all(dir.join("references")).expect("create existing target");
+        fs::write(dir.join("SKILL.md"), b"old-skill").expect("seed old skill");
+        fs::write(dir.join("references/keep.md"), b"old-reference").expect("seed old reference");
+        let staged = create_private_directory(&root, "hwp-export-test-stage").expect("stage");
+        fs::write(staged.join("SKILL.md"), b"new-skill").expect("seed staged skill");
+
+        let error = publish_staged_tree_with(&dir, &staged, |source, destination| {
+            if source == staged {
+                return Err(std::io::Error::new(
+                    ErrorKind::Other,
+                    "forced staged publish failure",
+                ));
+            }
+            fs::rename(source, destination)
+        })
+        .expect_err("a staged publish failure must be returned");
+        assert!(error.to_string().contains("복원"));
+        assert_eq!(fs::read(dir.join("SKILL.md")).unwrap(), b"old-skill");
+        assert_eq!(
+            fs::read(dir.join("references/keep.md")).unwrap(),
+            b"old-reference",
+            "failure must not leave a mixed-version target tree"
+        );
+        remove_regular_tree(&staged).expect("clean staged tree");
+        remove_regular_tree(&root).expect("clean test root");
     }
 
     #[test]

--- a/crates/hwp-cli/tests/table_edit.rs
+++ b/crates/hwp-cli/tests/table_edit.rs
@@ -98,6 +98,34 @@ fn set_cell_by_label_fills_unique_adjacent_cell_and_validates() {
 }
 
 #[test]
+fn set_cell_by_label_prefers_a_nonempty_adjacent_form_value_over_a_following_data_row() {
+    let source = label_form(
+        "label_adjacent_precedence",
+        "| 성명 | {{성명}} |\n|---|---|\n| below-target-must-remain | data |\n",
+    );
+    let output = tmp("label_adjacent_precedence_out.hwpx");
+    let result = hwp()
+        .arg("edit")
+        .arg(&source)
+        .arg("-o")
+        .arg(&output)
+        .args(["--set-cell-by-label", "성명=홍길동", "--verify"])
+        .output()
+        .unwrap();
+    assert!(
+        result.status.success(),
+        "adjacent form precedence: {}",
+        String::from_utf8_lossy(&result.stderr)
+    );
+    let text = cat(&output);
+    assert!(text.contains("홍길동"), "adjacent value is changed");
+    assert!(
+        text.contains("below-target-must-remain"),
+        "a following data-row cell must not be changed"
+    );
+}
+
+#[test]
 fn set_cell_by_label_fills_first_data_row_below_a_header_label() {
     let source = label_form("label_header", "| 성명 |\n|---|\n| |\n");
     let output = tmp("label_header_out.hwpx");

--- a/crates/hwp-convert/src/edit.rs
+++ b/crates/hwp-convert/src/edit.rs
@@ -35,7 +35,9 @@ pub fn normalize_form_label(label: &str) -> String {
 /// intentionally calls the readonly table walker so discovery cannot clear
 /// opaque HWPX XML or otherwise mutate the document. A label may address the
 /// immediately adjacent cell, or the first data cell directly below a label in
-/// the table's first row.
+/// a complete table header row. An empty or matching `{{label}}` cell is an
+/// explicit form-value marker, so it keeps adjacent-form precedence even when
+/// a later row makes the first row look like a complete header.
 pub fn find_form_cells_by_label(
     doc: &mut Document,
     label: &str,
@@ -80,32 +82,39 @@ pub fn find_form_cells_by_label(
                 if normalize_form_label(&visible) != wanted {
                     continue;
                 }
-                if header_is_complete && label_cell.row == 0 {
+                let right_col = label_cell.col.saturating_add(label_cell.col_span);
+                let adjacent = current
+                    .cells
+                    .iter()
+                    .find(|cell| cell.row == label_cell.row && cell.col == right_col);
+                let header = if header_is_complete && label_cell.row == 0 {
                     let first_data_row = label_cell.row.saturating_add(label_cell.row_span);
-                    if let Some(target) = current
+                    current
                         .cells
                         .iter()
                         .find(|cell| cell.row == first_data_row && cell.col == label_cell.col)
-                    {
-                        matches.push(FormCellCandidate {
-                            table: table_index,
-                            row: target.row,
-                            col: target.col,
-                        });
-                    }
                 } else {
-                    let right_col = label_cell.col.saturating_add(label_cell.col_span);
-                    if let Some(target) = current
-                        .cells
-                        .iter()
-                        .find(|cell| cell.row == label_cell.row && cell.col == right_col)
-                    {
-                        matches.push(FormCellCandidate {
-                            table: table_index,
-                            row: target.row,
-                            col: target.col,
-                        });
+                    None
+                };
+
+                // A matching placeholder is part of the documented form-value
+                // layout, not a second column heading. Prefer it before the
+                // complete-header rule; this preserves the legacy adjacent form
+                // contract without treating a multi-column header as a form.
+                let target = match (adjacent, header) {
+                    (Some(adjacent), Some(_)) if is_explicit_form_value(adjacent, &wanted) => {
+                        Some(adjacent)
                     }
+                    (_, Some(header)) => Some(header),
+                    (Some(adjacent), None) => Some(adjacent),
+                    (None, None) => None,
+                };
+                if let Some(target) = target {
+                    matches.push(FormCellCandidate {
+                        table: table_index,
+                        row: target.row,
+                        col: target.col,
+                    });
                 }
             }
             matches
@@ -119,6 +128,17 @@ pub fn find_form_cells_by_label(
     candidates.sort_unstable();
     candidates.dedup();
     candidates
+}
+
+fn is_explicit_form_value(cell: &hwp_model::Cell, wanted: &str) -> bool {
+    let visible = cell
+        .paragraphs
+        .iter()
+        .map(Paragraph::plain_text)
+        .collect::<Vec<_>>()
+        .join("\n");
+    let normalized = normalize_form_label(&visible);
+    normalized.is_empty() || normalized == format!("{{{{{wanted}}}}}")
 }
 
 /// 문서 전체에서 `from`을 `to`로 치환한다(본문·표 셀·글상자 문단 재귀).

--- a/docs/design/23-hwpx-skill-absorption.ko.md
+++ b/docs/design/23-hwpx-skill-absorption.ko.md
@@ -58,7 +58,7 @@ Phase 지도: **2.1** 스캐폴드 + 이 매트릭스. **2.2** 법정 8단계 �
 | analyze | `hwp info` + `hwp cat --format json` | 2.5 | composed — v0.12.0 릴리스 레시피 |
 | guard | `hwp validate` + `hwp render --report` | 2.5 | composed — v0.12.0 릴리스 레시피, raw structural-drift metric은 아님 |
 | edit-section | `hwp cat --format json` + anchor 기반 `hwp edit` | 2.5 | limited — v0.12.0 릴리스 레시피, raw section-index 계약 없음 |
-| fill-form | `hwp edit --set-cell-by-label` | 2.5 | limited — v0.12.0 릴리스 바이너리의 인접, header/data-row, scope, 원자적 거부 영수증(§3.1) |
+| fill-form | `hwp edit --set-cell-by-label` | 2.5 | limited — v0.12.1 릴리스 바이너리의 인접 양식 우선순위, header/data-row, scope, 원자적 거부 영수증. §3.1은 역사적 v0.12.0 기록으로 유지 |
 | to-pdf | `hwp convert --to pdf` / `hwp render` | 2.1 | verified — 기존 soffice 폴백은 **의도적으로 폐기** (네이티브 엔진만) |
 | render-pdf | to-pdf와 동일 | 2.1 | verified (`to-pdf --engine hwp`의 **별칭**) |
 | to-html | `hwp cat --format html` | 2.1 | verified |
@@ -87,7 +87,10 @@ Phase 지도: **2.1** 스캐폴드 + 이 매트릭스. **2.2** 법정 8단계 �
 
 첫 Phase 2.5 replacement 릴리스는 [v0.12.0](https://github.com/STAIxBWLB/hwp-cli/releases/tag/v0.12.0)이며 main 커밋 `79cec823053d6f7b212ee1288fb83eeb7114cef7`에 annotated tag로 생성했습니다. Apple Silicon archive `hwp-v0.12.0-aarch64-apple-darwin.tar.gz`의 SHA-256은 `5ba46e0622820ba13ed071158e4635b905e01633d44c1cfee089269e644149b8`입니다. checkout binary가 아닌 다운로드 asset은 `hwp 0.12.0`을 보고했고, 두 editing recipe와 `hwpx` sibling 없는 하나의 `hwp` tree를 export했으며 tagged install hash equality를 통과했습니다. 닫힌 여섯 템플릿, label-fill, split-run 증거는 `.planning/phases/02.5-editing-parity-and-hwpx-skill-retirement/02.5-release-compatibility.json`에 기록했습니다.
 
-편집 레시피 쌍은 v0.12.0을 최소 지원 버전으로 고정합니다. 상태는 의도적으로 경계를 둡니다. 네이티브 inspection과 guard는 composed 워크플로우이고, label과 section 편집은 limited 네이티브 워크플로우이며, raw unpack/repack은 intentionally retired입니다.
+편집 레시피 쌍은 수정된 label-form 및 일반 skill-export 계약이 처음 포함된 v0.12.1을 최소 지원
+버전으로 고정합니다. 상태는 의도적으로 경계를 둡니다. 네이티브 inspection과 guard는 composed
+워크플로우이고, label과 section 편집은 limited 네이티브 워크플로우이며, raw unpack/repack은 intentionally
+retired입니다.
 
 ### 3.2 여백 기록 (D-14)
 

--- a/docs/design/23-hwpx-skill-absorption.md
+++ b/docs/design/23-hwpx-skill-absorption.md
@@ -59,7 +59,7 @@ the concern disappears because the skill now ships inside the binary.
 | analyze | `hwp info` + `hwp cat --format json` | 2.5 | composed — released v0.12.0 recipe |
 | guard | `hwp validate` + `hwp render --report` | 2.5 | composed — released v0.12.0 recipe; not a raw structural-drift metric |
 | edit-section | `hwp cat --format json` + anchored `hwp edit` | 2.5 | limited — released v0.12.0 recipe; no raw section-index contract |
-| fill-form | `hwp edit --set-cell-by-label` | 2.5 | limited — v0.12.0 released-binary adjacent, header/data-row, scoped and atomic-refusal receipt (§3.1) |
+| fill-form | `hwp edit --set-cell-by-label` | 2.5 | limited — v0.12.1 released-binary adjacent-form precedence, header/data-row, scoped and atomic-refusal receipt; §3.1 remains the historical v0.12.0 record |
 | to-pdf | `hwp convert --to pdf` / `hwp render` | 2.1 | verified — the old soffice fallback is **intentionally dropped** (native engine only) |
 | render-pdf | same as to-pdf | 2.1 | verified (**alias** of `to-pdf --engine hwp`) |
 | to-html | `hwp cat --format html` | 2.1 | verified |
@@ -88,7 +88,10 @@ the concern disappears because the skill now ships inside the binary.
 
 The first Phase 2.5 replacement release is [v0.12.0](https://github.com/STAIxBWLB/hwp-cli/releases/tag/v0.12.0), annotated on main commit `79cec823053d6f7b212ee1288fb83eeb7114cef7`. Its Apple Silicon archive `hwp-v0.12.0-aarch64-apple-darwin.tar.gz` has SHA-256 `5ba46e0622820ba13ed071158e4635b905e01633d44c1cfee089269e644149b8`. The downloaded asset, never the checkout binary, reported `hwp 0.12.0`, exported one `hwp` tree with both editing recipes and no `hwpx` sibling, and passed tagged-install hash equality. The closed six-template, label-fill, and split-run evidence is in `.planning/phases/02.5-editing-parity-and-hwpx-skill-retirement/02.5-release-compatibility.json`.
 
-The editing recipe pair sets v0.12.0 as its minimum supported version. Its statuses are intentionally bounded: native inspection and guards are composed workflows; label and section editing are limited native workflows; raw unpack/repack is intentionally retired.
+The editing recipe pair sets v0.12.1 as its minimum supported version because that is the first
+release with the corrected label-form and regular skill-export contracts. Its statuses are
+intentionally bounded: native inspection and guards are composed workflows; label and section
+editing are limited native workflows; raw unpack/repack is intentionally retired.
 
 ### 3.2 Margin record (D-14)
 

--- a/skills/hwp/references/editing-recipes.ko.md
+++ b/skills/hwp/references/editing-recipes.ko.md
@@ -8,8 +8,9 @@
 
 ## 범위와 릴리스 경계
 
-지원 최소 `hwp` 버전은 **v0.12.0**입니다. 이 릴리스는 첫 Phase 2.5 replacement 후보입니다.
-로컬 빌드, 버전 없는 `PATH` 바이너리, 병합 전 브랜치는 retirement 또는 replacement 근거가 아닙니다.
+지원 최소 `hwp` 버전은 **v0.12.1**입니다. 이 릴리스에는 수정된 Phase 2.5 label-form 및 skill-export
+계약이 포함됩니다. 로컬 빌드, 버전 없는 `PATH` 바이너리, 병합 전 브랜치는 retirement 또는 replacement
+근거가 아닙니다.
 
 `templates/` 아래의 마크다운 8개는 번들 템플릿 SSOT로 유지합니다. 이전 바이너리 템플릿 6개는
 읽기 전용 retirement 호환성 코퍼스이며, 복사, 보관, 편집하지 않습니다.

--- a/skills/hwp/references/editing-recipes.md
+++ b/skills/hwp/references/editing-recipes.md
@@ -8,9 +8,9 @@ commands with a released `hwp` binary, not a local checkout.
 
 ## Scope and release boundary
 
-Minimum supported `hwp` version: **v0.12.0**. This release is the first Phase 2.5 replacement
-candidate. A local build, an unversioned `PATH` binary, or an unmerged branch is not retirement or
-replacement evidence.
+Minimum supported `hwp` version: **v0.12.1**. This release carries the corrected Phase 2.5
+label-form and skill-export contracts. A local build, an unversioned `PATH` binary, or an unmerged
+branch is not retirement or replacement evidence.
 
 The eight Markdown files under `templates/` remain the bundled template SSOT. The six old binary
 templates are a read-only retirement compatibility corpus; do not copy, archive, or edit them.


### PR DESCRIPTION
## Summary

- restore explicit adjacent form-value precedence while retaining complete multi-column header resolution
- stage and atomically publish regular skill export trees with symlink rejection and rollback coverage
- prepare v0.12.1 release notes and corrected Phase 2.5 compatibility floor

## Verification

- CARGO_TARGET_DIR=/tmp/hwp-cli-phase-02.5-target.JvN9W0 CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 scripts/check.sh
- focused label-form and skill-export regression tests