### PR TITLE
fix: close PR #161 review majors — split/merge/compare data-loss guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+**Fixed**
+
+- `hwp split --loss-report` now rejects a report path that aliases the input file, matching the
+  merge guard; the previous gap let the JSON report silently overwrite the input document
+  (#167).
+
+- `hwp split --pages` no longer drops content on multi-section documents: a page range whose
+  boundaries live in different sections now produces a fragment spanning those sections
+  (intermediate sections carried whole) instead of confining the slice to the start section
+  (#162).
+
+- `hwp merge` now id-shifts caption paragraphs (table and picture captions) on both graft paths
+  and grafts merged-in `header.bin_data` tables, shifting `BinRef::Id` references so hwp5-sourced
+  pictures keep resolving to their own payloads after a merge; exhausting the storage-id space
+  records a loss event instead of only a warning (#163, #164).
+
+- `hwp compare` now recurses into table cells and captions, so documents differing only inside
+  nested content are no longer reported identical; char-level LCS applies the same
+  `MAX_LCS_CELLS` ceiling as paragraph-level LCS, replacing a potential uncatchable OOM abort
+  with a graceful refusal (#165, #166).
+
 ## [0.12.1]
 
 **Fixed**

--- a/crates/hwp-cli/src/commands/merge.rs
+++ b/crates/hwp-cli/src/commands/merge.rs
@@ -52,8 +52,9 @@ fn infer_merge_format(output: &Path) -> anyhow::Result<MergeFormat> {
 
 /// Rejects a `--loss-report` path that aliases any input or the output, using
 /// the same path normalization `convert.rs` applies to its own report path
-/// (D-15's alias guard, extended from one input to N).
-fn reject_loss_report_aliases(
+/// (D-15's alias guard, extended from one input to N). Shared with
+/// `commands::split`, which passes its single input and `--out-dir`.
+pub(crate) fn reject_loss_report_aliases(
     report_path: &Path,
     inputs: &[PathBuf],
     output: &Path,

--- a/crates/hwp-cli/src/commands/preservation.rs
+++ b/crates/hwp-cli/src/commands/preservation.rs
@@ -189,6 +189,14 @@ pub(crate) fn inspect_document_merge_losses(
                     *count,
                 );
             }
+            hwp_convert::document_merge::MergeLoss::BinDataDropped { count, .. } => {
+                record_removed(
+                    &mut report,
+                    PreservationCode::BinaryAssetRemoved,
+                    PreservationResourceKind::BinaryAsset,
+                    *count,
+                );
+            }
         }
     }
     report

--- a/crates/hwp-cli/src/commands/split.rs
+++ b/crates/hwp-cli/src/commands/split.rs
@@ -145,6 +145,17 @@ pub fn run(
         .with_context(|| format!("입력 파일 이름을 확인할 수 없습니다: {}", input.display()))?
         .to_string();
 
+    // D-15 alias guard: the loss report must never alias the input (or the
+    // output directory) — an unguarded report write would silently overwrite
+    // the input with JSON. Same rejection merge applies, before any work.
+    if let Some(report_path) = loss_report {
+        crate::commands::merge::reject_loss_report_aliases(
+            report_path,
+            &[input.to_path_buf()],
+            out_dir,
+        )?;
+    }
+
     let document = load_document_with_options(input, &options).map_err(anyhow::Error::new)?;
 
     let outcome: SplitOutcome = if pages.is_empty() {
@@ -316,6 +327,32 @@ mod tests {
 
         let result = crate::commands::output::reject_output_aliases(&input, &[input.as_path()]);
         assert!(result.is_err());
+
+        std::fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn loss_report_경로가_입력과_같으면_거부() {
+        // Issue #167: the fragment-destination precheck never guarded the
+        // report path itself, so `--loss-report in.hwp` used to overwrite the
+        // input with JSON.
+        let dir = temp_dir("loss-report-alias-input");
+        let input = dir.join("in.hwp");
+        let out_dir = dir.join("frag");
+        write_three_section_hwp(&input);
+        let original = std::fs::read(&input).unwrap();
+
+        let result = run(
+            &input,
+            &out_dir,
+            &[],
+            false,
+            Some(input.as_path()),
+            PasswordArgs::default(),
+        );
+        assert!(result.is_err());
+        assert!(!out_dir.join("in-001.hwp").exists());
+        assert_eq!(std::fs::read(&input).unwrap(), original);
 
         std::fs::remove_dir_all(dir).unwrap();
     }

--- a/crates/hwp-cli/tests/document_workflows.rs
+++ b/crates/hwp-cli/tests/document_workflows.rs
@@ -173,6 +173,43 @@ fn split_publishes_all_fragments_or_none() {
 }
 
 #[test]
+fn split_refuses_loss_report_aliasing_the_input() {
+    // Issue #167: `hwp split in.hwp --out-dir frag --loss-report in.hwp` must
+    // be refused — the report write must never overwrite the input with JSON.
+    let dir = scratch_dir("split-loss-report-alias");
+    let input = write_input_hwp(&dir, "in", "본문입니다\n");
+    let out_dir = dir.join("frag");
+    let original = std::fs::read(&input).unwrap();
+
+    let output = hwp()
+        .arg("split")
+        .arg(&input)
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg("--loss-report")
+        .arg(&input)
+        .output()
+        .unwrap();
+    assert!(
+        !output.status.success(),
+        "입력과 같은 --loss-report 경로는 거부되어야 합니다"
+    );
+    // The refusal fires before --out-dir is even created, so no fragment set
+    // can exist — tolerate the directory simply being absent.
+    assert!(
+        !out_dir.exists() || fragment_paths(&out_dir, "in", "hwp").is_empty(),
+        "거부된 분할이 조각을 게시하면 안 됩니다"
+    );
+    assert_eq!(
+        std::fs::read(&input).unwrap(),
+        original,
+        "입력 파일이 훼손되면 안 됩니다"
+    );
+
+    std::fs::remove_dir_all(dir).unwrap();
+}
+
+#[test]
 fn 단일_구역_입력은_조각_하나만_낸다() {
     let dir = scratch_dir("single-section");
     let input = write_input_hwp(&dir, "solo", "단일 구역 본문\n");

--- a/crates/hwp-convert/src/document_compare.rs
+++ b/crates/hwp-convert/src/document_compare.rs
@@ -6,7 +6,10 @@
 //! inputs untouched (success criterion 3) — nothing on this path can write.
 //!
 //! **Text differences (D-11).** Paragraphs are flattened across sections into
-//! one ordered sequence per document and compared on their `chars` sequence
+//! one ordered sequence per document — top-level paragraphs plus the
+//! paragraphs nested in table cells/captions, picture captions, and generic
+//! control paragraph lists, visited depth-first in document order — and
+//! compared on their `chars` sequence
 //! with derived [`HwpChar`] equality — structural, not normalized (assumption
 //! A-09: no NFC/NFD folding, so two paragraphs differing only by Unicode
 //! normalization form report as changed). A hand-rolled paragraph-level LCS
@@ -24,12 +27,12 @@
 //! deletion / b-side insertion pairs are folded into one `Replace` entry. The
 //! same input pair therefore always produces the same report.
 //!
-//! **Bounded allocation (FLOW-03 `precision`).** The paragraph-level DP table
-//! has `a_len * b_len` cells. That product is computed with a checked
-//! multiply and refused above [`MAX_LCS_CELLS`] rather than allocated
-//! unbounded or silently degraded to a weaker comparison.
+//! **Bounded allocation (FLOW-03 `precision`).** Both the paragraph-level and
+//! the character-level DP tables have `a_len * b_len` cells. Each product is
+//! computed with a checked multiply and refused above [`MAX_LCS_CELLS`] rather
+//! than allocated unbounded or silently degraded to a weaker comparison.
 //!
-//! **Structure (D-12).** [`StructureDiff`] covers section counts, top-level
+//! **Structure (D-12).** [`StructureDiff`] covers section counts, flattened
 //! paragraph counts, a per-kind control inventory (the same multiset-counting
 //! shape `hwp-cli`'s `commands/preservation.rs` uses for its own control
 //! comparison), and table row/column geometry deltas, paired positionally.
@@ -39,7 +42,7 @@
 
 use std::collections::BTreeMap;
 
-use hwp_model::{Control, Document, HwpChar};
+use hwp_model::{Control, Document, HwpChar, Paragraph};
 
 /// The paragraph-level LCS DP table is refused above this many cells
 /// (`a_len * b_len`), rather than allocated unbounded or silently degraded to
@@ -67,8 +70,9 @@ pub enum ParagraphOp {
 }
 
 /// One paragraph-level operation. `a_index`/`b_index` are indices into the
-/// flattened top-level paragraph sequence of each document (not WCHAR
-/// offsets). `chars` is populated only for `Replace`.
+/// flattened paragraph sequence of each document (top-level plus nested
+/// cell/caption paragraphs; not WCHAR offsets). `chars` is populated only for
+/// `Replace`.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParagraphEntry {
     pub op: ParagraphOp,
@@ -106,9 +110,10 @@ pub struct TableGeometryDelta {
     pub cols: (u16, u16),
 }
 
-/// Structural differences per D-12: section counts, top-level paragraph
-/// counts, a per-kind control inventory, and table geometry deltas. Char
-/// shape / para shape formatting is deliberately out of scope for v1.
+/// Structural differences per D-12: section counts, flattened paragraph
+/// counts (nested cell/caption paragraphs included), a per-kind control
+/// inventory, and table geometry deltas. Char shape / para shape formatting
+/// is deliberately out of scope for v1.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructureDiff {
     pub sections: (usize, usize),
@@ -129,14 +134,14 @@ impl StructureDiff {
 }
 
 /// Compares two documents. Pure function, no I/O: the caller owns loading and
-/// rendering. Returns `Err` naming the paragraph-count ceiling when the LCS
-/// table would exceed [`MAX_LCS_CELLS`] cells.
+/// rendering. Returns `Err` naming the [`MAX_LCS_CELLS`] ceiling when either
+/// the paragraph-level or a character-level LCS table would exceed it.
 pub fn compare_documents(a: &Document, b: &Document) -> Result<DocumentDiff, String> {
     let a_paras = flatten_paragraph_chars(a);
     let b_paras = flatten_paragraph_chars(b);
 
     let ops = paragraph_lcs(&a_paras, &b_paras)?;
-    let paragraphs = fold_paragraph_ops(ops, &a_paras, &b_paras);
+    let paragraphs = fold_paragraph_ops(ops, &a_paras, &b_paras)?;
 
     let structure = structure_diff(a, b, a_paras.len(), b_paras.len());
 
@@ -150,16 +155,73 @@ pub fn compare_documents(a: &Document, b: &Document) -> Result<DocumentDiff, Str
     })
 }
 
-/// Flattens every section's paragraphs (top-level only — not nested table
-/// cell or caption paragraphs) into one ordered `chars` sequence per
-/// paragraph, in document order.
+/// Flattens every section's paragraphs — top-level plus the paragraphs
+/// nested in table cells/captions, picture captions, and generic control
+/// paragraph lists/captions — into one ordered `chars` sequence per
+/// paragraph, in depth-first document order.
 fn flatten_paragraph_chars(document: &Document) -> Vec<Vec<HwpChar>> {
-    document
-        .sections
-        .iter()
-        .flat_map(|section| section.paragraphs.iter())
-        .map(|paragraph| paragraph.chars.clone())
-        .collect()
+    let mut out = Vec::new();
+    walk_paragraphs(document, &mut |paragraph| out.push(paragraph.chars.clone()));
+    out
+}
+
+/// Visits every paragraph of the document in depth-first document order:
+/// each top-level paragraph, then the paragraphs nested in its controls.
+/// The nested traversal mirrors hwp-cli's
+/// `commands/preservation.rs::collect_paragraph_controls` (this crate cannot
+/// depend on that binary crate, so the traversal shape is mirrored rather
+/// than shared).
+fn walk_paragraphs(document: &Document, visit: &mut impl FnMut(&Paragraph)) {
+    for paragraph in document.sections.iter().flat_map(|s| s.paragraphs.iter()) {
+        visit(paragraph);
+        walk_nested_paragraphs(paragraph, visit);
+    }
+}
+
+/// Visits the paragraphs nested in `paragraph`'s controls: table cells and
+/// caption, picture caption, and generic paragraph lists and caption.
+fn walk_nested_paragraphs(paragraph: &Paragraph, visit: &mut impl FnMut(&Paragraph)) {
+    for control in &paragraph.controls {
+        match control {
+            Control::Table(table) => {
+                for cell in &table.cells {
+                    for nested in &cell.paragraphs {
+                        visit(nested);
+                        walk_nested_paragraphs(nested, visit);
+                    }
+                }
+                if let Some(caption) = &table.caption {
+                    for nested in &caption.paragraphs {
+                        visit(nested);
+                        walk_nested_paragraphs(nested, visit);
+                    }
+                }
+            }
+            Control::Picture(picture) => {
+                if let Some(caption) = &picture.caption {
+                    for nested in &caption.paragraphs {
+                        visit(nested);
+                        walk_nested_paragraphs(nested, visit);
+                    }
+                }
+            }
+            Control::Generic(generic) => {
+                for list in &generic.paragraph_lists {
+                    for nested in &list.paragraphs {
+                        visit(nested);
+                        walk_nested_paragraphs(nested, visit);
+                    }
+                }
+                if let Some(caption) = &generic.caption {
+                    for nested in &caption.paragraphs {
+                        visit(nested);
+                        walk_nested_paragraphs(nested, visit);
+                    }
+                }
+            }
+            Control::SectionDef(_) => {}
+        }
+    }
 }
 
 // ---- Paragraph-level LCS ----------------------------------------------
@@ -219,12 +281,13 @@ fn paragraph_lcs(a: &[Vec<HwpChar>], b: &[Vec<HwpChar>]) -> Result<Vec<AtomicOp>
 }
 
 /// Folds an adjacent a-side-deletion / b-side-insertion pair into one
-/// `Replace` entry and attaches its character sub-diff.
+/// `Replace` entry and attaches its character sub-diff. Returns `Err` when a
+/// replaced pair's character-level LCS table would exceed [`MAX_LCS_CELLS`].
 fn fold_paragraph_ops(
     ops: Vec<AtomicOp>,
     a: &[Vec<HwpChar>],
     b: &[Vec<HwpChar>],
-) -> Vec<ParagraphEntry> {
+) -> Result<Vec<ParagraphEntry>, String> {
     let mut out = Vec::with_capacity(ops.len());
     let mut iter = ops.into_iter().peekable();
     while let Some(op) = iter.next() {
@@ -238,7 +301,7 @@ fn fold_paragraph_ops(
             AtomicOp::Delete(ai) => {
                 if let Some(AtomicOp::Insert(bi)) = iter.peek().copied() {
                     iter.next();
-                    let chars = Some(char_lcs_runs(&a[ai], &b[bi]));
+                    let chars = Some(char_lcs_runs(&a[ai], &b[bi])?);
                     out.push(ParagraphEntry {
                         op: ParagraphOp::Replace,
                         a_index: Some(ai),
@@ -257,7 +320,7 @@ fn fold_paragraph_ops(
             AtomicOp::Insert(bi) => {
                 if let Some(AtomicOp::Delete(ai)) = iter.peek().copied() {
                     iter.next();
-                    let chars = Some(char_lcs_runs(&a[ai], &b[bi]));
+                    let chars = Some(char_lcs_runs(&a[ai], &b[bi])?);
                     out.push(ParagraphEntry {
                         op: ParagraphOp::Replace,
                         a_index: Some(ai),
@@ -275,7 +338,7 @@ fn fold_paragraph_ops(
             }
         }
     }
-    out
+    Ok(out)
 }
 
 // ---- Character-level LCS (only inside a Replace pair) -----------------
@@ -287,13 +350,25 @@ enum AtomicCharOp {
     Insert(usize),
 }
 
-/// Same DP shape as [`paragraph_lcs`], one level down: over `HwpChar`
-/// elements instead of paragraphs. No separate cell ceiling — a replaced
-/// pair's element counts are individual-paragraph sized, already bounded by
-/// the per-container reader limits each input passed through on load.
-fn char_lcs(a: &[HwpChar], b: &[HwpChar]) -> Vec<AtomicCharOp> {
+/// Same DP shape and cell ceiling as [`paragraph_lcs`], one level down: over
+/// `HwpChar` elements instead of paragraphs. The ceiling applies here too —
+/// a single paragraph can hold tens of millions of WCHARs under hwp5's
+/// default `max_stream_bytes`, so an unbounded table would abort on
+/// allocation failure rather than return a catchable error.
+fn char_lcs(a: &[HwpChar], b: &[HwpChar]) -> Result<Vec<AtomicCharOp>, String> {
     let a_len = a.len();
     let b_len = b.len();
+
+    let cells = a_len
+        .checked_mul(b_len)
+        .filter(|cells| *cells <= MAX_LCS_CELLS);
+    if a_len > 0 && b_len > 0 && cells.is_none() {
+        return Err(format!(
+            "문자 수 조합이 비교 가능한 한도를 초과했습니다: {a_len} x {b_len} 문자 \
+             (상한 MAX_LCS_CELLS = {MAX_LCS_CELLS}칸)"
+        ));
+    }
+
     let mut dp = vec![vec![0u32; b_len + 1]; a_len + 1];
     for (i, a_char) in a.iter().enumerate() {
         for (j, b_char) in b.iter().enumerate() {
@@ -321,7 +396,7 @@ fn char_lcs(a: &[HwpChar], b: &[HwpChar]) -> Vec<AtomicCharOp> {
         }
     }
     ops.reverse();
-    ops
+    Ok(ops)
 }
 
 /// Prefix sums of `wchar_width`, so element index `i` maps to its WCHAR
@@ -338,9 +413,10 @@ fn wchar_prefix(chars: &[HwpChar]) -> Vec<u32> {
 }
 
 /// Runs a character-level LCS over a replaced paragraph pair and coalesces
-/// the atomic ops into WCHAR-offset [`CharRun`]s.
-fn char_lcs_runs(a: &[HwpChar], b: &[HwpChar]) -> Vec<CharRun> {
-    let ops = char_lcs(a, b);
+/// the atomic ops into WCHAR-offset [`CharRun`]s. Returns `Err` when the
+/// pair's LCS table would exceed [`MAX_LCS_CELLS`].
+fn char_lcs_runs(a: &[HwpChar], b: &[HwpChar]) -> Result<Vec<CharRun>, String> {
+    let ops = char_lcs(a, b)?;
     let a_prefix = wchar_prefix(a);
     let b_prefix = wchar_prefix(b);
 
@@ -376,7 +452,7 @@ fn char_lcs_runs(a: &[HwpChar], b: &[HwpChar]) -> Vec<CharRun> {
             });
         }
     }
-    runs
+    Ok(runs)
 }
 
 // ---- Structural inventory (D-12) ---------------------------------------
@@ -419,32 +495,34 @@ fn structure_diff(
     }
 }
 
-/// Per-kind control counts, recursing into table cells/captions and picture
-/// captions exactly like `hwp-cli`'s `commands/preservation.rs::collect_paragraph_controls`
-/// (this crate cannot depend on that binary crate, so the counting shape is
-/// mirrored rather than shared).
+/// Per-kind control counts, recursing into table cells/captions, picture
+/// captions, and generic paragraph lists/captions via [`walk_paragraphs`] —
+/// the same nested coverage as `hwp-cli`'s
+/// `commands/preservation.rs::collect_paragraph_controls` (this crate cannot
+/// depend on that binary crate, so the counting shape is mirrored rather
+/// than shared).
 fn control_inventory(document: &Document) -> BTreeMap<[u8; 4], usize> {
     let mut counts = BTreeMap::new();
-    for paragraph in document.sections.iter().flat_map(|s| s.paragraphs.iter()) {
+    walk_paragraphs(document, &mut |paragraph| {
         for control in &paragraph.controls {
             *counts.entry(control.ctrl_id()).or_default() += 1;
         }
-    }
+    });
     counts
 }
 
-/// Flattened, ordered (rows, cols) for every table in the document.
+/// Flattened, ordered (rows, cols) for every table in the document,
+/// including tables nested in cells and captions.
 fn table_geometries(document: &Document) -> Vec<(u16, u16)> {
-    document
-        .sections
-        .iter()
-        .flat_map(|s| s.paragraphs.iter())
-        .flat_map(|p| &p.controls)
-        .filter_map(|control| match control {
-            Control::Table(table) => Some((table.rows, table.cols)),
-            _ => None,
-        })
-        .collect()
+    let mut out = Vec::new();
+    walk_paragraphs(document, &mut |paragraph| {
+        for control in &paragraph.controls {
+            if let Control::Table(table) = control {
+                out.push((table.rows, table.cols));
+            }
+        }
+    });
+    out
 }
 
 #[cfg(test)]
@@ -568,6 +646,40 @@ mod tests {
         let a: Vec<Vec<HwpChar>> = (0..big).map(|_| vec![HwpChar::Text('a')]).collect();
         let b: Vec<Vec<HwpChar>> = (0..4001).map(|_| vec![HwpChar::Text('b')]).collect();
         let err = paragraph_lcs(&a, &b).unwrap_err();
+        assert!(err.contains("MAX_LCS_CELLS"));
+    }
+
+    #[test]
+    fn cell_only_text_difference_is_not_identical() {
+        // The top-level paragraphs are identical on both sides; only the text
+        // inside one table cell differs.
+        let a = doc("| a | b |\n| - | - |\n| 1 | 2 |\n");
+        let b = doc("| a | b |\n| - | - |\n| 1 | 3 |\n");
+        let diff = compare_documents(&a, &b).unwrap();
+        assert!(!diff.identical);
+        assert!(diff.paragraphs.iter().any(|e| e.op != ParagraphOp::Equal));
+    }
+
+    #[test]
+    fn char_count_product_above_ceiling_is_refused() {
+        // Same ceiling shape as the paragraph-level test: the DP matrix is
+        // refused before it is allocated.
+        let big = MAX_LCS_CELLS / 4000 + 1;
+        let a: Vec<HwpChar> = (0..big).map(|_| HwpChar::Text('a')).collect();
+        let b: Vec<HwpChar> = (0..4001).map(|_| HwpChar::Text('b')).collect();
+        let err = char_lcs(&a, &b).unwrap_err();
+        assert!(err.contains("MAX_LCS_CELLS"));
+    }
+
+    #[test]
+    fn oversized_replaced_pair_surfaces_as_err() {
+        // End to end: two paragraphs are few enough for the paragraph-level
+        // LCS, but the replaced pair's char product exceeds the ceiling, so
+        // the compare returns Err instead of aborting on allocation failure.
+        let big = MAX_LCS_CELLS / 4000 + 1;
+        let a = doc(&format!("머리\n\n{}\n", "가".repeat(big)));
+        let b = doc(&format!("머리\n\n{}\n", "나".repeat(4001)));
+        let err = compare_documents(&a, &b).unwrap_err();
         assert!(err.contains("MAX_LCS_CELLS"));
     }
 

--- a/crates/hwp-convert/src/document_merge.rs
+++ b/crates/hwp-convert/src/document_merge.rs
@@ -13,12 +13,22 @@
 //!
 //! **Tier 2: general graft.** When a later input's header is not
 //! palette-compatible (an arbitrary, non-hwp-cli-generated document — a genuine
-//! Hancom-saved file), every DocHeader-referencing id it carries (char shape,
+//! Hancom-saved file), the DocHeader-referencing ids it carries (char shape,
 //! para shape, style, border fill, per-language face, tab def, numbering and
-//! bullet ids) is shifted by that collection's offset with no shared-base
-//! assumption. A `border_fill_id`/`border_fill` of 0 is the "unspecified"
-//! sentinel (not an index) and is never shifted, so grafting never invents a
-//! border where none existed.
+//! bullet ids, and hwp5 bin-data ids — `BinRef::Id`) are shifted by that
+//! collection's offset with no shared-base assumption, in body paragraphs and
+//! in every nested paragraph collection: table cells, Generic paragraph
+//! lists, and table/picture captions. The input's `header.bin_data` table is
+//! appended with colliding `storage_id`s reminted (and the payload streams
+//! renamed to match) so `BinRef::Id` keeps resolving through
+//! `Document::resolve_bin`'s `BIN{storage_id:04X}.{ext}` rule. A
+//! `border_fill_id`/`border_fill` of 0 is the "unspecified" sentinel (not an
+//! index) and is never shifted, so grafting never invents a border where none
+//! existed. Two reference classes are deliberately not shifted: `Style`
+//! entries are appended verbatim because no writer or render path reads their
+//! internal shape ids, and the input header's unparsed passthrough records
+//! (`extras`, `id_extras`, `id_mappings_counts`) are not grafted — the
+//! primary's stand, matching the singular package-passthrough policy (D-14).
 //!
 //! Every non-primary input's GSO (table/picture) object identities are
 //! renumbered from a running maximum across both tiers, so no two objects
@@ -57,6 +67,11 @@ pub enum MergeLoss {
     /// input were renumbered to avoid colliding with an earlier input's.
     /// This is a recorded, non-target change, not data loss.
     GsoObjectIdRenumbered { count: usize },
+    /// A non-primary input carried hwp5 BIN_DATA entries the merged header
+    /// could not graft because the u16 storage-id space was exhausted — the
+    /// remaining entries were dropped, so `BinRef::Id` references to them no
+    /// longer resolve (their payload streams are still carried).
+    BinDataDropped { input_index: usize, count: usize },
 }
 
 /// Result of [`merge_documents`].
@@ -115,9 +130,11 @@ fn dropped_package_passthrough_fields(input: &Document) -> Vec<&'static str> {
 /// argument order, after its header is grafted onto the running target: the
 /// palette-compatible fast path (tier 1) when the input's header is a
 /// hwp-cli-default-palette-family member, otherwise the general graft (tier 2)
-/// that shifts every DocHeader-referencing id unconditionally. Every
-/// non-primary input's GSO object identities are renumbered from a running
-/// maximum to avoid colliding with an earlier input's.
+/// that shifts each DocHeader-referencing id unconditionally (the module doc
+/// lists the two deliberately unshifted classes). Both tiers graft the input's
+/// hwp5 `header.bin_data` table and shift `BinRef::Id` picture references.
+/// Every non-primary input's GSO object identities are renumbered from a
+/// running maximum to avoid colliding with an earlier input's.
 ///
 /// Returns `Err` only when `inputs` is empty or a GSO object-id/z-order
 /// counter overflows.
@@ -141,11 +158,11 @@ pub fn merge_documents(inputs: &[Document]) -> Result<MergeOutcome, String> {
         let input_index = i + 1;
         let sections_before = target.sections.len();
 
-        if palette_compatible(&target.header, &input.header) {
-            graft_palette_compatible(&mut target, input);
+        let dropped_bin_data = if palette_compatible(&target.header, &input.header) {
+            graft_palette_compatible(&mut target, input)
         } else {
             general_path_used = true;
-            let offsets = graft_header_general(&mut target, input);
+            let (offsets, dropped) = graft_header_general(&mut target, input);
             for section in &input.sections {
                 let mut section = section.clone();
                 for p in &mut section.paragraphs {
@@ -153,6 +170,13 @@ pub fn merge_documents(inputs: &[Document]) -> Result<MergeOutcome, String> {
                 }
                 target.sections.push(section);
             }
+            dropped
+        };
+        if dropped_bin_data > 0 {
+            losses.push(MergeLoss::BinDataDropped {
+                input_index,
+                count: dropped_bin_data,
+            });
         }
 
         let renumbered = renumber_gso_objects(
@@ -185,18 +209,136 @@ pub fn merge_documents(inputs: &[Document]) -> Result<MergeOutcome, String> {
     })
 }
 
-/// Grafts `input`'s bin streams onto `target`, minting a `{prefix}{n}_` name on
-/// a collision and rewiring the returned map so callers can rewrite `Picture`
-/// references. Shared by both grafting tiers.
+/// Grafts `input`'s hwp5 BIN_DATA table onto `target` (appending, so the
+/// caller shifts `BinRef::Id` references by the returned offset), reminting a
+/// `storage_id` the running target already resolves — through its own
+/// bin_data table or through a stream already carrying the canonical name —
+/// so every grafted entry's payload keeps resolving under
+/// `Document::resolve_bin`'s `BIN{storage_id:04X}.{ext}` rule. Returns the id
+/// offset, the storage-id remap [`graft_bin_streams`] renames payload streams
+/// with, and the number of entries dropped because the u16 storage-id space
+/// was exhausted (once an entry is dropped every later entry is dropped too,
+/// keeping the surviving prefix 1:1 aligned with the shifted references).
+fn graft_bin_data(target: &mut Document, input: &Document) -> (u16, HashMap<u16, u16>, usize) {
+    let offset = target.header.bin_data.len() as u16;
+    let mut used: Vec<u16> = target
+        .header
+        .bin_data
+        .iter()
+        .filter_map(|b| b.storage_id)
+        .collect();
+    let mut remap: HashMap<u16, u16> = HashMap::new();
+    let mut dropped = 0usize;
+    let mut exhausted = false;
+
+    for item in &input.header.bin_data {
+        if exhausted {
+            dropped += 1;
+            continue;
+        }
+        let mut item = item.clone();
+        if let Some(storage_id) = item.storage_id {
+            let ext = item.extension.as_deref().unwrap_or("");
+            let new_id = if let Some(&mapped) = remap.get(&storage_id) {
+                mapped
+            } else if !used.contains(&storage_id) && !bin_stream_name_taken(target, storage_id, ext)
+            {
+                used.push(storage_id);
+                storage_id
+            } else {
+                // Mint the first id that is neither grafted nor stream-named
+                // already; exhausting the u16 space makes this entry (and
+                // every later one) ungraftable.
+                let mut candidate = used.iter().max().copied().unwrap_or(0);
+                let fresh = loop {
+                    match candidate.checked_add(1) {
+                        Some(next)
+                            if !used.contains(&next)
+                                && !bin_stream_name_taken(target, next, ext) =>
+                        {
+                            break Some(next);
+                        }
+                        Some(next) => candidate = next,
+                        None => break None,
+                    }
+                };
+                match fresh {
+                    Some(fresh) => {
+                        used.push(fresh);
+                        remap.insert(storage_id, fresh);
+                        fresh
+                    }
+                    None => {
+                        exhausted = true;
+                        dropped = 1;
+                        continue;
+                    }
+                }
+            };
+            item.storage_id = Some(new_id);
+        }
+        target.header.bin_data.push(item);
+    }
+    (offset, remap, dropped)
+}
+
+/// Whether a target bin stream already carries `BIN{storage_id:04X}.{ext}` as
+/// its trailing name — the name `Document::resolve_bin` derives for a
+/// bin_data entry with this storage id and extension.
+fn bin_stream_name_taken(target: &Document, storage_id: u16, ext: &str) -> bool {
+    let candidate = format!("BIN{storage_id:04X}.{ext}");
+    target.bin_streams.iter().any(|b| {
+        b.name
+            .rsplit('/')
+            .next()
+            .unwrap_or(&b.name)
+            .eq_ignore_ascii_case(&candidate)
+    })
+}
+
+/// If `bin` is the payload stream of one of `bin_data`'s entries (its
+/// trailing name matches `BIN{storage_id:04X}.{ext}`), returns the canonical
+/// name under the entry's post-graft storage id — the name
+/// `Document::resolve_bin` derives for the shifted `BinRef::Id`.
+fn reminted_canonical_name(
+    bin_data: &[hwp_model::BinDataItem],
+    bin: &BinStream,
+    storage_remap: &HashMap<u16, u16>,
+) -> Option<String> {
+    let trailing = bin.name.rsplit('/').next().unwrap_or(&bin.name);
+    bin_data.iter().find_map(|item| {
+        let storage_id = item.storage_id?;
+        let ext = item.extension.as_deref().unwrap_or("");
+        if trailing.eq_ignore_ascii_case(&format!("BIN{storage_id:04X}.{ext}")) {
+            let new_id = storage_remap
+                .get(&storage_id)
+                .copied()
+                .unwrap_or(storage_id);
+            Some(format!("BIN{new_id:04X}.{ext}"))
+        } else {
+            None
+        }
+    })
+}
+
+/// Grafts `input`'s bin streams onto `target`. A stream that is the payload
+/// of an hwp5 BIN_DATA entry takes the entry's reminted canonical name so
+/// `BinRef::Id` references keep resolving; every other stream keeps its name,
+/// minting a `{prefix}{n}_` name on a collision. The returned map rewires
+/// `BinRef::ItemRef` references. Shared by both grafting tiers.
 fn graft_bin_streams(
     target: &mut Document,
     input: &Document,
     prefix: &str,
+    storage_remap: &HashMap<u16, u16>,
 ) -> HashMap<String, String> {
     let mut rename: HashMap<String, String> = HashMap::new();
     for bin in &input.bin_streams {
         let mut name = bin.name.clone();
-        if target.bin_streams.iter().any(|b| b.name == name) {
+        if let Some(canonical) = reminted_canonical_name(&input.header.bin_data, bin, storage_remap)
+        {
+            name = canonical;
+        } else if target.bin_streams.iter().any(|b| b.name == name) {
             let mut n = target.bin_streams.len() + 1;
             loop {
                 let candidate = format!("{prefix}{n}_{}", bin.name);
@@ -218,14 +360,20 @@ fn graft_bin_streams(
 
 /// Grafts `input`'s off-palette header extras onto `target` with offset
 /// shifts, then appends `input`'s Sections (remapped, otherwise unchanged).
-/// Mirrors `hwp_convert::merge::part_paragraphs`'s offset arithmetic.
-fn graft_palette_compatible(target: &mut Document, input: &Document) {
+/// Mirrors `hwp_convert::merge::part_paragraphs`'s offset arithmetic, plus
+/// the bin-data graft `graft_bin_data` performs for hwp5-sourced inputs (a
+/// default-palette-family document saved as .hwp and read back carries
+/// `BinRef::Id` pictures). Returns the number of bin_data entries that could
+/// not be grafted (u16 storage-id space exhausted) for the caller to record
+/// as [`MergeLoss::BinDataDropped`].
+fn graft_palette_compatible(target: &mut Document, input: &Document) -> usize {
     let cs_off = target.header.char_shapes.len() as u16 - PALETTE_LEN;
     let ps_off = target.header.para_shapes.len() as u16 - BASE_PARA_SHAPES;
     let num_off = target.header.numbering_levels.len() as u16;
     let bul_off = target.header.bullet_chars.len() as u16;
 
-    let rename = graft_bin_streams(target, input, "merge");
+    let (bd_off, storage_remap, dropped) = graft_bin_data(target, input);
+    let rename = graft_bin_streams(target, input, "merge", &storage_remap);
 
     // Extend target with the input's off-palette extras (numbering/bullet
     // references shifted by the offsets computed above).
@@ -263,15 +411,18 @@ fn graft_palette_compatible(target: &mut Document, input: &Document) {
     for section in &input.sections {
         let mut section = section.clone();
         for p in &mut section.paragraphs {
-            remap_paragraph(p, ps_off, cs_off, &rename);
+            remap_paragraph(p, ps_off, cs_off, bd_off, &rename);
         }
         target.sections.push(section);
     }
+    dropped
 }
 
 /// Shifts one paragraph's off-palette id references (para shape, char shape
-/// runs) and rewires bin-stream (Picture) references after a rename,
-/// including nested table cells and Generic paragraph lists. A `SectionDef`
+/// runs), bin-data id references (`BinRef::Id`, shifted by the full bin-data
+/// offset — bin data has no shared palette base) and rewires bin-stream
+/// (Picture) references after a rename, including nested table cells,
+/// Generic paragraph lists and table/picture captions. A `SectionDef`
 /// control is untouched — it matches none of the arms below and stays as-is,
 /// which is exactly D-02's "each input's Section carried over unchanged"
 /// requirement. Mirrors `hwp_convert::merge::remap_paragraph`.
@@ -279,6 +430,7 @@ fn remap_paragraph(
     para: &mut Paragraph,
     ps_off: u16,
     cs_off: u16,
+    bd_off: u16,
     rename: &HashMap<String, String>,
 ) {
     if para.para_shape.0 >= BASE_PARA_SHAPES {
@@ -292,26 +444,39 @@ fn remap_paragraph(
     for control in &mut para.controls {
         match control {
             Control::Table(t) => {
+                if let Some(cap) = &mut t.caption {
+                    for p in &mut cap.paragraphs {
+                        remap_paragraph(p, ps_off, cs_off, bd_off, rename);
+                    }
+                }
                 for cell in &mut t.cells {
                     for p in &mut cell.paragraphs {
-                        remap_paragraph(p, ps_off, cs_off, rename);
+                        remap_paragraph(p, ps_off, cs_off, bd_off, rename);
                     }
                 }
             }
             Control::Generic(g) => {
                 for list in &mut g.paragraph_lists {
                     for p in &mut list.paragraphs {
-                        remap_paragraph(p, ps_off, cs_off, rename);
+                        remap_paragraph(p, ps_off, cs_off, bd_off, rename);
                     }
                 }
                 // Reference ids changed above — the original XML is stale.
                 g.hwpx_raw_xml = None;
             }
             Control::Picture(pic) => {
-                if let BinRef::ItemRef(name) = &mut pic.bin_ref
-                    && let Some(new_name) = rename.get(name)
-                {
-                    *name = new_name.clone();
+                match &mut pic.bin_ref {
+                    BinRef::ItemRef(name) => {
+                        if let Some(new_name) = rename.get(name) {
+                            *name = new_name.clone();
+                        }
+                    }
+                    BinRef::Id(id) => id.0 += bd_off,
+                }
+                if let Some(cap) = &mut pic.caption {
+                    for p in &mut cap.paragraphs {
+                        remap_paragraph(p, ps_off, cs_off, bd_off, rename);
+                    }
                 }
             }
             _ => {}
@@ -322,7 +487,8 @@ fn remap_paragraph(
 /// Per-non-primary-input collection-length offsets [`graft_header_general`]
 /// computes before it appends `input`'s header collections onto `target`'s,
 /// and [`remap_paragraph_general`] then applies to that input's paragraph
-/// tree. The tab-def/numbering/bullet/face offsets are consumed entirely
+/// tree (`bin_data` shifts hwp5 `BinRef::Id` picture references). The
+/// tab-def/numbering/bullet/face offsets are consumed entirely
 /// inside `graft_header_general` itself (they shift ids embedded *inside* the
 /// appended `ParaShape`/`CharShape` entries, not anything a `Paragraph`
 /// references directly) and so stay local to that function rather than living
@@ -333,6 +499,7 @@ struct HeaderOffsets {
     para_shape: u16,
     style: u16,
     border_fill: u16,
+    bin_data: u16,
     bin_rename: HashMap<String, String>,
 }
 
@@ -344,7 +511,11 @@ struct HeaderOffsets {
 /// sentinel (`hwp_model::header::CharShape`/`ParaShape` doc comments; the same
 /// 1-based convention applies to `hwp_model::BorderFillId` on `Table`/`Cell`)
 /// and is never shifted, so grafting never invents a border where none existed.
-fn graft_header_general(target: &mut Document, input: &Document) -> HeaderOffsets {
+/// hwp5 bin-data entries are appended by [`graft_bin_data`]; returns the
+/// offsets alongside the number of bin_data entries that could not be grafted
+/// (u16 storage-id space exhausted) for the caller to record as
+/// [`MergeLoss::BinDataDropped`].
+fn graft_header_general(target: &mut Document, input: &Document) -> (HeaderOffsets, usize) {
     let char_shape = target.header.char_shapes.len() as u16;
     let para_shape = target.header.para_shapes.len() as u16;
     let style = target.header.styles.len() as u16;
@@ -357,7 +528,8 @@ fn graft_header_general(target: &mut Document, input: &Document) -> HeaderOffset
         *offset = target.header.fonts[lang].len() as u16;
     }
 
-    let bin_rename = graft_bin_streams(target, input, "graft");
+    let (bin_data, storage_remap, dropped) = graft_bin_data(target, input);
+    let bin_rename = graft_bin_streams(target, input, "graft", &storage_remap);
 
     // Fonts, border fills, tab defs/stops, numberings/numbering_levels and
     // bullets/bullet_chars carry no id references of their own — append verbatim.
@@ -440,21 +612,27 @@ fn graft_header_general(target: &mut Document, input: &Document) -> HeaderOffset
         }
     }
 
-    HeaderOffsets {
-        char_shape,
-        para_shape,
-        style,
-        border_fill,
-        bin_rename,
-    }
+    (
+        HeaderOffsets {
+            char_shape,
+            para_shape,
+            style,
+            border_fill,
+            bin_data,
+            bin_rename,
+        },
+        dropped,
+    )
 }
 
 /// General-graft counterpart of `remap_paragraph`: shifts every id
 /// unconditionally (no shared-base guard — there is no assumed shared base on
-/// this path), adds `para.style` and the `Table`/`Cell` border-fill shift (with
-/// the zero-sentinel guard). Recurses into table cells and Generic paragraph
-/// lists exactly as `remap_paragraph` does — not into captions, matching that
-/// function's own scope.
+/// this path), adds `para.style`, the `Table`/`Cell` border-fill shift (with
+/// the zero-sentinel guard) and the hwp5 `BinRef::Id` bin-data shift.
+/// Recurses into every nested paragraph collection — table cells, Generic
+/// paragraph lists, and table/picture captions — so caption paragraphs
+/// resolve to the same shifted header entries as body paragraphs and caption
+/// pictures keep their rewired bin references.
 fn remap_paragraph_general(para: &mut Paragraph, offsets: &HeaderOffsets) {
     para.para_shape.0 += offsets.para_shape;
     para.style.0 += offsets.style;
@@ -466,6 +644,11 @@ fn remap_paragraph_general(para: &mut Paragraph, offsets: &HeaderOffsets) {
             Control::Table(t) => {
                 if t.border_fill.0 != 0 {
                     t.border_fill.0 += offsets.border_fill;
+                }
+                if let Some(cap) = &mut t.caption {
+                    for p in &mut cap.paragraphs {
+                        remap_paragraph_general(p, offsets);
+                    }
                 }
                 for cell in &mut t.cells {
                     if cell.border_fill.0 != 0 {
@@ -486,10 +669,18 @@ fn remap_paragraph_general(para: &mut Paragraph, offsets: &HeaderOffsets) {
                 g.hwpx_raw_xml = None;
             }
             Control::Picture(pic) => {
-                if let BinRef::ItemRef(name) = &mut pic.bin_ref
-                    && let Some(new_name) = offsets.bin_rename.get(name)
-                {
-                    *name = new_name.clone();
+                match &mut pic.bin_ref {
+                    BinRef::ItemRef(name) => {
+                        if let Some(new_name) = offsets.bin_rename.get(name) {
+                            *name = new_name.clone();
+                        }
+                    }
+                    BinRef::Id(id) => id.0 += offsets.bin_data,
+                }
+                if let Some(cap) = &mut pic.caption {
+                    for p in &mut cap.paragraphs {
+                        remap_paragraph_general(p, offsets);
+                    }
                 }
             }
             _ => {}
@@ -873,6 +1064,323 @@ mod tests {
                 }
             }
         }
+    }
+
+    // ── Review follow-up (#163): caption paragraphs on the general path ────
+
+    /// Builds a caption whose single paragraph is `para`.
+    fn caption_with_para(para: Paragraph) -> hwp_model::Caption {
+        hwp_model::Caption {
+            side: hwp_model::CaptionSide::Bottom,
+            direction: hwp_model::CaptionDirection::Horizontal,
+            gap: 0,
+            width: None,
+            last_width: 0,
+            paragraphs: vec![para],
+        }
+    }
+
+    /// Pushes fresh marker entries onto `doc`'s header and returns the ids a
+    /// caption paragraph then references.
+    fn push_caption_marker_shapes(
+        doc: &mut Document,
+    ) -> (hwp_model::ParaShapeId, hwp_model::StyleId, CharShapeId) {
+        doc.header.para_shapes.push(hwp_model::ParaShape {
+            line_spacing: 250,
+            ..Default::default()
+        });
+        let para_shape = hwp_model::ParaShapeId((doc.header.para_shapes.len() - 1) as u16);
+        doc.header.styles.push(hwp_model::Style {
+            name: "캡션스타일".to_string(),
+            english_name: "CaptionStyle".to_string(),
+            ..Default::default()
+        });
+        let style = hwp_model::StyleId((doc.header.styles.len() - 1) as u16);
+        doc.header.char_shapes.push(hwp_model::CharShape {
+            base_size: 4321,
+            ..Default::default()
+        });
+        let char_shape = CharShapeId((doc.header.char_shapes.len() - 1) as u16);
+        (para_shape, style, char_shape)
+    }
+
+    /// Asserts a merged caption paragraph's ids moved by the primary input's
+    /// collection lengths and resolve to the appended marker entries.
+    fn assert_caption_shapes_shifted(
+        merged: &Document,
+        primary: &Document,
+        caption_para: &Paragraph,
+        markers: (hwp_model::ParaShapeId, hwp_model::StyleId, CharShapeId),
+    ) {
+        let (para_shape, style, char_shape) = markers;
+        assert_eq!(
+            caption_para.para_shape.0,
+            para_shape.0 + primary.header.para_shapes.len() as u16
+        );
+        assert_eq!(
+            merged.header.para_shapes[caption_para.para_shape.0 as usize].line_spacing,
+            250
+        );
+        assert_eq!(
+            caption_para.style.0,
+            style.0 + primary.header.styles.len() as u16
+        );
+        assert_eq!(
+            merged.header.styles[caption_para.style.0 as usize].name,
+            "캡션스타일"
+        );
+        let (_, run_cs) = caption_para.char_shape_runs[0];
+        assert_eq!(
+            run_cs.0,
+            char_shape.0 + primary.header.char_shapes.len() as u16
+        );
+        assert_eq!(merged.header.char_shapes[run_cs.0 as usize].base_size, 4321);
+    }
+
+    #[test]
+    fn 일반_경로_표_캡션_문단도_이동된_모양으로_해석된다() {
+        let a = from_markdown("문서 A\n");
+        let mut b = non_palette_compatible(from_markdown("<table><tr><td>가</td></tr></table>\n"));
+        let markers = push_caption_marker_shapes(&mut b);
+        let (para_shape, style, char_shape) = markers;
+
+        let table = b.sections[0].paragraphs[0]
+            .controls
+            .iter_mut()
+            .find_map(|c| match c {
+                Control::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("표 컨트롤");
+        table.caption = Some(caption_with_para(Paragraph {
+            para_shape,
+            style,
+            char_shape_runs: vec![(0, char_shape)],
+            ..Default::default()
+        }));
+
+        let outcome = merge_documents(&[a.clone(), b]).unwrap();
+        assert!(outcome.general_path_used);
+        let merged_table = outcome.document.sections[a.sections.len()]
+            .paragraphs
+            .iter()
+            .flat_map(|p| &p.controls)
+            .find_map(|c| match c {
+                Control::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("병합된 표 컨트롤");
+        let caption_para = &merged_table
+            .caption
+            .as_ref()
+            .expect("캡션이 유지돼야 한다")
+            .paragraphs[0];
+        assert_caption_shapes_shifted(&outcome.document, &a, caption_para, markers);
+    }
+
+    #[test]
+    fn 일반_경로_그림_캡션_문단도_이동된_모양으로_해석된다() {
+        let a = from_markdown("문서 A\n");
+        let mut b = non_palette_compatible(from_markdown("문서 B\n"));
+        let markers = push_caption_marker_shapes(&mut b);
+        let (para_shape, style, char_shape) = markers;
+
+        let mut picture = sample_picture("cap-pic.png");
+        picture.caption = Some(caption_with_para(Paragraph {
+            para_shape,
+            style,
+            char_shape_runs: vec![(0, char_shape)],
+            ..Default::default()
+        }));
+        b.sections[0].paragraphs.insert(
+            0,
+            Paragraph {
+                controls: vec![Control::Picture(picture)],
+                ..Default::default()
+            },
+        );
+
+        let outcome = merge_documents(&[a.clone(), b]).unwrap();
+        assert!(outcome.general_path_used);
+        let merged_picture = outcome.document.sections[a.sections.len()]
+            .paragraphs
+            .iter()
+            .flat_map(|p| &p.controls)
+            .find_map(|c| match c {
+                Control::Picture(p) => Some(p),
+                _ => None,
+            })
+            .expect("병합된 그림 컨트롤");
+        let caption_para = &merged_picture
+            .caption
+            .as_ref()
+            .expect("캡션이 유지돼야 한다")
+            .paragraphs[0];
+        assert_caption_shapes_shifted(&outcome.document, &a, caption_para, markers);
+    }
+
+    // ── Review follow-up (#164): BinRef::Id / header.bin_data grafting ─────
+
+    /// Pushes an hwp5-style embedded bin-data entry plus its payload stream
+    /// (canonical `BIN{storage_id:04X}.png` name, as the hwp5 reader emits).
+    fn push_hwp5_bin(doc: &mut Document, storage_id: u16, data: &[u8]) {
+        doc.header.bin_data.push(hwp_model::BinDataItem {
+            attr: 1, // kind 1: embedded
+            storage_id: Some(storage_id),
+            extension: Some("png".to_string()),
+            ..Default::default()
+        });
+        doc.bin_streams.push(BinStream {
+            name: format!("BIN{storage_id:04X}.png"),
+            data: data.to_vec(),
+        });
+    }
+
+    /// Inserts a paragraph whose picture references `header.bin_data` entry
+    /// `id` (1-based, as the hwp5 reader emits).
+    fn insert_id_picture(doc: &mut Document, id: u16) {
+        let mut picture = sample_picture("");
+        picture.bin_ref = BinRef::Id(hwp_model::BinDataId(id));
+        doc.sections[0].paragraphs.insert(
+            0,
+            Paragraph {
+                controls: vec![Control::Picture(picture)],
+                ..Default::default()
+            },
+        );
+    }
+
+    fn only_picture(section: &Section) -> &hwp_model::Picture {
+        section
+            .paragraphs
+            .iter()
+            .flat_map(|p| &p.controls)
+            .find_map(|c| match c {
+                Control::Picture(p) => Some(p),
+                _ => None,
+            })
+            .expect("그림 컨트롤")
+    }
+
+    #[test]
+    fn 일반_경로_bin_ref_id_그림은_그라프트된_bin_data로_해석된다() {
+        let mut a = from_markdown("문서 A\n");
+        push_hwp5_bin(&mut a, 1, b"AAAA");
+        insert_id_picture(&mut a, 1);
+        let mut b = non_palette_compatible(from_markdown("문서 B\n"));
+        push_hwp5_bin(&mut b, 1, b"BBBB"); // storage id collides with a's
+        insert_id_picture(&mut b, 1);
+
+        let outcome = merge_documents(&[a, b]).unwrap();
+        assert!(outcome.general_path_used);
+        assert!(
+            !outcome
+                .losses
+                .iter()
+                .any(|loss| matches!(loss, MergeLoss::BinDataDropped { .. })),
+            "그라프트가 성공하면 bin-data 손실은 기록되지 않는다"
+        );
+
+        // The picture's reference is shifted by the primary's table length and
+        // resolution lands on the merged-in input's own payload bytes.
+        let merged_picture = only_picture(&outcome.document.sections[1]);
+        let BinRef::Id(id) = &merged_picture.bin_ref else {
+            panic!("BinRef::Id expected");
+        };
+        assert_eq!(id.0, 2, "기본 입력의 bin_data 하나만큼 이동해야 한다");
+        assert_eq!(
+            outcome.document.resolve_bin(&merged_picture.bin_ref),
+            Some(b"BBBB".as_slice())
+        );
+        // The grafted entry's storage id was reminted so its canonical stream
+        // name no longer collides with the primary's payload stream.
+        let grafted = &outcome.document.header.bin_data[(id.0 - 1) as usize];
+        assert_eq!(grafted.storage_id, Some(2));
+
+        // The primary input's own picture still resolves to its own payload.
+        let primary_picture = only_picture(&outcome.document.sections[0]);
+        assert_eq!(
+            outcome.document.resolve_bin(&primary_picture.bin_ref),
+            Some(b"AAAA".as_slice())
+        );
+    }
+
+    #[test]
+    fn 일반_경로_bin_ref_id는_충돌_없으면_원래_storage_id를_유지한다() {
+        let a = from_markdown("문서 A\n"); // no bin_data of its own
+        let mut b = non_palette_compatible(from_markdown("문서 B\n"));
+        push_hwp5_bin(&mut b, 7, b"CCCC");
+        insert_id_picture(&mut b, 1);
+
+        let outcome = merge_documents(&[a, b]).unwrap();
+        let merged_picture = only_picture(&outcome.document.sections[1]);
+        let BinRef::Id(id) = &merged_picture.bin_ref else {
+            panic!("BinRef::Id expected");
+        };
+        assert_eq!(id.0, 1, "기본 입력의 bin_data가 비어 있으면 이동 없음");
+        assert_eq!(
+            outcome.document.header.bin_data[0].storage_id,
+            Some(7),
+            "충돌이 없으면 storage id를 유지한다"
+        );
+        assert_eq!(
+            outcome.document.resolve_bin(&merged_picture.bin_ref),
+            Some(b"CCCC".as_slice())
+        );
+    }
+
+    #[test]
+    fn 일반_경로_캡션_안_그림의_bin_ref_id도_이동한다() {
+        let mut a = from_markdown("문서 A\n");
+        push_hwp5_bin(&mut a, 1, b"AAAA");
+        let mut b = non_palette_compatible(from_markdown("<table><tr><td>가</td></tr></table>\n"));
+        push_hwp5_bin(&mut b, 1, b"BBBB");
+
+        // The table's caption carries a picture referencing b's bin_data.
+        let mut caption_picture = sample_picture("");
+        caption_picture.bin_ref = BinRef::Id(hwp_model::BinDataId(1));
+        let table = b.sections[0].paragraphs[0]
+            .controls
+            .iter_mut()
+            .find_map(|c| match c {
+                Control::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("표 컨트롤");
+        table.caption = Some(caption_with_para(Paragraph {
+            controls: vec![Control::Picture(caption_picture)],
+            ..Default::default()
+        }));
+
+        let outcome = merge_documents(&[a, b]).unwrap();
+        let merged_table = outcome.document.sections[1]
+            .paragraphs
+            .iter()
+            .flat_map(|p| &p.controls)
+            .find_map(|c| match c {
+                Control::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("병합된 표 컨트롤");
+        let caption_picture = merged_table.caption.as_ref().expect("캡션").paragraphs[0]
+            .controls
+            .iter()
+            .find_map(|c| match c {
+                Control::Picture(p) => Some(p),
+                _ => None,
+            })
+            .expect("캡션 안 그림");
+        let BinRef::Id(id) = &caption_picture.bin_ref else {
+            panic!("BinRef::Id expected");
+        };
+        assert_eq!(
+            id.0, 2,
+            "캡션 안 그림의 bin 참조도 오프셋만큼 이동해야 한다"
+        );
+        assert_eq!(
+            outcome.document.resolve_bin(&caption_picture.bin_ref),
+            Some(b"BBBB".as_slice())
+        );
     }
 
     #[test]

--- a/crates/hwp-convert/src/document_split.rs
+++ b/crates/hwp-convert/src/document_split.rs
@@ -11,7 +11,10 @@
 //! exactly what this project forbids CI tests from asserting on). A boundary that
 //! falls inside a paragraph rounds forward to the start of the next paragraph
 //! (D-08), so the straddling paragraph stays whole in the fragment before the
-//! boundary and the fragment after it starts clean.
+//! boundary and the fragment after it starts clean. A range whose start and end
+//! pages live in different sections produces one fragment spanning those
+//! sections (intermediate sections carried whole), so no content between the
+//! two boundaries is dropped.
 //!
 //! This module must not depend on the sibling merge-grafting module: D-06's
 //! "whole DocHeader unchanged" is exactly the direction that needs no offset
@@ -151,11 +154,17 @@ fn round_boundary(doc: &Document, addr: ParagraphAddress) -> ParagraphAddress {
 /// font-driven layout pass. A boundary that falls inside a paragraph rounds
 /// forward to the next paragraph's start (D-08): the straddling paragraph stays
 /// whole in the fragment before the boundary, and the fragment after it starts
-/// at the following paragraph. Every fragment's slice is kept within a single
-/// section (the section the range's start address names); when the slice does
-/// not already start with that section's first paragraph (which carries its
-/// `Control::SectionDef`), that first paragraph is prepended so the fragment
-/// stays a well-formed section.
+/// at the following paragraph. A fragment's slice runs from its (rounded)
+/// start address through its (rounded) end address across section boundaries:
+/// the start section contributes from `start.paragraph` on, intermediate
+/// sections are carried whole, and the end section contributes up to
+/// `end.paragraph` (a range reaching the document's last page runs to the end
+/// of the last section), so no content between the two boundaries is dropped.
+/// When the slice does not already start with the start section's first
+/// paragraph (which carries its `Control::SectionDef`), that first paragraph
+/// is prepended so the fragment's first section stays well-formed; later
+/// sections keep their own first paragraphs, so they stay well-formed as-is.
+/// The fragment's `section_count` is set to the number of sections it carries.
 ///
 /// Returns `Err` for an empty range list, a range with `first > last` or
 /// `first == 0`, a range naming a page beyond the count [`page_start_addresses`]
@@ -222,31 +231,49 @@ pub fn split_page_ranges(doc: &Document, ranges: &[PageRange]) -> Result<SplitOu
             None
         };
 
-        let section_index = start.section;
-        let section = doc
-            .sections
-            .get(section_index)
-            .ok_or_else(|| "페이지 경계가 가리키는 구역을 찾을 수 없습니다".to_string())?;
-        let end_paragraph = match end {
-            Some(end) if end.section == section_index => end.paragraph,
-            _ => section.paragraphs.len(),
-        };
-        let start_paragraph = start.paragraph.min(end_paragraph);
+        // D-08 slice, spanning every section from the range's start address
+        // to its end address: intermediate sections are taken whole, so no
+        // content between the two boundaries is dropped.
+        let start_section = start.section;
+        let last_section = end.map_or(doc.sections.len() - 1, |end| end.section);
 
-        let mut paragraphs: Vec<Paragraph> =
-            section.paragraphs[start_paragraph..end_paragraph].to_vec();
-        if start_paragraph != 0
-            && let Some(first_paragraph) = section.paragraphs.first()
-        {
-            paragraphs.insert(0, first_paragraph.clone());
+        let mut sections: Vec<Section> = Vec::new();
+        for section_index in start_section..=last_section {
+            let section = doc
+                .sections
+                .get(section_index)
+                .ok_or_else(|| "페이지 경계가 가리키는 구역을 찾을 수 없습니다".to_string())?;
+            let slice_start = if section_index == start_section {
+                start.paragraph
+            } else {
+                0
+            };
+            let slice_end = match end {
+                Some(end) if end.section == section_index => end.paragraph,
+                _ => section.paragraphs.len(),
+            };
+            let slice_start = slice_start.min(slice_end);
+            if slice_start == slice_end && !sections.is_empty() {
+                // The end boundary sits exactly at this section's start —
+                // nothing of this section belongs to the fragment.
+                continue;
+            }
+            let mut paragraphs: Vec<Paragraph> =
+                section.paragraphs[slice_start..slice_end].to_vec();
+            if slice_start != 0
+                && let Some(first_paragraph) = section.paragraphs.first()
+            {
+                paragraphs.insert(0, first_paragraph.clone());
+            }
+            sections.push(Section {
+                paragraphs,
+                extras: section.extras.clone(),
+            });
         }
 
         let mut fragment = doc.clone();
-        fragment.sections = vec![Section {
-            paragraphs,
-            extras: section.extras.clone(),
-        }];
-        fragment.header.properties.section_count = 1;
+        fragment.header.properties.section_count = sections.len() as u16;
+        fragment.sections = sections;
         fragment.header.properties.caret = (0, 0, 0);
         fragments.push(fragment);
     }
@@ -376,7 +403,16 @@ mod tests {
     }
 
     fn set_page_start(doc: &mut Document, paragraph_index: usize, text_start: u32) {
-        doc.sections[0].paragraphs[paragraph_index]
+        set_section_page_start(doc, 0, paragraph_index, text_start);
+    }
+
+    fn set_section_page_start(
+        doc: &mut Document,
+        section_index: usize,
+        paragraph_index: usize,
+        text_start: u32,
+    ) {
+        doc.sections[section_index].paragraphs[paragraph_index]
             .line_segs
             .push(LineSeg {
                 text_start,
@@ -464,5 +500,104 @@ mod tests {
         assert!(has_section_def(
             &outcome.fragments[0].sections[0].paragraphs[0]
         ));
+    }
+
+    /// A page start on every section's first paragraph: page 1 = section 0,
+    /// page 2 = section 1, page 3 = section 2.
+    fn paged_three_section_doc() -> Document {
+        let mut doc = three_section_doc();
+        set_section_page_start(&mut doc, 0, 0, 0);
+        set_section_page_start(&mut doc, 1, 0, 0);
+        set_section_page_start(&mut doc, 2, 0, 0);
+        doc
+    }
+
+    #[test]
+    fn 구역을_넘는_페이지_범위는_중간_구역을_모두_담는다() {
+        let doc = paged_three_section_doc();
+
+        // Pages 1-2 must carry section 1 whole — the single-section slice
+        // used to drop it silently (issue #162).
+        let outcome = split_page_ranges(&doc, &[PageRange { first: 1, last: 2 }]).unwrap();
+        assert!(outcome.roundings.is_empty());
+        assert_eq!(outcome.fragments.len(), 1);
+        let fragment = &outcome.fragments[0];
+        // The range ends exactly at section 2's start, so section 2 is not
+        // part of the fragment at all.
+        assert_eq!(fragment.sections.len(), 2);
+        assert_eq!(fragment.header.properties.section_count, 2);
+        let text = plain_text(fragment);
+        assert!(text.contains("첫 구역"));
+        assert!(text.contains("둘째 구역"));
+        assert!(!text.contains("셋째 구역"));
+    }
+
+    #[test]
+    fn 마지막_페이지까지의_범위는_뒤따르는_구역을_버리지_않는다() {
+        let doc = paged_three_section_doc();
+
+        // A range running to the last page must reach the end of the last
+        // section, not the end of the start section.
+        let outcome = split_page_ranges(&doc, &[PageRange { first: 1, last: 3 }]).unwrap();
+        assert!(outcome.roundings.is_empty());
+        let fragment = &outcome.fragments[0];
+        assert_eq!(fragment.sections.len(), 3);
+        assert_eq!(fragment.header.properties.section_count, 3);
+        let text = plain_text(fragment);
+        assert!(text.contains("첫 구역"));
+        assert!(text.contains("둘째 구역"));
+        assert!(text.contains("셋째 구역"));
+    }
+
+    #[test]
+    fn 구역_중간에서_시작하는_범위도_뒤_구역을_담고_섹션정의를_보존한다() {
+        let mut doc = crate::from_markdown("구역1 첫째\n\n구역1 둘째\n");
+        doc.sections
+            .push(crate::from_markdown("구역2 첫째\n").sections[0].clone());
+        // Page 1 = section 0 paragraph 0; page 2 = section 0 paragraph 1
+        // (mid-section start); page 3 = section 1 paragraph 0.
+        set_section_page_start(&mut doc, 0, 0, 0);
+        set_section_page_start(&mut doc, 0, 1, 0);
+        set_section_page_start(&mut doc, 1, 0, 0);
+
+        let outcome = split_page_ranges(&doc, &[PageRange { first: 2, last: 3 }]).unwrap();
+        assert!(outcome.roundings.is_empty());
+        let fragment = &outcome.fragments[0];
+        assert_eq!(fragment.sections.len(), 2);
+        assert_eq!(fragment.header.properties.section_count, 2);
+        // The first section starts mid-way, so its SectionDef paragraph must
+        // be prepended (that paragraph carries the section's first text in
+        // this IR — the prepend is a duplicate, not a move); the second
+        // section keeps its own first paragraph.
+        assert!(has_section_def(&fragment.sections[0].paragraphs[0]));
+        assert!(has_section_def(&fragment.sections[1].paragraphs[0]));
+        assert_eq!(fragment.sections[0].paragraphs.len(), 2);
+        let text = plain_text(fragment);
+        assert!(text.contains("구역1 둘째"));
+        assert!(text.contains("구역2 첫째"));
+    }
+
+    #[test]
+    fn 구역_끝에_걸친_페이지_경계는_다음_구역_첫_문단으로_보정된다() {
+        let mut doc = three_section_doc();
+        let last_of_section0 = doc.sections[0].paragraphs.len() - 1;
+        set_section_page_start(&mut doc, 0, 0, 0);
+        // Page 2 starts strictly inside section 0's last paragraph — the
+        // boundary must round forward to section 1's first paragraph.
+        set_section_page_start(&mut doc, 0, last_of_section0, 3);
+
+        let outcome = split_page_ranges(&doc, &[PageRange { first: 1, last: 1 }]).unwrap();
+        assert_eq!(outcome.roundings.len(), 1);
+        assert_eq!(outcome.roundings[0].from.section, 0);
+        assert_eq!(outcome.roundings[0].from.paragraph, last_of_section0);
+        assert_eq!(outcome.roundings[0].from.wchar_offset, 3);
+        assert_eq!(outcome.roundings[0].to.section, 1);
+        assert_eq!(outcome.roundings[0].to.paragraph, 0);
+        // The straddling paragraph stays whole in the earlier fragment; the
+        // next section's content belongs to the following page range.
+        let fragment = &outcome.fragments[0];
+        assert_eq!(fragment.sections.len(), 1);
+        assert!(plain_text(fragment).contains("첫 구역"));
+        assert!(!plain_text(fragment).contains("둘째 구역"));
     }
 }


### PR DESCRIPTION
## Summary

Closes all six Major findings from the post-merge review of #161:

- **split `--loss-report` can overwrite the input file** — applies merge's `reject_loss_report_aliases` to split, so a report path aliasing the input is refused before any write. Closes #167
- **`--pages` silently drops content on multi-section documents** — the slice now spans from the start address through the end address across section boundaries (intermediate sections carried whole); `section_count` reflects the fragment's actual sections. Closes #162
- **General graft path never id-shifts caption paragraphs** — both graft paths now recurse into `Table::caption`/`Picture::caption`, shifting their `para_shape`/`style`/`char_shape_runs` and rewiring caption pictures' `bin_ref`s. Closes #163
- **`header.bin_data` never grafted; `BinRef::Id` never shifted** — merged-in bin_data tables are grafted with a storage-id offset (reminting colliding ids to canonical `BIN%04X` stream names), `BinRef::Id` references shift accordingly, and storage-id exhaustion records a `BinDataDropped` loss event instead of only a string warning. Closes #164
- **compare reports identical=true for cell-only differences** — `flatten_paragraph_chars`, `control_inventory`, and `table_geometries` now recurse into table cells and captions via a shared paragraph walker. Closes #165
- **char_lcs has no cell ceiling** — char-level LCS applies the same `MAX_LCS_CELLS` checked-multiply refusal as paragraph-level LCS. Closes #166

## Test plan

- New unit tests per finding (caption id-shift, BinRef::Id graft, cross-section slice + rounding events, cell-only diff detection, char-LCS ceiling refusal) plus a CLI integration test for the split loss-report alias refusal
- `scripts/check.sh` green locally (fmt / clippy 1.93.0 `-D warnings` / `cargo test --workspace` / structured-corpus gate; public pdf-parity gate skipped locally — no pinned pdfinfo — runs in CI)
- No font-dependent assertions added

## Notes

- The tier-2 merge module doc now lists the two remaining unshifted id classes explicitly (`Style` internals, unparsed header passthrough records) instead of overclaiming
- `crates/hwp-convert/src/merge.rs` (part-filling path) has the same caption-skip gap in its own remap — out of scope here, candidate for a follow-up issue