### PR TITLE
fix: preservation-report schema parity + typed border-fill loss event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 - `hwp merge` (tier 2) now shifts section-level border-fill references (hwp5
   `page_border_fills_raw` plus the parallel `extras` copies, and hwpx `borderFillIDRef`
   passthrough) by the border-fill offset, so merged-in page borders resolve against their own
-  table; malformed non-numeric references pass through unchanged (#171).
+  table (#171).
 
 - `hwp merge` no longer consumes object ids for tables with truncated `common_data` payloads,
   so `GsoObjectIdRenumbered` counts and id sequences stay accurate (#172).
@@ -59,6 +59,16 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 - `hwp split` removes stale `stem-NNN.ext` fragments from previous larger runs after a
   successful publication, and fragment names now use the lowercased input extension (#177).
+
+- The `preservation-report-v1` schema now enumerates every preservation code the CLI emits
+  (the merge/split codes `document_metadata_superseded`, `document_package_passthrough_dropped`,
+  `gso_object_id_renumbered`, and `page_range_paragraph_rounded` were missing), with a locking
+  test that fails CI if the schema and the `PreservationCode` wire strings drift apart again
+  (#179).
+
+- `hwp merge` (tier 2) now records a typed `section_border_fill_ref_unresolvable` loss event
+  when a section's hwpx `borderFillIDRef` passthrough carries a non-numeric value that cannot
+  be shifted, instead of silently leaving it pointing at the wrong border-fill table (#180).
 
 ## [0.12.1]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,7 @@ name = "hwp-model"
 version = "0.12.1"
 dependencies = [
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/hwp-cli/src/commands/preservation.rs
+++ b/crates/hwp-cli/src/commands/preservation.rs
@@ -197,6 +197,17 @@ pub(crate) fn inspect_document_merge_losses(
                     *count,
                 );
             }
+            hwp_convert::document_merge::MergeLoss::SectionBorderFillRefUnresolvable {
+                count,
+                ..
+            } => {
+                record_changed(
+                    &mut report,
+                    PreservationCode::SectionBorderFillRefUnresolvable,
+                    PreservationResourceKind::Control,
+                    *count,
+                );
+            }
         }
     }
     report
@@ -632,6 +643,31 @@ mod tests {
     #[test]
     fn document_merge_no_losses_stays_lossless() {
         assert!(inspect_document_merge_losses(&[]).is_lossless());
+    }
+
+    /// #180: an unshiftable non-numeric `borderFillIDRef` passthrough is a
+    /// recorded non-target change on the section's control, not a removal.
+    #[test]
+    fn document_merge_unresolvable_border_fill_ref_becomes_one_typed_changed_event() {
+        let losses = vec![MergeLoss::SectionBorderFillRefUnresolvable {
+            input_index: 1,
+            count: 2,
+        }];
+        let report = inspect_document_merge_losses(&losses);
+        assert_eq!(report.events.len(), 1);
+        assert_eq!(
+            report.events[0].code,
+            PreservationCode::SectionBorderFillRefUnresolvable
+        );
+        assert_eq!(report.events[0].resource, PreservationResourceKind::Control);
+        assert_eq!(
+            report.events[0].disposition,
+            PreservationDisposition::ChangedNonTarget
+        );
+        assert_eq!(report.events[0].count, 2);
+        // Content-free: the malformed attribute value never leaks.
+        let serialized = serde_json::to_string(&report).unwrap();
+        assert!(serialized.contains("section_border_fill_ref_unresolvable"));
     }
 
     #[test]

--- a/crates/hwp-convert/src/document_merge.rs
+++ b/crates/hwp-convert/src/document_merge.rs
@@ -32,8 +32,10 @@
 //! `<hp:pageBorderFill>` raw-XML passthrough children
 //! (`SectionDef::secpr_raw_children`) whose numeric `borderFillIDRef`
 //! attribute is rewritten in place. A passthrough child whose
-//! `borderFillIDRef` is present but not numeric is left verbatim — the
-//! reference already resolved nowhere — rather than rewritten blindly. Two
+//! `borderFillIDRef` is present but not numeric cannot be shifted onto the
+//! merged border-fill table, so it is kept verbatim and recorded as
+//! [`MergeLoss::SectionBorderFillRefUnresolvable`] (#180) rather than
+//! silently passing through to resolve against the wrong table. Two
 //! reference classes are deliberately not shifted: `Style`
 //! entries are appended verbatim because no writer or render path reads their
 //! internal shape ids, and the input header's unparsed passthrough records
@@ -82,6 +84,12 @@ pub enum MergeLoss {
     /// remaining entries were dropped, so `BinRef::Id` references to them no
     /// longer resolve (their payload streams are still carried).
     BinDataDropped { input_index: usize, count: usize },
+    /// A non-primary hwpx-origin input's `<hp:pageBorderFill>` passthrough
+    /// carried a `borderFillIDRef` that is present but not numeric, so the
+    /// tier-2 graft could not shift it onto the merged border-fill table —
+    /// the attribute is passed through verbatim and now resolves against the
+    /// wrong table (#180). A recorded, non-target change, not data loss.
+    SectionBorderFillRefUnresolvable { input_index: usize, count: usize },
 }
 
 /// Result of [`merge_documents`].
@@ -174,12 +182,19 @@ pub fn merge_documents(inputs: &[Document]) -> Result<MergeOutcome, String> {
         } else {
             general_path_used = true;
             let (offsets, dropped) = graft_header_general(&mut target, input)?;
+            let mut unresolvable_border_fill_refs = 0usize;
             for section in &input.sections {
                 let mut section = section.clone();
                 for p in &mut section.paragraphs {
-                    remap_paragraph_general(p, &offsets)?;
+                    unresolvable_border_fill_refs += remap_paragraph_general(p, &offsets)?;
                 }
                 target.sections.push(section);
+            }
+            if unresolvable_border_fill_refs > 0 {
+                losses.push(MergeLoss::SectionBorderFillRefUnresolvable {
+                    input_index,
+                    count: unresolvable_border_fill_refs,
+                });
             }
             dropped
         };
@@ -677,9 +692,13 @@ fn graft_header_general(
 /// Recurses into every nested paragraph collection — table cells, Generic
 /// paragraph lists, and table/picture captions — so caption paragraphs
 /// resolve to the same shifted header entries as body paragraphs and caption
-/// pictures keep their rewired bin references. `Err` when a shifted id
-/// overflows the u16 id space (#173).
-fn remap_paragraph_general(para: &mut Paragraph, offsets: &HeaderOffsets) -> Result<(), String> {
+/// pictures keep their rewired bin references. Returns the number of
+/// non-numeric `borderFillIDRef` passthrough attributes that could not be
+/// shifted and are left resolving against the wrong table (#180) — the
+/// caller records them as `MergeLoss::SectionBorderFillRefUnresolvable`.
+/// `Err` when a shifted id overflows the u16 id space (#173).
+fn remap_paragraph_general(para: &mut Paragraph, offsets: &HeaderOffsets) -> Result<usize, String> {
+    let mut unresolvable = 0usize;
     shift_id(&mut para.para_shape.0, offsets.para_shape)?;
     shift_id(&mut para.style.0, offsets.style)?;
     for (_, id) in &mut para.char_shape_runs {
@@ -693,7 +712,7 @@ fn remap_paragraph_general(para: &mut Paragraph, offsets: &HeaderOffsets) -> Res
                 }
                 if let Some(cap) = &mut t.caption {
                     for p in &mut cap.paragraphs {
-                        remap_paragraph_general(p, offsets)?;
+                        unresolvable += remap_paragraph_general(p, offsets)?;
                     }
                 }
                 for cell in &mut t.cells {
@@ -701,14 +720,14 @@ fn remap_paragraph_general(para: &mut Paragraph, offsets: &HeaderOffsets) -> Res
                         shift_id(&mut cell.border_fill.0, offsets.border_fill)?;
                     }
                     for p in &mut cell.paragraphs {
-                        remap_paragraph_general(p, offsets)?;
+                        unresolvable += remap_paragraph_general(p, offsets)?;
                     }
                 }
             }
             Control::Generic(g) => {
                 for list in &mut g.paragraph_lists {
                     for p in &mut list.paragraphs {
-                        remap_paragraph_general(p, offsets)?;
+                        unresolvable += remap_paragraph_general(p, offsets)?;
                     }
                 }
                 // Reference ids changed above — the original XML is stale.
@@ -725,16 +744,16 @@ fn remap_paragraph_general(para: &mut Paragraph, offsets: &HeaderOffsets) -> Res
                 }
                 if let Some(cap) = &mut pic.caption {
                     for p in &mut cap.paragraphs {
-                        remap_paragraph_general(p, offsets)?;
+                        unresolvable += remap_paragraph_general(p, offsets)?;
                     }
                 }
             }
             Control::SectionDef(def) => {
-                shift_section_def_border_fills(def, offsets.border_fill)?;
+                unresolvable += shift_section_def_border_fills(def, offsets.border_fill)?;
             }
         }
     }
-    Ok(())
+    Ok(unresolvable)
 }
 
 /// hwp5 PAGE_BORDER_FILL record tag (한글문서파일형식 5.0 §3 record-tag table:
@@ -749,7 +768,10 @@ const PAGE_BORDER_FILL_TAG: u16 = 0x0010 + 59;
 /// hwp5 raw records (`page_border_fills_raw`, plus their parallel `extras`
 /// copies — the hwp5 re-serialization 정본) and the hwpx
 /// `<hp:pageBorderFill>` raw-XML passthrough in `secpr_raw_children`.
-fn shift_section_def_border_fills(def: &mut SectionDef, offset: u16) -> Result<(), String> {
+/// Returns the number of non-numeric `borderFillIDRef` attributes that
+/// could not be shifted (#180).
+fn shift_section_def_border_fills(def: &mut SectionDef, offset: u16) -> Result<usize, String> {
+    let mut unresolvable = 0usize;
     for raw in &mut def.page_border_fills_raw {
         shift_page_border_fill_raw(raw, offset)?;
     }
@@ -759,11 +781,29 @@ fn shift_section_def_border_fills(def: &mut SectionDef, offset: u16) -> Result<(
         }
     }
     for child in &mut def.secpr_raw_children {
-        if let Some(rewritten) = shift_secpr_page_border_fill(child, offset)? {
-            *child = rewritten;
+        match shift_secpr_page_border_fill(child, offset)? {
+            SecprBorderFillShift::Rewritten(rewritten) => *child = rewritten,
+            SecprBorderFillShift::Unresolvable => unresolvable += 1,
+            SecprBorderFillShift::Untouched => {}
         }
     }
-    Ok(())
+    Ok(unresolvable)
+}
+
+/// Outcome of attempting to shift one `<hp:pageBorderFill>` raw-XML
+/// passthrough child (#180).
+enum SecprBorderFillShift {
+    /// Not a pageBorderFill element, no `borderFillIDRef` at all (nothing
+    /// references the table), or the "unspecified" sentinel id 0 — the child
+    /// is kept verbatim and records nothing.
+    Untouched,
+    /// The numeric `borderFillIDRef` was rewritten by the border-fill offset.
+    Rewritten(String),
+    /// `borderFillIDRef` is present but not a parseable u16 — it cannot be
+    /// shifted onto the merged border-fill table, so the child is kept
+    /// verbatim and the caller records
+    /// `MergeLoss::SectionBorderFillRefUnresolvable` (#180).
+    Unresolvable,
 }
 
 /// Shifts the 1-based border-fill id (bytes 12..14 — the layout the hwpx
@@ -785,13 +825,12 @@ fn shift_page_border_fill_raw(raw: &mut [u8], offset: u16) -> Result<(), String>
 }
 
 /// Rewrites the numeric `borderFillIDRef` attribute of a preserved
-/// `<hp:pageBorderFill>` raw-XML child by `offset`, returning the rewritten
-/// child. Returns `Ok(None)` — the child is kept verbatim — when it is not a
-/// pageBorderFill element, carries no `borderFillIDRef` (nothing references
-/// the table), or carries a non-numeric one (a malformed reference that
-/// already resolved nowhere, left alone rather than rewritten blindly, #171).
-/// `Err` when the shift overflows the u16 id space (#173).
-fn shift_secpr_page_border_fill(child: &str, offset: u16) -> Result<Option<String>, String> {
+/// `<hp:pageBorderFill>` raw-XML child by `offset`. See
+/// [`SecprBorderFillShift`] for the three outcomes; in particular a present
+/// but non-numeric (or unterminated) reference is reported `Unresolvable`
+/// rather than silently passed through (#180). `Err` when the shift
+/// overflows the u16 id space (#173).
+fn shift_secpr_page_border_fill(child: &str, offset: u16) -> Result<SecprBorderFillShift, String> {
     let is_page_border_fill = child
         .trim_start()
         .strip_prefix('<')
@@ -802,24 +841,24 @@ fn shift_secpr_page_border_fill(child: &str, offset: u16) -> Result<Option<Strin
         .map(|name| name.rsplit(':').next().unwrap_or(name) == "pageBorderFill")
         .unwrap_or(false);
     if !is_page_border_fill {
-        return Ok(None);
+        return Ok(SecprBorderFillShift::Untouched);
     }
     const ATTR: &str = "borderFillIDRef=\"";
     let Some(attr_pos) = child.find(ATTR) else {
-        return Ok(None);
+        return Ok(SecprBorderFillShift::Untouched);
     };
     let value_start = attr_pos + ATTR.len();
     let Some(value_end) = child[value_start..].find('"').map(|i| value_start + i) else {
-        return Ok(None);
+        return Ok(SecprBorderFillShift::Unresolvable);
     };
     let Ok(id) = child[value_start..value_end].parse::<u16>() else {
-        return Ok(None);
+        return Ok(SecprBorderFillShift::Unresolvable);
     };
     if id == 0 {
-        return Ok(None); // "unspecified" sentinel — never shifted
+        return Ok(SecprBorderFillShift::Untouched); // "unspecified" sentinel — never shifted
     }
     let shifted = id.checked_add(offset).ok_or_else(header_id_overflow)?;
-    Ok(Some(format!(
+    Ok(SecprBorderFillShift::Rewritten(format!(
         "{}{shifted}{}",
         &child[..value_start],
         &child[value_end..]
@@ -1894,10 +1933,19 @@ mod tests {
             "borderFillIDRef가 오프셋만큼 이동해야 한다: {}",
             def.secpr_raw_children[1]
         );
+        // Numeric references shift cleanly and record no loss (#180).
+        assert!(
+            !outcome
+                .losses
+                .iter()
+                .any(|loss| matches!(loss, MergeLoss::SectionBorderFillRefUnresolvable { .. })),
+            "숫자 참조는 손실 없이 이동해야 한다: {:?}",
+            outcome.losses
+        );
     }
 
     #[test]
-    fn 일반_경로_숫자가_아닌_border_fill_idref는_원문을_유지한다() {
+    fn 일반_경로_숫자가_아닌_border_fill_idref는_원문을_유지하고_손실로_기록한다() {
         let a = from_markdown("문서 A\n");
         let mut b = non_palette_compatible(from_markdown("문서 B\n"));
         let malformed =
@@ -1912,6 +1960,22 @@ mod tests {
         assert_eq!(
             def.secpr_raw_children[0], malformed,
             "안전하게 재작성할 수 없는 참조는 원문 그대로 둔다"
+        );
+        // #180: the verbatim passthrough is no longer silent — exactly one
+        // typed loss event is recorded for the unshiftable reference.
+        let recorded: Vec<&MergeLoss> = outcome
+            .losses
+            .iter()
+            .filter(|loss| matches!(loss, MergeLoss::SectionBorderFillRefUnresolvable { .. }))
+            .collect();
+        assert_eq!(
+            recorded,
+            [&MergeLoss::SectionBorderFillRefUnresolvable {
+                input_index: 1,
+                count: 1
+            }],
+            "이동하지 못한 참조 하나가 정확히 한 건의 손실로 기록돼야 한다: {:?}",
+            outcome.losses
         );
     }
 

--- a/crates/hwp-model/Cargo.toml
+++ b/crates/hwp-model/Cargo.toml
@@ -8,3 +8,9 @@ rust-version.workspace = true
 
 [dependencies]
 serde = { workspace = true }
+
+[dev-dependencies]
+# Test-only: the schema-locking test parses
+# `schemas/preservation-report-v1.schema.json` to compare its `code` enum
+# against every `PreservationCode` wire string (#179).
+serde_json = { workspace = true }

--- a/crates/hwp-model/src/preservation.rs
+++ b/crates/hwp-model/src/preservation.rs
@@ -41,6 +41,12 @@ pub enum PreservationCode {
     /// ledgers it for audit but excludes it from `--strict` refusal (#174).
     PageRangeParagraphRounded,
     PictureControlRemoved,
+    /// An hwpx-origin `hwp merge` input's `<hp:pageBorderFill>` passthrough
+    /// carried a `borderFillIDRef` that is present but not numeric, so the
+    /// tier-2 graft could not shift it onto the merged border-fill table and
+    /// passed it through verbatim — the reference now resolves against the
+    /// wrong table (#180).
+    SectionBorderFillRefUnresolvable,
 }
 
 impl PreservationCode {
@@ -64,6 +70,7 @@ impl PreservationCode {
             Self::OpaqueControlUnrepresentable => "opaque_control_unrepresentable",
             Self::PageRangeParagraphRounded => "page_range_paragraph_rounded",
             Self::PictureControlRemoved => "picture_control_removed",
+            Self::SectionBorderFillRefUnresolvable => "section_border_fill_ref_unresolvable",
         }
     }
 }
@@ -229,6 +236,103 @@ impl WriteReport {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeSet;
+
+    /// Every `PreservationCode` variant, exhaustively. The trailing `match`
+    /// has no wildcard arm on purpose: adding a variant without extending
+    /// this list is a compile error, so the schema-locking test below cannot
+    /// silently miss a new code (#179).
+    fn every_preservation_code() -> Vec<PreservationCode> {
+        use PreservationCode::*;
+        let all = [
+            BinaryAssetRemoved,
+            BinaryRelationshipRemoved,
+            ControlMetadataUnrepresentable,
+            ControlRemoved,
+            DocumentMetadataSuperseded,
+            DocumentPackagePassthroughDropped,
+            GsoHeaderUnrepresentable,
+            GsoObjectIdRenumbered,
+            GsoShapeUnrepresentable,
+            HwpContainerStorageRemoved,
+            HwpContainerStreamRemoved,
+            HwpOpaqueStreamChanged,
+            HwpxOpaqueEntryChanged,
+            HwpxPackageEntryRemoved,
+            MetadataValueRemoved,
+            OpaqueControlUnrepresentable,
+            PageRangeParagraphRounded,
+            PictureControlRemoved,
+            SectionBorderFillRefUnresolvable,
+        ];
+        for code in all {
+            match code {
+                BinaryAssetRemoved
+                | BinaryRelationshipRemoved
+                | ControlMetadataUnrepresentable
+                | ControlRemoved
+                | DocumentMetadataSuperseded
+                | DocumentPackagePassthroughDropped
+                | GsoHeaderUnrepresentable
+                | GsoObjectIdRenumbered
+                | GsoShapeUnrepresentable
+                | HwpContainerStorageRemoved
+                | HwpContainerStreamRemoved
+                | HwpOpaqueStreamChanged
+                | HwpxOpaqueEntryChanged
+                | HwpxPackageEntryRemoved
+                | MetadataValueRemoved
+                | OpaqueControlUnrepresentable
+                | PageRangeParagraphRounded
+                | PictureControlRemoved
+                | SectionBorderFillRefUnresolvable => {}
+            }
+        }
+        all.to_vec()
+    }
+
+    /// #179: the published schema's `code` enum must list exactly the wire
+    /// strings of every `PreservationCode`. Adding a variant without updating
+    /// `schemas/preservation-report-v1.schema.json` fails this test, and the
+    /// exhaustive list above fails to compile until the variant is named.
+    #[test]
+    fn schema_code_enum_matches_every_preservation_code_wire_string() {
+        let schema: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../schemas/preservation-report-v1.schema.json"
+        ))
+        .unwrap();
+        let schema_codes: Vec<&str> = schema["$defs"]["event"]["properties"]["code"]["enum"]
+            .as_array()
+            .expect("schema $defs/event code enum")
+            .iter()
+            .map(|value| value.as_str().expect("string enum entry"))
+            .collect();
+        assert!(
+            schema_codes.windows(2).all(|pair| pair[0] < pair[1]),
+            "schema code enum must stay sorted: {schema_codes:?}"
+        );
+        let schema_set: BTreeSet<&str> = schema_codes.iter().copied().collect();
+        let wire_strings: BTreeSet<&str> = every_preservation_code()
+            .iter()
+            .map(|code| code.as_str())
+            .collect();
+        assert_eq!(
+            schema_set, wire_strings,
+            "schemas/preservation-report-v1.schema.json code enum drifted from PreservationCode"
+        );
+    }
+
+    /// Every variant's serde wire string equals its `as_str()` — the two
+    /// spellings can never drift apart.
+    #[test]
+    fn serde_wire_string_matches_as_str_for_every_code() {
+        for code in every_preservation_code() {
+            assert_eq!(
+                serde_json::to_string(&code).unwrap(),
+                format!("\"{}\"", code.as_str()),
+            );
+        }
+    }
 
     /// D-14: every pre-existing code's wire string is a published contract —
     /// this plan's four new variants must be additive only. Locks each
@@ -308,6 +412,19 @@ mod tests {
         assert_eq!(
             PreservationCode::PageRangeParagraphRounded.as_str(),
             "page_range_paragraph_rounded"
+        );
+    }
+
+    /// The #180 variant and its snake_case wire string.
+    #[test]
+    fn section_border_fill_ref_unresolvable_has_the_expected_wire_string() {
+        assert_eq!(
+            PreservationCode::SectionBorderFillRefUnresolvable.as_str(),
+            "section_border_fill_ref_unresolvable"
+        );
+        assert_eq!(
+            serde_json::to_string(&PreservationCode::SectionBorderFillRefUnresolvable).unwrap(),
+            "\"section_border_fill_ref_unresolvable\""
         );
     }
 

--- a/schemas/preservation-report-v1.schema.json
+++ b/schemas/preservation-report-v1.schema.json
@@ -26,7 +26,10 @@
             "binary_relationship_removed",
             "control_metadata_unrepresentable",
             "control_removed",
+            "document_metadata_superseded",
+            "document_package_passthrough_dropped",
             "gso_header_unrepresentable",
+            "gso_object_id_renumbered",
             "gso_shape_unrepresentable",
             "hwp_container_storage_removed",
             "hwp_container_stream_removed",
@@ -35,7 +38,9 @@
             "hwpx_package_entry_removed",
             "metadata_value_removed",
             "opaque_control_unrepresentable",
-            "picture_control_removed"
+            "page_range_paragraph_rounded",
+            "picture_control_removed",
+            "section_border_fill_ref_unresolvable"
           ]
         },
         "resource": {


### PR DESCRIPTION
## Summary

- **Schema drift (#179)**: `schemas/preservation-report-v1.schema.json` now enumerates every preservation code the CLI emits — `document_metadata_superseded`, `document_package_passthrough_dropped`, `gso_object_id_renumbered`, and `page_range_paragraph_rounded` were missing, so merge/split loss reports carrying them failed schema validation. A new locking test in `hwp-model` asserts the schema enum equals the full set of `PreservationCode` wire strings (compile-time exhaustive variant enumeration + negative-verified), so the two cannot drift apart again. Closes #179
- **Typed loss event (#180, deferred from #171)**: a section's hwpx `borderFillIDRef` passthrough carrying a non-numeric (or unterminated) value cannot be shifted on the tier-2 graft path. It now records a typed `MergeLoss::SectionBorderFillRefUnresolvable` → `section_border_fill_ref_unresolvable` / `control` / `changed_non_target` event instead of silently resolving against the primary's border-fill table. The new code is additive per the wire-string policy and is covered by the schema enum + locking tests. Closes #180

## Test plan

- New tests: schema↔wire-string lock (negative-verified by reverting one enum entry), serde↔`as_str()` parity for all codes, merge-level loss recording for unresolvable refs (numeric refs still shift with no loss), CLI mapping test with serialized wire string
- `scripts/check.sh` green locally (fmt / clippy 1.93.0 `-D warnings` / `cargo test --workspace` / structured-corpus; public pdf-parity gate runs in CI)