### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.13.0]
+
 **Added**
 
 - Markdown-to-HWP conversion now maps unordered list depth to the official symbol ladder

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-cli"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "hwp-model",
  "hwpx",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-render"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "encoding_rs",
  "flate2",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "aes",
  "cfb",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.12.1"
+version = "0.13.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"


### PR DESCRIPTION
## Summary

Release v0.13.0 — bumps the workspace version (0.12.1 → 0.13.0, `Cargo.toml` + `Cargo.lock` only) and closes the CHANGELOG section.

Contents (already merged): PR #168 (PR #161 review majors), #170 (part-filling caption shift), #178 (review minors), #181 (preservation schema parity + border-fill loss event), #182 (backlog sweep: markdown round-trip, lint gate, edit --verify, list ladders, verified skill recipes).

## Test plan

- `scripts/check.sh` green on the content PRs; this branch changes version metadata and CHANGELOG headings only
- After merge: tag the merge commit `v0.13.0` and push — release.yml verifies the tagged commit's green CI, builds, and publishes the GitHub Release with the `0.13.0` CHANGELOG section as its body
