### PR TITLE
chore(release): v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.14.0]
+
 **Added**
 
 - The document-level workflows are reachable over MCP: `hwp_merge`, `hwp_split` and `hwp_compare`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-cli"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "hwp-model",
  "hwpx",
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -758,7 +758,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-render"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "encoding_rs",
  "flate2",
@@ -778,7 +778,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "aes",
  "cfb",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.13.0"
+version = "0.14.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"

--- a/README.ko.md
+++ b/README.ko.md
@@ -110,7 +110,7 @@ curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/inst
 기본 위치는 `~/.local/bin`이다(PATH에 없으면 안내를 출력한다). 위치·버전은 인자나 환경변수로 바꾼다:
 
 ```sh
-curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.13.0
+curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.14.0
 HWP_INSTALL_DIR=~/bin sh scripts/install.sh
 ```
 
@@ -151,7 +151,7 @@ RHEL/CentOS 7+ 및 그 이후 배포판에서 그대로 돌아간다. 빌드 러
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
-  | sh -s -- --tag v0.13.0 --dir ./bin
+  | sh -s -- --tag v0.14.0 --dir ./bin
 ```
 
 플랫폼이 배포 번들을 수집하기 전에 바이너리가 있어야 하므로(Vercel `includeFiles`, Next.js

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The default location is `~/.local/bin` (if it is not on PATH, the script says so
 location or version with arguments or environment variables:
 
 ```sh
-curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.13.0
+curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.14.0
 HWP_INSTALL_DIR=~/bin sh scripts/install.sh
 ```
 
@@ -167,7 +167,7 @@ to bump:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
-  | sh -s -- --tag v0.13.0 --dir ./bin
+  | sh -s -- --tag v0.14.0 --dir ./bin
 ```
 
 Run this from the build command (or a `prebuild` script) so the binary exists before the platform


### PR DESCRIPTION
Close the CHANGELOG section and bump the workspace version for v0.14.0.

- `CHANGELOG.md` — `[Unreleased]` closes as `[0.14.0]` (the MCP document-level workflows and the AI-integration documentation refresh from #185).
- `Cargo.toml` / `Cargo.lock` — 0.13.0 → 0.14.0 via `scripts/release.sh`, workspace crates only (`--offline`, so no external dependency moved).
- `README.md` / `README.ko.md` — the `install.sh --tag` examples re-pin at v0.14.0, the version-pin gate added to the release checklist in #185.

Tag after this merges and main is green: `git tag -a v0.14.0 -m v0.14.0 && git push origin v0.14.0`.