### PR TITLE
docs(design): remote MCP deployment design (doc 22)

### DIFF
--- a/docs/README.ko.md
+++ b/docs/README.ko.md
@@ -12,6 +12,7 @@
 | [manual/cli-reference.ko.md](manual/cli-reference.ko.md) | clap 정의에서 자동 생성되는 CLI 레퍼런스(수동 편집 금지) |
 | [manual/ai-integrations.ko.md](manual/ai-integrations.ko.md) | AI 클라이언트 설정: MCP 등록, 에이전트 스킬, claude.ai 번들 |
 | [manual/amazon-quick-desktop.ko.md](manual/amazon-quick-desktop.ko.md) | Amazon Quick Desktop 설정, end-to-end 검증, 에이전트 지침, 문제 해결 |
+| [design/22-remote-mcp-deployment.ko.md](design/22-remote-mcp-deployment.ko.md) | Remote MCP deployment 설계: 공유 `hwp serve` HTTP adapter와 Cloudflare·AgentCore 호스팅 tier |
 | [design/23-hwpx-skill-absorption.ko.md](design/23-hwpx-skill-absorption.ko.md) | 퇴역한 다운스트림 `hwpx` 스킬과 네이티브 명령의 패리티 기록 |
 | [release-readiness.ko.md](release-readiness.ko.md) | 릴리스 전 게이트 체크리스트 |
 | [hancom-verification-checklist.ko.md](hancom-verification-checklist.ko.md) | 한글 실기 검증 체크리스트 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Notes on the HWP 5.0 format specification material used when working on the pars
 | [manual/cli-reference.md](manual/cli-reference.md) | CLI reference generated from the clap definitions (do not edit by hand) |
 | [manual/ai-integrations.md](manual/ai-integrations.md) | AI client setup: MCP registration, the agent skill, the claude.ai bundle |
 | [manual/amazon-quick-desktop.md](manual/amazon-quick-desktop.md) | Amazon Quick Desktop setup, end-to-end verification, agent instructions, and troubleshooting |
+| [design/22-remote-mcp-deployment.md](design/22-remote-mcp-deployment.md) | Remote MCP deployment design: the shared `hwp serve` HTTP adapter and the Cloudflare and AgentCore hosting tiers |
 | [design/23-hwpx-skill-absorption.md](design/23-hwpx-skill-absorption.md) | Parity record of the retired downstream `hwpx` skill against the native commands |
 | [release-readiness.md](release-readiness.md) | Pre-release gate checklist |
 | [hancom-verification-checklist.md](hancom-verification-checklist.md) | Checklist for verifying files in Hancom Office |

--- a/docs/design/00-overview.ko.md
+++ b/docs/design/00-overview.ko.md
@@ -90,6 +90,7 @@
 | 19 | [hwp5-spec-supplement](19-hwp5-spec-supplement.ko.md) | **HWP 5.0 명세 보완 색인** — 정오표·버전-레이아웃 매트릭스·적합성 체크리스트·소비 의미론 (07·03·05·10·08이 근거 데이터) |
 | 20 | [remote-mcp](20-remote-mcp.ko.md) | **Remote MCP transport 설계** - Web client용 향후 Streamable HTTP, OAuth resource server, tenant 격리, artifact 전송, limit 및 security gate |
 | 21 | [pdf-parity](21-pdf-parity.ko.md) | **PDF 동등성 계약 (한컴오피스 2024)** — parity 하네스가 읽는 오라클, 다섯 지표 집합, 임계값, 글꼴 게이트, 데이터 정책, 비목표 (issue #79) |
+| 22 | [remote-mcp-deployment](22-remote-mcp-deployment.ko.md) | **Remote MCP deployment 설계** — doc 20을 무엇으로 만들고 어디에 올리는지: 공유 `hwp serve` HTTP adapter, `tiny_http` dependency 결정(doc 20 §8 gate), 두 tier(Cloudflare Workers + Containers, Amazon Quick connector 뒤의 AgentCore) |
 | 23 | [hwpx-skill-absorption](23-hwpx-skill-absorption.ko.md) | **hwpx 스킬 흡수** — 서브커맨드 단위 패리티 매트릭스(구 서브커맨드 28개 + 스크립트 수준 보장, verified/inferred 표기), D-14 여백 기록, Phase 2.2~2.5가 제자리에서 갱신하는 살아있는 체크리스트 (issue #121, skills#35) |
 
 ---

--- a/docs/design/00-overview.md
+++ b/docs/design/00-overview.md
@@ -94,6 +94,7 @@ width 1, inline width 8, extended width 8). Lossless round-tripping is preserved
 | 19 | [hwp5-spec-supplement](19-hwp5-spec-supplement.md) | **HWP 5.0 spec supplement index** — errata, version-layout matrix, conformance checklist, consumption semantics (07·03·05·10·08 are the underlying data) |
 | 20 | [remote-mcp](20-remote-mcp.md) | **Remote MCP transport design** - future Streamable HTTP, OAuth resource-server, tenant isolation, artifact transfer, limits and security gates for web clients |
 | 21 | [pdf-parity](21-pdf-parity.md) | **PDF parity contract (Hancom Office 2024)** — oracle, five-metric set, thresholds, font gate, data policy and non-goals the parity harness reads (issue #79) |
+| 22 | [remote-mcp-deployment](22-remote-mcp-deployment.md) | **Remote MCP deployment design** — how doc 20 gets built and hosted: the shared `hwp serve` HTTP adapter, the `tiny_http` dependency decision (doc 20 §8 gate), and two tiers (Cloudflare Workers + Containers, AgentCore behind an Amazon Quick connector) |
 | 23 | [hwpx-skill-absorption](23-hwpx-skill-absorption.md) | **hwpx skill absorption** — subcommand-grain parity matrix (28 old subcommands + script-level guarantees, verified/inferred marked), the D-14 margin record, the living checklist phases 2.2-2.5 update in place (issue #121, skills#35) |
 
 ---

--- a/docs/design/20-remote-mcp.ko.md
+++ b/docs/design/20-remote-mcp.ko.md
@@ -238,6 +238,14 @@ maintained protocol/HTTP primitive를 우선한다. no tokio/no SDK 유지는 un
 6. **Operations:** production enablement 전에 SLO, capacity, key rotation, incident response,
    deletion verification, backup 정책, cost control 정의.
 
+**Deployment tier.** [Doc 22](22-remote-mcp-deployment.ko.md)는 위 1번, 3번, 4번 항목을 무엇으로
+만들고 어디에 올리는지 규정한다. 추출한 protocol core 위의 공유 `hwp serve` HTTP adapter, 이
+문서 §8이 요구하는 dependency 결정, 그리고 두 hosting tier(Cloudflare Workers + Containers,
+Amazon Quick connector 뒤의 AgentCore)가 그 내용이다. doc 22는 이 문서에 대한 amendment 두 건을
+기록한다. §3.1의 "library-visible module"은 두 adapter가 공유하는 binary 내부 module로 바뀌고,
+§10의 writable path 실패 기준은 단일 session microVM workspace에 한해 좁혀진다. §3.2의 artifact
+model은 여전히 필수이며 아직 구현되지 않았다.
+
 ## 10. Acceptance/failure 기준
 
 Remote MCP 구현은 다음을 모두 입증해야 통과한다.

--- a/docs/design/20-remote-mcp.md
+++ b/docs/design/20-remote-mcp.md
@@ -249,6 +249,14 @@ security tests pass without recreating an unsafe framework.
 6. **Operations:** define SLOs, capacity, key rotation, incident response, deletion verification,
    backups if any, and cost controls before production enablement.
 
+**Deployment tiers.** [Doc 22](22-remote-mcp-deployment.md) specifies how items 1, 3, and 4 above
+are built and hosted: a shared `hwp serve` HTTP adapter over the extracted protocol core, the
+dependency decision this document's §8 requires, and two hosting tiers (Cloudflare Workers plus
+Containers, and AgentCore behind an Amazon Quick connector). It records two amendments to this
+document: §3.1's "library-visible module" becomes a binary-internal module shared by both adapters,
+and §10's writable-path failure criterion is narrowed for a single-session microVM workspace. The
+artifact model of §3.2 remains required and unimplemented.
+
 ## 10. Acceptance and failure criteria
 
 A Remote MCP implementation is acceptable only when all of the following are demonstrated:

--- a/docs/design/22-remote-mcp-deployment.ko.md
+++ b/docs/design/22-remote-mcp-deployment.ko.md
@@ -1,0 +1,400 @@
+[한국어](22-remote-mcp-deployment.ko.md) · [English](22-remote-mcp-deployment.md)
+
+# Remote MCP deployment 설계
+
+> **상태:** 설계 전용. HTTP adapter, container image, Worker, cloud runtime 중 어느 것도 아직
+> 존재하지 않는다. 출시된 제품은 여전히 stdio 기반 `hwp mcp`뿐이다.
+
+[Doc 20](20-remote-mcp.ko.md)은 Remote MCP service가 *무엇을* 보장해야 하는지를 정의한다.
+endpoint 계약, 인증, 격리, limit, release gate가 거기에 해당한다. 이 문서는 그것을 *어떻게*
+만들고 *어디에서* 실행하는지를 정의한다. runtime dependency를 선택하고(doc 20 §8 gate),
+platform에 중립적인 Rust HTTP adapter 하나를 규정하며, 그 adapter를 공유하는 deployment tier
+두 가지를 규정한다.
+
+[Issue #52](https://github.com/STAIxBWLB/hwp-cli/issues/52)는 remote service의 consumer, 담당자,
+OAuth 정책, 예산이 명명되지 않았다는 이유로 deferred 상태로 닫혔으며, 그 조건이 갖추어지면 범위를
+좁힌 새 delivery issue를 열라고 요구한다. 이 문서가 그 조건을 제공하며, 이 문서와 함께 등록하는
+delivery issue가 activation record가 된다.
+
+## 1. 결정 요약
+
+| 질문 | 결정 |
+|---|---|
+| 문서 처리는 어디에서 실행하는가 | container 안에서 동작하는 native `hwp serve` HTTP mode. `hwp mcp`를 shell-out하는 bridge도 아니고 wasm도 아니다 |
+| HTTP dependency (doc 20 §8) | 동기 방식 `tiny_http`. workspace의 no-tokio, no-SDK 기조를 유지한다 |
+| service는 어디에서 실행하는가 | 하나의 binary를 공유하는 두 tier. **Tier A**는 Cloudflare Workers + Containers, **Tier B**는 Amazon Quick Suite connector 뒤의 AWS Bedrock AgentCore |
+| token은 누가 발행하는가 | Tier A는 `@cloudflare/workers-oauth-provider`를 사용해 Worker 자신이 발행하며 Google은 upstream IdP다. Tier B는 Amazon Cognito가 발행하며 Google은 federated IdP다 |
+| 첫 구현의 file 전송 방식 | doc 20 §3.2의 artifact model이 아니라 session workspace. §7에 amendment로 기록한다 |
+
+tier의 구현 순서는 이 문서에서 고정하지 않는다. 공유 Rust 작업이 완료되면 두 tier는 같은
+binary로부터 각각 독립적으로 배포할 수 있다.
+
+## 2. Platform 평가
+
+세 가지 hosting model을 요구사항에 대조해 비교했다. service는 사용자를 인증하고, token을
+발행하며, Google 로그인을 지원해야 하고, filesystem과 font file을 필요로 하는 native Rust
+binary를 실행해야 한다.
+
+| 기준 | Cloudflare Workers + Containers | AWS AgentCore + Quick | Vercel Functions |
+|---|---|---|---|
+| native binary 실행 | Worker가 호출하는 Containers(microVM) | container 자체가 배포 단위 | function에 binary를 동봉하거나 beta Rust runtime 사용 |
+| MCP client용 OAuth authorization server | first-party로 제공. `workers-oauth-provider`가 `/authorize`, `/token`, RFC 7591 dynamic client registration을 구현한다 | Cognito가 JWT를 발행하지만 dynamic client registration이 없어서 client를 관리자가 등록한다 | first-party 제공이 없어서 외부 IdP를 붙이거나 직접 구현해야 한다 |
+| session affinity | Durable Object와 Container class로 직접 조립한다 | 관리형으로 제공한다. runtime이 `Mcp-Session-Id`를 주입하고 session을 전용 microVM으로 라우팅한다 | 제공하지 않는다. instance를 지정할 수 없다 |
+| `/mcp` 외의 추가 HTTP route | 사용할 수 있으므로 file upload sideband를 둘 수 있다 | 사용할 수 없다. `0.0.0.0:8000/mcp`가 계약의 전부다 | 사용할 수 있다 |
+| CPU architecture | amd64 | **arm64 필수** | amd64 |
+| doc 20과의 정합성 | backlog 1번과 3번을 진전시킨다 | 여기에 더해 doc 20 §1이 지목한 Quick pilot, 즉 backlog 4번에 도달한다 | auth server가 없다는 점을 제외하면 Cloudflare와 같다 |
+| 비용 구조 | Workers Paid 구독료와 container 사용량 | 구독료 없이 vCPU와 memory를 초 단위로 과금 | Pro seat 구독료와 사용량 |
+
+**Vercel은 채택하지 않는다.** first-party authorization server가 없어서 가입과 token 발행을
+third-party identity service에 의존해야 하고, instance affinity가 없어서 doc 20 §3.2의 완전한
+artifact model이 후속 phase가 아니라 선결 조건이 된다. 다른 platform이 두 문제를 모두 없애 주는
+상황에서 이 비용을 치를 이유가 없다.
+
+**남은 두 platform은 모두 규정한다.** 서로 다른 consumer를 담당하기 때문이다. Tier A는 누구나
+Google 계정으로 가입하고 임의의 MCP client로 접속하는 공개 service를 담당한다. Tier B는 관리자가
+Amazon Quick Suite 안에 connector 하나를 등록하는 조직을 담당하며, 이것이 doc 20 §1이 처음부터
+지목한 consumer다. Rust 작업은 두 tier에서 동일하고, adapter의 설정과 주변 cloud resource만
+다르다.
+
+## 3. 공유 Rust 작업
+
+### 3.1 Protocol core 추출
+
+HTTP 작업을 시작하기 전에 `crates/hwp-cli/src/commands/mcp.rs`를 module directory로 분리한다.
+doc 20 §3.1이 요구하는 사항이다.
+
+| 파일 | 내용 |
+|---|---|
+| `commands/mcp/mod.rs` | protocol core. `handle_request`, protocol negotiation, tool registry, schema, dispatch |
+| `commands/mcp/authority.rs` | `FileAuthority` trait와 `LocalFsContext`. 기존 canonical root 검사와 font directory 처리 |
+| `commands/mcp/stdio.rs` | 기존 newline framing loop. zeroizing read buffer와 password scrubbing 포함 |
+| `commands/mcp/http.rs` | `hwp serve` adapter |
+
+**doc 20 §3.1에 대한 amendment.** doc 20은 "library-visible module"을 요구한다. 그런데 protocol
+core는 binary-private command module 16개를 약 70개 지점에서 참조하므로, 이를 library로 올리면
+현재 binary 밖에 consumer가 하나도 없는 상태에서 `commands/`의 대부분을 `hwp_cli` library로
+옮기게 된다. 따라서 첫 구현은 core를 binary 내부에 두고, 같은 `hwp` binary에 컴파일되는 두
+adapter가 이를 공유하도록 한다. doc 20 자신도 현재 함수들을 "starting seams, not the final
+public API"라고 서술하고 있다. library로의 승격은 binary 밖의 consumer가 실제로 생길 때 수행한다.
+
+stdio adapter는 현재 동작을 byte 단위로 그대로 유지한다. tool이 정확히 20개임을 확인하는 기존
+stdio process test가 이 분리 작업 전체의 regression gate 역할을 한다.
+
+### 3.2 `hwp serve` 계약
+
+새 subcommand가 protocol core를 HTTP로 노출한다. 이 server는 private hop이다. 두 tier 모두에서
+신뢰된 edge가 TLS를 종단하고, 호출자를 인증하고, origin을 검증하며, request body 크기를 제한한
+뒤에야 요청이 이 server에 도달한다.
+
+| Route | 동작 |
+|---|---|
+| `POST /mcp` | body를 1 MiB로 제한하며, 이는 stdio의 `MAX_REQUEST_LINE_BYTES`와 같은 값이다. request는 `200 application/json`을 반환하고, notification은 protocol 출력이 없으므로 빈 body와 함께 `202`를 반환한다 |
+| `GET /mcp` | `405`. server가 push하지 않으므로 SSE stream을 제공하지 않는다 |
+| `GET /healthz` | listener가 bind되면 `200`. container platform이 readiness를 확인하는 지점이다 |
+| `POST /files/{name}` | `--files`로만 활성화한다. upload를 workspace root로 streaming한다 |
+| `GET /files/{name}` | `--files`로만 활성화한다. workspace file을 streaming으로 반환한다 |
+
+flag는 `--addr`(기본값 `0.0.0.0:8080`, Tier B는 `0.0.0.0:8000`), `--root`(**필수**. root가 없으면
+경고만 하는 stdio와 다르다), `--font-dir`, `--files`다.
+
+adapter가 강제하는 규칙은 다음과 같다.
+
+- `--root` 없이는 기동을 거부한다. remote deployment는 filesystem 권한이 제한되지 않은 상태로
+  실행되지 않는다.
+- 들어오는 `Mcp-Session-Id`는 받아들이되 무시한다. Tier B의 platform이 이 header를 주입하며,
+  session affinity는 document server가 아니라 platform의 책임이다.
+- `/files` route에서는 `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`에 일치하는 이름만 받고, root 아래로
+  해석하며, 파일 하나를 64 MiB로 workspace 전체를 256 MiB로 제한하고, 제한을 넘으면 부분 업로드
+  파일을 삭제한다.
+- 요청을 한 번에 하나씩 처리한다. container 하나가 MCP session 하나를 담당하므로 악용할 동시성도
+  없고 framing이 뒤섞일 여지도 없다.
+
+### 3.3 Remote-safe inline content
+
+Tier B는 `/mcp` 외의 route를 노출하지 않으므로 문서가 JSON-RPC 안으로 이동해야 한다. 이에 따라
+tool schema에 inline mode를 추가한다. 문서 입력이나 출력을 path 대신 크기 제한이 있는 base64
+content로 주고받는 방식이다. 이 패턴은 현재 server에 이미 존재한다. `hwp_compose`는 `spec`을
+inline이나 `spec_path`로 받고, `hwp_template`은 `inline_contract_input`으로 template과 data를
+inline으로 받는다.
+
+이는 doc 20 §3.2가 요구하는 remote schema의 첫 부분이다. tenant 소유 upload, immutable output,
+보존 기간, object store 기반 signed download URL을 포함하는 완전한 artifact model은 두 tier
+모두에서 후속 phase로 남는다.
+
+## 4. Dependency 결정 기록
+
+이 절은 async runtime이나 MCP SDK를 부수적 선택으로 추가하는 것을 금지하는 doc 20 §8의 decision
+gate를 충족한다.
+
+### 4.1 선택지
+
+**선택지 1: tokio와 axum을 쓰는 Rust MCP SDK.** 완전한 Streamable HTTP 적합성, SSE, session
+처리를 이미 구현되고 검증된 상태로 얻는다. 반대 근거는 이렇다. 이 architecture에서는 edge가 이미
+인증, session, origin 검증, body limit을 담당하고 SSE stream도 제공하지 않으므로, SDK가 주는
+것의 대부분이 중복이거나 사용되지 않는다. 또한 tokio를 의도적으로 배제해 온 workspace에 tokio를
+들이게 되고, 20개 tool을 SDK API에 맞춰 다시 등록해야 하며, compile time과 binary 크기와 MSRV
+부담이 늘어난다. doc 20 §3.1은 동기 문서 작업을 async I/O executor 위에서 실행하지 말라고
+경고하는데, 이를 지키려면 전반에 걸쳐 `spawn_blocking` 규율이 필요해진다.
+
+**선택지 2: SDK 없이 async HTTP stack만 사용.** 선택지 1의 tokio 비용은 그대로 치르면서
+hand-written protocol core를 유지하므로, 선택지 1의 적합성 이점을 전혀 얻지 못한다.
+
+**선택지 3: `tiny_http` 기반 동기 server.** 유지보수되는 작은 dependency 하나를 thread 모델로
+사용하며 async runtime이 없다. 기존 protocol core를 그대로 재사용하고, 블로킹 문서 작업이 request
+thread 위에서 자연스럽게 실행된다.
+
+### 4.2 결정
+
+**선택지 3을 채택한다.** doc 20 §8은 적합성, cancellation, streaming, 보안 test가 안전하지 않은
+framework를 재발명하지 않고도 통과하는 경우에만 no-tokio 기조 유지를 허용한다. 이 조건은 노력이
+아니라 범위 축소로 충족된다. container 내부의 HTTP 표면은 route가 최대 다섯 개인 private hop이고
+신뢰된 edge를 통하지 않으면 도달할 수 없으므로, 적대적 입력 parsing, TLS, slow client 방어,
+origin 검증은 edge의 책임이다. streaming은 명시적으로 제공하지 않는다. cancellation은 edge의
+deadline과 뒤이은 container 종료로 처리한다.
+
+`TcpListener`를 직접 parsing하는 대신 `tiny_http`를 고른 이유는, doc 20 §8이 custom parsing보다
+유지보수되는 HTTP primitive를 선호하기 때문이다.
+
+**재검토 조건.** client가 SSE나 resumable stream을 요구하거나, 하나의 process가 여러 session을
+동시에 담당해야 하는 상황이 오면 이 결정은 선택지 1로 뒤집히며, 새 기록이 이 절을 대체한다.
+
+## 5. Tier A: Cloudflare 공개 service
+
+```text
+MCP client
+   |  HTTPS
+   v
+Worker (TypeScript)
+   |  workers-oauth-provider: /authorize, /token, /register (dynamic client registration)
+   |  Google upstream IdP. 최초 login 시 user record 생성
+   |  personal access token middleware, body limit, origin 검사, audit
+   v
+Durable Object HwpSession. 이름은 principal과 session 식별자에서 파생
+   |  Container class: idle sleep, 최대 수명 alarm, deadline, egress 차단
+   v
+microVM: hwp serve --addr 0.0.0.0:8080 --root /work --files --font-dir <fonts>
+```
+
+### 5.1 가입, 로그인, token 발행
+
+MCP client가 상대하는 OAuth authorization server는 Worker 자신이고, Google은 upstream identity
+provider일 뿐이다. 이것이 MCP `2025-06-18` specification의 third-party authorization flow다.
+client는 Google token을 받지 않고 이 service가 발행한 token만 받는다.
+
+1. 인증 없이 `POST /mcp`를 보내면 `401`과 `WWW-Authenticate` challenge를 받는다.
+2. client가 protected-resource metadata와 authorization-server metadata를 읽고 `/register`에서
+   스스로 등록한다. dynamic client registration이 있으므로 관리자가 미리 준비할 것이 없다.
+3. client가 browser로 `/authorize`를 연다. Worker가 동의 화면을 표시한 뒤 `openid email profile`
+   scope로 Google에 redirect한다.
+4. Google이 `/callback`으로 돌아온다. Worker가 code를 교환하고 identity claim을 읽은 뒤,
+   **`sub` claim이 처음 보는 값이면 user record를 생성한다. 최초 Google 로그인이 곧 가입이다.**
+   이어서 `mcp:tools` scope로 authorization을 완료한다.
+5. client가 PKCE로 `/token`에서 code를 교환해 이 service의 access token을 받는다. grant와 token은
+   KV namespace에 hash 형태로 저장하며, provider library는 이 binding 이름이 `OAUTH_KV`일 것을
+   요구한다.
+
+OAuth flow 대신 고정 header로 설정하는 client를 위해 dashboard가 personal access token을
+발행한다. token은 `hwp_pat_` 뒤에 32 byte 난수를 base64url로 붙인 형태이며, 생성 시 한 번만
+보여 주고 저장은 SHA-256 hash로만 한다. OAuth provider 앞의 middleware가 이 prefix를 인식해
+hash를 조회하고 동등한 identity로 같은 MCP handler를 호출하므로, 이후 authorization 경로는
+정확히 하나다.
+
+### 5.2 데이터 모델
+
+```sql
+CREATE TABLE users (
+  id            TEXT PRIMARY KEY,
+  google_sub    TEXT NOT NULL UNIQUE,
+  email         TEXT NOT NULL,
+  name          TEXT,
+  created_at    INTEGER NOT NULL,
+  last_login_at INTEGER
+);
+
+CREATE TABLE pats (
+  id           TEXT PRIMARY KEY,
+  user_id      TEXT NOT NULL REFERENCES users(id),
+  token_hash   TEXT NOT NULL UNIQUE,
+  label        TEXT,
+  created_at   INTEGER NOT NULL,
+  last_used_at INTEGER,
+  revoked_at   INTEGER
+);
+
+CREATE TABLE audit (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts          INTEGER NOT NULL,
+  request_id  TEXT,
+  user_id     TEXT,
+  session_ref TEXT,
+  tool        TEXT,
+  outcome     TEXT NOT NULL,
+  duration_ms INTEGER,
+  bytes_in    INTEGER,
+  bytes_out   INTEGER
+);
+
+CREATE INDEX idx_pats_user ON pats(user_id);
+CREATE INDEX idx_audit_ts ON audit(ts);
+```
+
+identity key는 email 주소가 아니라 Google `sub` claim이다. email 주소는 다른 사람에게 재배정될
+수 있기 때문이다. `session_ref`에는 session 식별자 자체가 아니라 그 hash를 저장하며, audit table은
+tool argument, path, 문서 내용, token을 담지 않는다. doc 20 §7의 요구사항이다.
+
+### 5.3 Session 수명 주기
+
+| 사건 | 처리 방식 |
+|---|---|
+| `initialize` | Worker가 난수 session 식별자를 만들고 principal과 그 식별자로 Durable Object 이름을 정한다. container가 기동해 readiness 확인을 통과하면 response에 `Mcp-Session-Id`를 실어 보낸다 |
+| 이후 호출 | 같은 header가 같은 object에 도달하므로 같은 microVM, 같은 workspace, 같은 process를 사용한다 |
+| 30분 유휴 | container class가 instance를 정지시킨다. object가 session을 dead로 표시하므로 다음 호출은 `404`가 되고 client가 재초기화한다 |
+| `DELETE /mcp` | container를 종료하고 session을 dead로 표시하며 alarm을 해제한 뒤 `204`를 반환한다. 멱등하다 |
+| 최대 수명 8시간 | alarm이 session을 종료시켜 재초기화를 강제한다. doc 20 §7의 요구사항이다 |
+| deadline 초과 | 기본 120초, rendering과 conversion과 certification은 300초다. Worker가 요청을 중단하고 container를 종료한 뒤 timeout을 반환한다 |
+| crash 또는 eviction | process 종료가 container를 멈추고 object가 session을 dead로 표시하므로 이후 호출은 `404`가 된다 |
+| workspace 정리 | teardown이 보장한다. workspace는 영속되지 않는 container 로컬 disk이므로 회수할 잔여물이 남지 않는다 |
+
+**다른 principal의 접근은 구조적으로 차단된다.** object 이름이 인증된 principal에서 파생되므로,
+남의 session 식별자를 제시하면 한 번도 초기화된 적 없는 다른 object로 해석되고, 응답은 식별자의
+소유자에 대해 아무것도 알려 주지 않는 평범한 `404`가 된다.
+
+### 5.4 Resource 구성
+
+`deploy/cloudflare/` project가 Worker source, wrangler 설정, D1 schema, container 정의를 담는다.
+설정은 container class와 그 Durable Object migration, `OAUTH_KV` namespace, D1 database,
+dashboard 정적 asset을 binding한다. secret은 Google client id와 secret, 그리고 cookie 서명
+key다.
+
+container image는 `serve`가 릴리스에 포함되기 전까지 repository source에서 빌드한다. `serve`를
+담은 릴리스가 나온 뒤에는 checksum을 검증한 릴리스 tarball을 slim base에 내려받는 방식으로
+전환한다. 그러면 배포 경로에서 Rust toolchain이 빠지고 cold start가 짧아진다. font는 배포판의
+Nanum package를 사용하며, 이는 CI가 이미 쓰고 있는 font 기준선과 일치한다.
+
+## 6. Tier B: Amazon Quick connector 뒤의 AgentCore
+
+```text
+Amazon Quick Suite
+   |  관리자가 MCP integration 하나를 등록하고, 각 사용자가 개별적으로 인가한다
+   v
+Amazon Cognito user pool: 셀프서비스 가입, Google federation, JWT 발행
+   v
+AgentCore Runtime: JWT를 검증하고 Mcp-Session-Id를 주입 및 라우팅하며
+   session마다 전용 microVM을 제공한다
+   v
+arm64 container: hwp serve --addr 0.0.0.0:8000 --root /work --font-dir <fonts>
+```
+
+### 6.1 Platform 계약
+
+AgentCore Runtime은 container가 **arm64** image로 `0.0.0.0:8000/mcp`에서 Streamable HTTP를
+제공할 것을 요구하며, `Mcp-Session-Id`를 스스로 관리한다. 요청에 해당 header가 없으면 추가하고,
+session을 그 전용 microVM으로 라우팅한다. 따라서 server는 platform이 부여한 session 식별자를
+거부하지 않고 수용해야 하는데, 이는 §3.2가 이미 요구하는 사항이다.
+
+여기에서 두 가지가 따라 나온다. 첫째, Tier A가 Durable Object와 container class로 직접 조립하는
+격리 계층을 platform이 제공하므로 Tier B에는 자체 edge code가 필요 없다. 둘째, runtime이 MCP
+endpoint만 노출하므로 `/files` sideband가 존재할 수 없고, §3.3의 inline content mode가 선택이
+아니라 선결 조건이 된다.
+
+### 6.2 가입, 로그인, token 발행
+
+Cognito가 Tier A에서 Worker가 담당하던 세 요구사항을 그대로 담당한다. user pool이 셀프서비스
+가입을 제공하고, Google을 federated identity provider로 추가하면 사용자가 Google 계정으로
+로그인하며, pool이 발행한 JWT를 AgentCore의 inbound authorizer가 검증한다.
+
+Cognito는 dynamic client registration을 구현하지 않으므로, Quick 관리자가 authorization
+endpoint와 token endpoint, client credential을 직접 입력해 connector를 등록한다. Amazon Quick
+Suite는 바로 이 방식을 지원한다. integration 콘솔은 dynamic registration을 제공하는 server를
+받거나 endpoint와 credential 값을 명시적으로 받으며, three-legged OAuth를 사용하므로 Quick이
+사용자를 대신해 tool을 호출하기 전에 각 사용자가 자신의 identity로 connector를 인가한다.
+dynamic registration이 없어도 무방한 이유는 여기에서 등록이 관리 행위이기 때문이다. 반면 Tier
+A의 셀프서비스 client에는 dynamic registration이 필요하다.
+
+### 6.3 추가 작업
+
+- 새 release target `aarch64-unknown-linux-gnu`와 arm64 container image.
+- image repository, AgentCore runtime 설정, log 전달 구성.
+- region을 확정하기 전에 확인할 사항. 의도한 region에서 AgentCore와 Quick MCP integration이 모두
+  제공되는지, 그리고 runtime의 현재 유휴 및 최대 session 수명이 doc 20 §7의 값과 어떻게
+  대비되는지 확인한다.
+
+## 7. File 권한 모델
+
+두 tier의 첫 구현은 doc 20 §3.2의 artifact model 대신 **session workspace**를 사용한다. Tier A는
+`/files` route로, Tier B는 tool argument의 inline content로 workspace를 채운다. tool은 계속 path
+argument를 받지만, 그 path는 하나의 private workspace 안의 상대 이름이다.
+
+**doc 20 §10에 대한 amendment.** doc 20은 "local path schemas remain remotely writable" 상태의
+릴리스를 실패로 규정한다. 이 기준이 겨냥하는 것은 client의 path argument가 다른 tenant의 데이터나
+host filesystem에 도달할 수 있는 공유 server다. 그런데 여기의 두 tier에서 path는 다른 tenant의
+데이터를 담지 않고 network egress도 없으며 session이 끝나면 파기되는 단일 session microVM 안에서
+해석되고, process 내부의 기존 canonicalize 및 containment 검사도 그대로 동작한다. 따라서 이
+tier들에 한해 기준을 다음과 같이 수정한다. 절대 경로와 traversal은 여전히 거부하며, workspace는
+결코 공유하거나 재사용하지 않는다.
+
+이 amendment가 미루는 것, 그래서 후속 phase가 반드시 제공해야 하는 것은 §3.2의 나머지다. object
+store를 기반으로 하는 두 번째 `FileAuthority` 구현, tenant가 소유하는 불투명한 artifact 식별자,
+보존 기간을 갖는 immutable output, 인증된 endpoint나 단기 signed URL을 통한 download가 여기에
+해당한다. §3.2를 문면 그대로 충족하는 것은 그 phase뿐이다.
+
+## 8. doc 20 §10 기준 보안 상태
+
+첫 구현이 충족하는 항목과 각 항목을 강제하는 지점은 다음과 같다.
+
+| 기준 | 강제 지점 |
+|---|---|
+| stdio가 기본으로 유지되고 tool이 정확히 20개로 노출된다 | 기존 stdio process test가 core 분리를 gate한다 |
+| 인증이 tool 실행보다 먼저 수행된다 | Tier A는 OAuth provider와 token middleware가 handler 이전에 거부한다. Tier B는 runtime의 JWT authorizer가 container 이전에 거부한다 |
+| session이 principal에 묶이고 다른 principal의 접근은 닫힌 채 실패한다 | Tier A는 object 이름이 principal에서 파생되므로 남의 session 식별자는 정보를 주지 않는 `404`가 된다. Tier B는 platform이 session을 인가된 호출자 범위로 한정한다 |
+| request, upload, workspace, deadline limit이 결정적 정리와 함께 강제된다 | edge에서 parsing 이전에 body를 거부하고 `hwp serve`에서 한 번 더 거부한다. 파일과 workspace 상한은 adapter가, deadline과 종료는 edge가 담당한다 |
+| tenant끼리 서로의 데이터를 읽거나 덮어쓸 수 없다 | session마다 microVM이 하나씩이고 공유 filesystem이 없으며, process 내부의 기존 root containment가 함께 동작한다 |
+| 종료가 부분 산출물이나 재사용 가능한 권한을 남기지 않는다 | workspace가 microVM과 함께 파기되고 session 식별자는 dead로 표시된다 |
+| log에 token, 문서 내용, path가 남지 않는다 | audit schema가 metadata만 저장하고 token은 hash로만 보관한다 |
+| edge를 우회해 backend에 도달할 수 없다 | 두 runtime 모두 container를 공개하지 않으며, `hwp serve`는 root 없이는 기동조차 거부한다 |
+| 문서 worker에 network egress가 없다 | Tier A는 container의 egress를 비활성화하고, Tier B는 runtime의 network 설정으로 처리한다 |
+| proxy 뒤에 놓인 무제한 `hwp mcp`가 아니다 | shell-out이 없다. native adapter가 protocol core를 공유하며 단일 session microVM 안에서 제한된 상태로 동작한다 |
+
+미루는 항목은 다음과 같으며, 첫 구현을 완성본으로 오해하지 않도록 여기에 명시한다. §3.2의 완전한
+artifact model, SSE와 resumable stream, 요청 단위 cancellation(현재는 deadline이 session 자체를
+끝낸다), session당 2개 동시 job(§7은 2개를 허용하지만 server는 순차 처리한다), `mcp:tools`보다
+세분화된 scope, 비 browser client를 위해 origin 부재를 허용하는 대신 적용할 엄격한 origin
+allowlist, 그리고 §9의 5번 항목이 일반 공개 전에 요구하는 독립 검토가 여기에 해당한다.
+
+## 9. 운영
+
+**구현 중 확정해야 할 배포 위험.** MCP client가 `GET /mcp`의 `405`를 수용하는지 확인해야 한다.
+transport specification은 push stream을 제공하지 않는 server에 대해 이를 허용하지만, SSE 작업을
+검토하기 전에 실제 대상 client로 확인해야 한다. `initialize` 시점의 container cold start는 slim
+릴리스 tarball image로 줄인다. Google OAuth application은 검증을 받기 전까지 소수의 test 사용자로
+제한되며, Cognito에도 자체 quota가 있다. Cloudflare containers의 설정 표면은 아직 변하고 있으므로
+field 이름과 instance type은 이 문서를 믿지 말고 구현 시점에 확인한다. 배포 단계에서 Rust를
+빌드하면 build limit을 넘을 수 있으며, 그럴 경우 CI에서 image를 빌드하고 registry에서 참조한다.
+
+**비용 구조.** Tier A는 Workers Paid 구독이며 포함된 container 할당량이 경량 사용을 감당하고 그
+이상은 memory와 vCPU로 과금된다. Tier B는 구독료가 없고 vCPU와 memory를 초 단위로 과금하며,
+Cognito는 월간 활성 사용자 기준 이하에서는 무료다. 파일럿 규모에서는 어느 쪽도 비싸지 않지만,
+공개적으로 알리기 전에 두 경우 모두 지출 경보를 설정해야 한다.
+
+**릴리스 연동.** image가 릴리스 binary를 설치하는 방식으로 바뀐 뒤에는, service가 반영해야 하는
+hwp 릴리스마다 version과 checksum을 올리고 재배포해야 한다. 이 과정의 CI 자동화는 배포 자체가
+안정될 때까지 의도적으로 미룬다.
+
+## 10. Issue #52의 activation requirement
+
+Issue #52는 deferred 상태로 닫히면서, 구현을 시작하기 전에 명명하고 수용해야 할 항목 일곱 가지를
+제시한다. 이 문서는 그 항목들에 다음과 같이 답한다.
+
+| 요구 항목 | 답변 |
+|---|---|
+| 구체적 web consumer와 그 MCP protocol version | Tier A는 `2025-06-18` Streamable HTTP를 사용하는 임의의 MCP client이며, 현재 server가 이미 협상하는 version이다. Tier B는 doc 20 §1이 지목한 Amazon Quick Suite다 |
+| 배포 및 보안 담당자 | 파일럿을 넘는 트래픽이 생기기 전까지는 repository owner가 담당한다. 착수 시점에 확정한다 |
+| OAuth issuer, audience, scope, authorization 정책 | Tier A는 Worker가 issuer이고 그 MCP endpoint가 audience이며 scope는 `mcp:tools`, upstream identity provider는 Google이다(§5.1). Tier B는 Cognito user pool이 issuer이고 AgentCore runtime이 audience를 검증한다(§6.2) |
+| Tenant와 session의 identity 및 영속성 모델 | principal은 검증된 identity claim에서 파생하며 key는 Google `sub` claim이다. session은 그 principal에 묶인 server 발행 식별자다. 사용자와 token은 관계형 저장소에 영속하고, session workspace는 전혀 영속하지 않는다(§5.2, §5.3) |
+| Upload와 output limit, 보존, 삭제, 남용 통제 | §3.2와 doc 20 §7의 상한을 적용한다. workspace가 microVM과 함께 사라지므로 보존 기간은 구조적으로 0이다. rate limit은 §8에 미루는 항목으로 명시했으며, 공개 announce 전에 반드시 도입해야 한다 |
+| Hosting 대상, rate limit, 예산, 모니터링 | hosting 대상과 비용 구조는 §2와 §9에 있다. 공개 announce 전에 지출 경보가 필요하다. 예산 상한 수치와 service level objective는 남은 미결 항목이며 doc 20 §9의 6번으로 미룬다 |
+| dependency 최소화 및 no-SDK 불변식의 실용성 여부 | 유지한다. §4가 비교 과정을 기록하며, 작은 동기 HTTP dependency 하나만 추가해 불변식을 지킨다 |
+
+따라서 작성 시점 기준으로 두 항목이 미결로 남는다. repository owner를 넘어서는 담당자 지정과,
+예산 상한 수치 및 그 모니터링 목표가 그것이다. 두 항목 모두 설계 결정이 아니라 운영 결정이며,
+§3의 공유 Rust 작업을 막지 않는다.

--- a/docs/design/22-remote-mcp-deployment.md
+++ b/docs/design/22-remote-mcp-deployment.md
@@ -1,0 +1,407 @@
+[한국어](22-remote-mcp-deployment.ko.md) · [English](22-remote-mcp-deployment.md)
+
+# Remote MCP deployment design
+
+> **Status:** design only. No HTTP adapter, container image, Worker, or cloud runtime exists yet.
+> The shipped product is still `hwp mcp` over stdio.
+
+[Doc 20](20-remote-mcp.md) defines *what* a Remote MCP service must guarantee: endpoint contract,
+authentication, isolation, limits, and release gates. This document defines *how* it gets built
+and *where* it runs. It selects the runtime dependency (doc 20 §8 gate), specifies one
+platform-neutral Rust HTTP adapter, and specifies two deployment tiers that share it.
+
+[Issue #52](https://github.com/STAIxBWLB/hwp-cli/issues/52) was closed as deferred because the
+remote service had no named consumer, owner, OAuth policy, or budget, and it asks for a fresh
+scoped delivery issue once those exist. This document supplies them, and the delivery issue that
+accompanies it is the activation record.
+
+## 1. Decision summary
+
+| Question | Decision |
+|---|---|
+| Where does document work run? | A native `hwp serve` HTTP mode inside a container, not a bridge that shells out to `hwp mcp`, and not wasm |
+| HTTP dependency (doc 20 §8) | Synchronous `tiny_http`, keeping the workspace's no-tokio, no-SDK stance |
+| Where does the service run? | Two tiers sharing one binary: **Tier A** Cloudflare Workers + Containers, **Tier B** AWS Bedrock AgentCore behind an Amazon Quick Suite connector |
+| Who issues tokens? | Tier A: the Worker itself, via `@cloudflare/workers-oauth-provider`, with Google as upstream IdP. Tier B: Amazon Cognito, with Google as a federated IdP |
+| File transfer in the first implementation | Session workspace, not the doc 20 §3.2 artifact model. Recorded as an amendment in §7 |
+
+Tier order is not fixed by this document. Each tier is independently deployable from the same
+binary once the shared Rust work lands.
+
+## 2. Platform evaluation
+
+Three hosting models were compared against the requirements that the service must authenticate
+users, issue tokens, support Google sign-in, and execute a native Rust binary that needs a
+filesystem and font files.
+
+| Criterion | Cloudflare Workers + Containers | AWS AgentCore + Quick | Vercel Functions |
+|---|---|---|---|
+| Runs a native binary | Containers (microVM) invoked from a Worker | Container is the unit of deployment | Binary bundled into a function, or the beta Rust runtime |
+| OAuth authorization server for MCP clients | First-party: `workers-oauth-provider` implements `/authorize`, `/token`, and RFC 7591 dynamic client registration | Cognito issues JWTs; no dynamic client registration, so clients are registered by an administrator | None first-party; requires an external IdP or a hand-written server |
+| Session affinity | Built by hand from a Durable Object plus the Container class | Managed: the runtime injects `Mcp-Session-Id` and routes a session to its own microVM | None; instances are not addressable |
+| Extra HTTP routes beside `/mcp` | Available, so a file-upload sideband is possible | Not available; `0.0.0.0:8000/mcp` is the entire contract | Available |
+| CPU architecture | amd64 | **arm64 required** | amd64 |
+| Fit with doc 20 | Advances backlog items 1 and 3 | Additionally reaches backlog item 4, the Quick pilot named in doc 20 §1 | Same as Cloudflare, minus the auth server |
+| Cost shape | Workers Paid subscription plus container usage | Per-second vCPU and memory metering, no subscription | Pro seat subscription plus usage |
+
+**Vercel is rejected.** It offers no first-party authorization server, so signup and token
+issuance would depend on a third-party identity service, and it offers no instance affinity, so
+the full artifact model of doc 20 §3.2 would be a precondition rather than a later phase. Neither
+cost is justified when another platform removes both problems.
+
+**Both remaining platforms are specified**, because they serve different consumers. Tier A serves
+an open service where any person signs up with a Google account and connects any MCP client.
+Tier B serves an organization whose administrator registers one connector inside Amazon Quick
+Suite, which is the consumer doc 20 §1 named from the start. The Rust work is identical for both;
+only the adapter's configuration and the surrounding cloud resources differ.
+
+## 3. Shared Rust workstream
+
+### 3.1 Protocol core extraction
+
+`crates/hwp-cli/src/commands/mcp.rs` is split into a module directory before any HTTP work
+begins, as required by doc 20 §3.1:
+
+| File | Contents |
+|---|---|
+| `commands/mcp/mod.rs` | Protocol core: `handle_request`, protocol negotiation, tool registry, schemas, dispatch |
+| `commands/mcp/authority.rs` | `FileAuthority` trait plus `LocalFsContext`, the existing canonical-root and font-directory checks |
+| `commands/mcp/stdio.rs` | The existing newline-framed loop, including the zeroizing read buffer and password scrubbing |
+| `commands/mcp/http.rs` | The `hwp serve` adapter |
+
+**Amendment to doc 20 §3.1.** Doc 20 asks for a "library-visible module". The protocol core
+reaches into 16 binary-private command modules across roughly 70 call sites, so making it
+library-visible would move most of `commands/` into the `hwp_cli` library for no current
+out-of-binary consumer. The first implementation therefore keeps the core binary-internal and
+shares it between the two adapters compiled into the same `hwp` binary. Doc 20 already describes
+the current functions as "starting seams, not the final public API". Promotion to the library
+happens when a consumer outside the binary actually exists.
+
+The stdio adapter keeps its present behavior byte for byte. The existing stdio process test,
+which asserts exactly 20 tools, is the regression gate for the whole split.
+
+### 3.2 `hwp serve` contract
+
+A new subcommand runs the protocol core over HTTP. It is a private hop: in both tiers a trusted
+edge terminates TLS, authenticates the caller, validates origin, and caps the request body before
+anything reaches this server.
+
+| Route | Behavior |
+|---|---|
+| `POST /mcp` | Body capped at 1 MiB, mirroring the stdio `MAX_REQUEST_LINE_BYTES`. A request returns `200 application/json`; a notification produces no protocol output and returns `202` with an empty body |
+| `GET /mcp` | `405`. The server never pushes, so no SSE stream is offered |
+| `GET /healthz` | `200` once the listener is bound. Container platforms probe this for readiness |
+| `POST /files/{name}` | Enabled only by `--files`. Streams an upload into the workspace root |
+| `GET /files/{name}` | Enabled only by `--files`. Streams a workspace file back |
+
+Flags: `--addr` (default `0.0.0.0:8080`; Tier B runs `0.0.0.0:8000`), `--root` (**mandatory**, unlike
+stdio where an absent root only warns), `--font-dir`, and `--files`.
+
+Rules the adapter enforces:
+
+- Refuse to start without `--root`. A remote deployment never runs with unrestricted filesystem
+  authority.
+- Accept and ignore any inbound `Mcp-Session-Id`. Tier B's platform injects one, and session
+  affinity is the platform's responsibility, not the document server's.
+- On the `/files` routes, accept a name matching `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`, resolve it
+  under the root, cap one file at 64 MiB and the workspace at 256 MiB, and unlink a partial upload
+  when a cap is breached.
+- Handle one request at a time. One container serves one MCP session, so there is no concurrency
+  to exploit and no interleaving to corrupt.
+
+### 3.3 Remote-safe inline content
+
+Tier B exposes no route other than `/mcp`, so documents must travel inside JSON-RPC. Tool schemas
+gain an inline mode in which a document input or output is base64 content with a size cap rather
+than a path. The pattern already exists in the current server: `hwp_compose` accepts a `spec`
+inline or as `spec_path`, and `hwp_template` accepts inline template and data through
+`inline_contract_input`.
+
+This is the first slice of the doc 20 §3.2 remote schema requirement. The complete artifact model,
+meaning tenant-owned uploads, immutable outputs, retention, and signed download URLs backed by an
+object store, is a later phase in both tiers.
+
+## 4. Dependency decision record
+
+This section satisfies the decision gate in doc 20 §8, which forbids adding an async runtime or an
+MCP SDK as an incidental choice.
+
+### 4.1 Options
+
+**Option 1: the Rust MCP SDK with tokio and axum.** Complete Streamable HTTP conformance, SSE, and
+session handling arrive already implemented and tested. Against it: in this architecture the edge
+already owns authentication, sessions, origin validation, and body limits, and no SSE stream is
+offered, so most of what the SDK provides is either duplicated or unused. It introduces tokio into
+a workspace that deliberately has none, requires re-registering 20 tools against the SDK's API,
+and adds compile time, binary size, and MSRV exposure. Doc 20 §3.1 also warns that synchronous
+document work must not run on an async I/O executor, which would require `spawn_blocking`
+discipline throughout.
+
+**Option 2: an async HTTP stack without the SDK.** Pays the tokio cost of option 1 while keeping
+the hand-written protocol core, so it buys none of option 1's conformance benefit.
+
+**Option 3: a synchronous server on `tiny_http`.** One small maintained dependency, a thread-based
+model, no async runtime. The existing protocol core is reused unchanged, and blocking document work
+runs naturally on the request thread.
+
+### 4.2 Decision
+
+**Option 3.** Doc 20 §8 permits keeping the no-tokio stance only if conformance, cancellation,
+streaming, and security tests pass without recreating an unsafe framework. That condition is met
+by scope reduction rather than by effort: the in-container HTTP surface is a private hop with at
+most five routes, unreachable except through the trusted edge, so hostile-input parsing, TLS,
+slow-client defense, and origin validation are the edge's responsibility. Streaming is explicitly
+not offered. Cancellation is the edge's deadline followed by container termination.
+
+`tiny_http` is chosen over hand-rolled `TcpListener` parsing because doc 20 §8 prefers maintained
+HTTP primitives over custom parsing.
+
+**Revisit trigger.** If a client requires SSE or resumable streams, or if one process must ever
+host multiple sessions concurrently, this decision flips to option 1 and a new record supersedes
+this section.
+
+## 5. Tier A: Cloudflare public service
+
+```text
+MCP client
+   |  HTTPS
+   v
+Worker (TypeScript)
+   |  workers-oauth-provider: /authorize, /token, /register (dynamic client registration)
+   |  Google upstream IdP; first login creates the user record
+   |  personal access token middleware; body limit; origin check; audit
+   v
+Durable Object HwpSession, named tenant-principal plus session
+   |  Container class: idle sleep, maximum-lifetime alarm, deadlines, no egress
+   v
+microVM: hwp serve --addr 0.0.0.0:8080 --root /work --files --font-dir <fonts>
+```
+
+### 5.1 Signup, login, and token issuance
+
+The Worker is the OAuth authorization server that MCP clients talk to, and Google is only the
+upstream identity provider. This is the third-party authorization flow of the MCP `2025-06-18`
+specification: the client never receives a Google token, only a token this service minted.
+
+1. An unauthenticated `POST /mcp` returns `401` with a `WWW-Authenticate` challenge.
+2. The client reads protected-resource and authorization-server metadata, then registers itself at
+   `/register`. Dynamic client registration means no administrator has to pre-provision anything.
+3. The client opens `/authorize` in a browser. The Worker shows a consent screen, then redirects to
+   Google with the `openid email profile` scopes.
+4. Google returns to `/callback`. The Worker exchanges the code, reads the identity claims, and
+   **creates the user record if the `sub` claim is new. First Google login is signup.** It then
+   completes authorization with the `mcp:tools` scope.
+5. The client exchanges its code at `/token` using PKCE and receives this service's access token.
+   Grants and tokens are stored hashed in a KV namespace, which the provider library requires to be
+   bound as `OAUTH_KV`.
+
+For clients configured with a static header rather than an OAuth flow, a dashboard issues personal
+access tokens. A token is `hwp_pat_` followed by 32 random bytes in base64url, shown once at
+creation and stored only as a SHA-256 hash. A middleware ahead of the OAuth provider recognizes the
+prefix, looks the hash up, and invokes the same MCP handler with an equivalent identity, so there is
+exactly one authorization path downstream.
+
+### 5.2 Data model
+
+```sql
+CREATE TABLE users (
+  id            TEXT PRIMARY KEY,
+  google_sub    TEXT NOT NULL UNIQUE,
+  email         TEXT NOT NULL,
+  name          TEXT,
+  created_at    INTEGER NOT NULL,
+  last_login_at INTEGER
+);
+
+CREATE TABLE pats (
+  id           TEXT PRIMARY KEY,
+  user_id      TEXT NOT NULL REFERENCES users(id),
+  token_hash   TEXT NOT NULL UNIQUE,
+  label        TEXT,
+  created_at   INTEGER NOT NULL,
+  last_used_at INTEGER,
+  revoked_at   INTEGER
+);
+
+CREATE TABLE audit (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  ts          INTEGER NOT NULL,
+  request_id  TEXT,
+  user_id     TEXT,
+  session_ref TEXT,
+  tool        TEXT,
+  outcome     TEXT NOT NULL,
+  duration_ms INTEGER,
+  bytes_in    INTEGER,
+  bytes_out   INTEGER
+);
+
+CREATE INDEX idx_pats_user ON pats(user_id);
+CREATE INDEX idx_audit_ts ON audit(ts);
+```
+
+The identity key is the Google `sub` claim, not the email address, because an email address can be
+reassigned. `session_ref` is a hash of the session identifier, never the identifier itself, and the
+audit table holds no tool arguments, paths, document content, or tokens, as doc 20 §7 requires.
+
+### 5.3 Session lifecycle
+
+| Event | Mechanism |
+|---|---|
+| `initialize` | The Worker mints a random session identifier and derives the Durable Object name from the principal and that identifier. The container starts, the readiness probe passes, and the response carries `Mcp-Session-Id` |
+| Later calls | The same header reaches the same object, therefore the same microVM, workspace, and process |
+| Idle 30 minutes | The container class stops the instance. The object marks the session dead, so the next call returns `404` and the client reinitializes |
+| `DELETE /mcp` | Terminates the container, marks the session dead, cancels the alarm, and returns `204`. Idempotent |
+| Maximum lifetime 8 hours | An alarm terminates the session, which forces reinitialization as doc 20 §7 requires |
+| Deadline exceeded | 120 seconds by default and 300 seconds for rendering, conversion, and certification. The Worker aborts, terminates the container, and returns a timeout |
+| Crash or eviction | The process exit stops the container, the object marks the session dead, and later calls return `404` |
+| Workspace cleanup | Guaranteed by teardown. The workspace is container-local disk that is never persisted, so nothing survives to be collected |
+
+**Cross-principal access fails closed by construction.** The object name derives from the
+authenticated principal, so presenting another person's session identifier resolves to a different
+object that was never initialized, and the response is an ordinary `404` that reveals nothing about
+who owns the identifier.
+
+### 5.4 Resources
+
+A `deploy/cloudflare/` project holds the Worker source, the wrangler configuration, the D1 schema,
+and the container definition. The configuration binds the container class with its Durable Object
+migration, the `OAUTH_KV` namespace, the D1 database, and the dashboard's static assets. Secrets are
+the Google client identifier and secret, plus a cookie signing key.
+
+The container image is built from repository source while `serve` is unreleased. Once a release
+carries `serve`, the image switches to downloading the checksum-verified release tarball onto a slim
+base, which removes the Rust toolchain from the deploy path and shortens cold starts. Fonts come
+from the distribution's Nanum package, matching the font baseline that CI already uses.
+
+## 6. Tier B: AgentCore behind an Amazon Quick connector
+
+```text
+Amazon Quick Suite
+   |  an administrator registers one MCP integration; each person authorizes it individually
+   v
+Amazon Cognito user pool: self-service signup, Google federation, JWT issuance
+   v
+AgentCore Runtime: validates the JWT, injects and routes Mcp-Session-Id,
+   gives each session its own microVM
+   v
+arm64 container: hwp serve --addr 0.0.0.0:8000 --root /work --font-dir <fonts>
+```
+
+### 6.1 Platform contract
+
+AgentCore Runtime requires the container to serve Streamable HTTP at `0.0.0.0:8000/mcp` from an
+**arm64** image, and it manages `Mcp-Session-Id` itself, adding the header when a request lacks one
+and routing a session to its dedicated microVM. The server must therefore tolerate a
+platform-supplied session identifier rather than reject it, which §3.2 already requires.
+
+Two consequences follow. First, the isolation layer that Tier A assembles from a Durable Object and
+a container class is provided by the platform, so Tier B needs no edge code of its own. Second, the
+runtime exposes only the MCP endpoint, so the `/files` sideband cannot exist and the inline content
+mode of §3.3 is a hard prerequisite rather than an option.
+
+### 6.2 Signup, login, and token issuance
+
+Cognito covers the same three requirements that the Worker covers in Tier A: a user pool provides
+self-service signup, Google is added as a federated identity provider so people sign in with a
+Google account, and the pool issues the JWT that AgentCore's inbound authorizer validates.
+
+Cognito does not implement dynamic client registration, so a Quick administrator registers the
+connector manually with the authorization and token endpoints and the client credentials. Amazon
+Quick Suite supports exactly this: its integration console accepts either a server that offers
+dynamic registration or explicit endpoint and credential values, and it uses three-legged OAuth so
+each person authorizes the connector under their own identity before Quick calls tools on their
+behalf. The absence of dynamic registration is acceptable here precisely because registration is an
+administrative act, whereas Tier A's self-service clients need it.
+
+### 6.3 Additional work
+
+- A new release target, `aarch64-unknown-linux-gnu`, and an arm64 container image.
+- An image repository, the AgentCore runtime configuration, and log delivery.
+- Verification before committing to a region: whether AgentCore and Quick MCP integration are both
+  available in the intended region, and the runtime's current idle and maximum session lifetimes
+  against the values in doc 20 §7.
+
+## 7. File authority
+
+The first implementation of both tiers uses a **session workspace** rather than the artifact model
+of doc 20 §3.2. Tier A populates it through the `/files` routes; Tier B populates it through inline
+content in tool arguments. Tools continue to take path arguments, but a path is a relative name
+inside one private workspace.
+
+**Amendment to doc 20 §10.** Doc 20 fails a release whose "local path schemas remain remotely
+writable". That criterion targets a shared server on which a client's path argument could reach
+another tenant's data or the host filesystem. In both tiers here, the path resolves inside a
+single-session microVM that holds no other tenant's data, has no network egress, and is destroyed
+when the session ends, and the existing canonicalize-and-contain check still runs inside the
+process. The criterion is therefore amended for these tiers: absolute paths and traversal remain
+rejected, and a workspace is never shared or reused.
+
+What the amendment defers, and what a later phase must deliver, is the rest of §3.2: a second
+`FileAuthority` implementation backed by an object store, opaque artifact identifiers owned by a
+tenant, immutable outputs with retention, and download through an authenticated endpoint or a
+short-lived signed URL. Only that phase satisfies §3.2 as written.
+
+## 8. Security posture against doc 20 §10
+
+Satisfied by the first implementation, with the point that enforces each:
+
+| Criterion | Enforcement |
+|---|---|
+| stdio stays the default and still exposes exactly 20 tools | The existing stdio process test gates the core split |
+| Authentication precedes tool execution | Tier A: the OAuth provider and the token middleware both reject before the handler. Tier B: the runtime's JWT authorizer rejects before the container |
+| Sessions bind to a principal and cross-principal access fails closed | Tier A: the object name derives from the principal, so a foreign session identifier yields an uninformative `404`. Tier B: the platform scopes sessions to the authorized caller |
+| Request, upload, workspace, and deadline limits with deterministic cleanup | Body rejection before parsing at the edge and again in `hwp serve`; file and workspace caps in the adapter; deadlines and termination at the edge |
+| Tenants cannot read or overwrite each other's data | One microVM per session, no shared filesystem, plus the existing root containment inside the process |
+| Termination leaves no published partial output and no reusable authority | The workspace dies with the microVM and the session identifier is marked dead |
+| No tokens, document content, or paths in logs | The audit schema stores metadata only; tokens are stored hashed |
+| The backend cannot be reached by bypassing the edge | Neither runtime exposes the container publicly, and `hwp serve` additionally refuses to run without a root |
+| Document workers have no network egress | Egress disabled on the container in Tier A; the runtime's network configuration in Tier B |
+| The service is not an unrestricted `hwp mcp` behind a proxy | There is no shell-out. A native adapter shares the protocol core and runs confined in a single-session microVM |
+
+Deferred, and listed here so no reader mistakes the first implementation for a complete one: the
+full artifact model of §3.2; SSE and resumable streams; per-request cancellation, since a deadline
+currently ends the session; more than one concurrent job per session, since the server is
+sequential while §7 permits two; scopes finer than `mcp:tools`; a strict origin allowlist rather
+than allowing an absent origin for non-browser clients; and the independent review that §9 item 5
+requires before general availability.
+
+## 9. Operations
+
+**Deployment risks to settle during implementation.** Whether MCP clients tolerate `405` on
+`GET /mcp`, which the transport specification permits when a server offers no push stream, and
+which must be confirmed against the clients that matter before any SSE work is considered.
+Container cold start on `initialize`, which the slim release-tarball image reduces. Google OAuth
+applications remain limited to a small number of test users until verification, and Cognito has
+its own quotas. The Cloudflare containers configuration surface is still moving, so field names and
+instance types are verified at implementation time rather than trusted from this document. Building
+Rust inside the deploy step may exceed build limits, in which case the image is built in CI and
+referenced from a registry.
+
+**Cost shape.** Tier A is a Workers Paid subscription whose included container allowance covers
+light use, with metered memory and vCPU beyond it. Tier B has no subscription and meters vCPU and
+memory per second, with Cognito free below its monthly active user threshold. Neither is expensive
+at pilot scale; both need a spending alarm before any public announcement.
+
+**Release coupling.** Once the image installs a release binary, every hwp release that the service
+should pick up requires a version and checksum bump followed by a redeploy. Automating that in CI
+is deliberately deferred until the deployment itself is stable.
+
+## 10. Activation requirements from issue #52
+
+Issue #52 was closed as deferred and lists seven items that must be named and accepted before
+implementation starts. This document answers them as follows.
+
+| Requirement | Answer |
+|---|---|
+| A concrete web consumer and its MCP protocol version | Tier A: any MCP client that speaks `2025-06-18` Streamable HTTP, which the existing server already negotiates. Tier B: Amazon Quick Suite, the consumer doc 20 §1 named |
+| Deployment and security owners | The repository owner, until the service has more than pilot traffic. Confirm at kickoff |
+| OAuth issuer, audience, scopes, and authorization policy | Tier A: the Worker is the issuer, its MCP endpoint is the audience, the scope is `mcp:tools`, and Google is the upstream identity provider (§5.1). Tier B: a Cognito user pool is the issuer and the AgentCore runtime validates the audience (§6.2) |
+| Tenant and session identity and persistence model | Principal derives from validated identity claims, keyed on the Google `sub` claim. A session is a server-minted identifier bound to that principal. Users and tokens persist in a relational store; session workspaces do not persist at all (§5.2, §5.3) |
+| Upload and output limits, retention, deletion, abuse controls | The caps in §3.2 and doc 20 §7. Retention is zero by construction, because a workspace dies with its microVM. Rate limiting is named as deferred in §8 and must land before public announcement |
+| Hosting target, rate limits, budget, monitoring | Hosting targets and cost shape are in §2 and §9. A spending alarm is required before any public announcement. A numeric budget cap and service-level objectives are the remaining open items, deferred to doc 20 §9 item 6 |
+| Whether the dependency-minimal, no-SDK invariant remains practical | Yes. §4 records the comparison and keeps the invariant with one small synchronous HTTP dependency |
+
+Two items therefore remain open at the time of writing: the named owners beyond the repository
+owner, and a numeric budget cap with its monitoring targets. Both are operational decisions rather
+than design decisions, and neither blocks the shared Rust work in §3.


### PR DESCRIPTION
## Summary

[Doc 20](https://github.com/STAIxBWLB/hwp-cli/blob/main/docs/design/20-remote-mcp.md) defines
*what* a Remote MCP service must guarantee. This adds doc 22, which defines *how* it gets built
and *where* it runs, so that #52 (closed as deferred for want of a named consumer, owner, OAuth
policy, and budget) has the scoped basis its closing comment asked for.

Design only. No adapter, container image, Worker, or cloud resource is created by this PR.

## What doc 22 decides

- **The doc 20 §8 dependency gate is resolved.** A synchronous `tiny_http` adapter over the
  extracted protocol core, keeping the no-tokio and no-SDK invariant. The rmcp-with-tokio and
  bare-axum alternatives are recorded along with the condition that would flip the decision, which
  is a client that needs SSE or one process hosting several sessions.
- **One platform-neutral `hwp serve` HTTP mode**: `POST /mcp` with the same 1 MiB cap as the stdio
  line limit, notifications answered `202`, `GET /mcp` answered `405`, `/healthz`, an optional
  `/files` sideband, and a mandatory `--root`. Plus the `commands/mcp` module split and the
  `FileAuthority` trait that doc 20 §3.1 asks for.
- **Two hosting tiers sharing that binary.** Cloudflare Workers and Containers, where
  `workers-oauth-provider` makes the Worker the OAuth authorization server that MCP clients talk
  to, with Google upstream and first login as signup. And AgentCore behind an Amazon Quick Suite
  connector, where Cognito handles signup, Google federation, and token issuance, and the runtime
  manages session-to-microVM routing itself. Vercel is evaluated and rejected: no first-party
  authorization server and no session affinity.

## Amendments to doc 20 recorded here

1. **§3.1**: the protocol core stays binary-internal rather than library-visible for now, because
   it references 16 binary-private command modules across 70 call sites and has no consumer outside
   the binary yet.
2. **§10**: the writable-path failure criterion is narrowed for a single-session microVM workspace
   that holds no other tenant's data, has no egress, and is destroyed with the session.

§3.2's artifact model stays required and unimplemented.

## Verification

`scripts/check.sh` passes locally: `check: OK (fmt/clippy/test/pdf-runner/structured-corpus/public-parity=skipped)`.
Both language files change in the same commit, section numbering matches across the pair, and the
new document is indexed in `design/00-overview` and `docs/README` on both sides.

## Follow-up

A delivery issue superseding #52 will carry the task breakdown. Implementation starts only on
explicit instruction.