### PR TITLE
feat(mcp): add `hwp serve`, an HTTP adapter for the protocol core (#189 R2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +258,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chunked_transfer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
 
 [[package]]
 name = "cipher"
@@ -695,6 +707,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hwp-cli"
 version = "0.14.0"
 dependencies = [
@@ -726,6 +744,7 @@ dependencies = [
  "sha1",
  "sha2",
  "tiny-skia",
+ "tiny_http",
  "windows-sys",
  "zeroize",
  "zip",
@@ -2004,6 +2023,18 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
+]
+
+[[package]]
+name = "tiny_http"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389915df6413a2e74fb181895f933386023c71110878cd0825588928e64cdc82"
+dependencies = [
+ "ascii",
+ "chunked_transfer",
+ "httpdate",
+ "log",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,9 @@ sha2 = "0.11"
 aes = "0.9.1"
 getrandom = "0.3"
 pulldown-cmark = { version = "0.13", default-features = false }
+# `hwp serve` HTTP adapter (doc 22 §4 결정 기록) — 동기식 thread 모델이라 tokio를
+# 들이지 않는다. 새로 붙는 하위 트리는 ascii/chunked_transfer/httpdate뿐이다.
+tiny_http = "0.12"
 
 # Rendering
 tiny-skia = "0.12"

--- a/README.ko.md
+++ b/README.ko.md
@@ -459,9 +459,11 @@ Windows에서는 `%USERPROFILE%\AppData\LocalLow` 아래에 전용 교환 root(�
 거부될 수 있다. Quick의 로컬 폴더 권한은 이 쓰기 무결성을 바꾸지 않으므로 전용 가이드의
 생성·import JSON·복구 절차를 따른다.
 
-Amazon Quick Web은 로컬 stdio 프로세스를 시작할 수 없다. 인증된 Streamable HTTP, tenant 격리,
-artifact 전송 요구사항은 후속 작업용 [Remote MCP transport](docs/design/20-remote-mcp.ko.md)에
-정리했으며 현재 릴리스에는 HTTP runtime이 없다.
+Amazon Quick Web은 로컬 stdio 프로세스를 시작할 수 없다. 이제 `hwp serve`가 같은 도구를
+컨테이너 배포용 HTTP로 제공한다(`POST /mcp`,
+[배포 설계](docs/design/22-remote-mcp-deployment.ko.md) 참고). 다만 이 서버는 앞단에 신뢰된
+edge가 있다고 전제하는 private hop이다. 인증된 Streamable HTTP, tenant 격리, artifact 전송은
+여전히 [Remote MCP transport](docs/design/20-remote-mcp.ko.md)의 후속 작업이다.
 
 ### 노출 도구 (20종)
 

--- a/README.md
+++ b/README.md
@@ -493,9 +493,11 @@ expand environment variables). Quick starts the local MCP child at Low mandatory
 not change that write integrity; use the dedicated runbook's creation, import JSON, and recovery
 steps.
 
-Amazon Quick Web cannot launch a local stdio process. Authenticated Streamable HTTP, tenant
-isolation and artifact transfer are specified for future work in
-[Remote MCP transport](docs/design/20-remote-mcp.md); no HTTP runtime is included today.
+Amazon Quick Web cannot launch a local stdio process. `hwp serve` now runs the same tools over
+HTTP for container deployment (`POST /mcp`, see [deployment design](docs/design/22-remote-mcp-deployment.md)),
+but it is a private hop that expects a trusted edge in front of it: authenticated Streamable HTTP,
+tenant isolation and artifact transfer remain future work in
+[Remote MCP transport](docs/design/20-remote-mcp.md).
 
 ### Exposed tools (20)
 

--- a/crates/hwp-cli/Cargo.toml
+++ b/crates/hwp-cli/Cargo.toml
@@ -34,6 +34,7 @@ libc = { workspace = true }
 encoding_rs = { workspace = true }
 resvg = { workspace = true }
 zeroize = { workspace = true }
+tiny_http = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [

--- a/crates/hwp-cli/src/cli.rs
+++ b/crates/hwp-cli/src/cli.rs
@@ -498,6 +498,21 @@ pub enum Cmd {
         #[arg(long)]
         root: Vec<PathBuf>,
     },
+    /// MCP HTTP server for container deployment: the same tools over POST /mcp
+    Serve {
+        /// Listen address. Port 0 picks a free port and prints the bound address to stderr
+        #[arg(long, default_value = "0.0.0.0:8080")]
+        addr: std::net::SocketAddr,
+        /// Workspace root: all file access is restricted to this directory
+        #[arg(long)]
+        root: PathBuf,
+        /// Default font directory for the render and diff tools (repeatable)
+        #[arg(long)]
+        font_dir: Vec<PathBuf>,
+        /// Enable POST and GET /files/{name} upload and download inside the root
+        #[arg(long)]
+        files: bool,
+    },
 
     /// Self-update: fetch the latest `hwp` from GitHub releases and replace the running binary
     Update {

--- a/crates/hwp-cli/src/commands/mcp/http.rs
+++ b/crates/hwp-cli/src/commands/mcp/http.rs
@@ -1,0 +1,249 @@
+//! HTTP adapter: Streamable-HTTP style `POST /mcp` for container deployment.
+//!
+//! 이 서버는 private hop이다. 신뢰된 edge(Cloudflare Worker, AgentCore runtime)가
+//! TLS 종단·인증·origin 검증·body 제한을 이미 수행한 뒤에야 요청이 도달한다
+//! (docs/design/22-remote-mcp-deployment.md §3.2, §4).
+//!
+//! stdio adapter와 같은 protocol core를 공유하므로 도구 의미론이 갈라지지 않는다.
+
+use std::fs::File;
+use std::io::{self, Cursor, Read as _};
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+
+use tiny_http::{Header, Method, Request, Response, Server};
+use zeroize::Zeroizing;
+
+use super::authority::{LocalFsContext, canonicalize_mcp_path};
+use super::{MAX_REQUEST_LINE_BYTES, handle_request};
+
+/// `--files` 업로드 한 건의 상한.
+const MAX_FILE_BYTES: u64 = 64 * 1024 * 1024;
+/// workspace 전체 사용량 상한.
+const MAX_WORKSPACE_BYTES: u64 = 256 * 1024 * 1024;
+
+type Body = Response<Cursor<Vec<u8>>>;
+
+fn plain(status: u16, body: &str) -> Body {
+    Response::from_string(body).with_status_code(status)
+}
+
+fn empty(status: u16) -> Body {
+    Response::from_data(Vec::new()).with_status_code(status)
+}
+
+fn header(name: &str, value: &str) -> Header {
+    // 호출부가 상수만 넘기므로 실패할 수 없다.
+    Header::from_bytes(name.as_bytes(), value.as_bytes())
+        .expect("정적 헤더 이름/값은 항상 유효하다")
+}
+
+/// HTTP JSON-RPC 서버. 요청을 한 번에 하나씩 처리한다.
+///
+/// container 하나가 MCP session 하나를 담당하므로 순차 처리가 곧 올바른 동작이다.
+// ponytail: 단일 스레드 루프 — 긴 도구 호출은 /healthz까지 지연시킨다. 한 프로세스가
+// 여러 session을 담당해야 하는 날이 오면 doc 22 §4의 선택지 1로 뒤집는다.
+pub fn serve(
+    addr: SocketAddr,
+    root: PathBuf,
+    font_dirs: Vec<PathBuf>,
+    files: bool,
+) -> anyhow::Result<()> {
+    let canonical_root = canonicalize_mcp_path(&root).map_err(|error| {
+        anyhow::anyhow!(
+            "--root 경로를 확인할 수 없습니다: {} ({error})",
+            root.display()
+        )
+    })?;
+    if !canonical_root.is_dir() {
+        anyhow::bail!(
+            "--root 는 디렉터리여야 합니다: {}",
+            canonical_root.display()
+        );
+    }
+    let ctx = LocalFsContext::new(font_dirs, vec![canonical_root.clone()]);
+
+    let server = Server::http(addr)
+        .map_err(|error| anyhow::anyhow!("{addr} 에 바인드할 수 없습니다: {error}"))?;
+    let bound = server
+        .server_addr()
+        .to_ip()
+        .ok_or_else(|| anyhow::anyhow!("수신 주소를 확인할 수 없습니다"))?;
+    // 실제 바인드된 주소를 한 줄로 알린다(--addr 의 포트 0을 쓸 때 필요).
+    // stdout은 도구 출력 전용이므로 운영 로그는 stderr로 보낸다.
+    eprintln!("hwp serve: listening on http://{bound}");
+
+    for mut request in server.incoming_requests() {
+        let path = request.url().split('?').next().unwrap_or("").to_string();
+        let method = request.method().clone();
+        let result = match (&method, path.as_str()) {
+            (Method::Get, "/healthz") => request.respond(plain(200, "ok")),
+            (Method::Post, "/mcp") => {
+                let response = handle_mcp(&mut request, &ctx);
+                request.respond(response)
+            }
+            // server push가 없으므로 SSE stream을 제공하지 않는다.
+            (_, "/mcp") => request.respond(empty(405).with_header(header("Allow", "POST"))),
+            _ if files && path.starts_with("/files/") => {
+                handle_files(request, &method, &path["/files/".len()..], &canonical_root)
+            }
+            _ => request.respond(plain(404, "not found")),
+        };
+        if let Err(error) = result {
+            eprintln!("hwp serve: 응답 전송 실패: {error}");
+        }
+    }
+    Ok(())
+}
+
+fn handle_mcp(request: &mut Request, ctx: &LocalFsContext) -> Body {
+    if request
+        .body_length()
+        .is_some_and(|n| n > MAX_REQUEST_LINE_BYTES)
+    {
+        return plain(413, "request body too large");
+    }
+    let mut body = Zeroizing::new(Vec::new());
+    let capped = (MAX_REQUEST_LINE_BYTES as u64).saturating_add(1);
+    if request
+        .as_reader()
+        .take(capped)
+        .read_to_end(&mut body)
+        .is_err()
+    {
+        return plain(400, "cannot read request body");
+    }
+    if body.len() > MAX_REQUEST_LINE_BYTES {
+        return plain(413, "request body too large");
+    }
+    let Ok(line) = std::str::from_utf8(&body) else {
+        return plain(400, "request body is not valid UTF-8");
+    };
+    match handle_request(line.trim(), ctx) {
+        Some(response) => {
+            Response::from_string(response).with_header(header("Content-Type", "application/json"))
+        }
+        // 알림은 프로토콜 응답이 없다.
+        None => empty(202),
+    }
+}
+
+fn handle_files(
+    mut request: Request,
+    method: &Method,
+    name: &str,
+    root: &Path,
+) -> Result<(), io::Error> {
+    if !valid_file_name(name) {
+        return request.respond(plain(400, "invalid file name"));
+    }
+    let target = root.join(name);
+    match method {
+        Method::Post => {
+            let response = store_file(&mut request, &target, root);
+            request.respond(response)
+        }
+        Method::Get => match File::open(&target) {
+            Ok(file) => request.respond(
+                Response::from_file(file)
+                    .with_header(header("Content-Type", "application/octet-stream")),
+            ),
+            Err(_) => request.respond(plain(404, "not found")),
+        },
+        _ => request.respond(empty(405).with_header(header("Allow", "GET, POST"))),
+    }
+}
+
+fn store_file(request: &mut Request, target: &Path, root: &Path) -> Body {
+    let declared = request.body_length().map(|n| n as u64);
+    if declared.is_some_and(|n| n > MAX_FILE_BYTES) {
+        return plain(413, "file too large");
+    }
+    // 받기 전에 workspace 총량을 확인한다.
+    // ponytail: 단일 스레드 루프라 이 사전 확인과 쓰기 사이에 경합이 없다.
+    // 동시 처리를 도입하면 잠금 아래에서 다시 확인해야 한다.
+    let used = workspace_bytes(root).unwrap_or(0);
+    if used.saturating_add(declared.unwrap_or(0)) > MAX_WORKSPACE_BYTES {
+        return plain(413, "workspace quota exceeded");
+    }
+
+    let mut file = match File::create(target) {
+        Ok(file) => file,
+        Err(error) => return plain(500, &format!("cannot create file: {error}")),
+    };
+    let capped = MAX_FILE_BYTES.saturating_add(1);
+    let written = io::copy(&mut request.as_reader().take(capped), &mut file);
+    drop(file);
+
+    let discard = |message: &str| -> Body {
+        let _ = std::fs::remove_file(target);
+        plain(413, message)
+    };
+    match written {
+        Err(error) => {
+            let _ = std::fs::remove_file(target);
+            plain(500, &format!("cannot write file: {error}"))
+        }
+        Ok(count) if count > MAX_FILE_BYTES => discard("file too large"),
+        Ok(_) if workspace_bytes(root).unwrap_or(0) > MAX_WORKSPACE_BYTES => {
+            discard("workspace quota exceeded")
+        }
+        Ok(_) => empty(200),
+    }
+}
+
+/// `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`
+///
+/// 허용 문자에 `/`와 선행 `.`이 없으므로 `root.join(name)`은 root를 벗어날 수 없다.
+///
+/// percent-escape는 의도적으로 복호하지 않는다. 허용 문자 집합이 이미 URL-safe라
+/// 정상적인 이름은 인코딩이 필요 없고, 복호를 하면 `%2e%2e` 같은 입력이 traversal로
+/// 되살아난다. 인코딩된 이름은 `%`에서 걸려 그대로 거부된다.
+fn valid_file_name(name: &str) -> bool {
+    let bytes = name.as_bytes();
+    if bytes.is_empty() || bytes.len() > 128 {
+        return false;
+    }
+    if !bytes[0].is_ascii_alphanumeric() {
+        return false;
+    }
+    bytes
+        .iter()
+        .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-'))
+}
+
+fn workspace_bytes(root: &Path) -> io::Result<u64> {
+    let mut total = 0;
+    for entry in std::fs::read_dir(root)? {
+        let entry = entry?;
+        let meta = entry.metadata()?;
+        total += if meta.is_dir() {
+            workspace_bytes(&entry.path()).unwrap_or(0)
+        } else {
+            meta.len()
+        };
+    }
+    Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::valid_file_name;
+
+    #[test]
+    fn file_names_reject_traversal_and_hidden_entries() {
+        assert!(valid_file_name("a.hwpx"));
+        assert!(valid_file_name("out-1_final.pdf"));
+        assert!(valid_file_name("A"));
+
+        assert!(!valid_file_name(""));
+        assert!(!valid_file_name(".hidden"));
+        assert!(!valid_file_name("-dash"));
+        assert!(!valid_file_name(".."));
+        assert!(!valid_file_name("a/b"));
+        assert!(!valid_file_name("../escape"));
+        assert!(!valid_file_name("한글.hwpx"));
+        assert!(!valid_file_name(&"a".repeat(129)));
+        assert!(valid_file_name(&"a".repeat(128)));
+    }
+}

--- a/crates/hwp-cli/src/commands/mcp/mod.rs
+++ b/crates/hwp-cli/src/commands/mcp/mod.rs
@@ -7,9 +7,11 @@
 //! 도구는 라이브러리 계층을 직접 감싼다(commands/*::run 아님 — 그건 stdout 출력).
 
 mod authority;
+mod http;
 mod stdio;
 
 pub use authority::FileAuthority;
+pub use http::serve;
 pub use stdio::run;
 
 use authority::{checked_read_path, checked_write_path, font_dirs_for};

--- a/crates/hwp-cli/src/i18n.rs
+++ b/crates/hwp-cli/src/i18n.rs
@@ -761,6 +761,32 @@ pub const KO: &[(&str, &str, &str)] = &[
         "root",
         "모든 파일 접근을 이 디렉터리 아래로 제한 (반복 가능). 기본: 제한 없음",
     ),
+    // serve
+    (
+        "serve",
+        "",
+        "컨테이너 배포용 MCP HTTP 서버 — 같은 도구를 POST /mcp로 제공",
+    ),
+    (
+        "serve",
+        "addr",
+        "수신 주소. 포트가 0이면 빈 포트를 골라 바인드된 주소를 stderr로 출력",
+    ),
+    (
+        "serve",
+        "root",
+        "작업 공간 root — 모든 파일 접근을 이 디렉터리 아래로 제한",
+    ),
+    (
+        "serve",
+        "font_dir",
+        "렌더/diff 도구의 기본 폰트 디렉터리 (반복 가능)",
+    ),
+    (
+        "serve",
+        "files",
+        "root 아래에서 POST/GET /files/{name} 업로드·다운로드 활성화",
+    ),
     // update
     (
         "update",

--- a/crates/hwp-cli/src/main.rs
+++ b/crates/hwp-cli/src/main.rs
@@ -182,6 +182,12 @@ fn real_main() -> anyhow::Result<()> {
             }
         },
         Cmd::Mcp { font_dir, root } => commands::mcp::run(font_dir, root),
+        Cmd::Serve {
+            addr,
+            root,
+            font_dir,
+            files,
+        } => commands::mcp::serve(addr, root, font_dir, files),
         Cmd::Update {
             check,
             tag,

--- a/crates/hwp-cli/tests/serve_http.rs
+++ b/crates/hwp-cli/tests/serve_http.rs
@@ -1,0 +1,294 @@
+//! `hwp serve` HTTP adapter surface — the container-deployment contract of
+//! docs/design/22-remote-mcp-deployment.md §3.2.
+//!
+//! Every case drives a real `hwp serve` process over a real socket. The server binds
+//! `127.0.0.1:0` and prints the chosen port on its first stderr line, so the tests never
+//! guess a port. Documents are produced by the server itself (`hwp_new`), so this suite
+//! needs no fixture and no font, which keeps it CI-safe on all three platforms.
+//!
+//! The HTTP client here is a hand-rolled `TcpStream` exchange rather than a new
+//! dev-dependency; a request/response pair over `Connection: close` is a few lines.
+
+use std::io::{BufRead, BufReader, Read, Write};
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+
+/// The 20 tools the MCP surface publishes; must agree with `cli_surface.rs`.
+const EXPECTED_TOOLS: [&str; 20] = [
+    "hwp_certify",
+    "hwp_compare",
+    "hwp_compose",
+    "hwp_convert",
+    "hwp_diff",
+    "hwp_edit",
+    "hwp_fill",
+    "hwp_grep",
+    "hwp_info",
+    "hwp_lint",
+    "hwp_list_bookmarks",
+    "hwp_list_fields",
+    "hwp_merge",
+    "hwp_new",
+    "hwp_read",
+    "hwp_render",
+    "hwp_slots",
+    "hwp_split",
+    "hwp_template",
+    "hwp_validate",
+];
+
+/// A running server; killed on drop so a failing assertion never leaks a process.
+struct Serve {
+    child: Child,
+    addr: String,
+    root: PathBuf,
+}
+
+impl Drop for Serve {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_dir_all(&self.root);
+    }
+}
+
+fn tmp_dir(test: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("hwp-serve-{}-{test}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn spawn(test: &str, files: bool) -> Serve {
+    let root = tmp_dir(test);
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_hwp"));
+    cmd.arg("serve")
+        .arg("--addr")
+        .arg("127.0.0.1:0")
+        .arg("--root")
+        .arg(&root);
+    if files {
+        cmd.arg("--files");
+    }
+    let mut child = cmd
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+
+    // The bound address arrives on the first stderr line.
+    let stderr = child.stderr.take().unwrap();
+    let mut first = String::new();
+    BufReader::new(stderr).read_line(&mut first).unwrap();
+    let addr = first
+        .trim()
+        .rsplit("http://")
+        .next()
+        .unwrap_or_default()
+        .to_string();
+    assert!(!addr.is_empty(), "바인드 주소를 읽지 못했습니다: {first:?}");
+
+    Serve { child, addr, root }
+}
+
+/// Minimal HTTP/1.1 exchange. Returns (status, body).
+fn request(addr: &str, method: &str, path: &str, body: &[u8]) -> (u16, Vec<u8>) {
+    let (status, _, body) = request_full(addr, method, path, body);
+    (status, body)
+}
+
+/// Same, but also returns the raw header block so tests can assert on `Allow`.
+fn request_full(addr: &str, method: &str, path: &str, body: &[u8]) -> (u16, String, Vec<u8>) {
+    let mut stream = TcpStream::connect(addr).unwrap();
+    let head = format!(
+        "{method} {path} HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\nContent-Length: {}\r\n\r\n",
+        body.len()
+    );
+    stream.write_all(head.as_bytes()).unwrap();
+    stream.write_all(body).unwrap();
+    stream.flush().unwrap();
+
+    let mut raw = Vec::new();
+    stream.read_to_end(&mut raw).unwrap();
+    let split = raw
+        .windows(4)
+        .position(|w| w == b"\r\n\r\n")
+        .expect("헤더와 본문 경계를 찾지 못했습니다");
+    let headers = String::from_utf8_lossy(&raw[..split]).to_string();
+    let status = headers
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .and_then(|code| code.parse().ok())
+        .expect("상태 줄을 해석하지 못했습니다");
+    (status, headers, raw[split + 4..].to_vec())
+}
+
+fn rpc(addr: &str, payload: &str) -> (u16, serde_json::Value) {
+    let (status, body) = request(addr, "POST", "/mcp", payload.as_bytes());
+    let value = if body.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&body).expect("JSON 응답을 해석하지 못했습니다")
+    };
+    (status, value)
+}
+
+fn call_tool(addr: &str, name: &str, arguments: serde_json::Value) -> serde_json::Value {
+    let payload = serde_json::json!({
+        "jsonrpc": "2.0", "id": 9, "method": "tools/call",
+        "params": {"name": name, "arguments": arguments},
+    });
+    let (status, value) = rpc(addr, &payload.to_string());
+    assert_eq!(status, 200, "{name} 호출이 200이 아닙니다");
+    value["result"].clone()
+}
+
+#[test]
+fn serve_speaks_the_same_protocol_as_stdio() {
+    let server = spawn("session", false);
+    let addr = &server.addr;
+
+    let (status, body) = request(addr, "GET", "/healthz", b"");
+    assert_eq!(status, 200);
+    assert_eq!(body, b"ok");
+
+    let (status, value) = rpc(
+        addr,
+        r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}"#,
+    );
+    assert_eq!(status, 200);
+    assert_eq!(value["result"]["protocolVersion"], "2025-06-18");
+    assert_eq!(value["result"]["serverInfo"]["name"], "hwp-cli");
+
+    // 알림에는 프로토콜 응답이 없다.
+    let (status, body) = request(
+        addr,
+        "POST",
+        "/mcp",
+        br#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#,
+    );
+    assert_eq!(status, 202);
+    assert!(body.is_empty(), "알림 응답 본문이 비어야 합니다");
+
+    let (status, value) = rpc(addr, r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#);
+    assert_eq!(status, 200);
+    let mut names: Vec<&str> = value["result"]["tools"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|tool| tool["name"].as_str().unwrap())
+        .collect();
+    names.sort_unstable();
+    assert_eq!(names, EXPECTED_TOOLS, "도구 20종");
+}
+
+#[test]
+fn serve_runs_tools_inside_the_root() {
+    let server = spawn("tools", false);
+    let addr = &server.addr;
+    let made = server.root.join("made.hwpx");
+
+    let result = call_tool(
+        addr,
+        "hwp_new",
+        serde_json::json!({"output": made.to_str().unwrap(), "markdown": "# 제목\n\n본문."}),
+    );
+    assert_eq!(result["isError"], false, "hwp_new: {result}");
+    assert!(made.exists(), "문서가 생성되지 않았습니다");
+
+    let result = call_tool(
+        addr,
+        "hwp_info",
+        serde_json::json!({"path": made.to_str().unwrap()}),
+    );
+    assert_eq!(result["isError"], false, "hwp_info: {result}");
+
+    // --root 밖 쓰기는 stdio와 동일하게 거부된다.
+    let outside = std::env::temp_dir().join("hwp-serve-escape.hwpx");
+    let result = call_tool(
+        addr,
+        "hwp_new",
+        serde_json::json!({"output": outside.to_str().unwrap(), "markdown": "x"}),
+    );
+    assert_eq!(result["isError"], true, "root 밖 쓰기가 허용되었습니다");
+    assert!(!outside.exists(), "root 밖에 파일이 생겼습니다");
+}
+
+#[test]
+fn serve_rejects_oversized_and_unsupported_requests() {
+    let server = spawn("limits", false);
+    let addr = &server.addr;
+
+    // 1 MiB 초과 본문은 파싱 전에 거부한다.
+    let oversized = vec![b'x'; 1024 * 1024 + 1];
+    let (status, _) = request(addr, "POST", "/mcp", &oversized);
+    assert_eq!(status, 413);
+
+    // server push가 없으므로 SSE stream을 제공하지 않는다.
+    let (status, headers, _) = request_full(addr, "GET", "/mcp", b"");
+    assert_eq!(status, 405);
+    assert!(
+        headers.to_ascii_lowercase().contains("allow: post"),
+        "405 응답에 Allow 헤더가 없습니다: {headers}"
+    );
+
+    let (status, _) = request(addr, "GET", "/nope", b"");
+    assert_eq!(status, 404);
+
+    // --files 없이는 파일 라우트가 존재하지 않는다.
+    let (status, _) = request(addr, "POST", "/files/a.bin", b"data");
+    assert_eq!(status, 404);
+}
+
+#[test]
+fn serve_files_roundtrip_and_name_rules() {
+    let server = spawn("files", true);
+    let addr = &server.addr;
+
+    let (status, _) = request(addr, "POST", "/files/a.bin", b"hello-hwp");
+    assert_eq!(status, 200);
+    let (status, body) = request(addr, "GET", "/files/a.bin", b"");
+    assert_eq!(status, 200);
+    assert_eq!(body, b"hello-hwp");
+
+    let (status, _) = request(addr, "GET", "/files/missing.bin", b"");
+    assert_eq!(status, 404);
+
+    // 허용 문자에 `/`와 선행 `.`이 없으므로 traversal이 성립하지 않는다.
+    for name in [".hidden", "-dash", "%2e%2e", "%ED%95%9C.hwpx"] {
+        let (status, _) = request(addr, "POST", &format!("/files/{name}"), b"data");
+        assert_eq!(status, 400, "이름 {name} 이 거부되지 않았습니다");
+    }
+
+    let entries: Vec<_> = std::fs::read_dir(&server.root)
+        .unwrap()
+        .map(|e| e.unwrap().file_name())
+        .collect();
+    assert_eq!(entries, ["a.bin"], "workspace에 예상 밖 파일이 있습니다");
+}
+
+#[test]
+fn serve_refuses_to_start_without_a_usable_root() {
+    let missing_root = Command::new(env!("CARGO_BIN_EXE_hwp"))
+        .args(["serve", "--addr", "127.0.0.1:0"])
+        .output()
+        .unwrap();
+    assert!(
+        !missing_root.status.success(),
+        "--root 없이 기동이 성공했습니다"
+    );
+
+    let absent = std::env::temp_dir().join(format!("hwp-serve-absent-{}", std::process::id()));
+    assert!(!Path::new(&absent).exists());
+    let bad_root = Command::new(env!("CARGO_BIN_EXE_hwp"))
+        .args(["serve", "--addr", "127.0.0.1:0", "--root"])
+        .arg(&absent)
+        .output()
+        .unwrap();
+    assert!(
+        !bad_root.status.success(),
+        "존재하지 않는 --root 로 기동이 성공했습니다"
+    );
+}

--- a/docs/manual/cli-reference.ko.md
+++ b/docs/manual/cli-reference.ko.md
@@ -30,6 +30,7 @@
 - [`hwp certify`](#hwp-certify)
 - [`hwp corpus`](#hwp-corpus)
 - [`hwp mcp`](#hwp-mcp)
+- [`hwp serve`](#hwp-serve)
 - [`hwp update`](#hwp-update)
 - [`hwp skill`](#hwp-skill)
 - [`hwp skill export`](#hwp-skill-export)
@@ -384,6 +385,19 @@ MCP(Model Context Protocol) stdio 서버 — AI 에이전트용 도구 인터페
 |---|---|---|---|
 | `--font-dir` | `<FONT_DIR>` |  | 렌더/diff 도구의 기본 폰트 디렉터리 (반복 가능) |
 | `--root` | `<ROOT>` |  | 모든 파일 접근을 이 디렉터리 아래로 제한 (반복 가능). 기본: 제한 없음 |
+
+## `hwp serve`
+
+컨테이너 배포용 MCP HTTP 서버 — 같은 도구를 POST /mcp로 제공
+
+**사용법:** `hwp serve [OPTIONS] --root <ROOT>`
+
+| 인자/플래그 | 값 | 기본값 | 설명 |
+|---|---|---|---|
+| `--addr` | `<ADDR>` | `0.0.0.0:8080` | 수신 주소. 포트가 0이면 빈 포트를 골라 바인드된 주소를 stderr로 출력 |
+| `--root` | `<ROOT>` |  | 작업 공간 root — 모든 파일 접근을 이 디렉터리 아래로 제한 |
+| `--font-dir` | `<FONT_DIR>` |  | 렌더/diff 도구의 기본 폰트 디렉터리 (반복 가능) |
+| `--files` |  |  | root 아래에서 POST/GET /files/{name} 업로드·다운로드 활성화 |
 
 ## `hwp update`
 

--- a/docs/manual/cli-reference.md
+++ b/docs/manual/cli-reference.md
@@ -30,6 +30,7 @@ This document is generated from the clap definitions of the `hwp` CLI. Do not ed
 - [`hwp certify`](#hwp-certify)
 - [`hwp corpus`](#hwp-corpus)
 - [`hwp mcp`](#hwp-mcp)
+- [`hwp serve`](#hwp-serve)
 - [`hwp update`](#hwp-update)
 - [`hwp skill`](#hwp-skill)
 - [`hwp skill export`](#hwp-skill-export)
@@ -384,6 +385,19 @@ MCP (Model Context Protocol) stdio server: a tool interface for AI agents
 |---|---|---|---|
 | `--font-dir` | `<FONT_DIR>` |  | Default font directory for the render and diff tools (repeatable) |
 | `--root` | `<ROOT>` |  | Restrict all file access to this directory (repeatable). Default: unrestricted |
+
+## `hwp serve`
+
+MCP HTTP server for container deployment: the same tools over POST /mcp
+
+**Usage:** `hwp serve [OPTIONS] --root <ROOT>`
+
+| Argument/flag | Value | Default | Description |
+|---|---|---|---|
+| `--addr` | `<ADDR>` | `0.0.0.0:8080` | Listen address. Port 0 picks a free port and prints the bound address to stderr |
+| `--root` | `<ROOT>` |  | Workspace root: all file access is restricted to this directory |
+| `--font-dir` | `<FONT_DIR>` |  | Default font directory for the render and diff tools (repeatable) |
+| `--files` |  |  | Enable POST and GET /files/{name} upload and download inside the root |
 
 ## `hwp update`
 


### PR DESCRIPTION
## Summary

Task R2 of #189, implementing [doc 22 §3.2](https://github.com/STAIxBWLB/hwp-cli/blob/main/docs/design/22-remote-mcp-deployment.md).
`hwp serve` runs the 20 MCP tools over HTTP so the binary can be deployed in a container, sharing
the protocol core that #190 extracted rather than forking tool semantics.

This is deliberately a **private hop**: it expects a trusted edge (a Cloudflare Worker, an
AgentCore runtime) to have already terminated TLS, authenticated the caller, checked origin, and
capped the body. It is not an authenticated public server, and the README now says so.

## The contract

| Route | Behavior |
|---|---|
| `POST /mcp` | Body capped at 1 MiB, the same constant the stdio line reader uses. A request returns `200 application/json`; a notification returns `202` with an empty body |
| `GET /mcp` | `405` with `Allow: POST`. The server never pushes, so no SSE stream is offered |
| `GET /healthz` | `200 ok`, the container readiness probe target |
| `POST\|GET /files/{name}` | Only with `--files`. 64 MiB per file, 256 MiB per workspace, partial uploads unlinked on breach |

Flags: `--addr` (default `0.0.0.0:8080`), `--root` (**required** — clap refuses a rootless start),
`--font-dir`, `--files`. Port 0 binds a free port and prints it on one stderr line, which is what
makes the integration test possible. Inbound `Mcp-Session-Id` is accepted and ignored, because
session affinity belongs to the platform.

## Dependency

`tiny_http = "0.12"`, the choice recorded in the doc 22 §4 ADR. It keeps the workspace's no-tokio,
no-SDK stance: a single-threaded `incoming_requests()` loop gives the specified sequential handling
by construction, and blocking document work runs on the request thread. The new subtree is four
crates: `ascii`, `chunked_transfer`, `httpdate`, `log`.

## Safety notes for review

- `--root` is mandatory and canonicalized, and must be a directory. The existing sandbox runs
  unchanged inside the protocol core, so a tool argument pointing outside the root is refused with
  the same message stdio gives.
- `/files` names must match `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`. The charset excludes `/` and a
  leading `.`, so `root.join(name)` cannot traverse. Percent-escapes are deliberately **not**
  decoded: legitimate names never need encoding, and decoding would revive `%2e%2e` as traversal.
- Request bodies go into a `Zeroizing<Vec<u8>>` because a per-call `password` can transit them,
  matching the stdio loop's hygiene.
- Two ponytail comments mark deliberate ceilings: the single-threaded loop (a long tool call delays
  `/healthz`) and the pre-accept workspace walk (race-free only because the loop is sequential).

## Verification

- `scripts/check.sh` green.
- New `crates/hwp-cli/tests/serve_http.rs` drives a real process over a real socket with a
  hand-rolled `TcpStream` client (no new dev-dependency): protocol parity including the 20-tool
  list, a tool call that creates a document and reads it back, refusal to write outside the root,
  413/405/404/202 cases, the `/files` round trip with name-rule rejections, and both rootless and
  missing-root startup failures. Fixture-free and font-free, so it is CI-safe on all three
  platforms.
- Manual smoke against a live server confirmed the full path: `hwp_new` into the workspace,
  `hwp_info` on the result, then `GET /files/made.hwpx` returning the 6 KB document.
- `docs/manual/cli-reference{,.ko}.md` regenerated by the gate; README updated in both languages in
  the same commit.
