### PR TITLE
feat(deploy): scaffold the Cloudflare tier of the remote MCP service (#189 A1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# The Cloudflare container image builds from the repository root (its Dockerfile
+# needs the whole Cargo workspace), so everything the build does not need must be
+# excluded here or it is uploaded as build context. `target/` alone is ~17 GB.
+
+target/
+**/target/
+
+# Never ship documents or fonts into an image.
+fixtures/
+fonts/
+corpus/
+docs/spec.txt
+
+# Tooling and local state.
+.git/
+.github/
+.planning/
+node_modules/
+**/node_modules/
+deploy/cloudflare/.wrangler/
+deploy/cloudflare/.dev.vars
+Formula/
+*.log

--- a/deploy/cloudflare/.gitignore
+++ b/deploy/cloudflare/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.wrangler/
+.dev.vars
+worker-configuration.d.ts

--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -23,7 +23,7 @@ to deploy once they exist.
 2. **A Cloudflare API token** for the deploy host, with: Workers Scripts:Edit,
    Workers KV Storage:Edit, D1:Edit, Containers:Edit, Account Settings:Read.
 3. **A Google OAuth client** (type: Web application) with the redirect URI
-   `https://hwp-mcp.<account>.workers.dev/callback`. Keep the client id and secret.
+   `https://hwp-mcp.young-joon-lee.workers.dev/callback`. Keep the client id and secret.
 4. **A $10/month billing notification** (Dashboard → Notifications). The budget cap
    for this service is $10/month; see *Cost* below.
 
@@ -49,16 +49,26 @@ CLOUDFLARE_ACCOUNT_ID=...
 EOF
 ```
 
+## Already provisioned
+
+Account `entelecheia` (`b378caab1c7aea09cb77db791fe5f3f8`), workers.dev subdomain
+`young-joon-lee`, so the service URL is
+`https://hwp-mcp.young-joon-lee.workers.dev`.
+
+These exist and their ids are already in `wrangler.jsonc` — do not recreate them:
+
+| Resource | Id |
+|---|---|
+| KV namespace `OAUTH_KV` | `6e717629e44a48b4afc8e2b52684cfe9` |
+| D1 database `hwp-mcp` | `b8a7e5b9-7c14-4354-91a6-52e5c36d45c8` |
+
+`schema.sql` is applied to the remote database; `users`, `pats` and `audit` are live.
+
 ## First deploy
 
 ```bash
 set -a && . ~/.config/hwp-mcp-deploy.env && set +a
 npm ci
-
-# Create the stores, then paste the printed ids into wrangler.jsonc.
-npx wrangler kv namespace create OAUTH_KV
-npx wrangler d1 create hwp-mcp
-npx wrangler d1 execute hwp-mcp --remote --file schema.sql
 
 # Secrets (never in wrangler.jsonc).
 npx wrangler secret put GOOGLE_CLIENT_ID
@@ -76,12 +86,12 @@ image. The Worker URL may answer before container routes do.
 ```bash
 # 1. Protocol, from a machine with a browser.
 npx @modelcontextprotocol/inspector
-#    Transport: Streamable HTTP → https://hwp-mcp.<account>.workers.dev/mcp
+#    Transport: Streamable HTTP → https://hwp-mcp.young-joon-lee.workers.dev/mcp
 #    Expect: dynamic registration → Google sign-in → initialize returns
 #    Mcp-Session-Id → tools/list shows exactly 20 tools.
 
 # 2. A real client.
-claude mcp add --transport http hwp https://hwp-mcp.<account>.workers.dev/mcp
+claude mcp add --transport http hwp https://hwp-mcp.young-joon-lee.workers.dev/mcp
 ```
 
 Then check the negatives, which are the parts worth distrusting:

--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -1,0 +1,135 @@
+# hwp MCP on Cloudflare
+
+The Cloudflare tier of [docs/design/22-remote-mcp-deployment.md](../../docs/design/22-remote-mcp-deployment.md):
+a public MCP service where anyone signs in with a Google account and drives the
+20 hwp tools from any MCP client.
+
+A Worker is the public edge — it is this service's OAuth **authorization server**,
+not merely a resource server, so clients register themselves and no administrator
+provisions anything. Each session gets its own container instance running
+`hwp serve --root /work`, and the workspace dies with it.
+
+```
+MCP client ──HTTPS──► Worker ──► Durable Object (one per session) ──► container: hwp serve
+                      OAuth + Google, PAT auth, limits, audit          --root /work, no egress
+```
+
+## Owner prerequisites
+
+These four cannot be done by an agent. Everything else in this directory is ready
+to deploy once they exist.
+
+1. **Workers Paid** ($5/month) on the Cloudflare account. Containers require it.
+2. **A Cloudflare API token** for the deploy host, with: Workers Scripts:Edit,
+   Workers KV Storage:Edit, D1:Edit, Containers:Edit, Account Settings:Read.
+3. **A Google OAuth client** (type: Web application) with the redirect URI
+   `https://hwp-mcp.<account>.workers.dev/callback`. Keep the client id and secret.
+4. **A $10/month billing notification** (Dashboard → Notifications). The budget cap
+   for this service is $10/month; see *Cost* below.
+
+## Where to deploy from
+
+`wrangler deploy` builds the container image locally, so the deploy host needs a
+running Docker engine and an amd64 target. Use the Ubuntu build host rather than a
+Mac without Docker:
+
+```bash
+ssh yjlee@172.16.229.33
+# one-time: install Node 22+ (fnm or the distribution package), clone the repo
+cd ~/hwp-cli/deploy/cloudflare
+```
+
+Store credentials once, readable only by you:
+
+```bash
+install -m 600 /dev/null ~/.config/hwp-mcp-deploy.env
+cat > ~/.config/hwp-mcp-deploy.env <<'EOF'
+CLOUDFLARE_API_TOKEN=...
+CLOUDFLARE_ACCOUNT_ID=...
+EOF
+```
+
+## First deploy
+
+```bash
+set -a && . ~/.config/hwp-mcp-deploy.env && set +a
+npm ci
+
+# Create the stores, then paste the printed ids into wrangler.jsonc.
+npx wrangler kv namespace create OAUTH_KV
+npx wrangler d1 create hwp-mcp
+npx wrangler d1 execute hwp-mcp --remote --file schema.sql
+
+# Secrets (never in wrangler.jsonc).
+npx wrangler secret put GOOGLE_CLIENT_ID
+npx wrangler secret put GOOGLE_CLIENT_SECRET
+openssl rand -hex 32 | npx wrangler secret put COOKIE_ENCRYPTION_KEY
+
+npx wrangler deploy
+```
+
+The first deploy takes several minutes: it compiles the Rust workspace inside the
+image. The Worker URL may answer before container routes do.
+
+## Verifying
+
+```bash
+# 1. Protocol, from a machine with a browser.
+npx @modelcontextprotocol/inspector
+#    Transport: Streamable HTTP → https://hwp-mcp.<account>.workers.dev/mcp
+#    Expect: dynamic registration → Google sign-in → initialize returns
+#    Mcp-Session-Id → tools/list shows exactly 20 tools.
+
+# 2. A real client.
+claude mcp add --transport http hwp https://hwp-mcp.<account>.workers.dev/mcp
+```
+
+Then check the negatives, which are the parts worth distrusting:
+
+| Check | Expect |
+|---|---|
+| A second account's token plus the first account's `Mcp-Session-Id` | `404`, revealing nothing |
+| A body over 1 MiB on `POST /mcp` | `413` before any parsing |
+| `GET /mcp` | `405` with `Allow` — both clients above must tolerate it |
+| `DELETE /mcp`, then any call on that session | `204`, then `404` |
+| A tool argument pointing outside the workspace | refused, same message the stdio server gives |
+
+After testing, confirm the container count returns to zero in the dashboard.
+
+## Cost
+
+Workers Paid is $5/month and includes 25 GiB-hours of container memory, 375 vCPU
+minutes and 200 GB-hours of disk. The `basic` instance type is 1 GiB, so roughly
+25 hours of *active* container time per month are included; beyond that it is
+about $0.009 per hour. Containers scale to zero, so idle sessions cost nothing.
+
+Three guards keep this inside the $10 cap: `sleepAfter` is 10 minutes,
+`max_instances` is 5, and the billing notification above fires at $10.
+
+## Layout
+
+| Path | Purpose |
+|---|---|
+| `src/index.ts` | Entry point: PAT branch, then the OAuth provider; exports the session Durable Object |
+| `src/mcp-api.ts` | The authenticated `/mcp` and `/files/{name}` surface; mints and routes sessions |
+| `src/session.ts` | `HwpSession` — one container per session, deadlines, idle and lifetime expiry |
+| `src/google-handler.ts` | Consent screen, Google round trip, and the callback where first login becomes signup |
+| `src/pat.ts` | Personal access tokens for header-configured clients |
+| `src/users.ts` | The user upsert keyed on the Google `sub` claim |
+| `src/audit.ts` | Metadata-only audit writes |
+| `src/limits.ts` | Every limit in one place, mirroring doc 20 §7 |
+| `container/Dockerfile` | Builds `hwp` and runs `hwp serve` |
+| `schema.sql` | D1 tables |
+
+## Known scope
+
+This tier uses the **session workspace** model, not the artifact model of
+[doc 20 §3.2](../../docs/design/20-remote-mcp.md). Files live in one container's
+private workspace and are destroyed with it, so a client that loses its session
+re-uploads. The amendment is recorded in doc 22 §7; the artifact model stays
+required and unimplemented.
+
+Also deliberately absent for now: SSE and resumable streams, per-request
+cancellation (a blown deadline ends the session), more than one concurrent job per
+session, scopes finer than `mcp:tools`, a strict origin allowlist, and the
+independent security review doc 20 §9 item 5 requires before general availability.

--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -31,9 +31,10 @@ Two things about the Google side are worth knowing before anyone else tries to s
   `hello@jeju.ai` is listed; `yj.lee@chu.ac.kr` was rejected because it is not a Google account.
   Add more under Google Auth Platform → Audience → Test users, or publish the app (which then
   needs verification).
-- The consent screen is shared per Google Cloud project, so it currently shows the project's
-  existing app name, **Obsidian**, not "hwp MCP". Changing it would rename the consent screen for
-  the other client in that project; a dedicated project is the clean fix if the branding matters.
+- The consent screen is shared per Google Cloud project. Its app name is **STAIx**, which is what
+  people see when they sign in. Renaming it there renames it for every OAuth client in the
+  `chu-rise` project, so a dedicated project is the clean fix if this service ever needs its own
+  branding.
 
 ## Where to deploy from
 

--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -96,6 +96,26 @@ Then check the negatives, which are the parts worth distrusting:
 
 After testing, confirm the container count returns to zero in the dashboard.
 
+## What is already verified
+
+The container half was built and exercised on an amd64 host before any Cloudflare
+account existed, so the only untested part of this directory is the Worker running
+against real Cloudflare services.
+
+| Checked | Result |
+|---|---|
+| `docker build` from the repo root | 134 MB image; the Rust release build takes well under a minute on a large host |
+| `hwp serve` startup | binds and prints `hwp serve: listening on http://0.0.0.0:8080` |
+| `GET /healthz`, `POST /mcp` initialize, `tools/list` | 200, correct handshake, exactly 20 tools |
+| `GET /mcp` | 405 |
+| `/files` upload, download, and a rejected `.hidden` name | 200, byte-identical, 400 |
+| `hwp_new` into `/work`, then `GET /files/made.hwpx` | created and downloadable |
+| A tool writing outside `/work` | refused, same message the stdio server gives |
+| Process identity and fonts | runs as `hwp` (uid 10001); fonts-nanum present |
+
+`wrangler deploy --dry-run` bundles the Worker (about 52 KiB gzipped) and resolves
+all four bindings plus the container.
+
 ## Cost
 
 Workers Paid is $5/month and includes 25 GiB-hours of container memory, 375 vCPU

--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -22,7 +22,7 @@ All four are satisfied; nothing here needs repeating for a first deploy.
 |---|---|
 | Workers Paid | Active. `wrangler containers list` succeeds, which is the authoritative test |
 | API token `hwp-mcp deploy` | Created, scoped to the `entelecheia` account with Workers Scripts, Workers KV Storage, D1 and Containers all at Edit. Verified against `/user/tokens/verify` and stored on the deploy host at `~/.config/hwp-mcp-deploy.env` (mode 600) |
-| Google OAuth client `hwp MCP` | Web application in project `chu-rise`, redirect URI `https://hwp-mcp.young-joon-lee.workers.dev/callback`. Its id and secret are Worker secrets already |
+| Google OAuth client `hwp MCP` | Web application in project `chu-rise`, redirect URI `https://hwp-mcp.staix.workers.dev/callback`. Its id and secret are Worker secrets already |
 | Budget notification | Cloudflare's auto-created budget alert is already exactly $10 USD to yj.lee@me.com |
 
 Two things about the Google side are worth knowing before anyone else tries to sign in:
@@ -60,8 +60,8 @@ EOF
 ## Already provisioned
 
 Account `entelecheia` (`b378caab1c7aea09cb77db791fe5f3f8`), workers.dev subdomain
-`young-joon-lee`, so the service URL is
-`https://hwp-mcp.young-joon-lee.workers.dev`.
+`staix`, so the service URL is
+`https://hwp-mcp.staix.workers.dev`.
 
 These exist and their ids are already in `wrangler.jsonc` — do not recreate them:
 
@@ -100,12 +100,12 @@ image. The Worker URL may answer before container routes do.
 ```bash
 # 1. Protocol, from a machine with a browser.
 npx @modelcontextprotocol/inspector
-#    Transport: Streamable HTTP → https://hwp-mcp.young-joon-lee.workers.dev/mcp
+#    Transport: Streamable HTTP → https://hwp-mcp.staix.workers.dev/mcp
 #    Expect: dynamic registration → Google sign-in → initialize returns
 #    Mcp-Session-Id → tools/list shows exactly 20 tools.
 
 # 2. A real client.
-claude mcp add --transport http hwp https://hwp-mcp.young-joon-lee.workers.dev/mcp
+claude mcp add --transport http hwp https://hwp-mcp.staix.workers.dev/mcp
 ```
 
 Then check the negatives, which are the parts worth distrusting:

--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -14,18 +14,26 @@ MCP client ──HTTPS──► Worker ──► Durable Object (one per session
                       OAuth + Google, PAT auth, limits, audit          --root /work, no egress
 ```
 
-## Owner prerequisites
+## Owner prerequisites — done
 
-These four cannot be done by an agent. Everything else in this directory is ready
-to deploy once they exist.
+All four are satisfied; nothing here needs repeating for a first deploy.
 
-1. **Workers Paid** ($5/month) on the Cloudflare account. Containers require it.
-2. **A Cloudflare API token** for the deploy host, with: Workers Scripts:Edit,
-   Workers KV Storage:Edit, D1:Edit, Containers:Edit, Account Settings:Read.
-3. **A Google OAuth client** (type: Web application) with the redirect URI
-   `https://hwp-mcp.young-joon-lee.workers.dev/callback`. Keep the client id and secret.
-4. **A $10/month billing notification** (Dashboard → Notifications). The budget cap
-   for this service is $10/month; see *Cost* below.
+| Item | State |
+|---|---|
+| Workers Paid | Active. `wrangler containers list` succeeds, which is the authoritative test |
+| API token `hwp-mcp deploy` | Created, scoped to the `entelecheia` account with Workers Scripts, Workers KV Storage, D1 and Containers all at Edit. Verified against `/user/tokens/verify` and stored on the deploy host at `~/.config/hwp-mcp-deploy.env` (mode 600) |
+| Google OAuth client `hwp MCP` | Web application in project `chu-rise`, redirect URI `https://hwp-mcp.young-joon-lee.workers.dev/callback`. Its id and secret are Worker secrets already |
+| Budget notification | Cloudflare's auto-created budget alert is already exactly $10 USD to yj.lee@me.com |
+
+Two things about the Google side are worth knowing before anyone else tries to sign in:
+
+- The app's publishing status is **Testing**, so only listed test users can complete the flow.
+  `hello@jeju.ai` is listed; `yj.lee@chu.ac.kr` was rejected because it is not a Google account.
+  Add more under Google Auth Platform → Audience → Test users, or publish the app (which then
+  needs verification).
+- The consent screen is shared per Google Cloud project, so it currently shows the project's
+  existing app name, **Obsidian**, not "hwp MCP". Changing it would rename the consent screen for
+  the other client in that project; a dedicated project is the clean fix if the branding matters.
 
 ## Where to deploy from
 
@@ -66,16 +74,22 @@ These exist and their ids are already in `wrangler.jsonc` — do not recreate th
 
 ## First deploy
 
+All three Worker secrets (`GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `COOKIE_ENCRYPTION_KEY`)
+are already set, so a first deploy is just:
+
 ```bash
+ssh yjlee@172.16.229.33
+cd ~/hwp-cli/deploy/cloudflare        # clone the repo here if it is not present
 set -a && . ~/.config/hwp-mcp-deploy.env && set +a
 npm ci
-
-# Secrets (never in wrangler.jsonc).
-npx wrangler secret put GOOGLE_CLIENT_ID
-npx wrangler secret put GOOGLE_CLIENT_SECRET
-openssl rand -hex 32 | npx wrangler secret put COOKIE_ENCRYPTION_KEY
-
 npx wrangler deploy
+```
+
+The first deploy takes several minutes: it compiles the Rust workspace inside the container image.
+Rebuilding a secret is only needed if one is rotated:
+
+```bash
+openssl rand -hex 32 | npx wrangler secret put COOKIE_ENCRYPTION_KEY
 ```
 
 The first deploy takes several minutes: it compiles the Rust workspace inside the

--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -120,6 +120,47 @@ Then check the negatives, which are the parts worth distrusting:
 
 After testing, confirm the container count returns to zero in the dashboard.
 
+## Deployed and verified
+
+Live at `https://hwp-mcp.staix.workers.dev`. The whole path was exercised against
+the real service: dynamic client registration, the consent screen, Google
+sign-in, an access token this Worker issued (never a Google one), `initialize`
+starting a container, `tools/list` returning all 20 tools, `hwp_new` writing into
+the workspace, and the document coming back through `/files`.
+
+Negative cases, all confirmed on the deployed service:
+
+| Case | Result |
+|---|---|
+| No credentials, or an unknown personal access token | `401` with a `WWW-Authenticate` challenge |
+| A session id this service never minted, on `/mcp` and on `/files` | `404`, revealing nothing |
+| `GET /mcp` | `405` — no server-push stream is offered |
+| Body over 1 MiB | `413` before parsing |
+| File name outside the allowed charset | `400` |
+| Tool writing outside the workspace | refused, same message the stdio server gives |
+| `DELETE`, then reuse of that session | `204`, then `404` |
+
+Five consecutive full round trips pass with no flakiness.
+
+### Three defects this verification caught
+
+Worth recording, because each one only appeared against the deployed service:
+
+1. **An invented session id was accepted.** The guard asked "is this session
+   dead?", but a never-initialized Durable Object has no dead flag either, so a
+   made-up id started a fresh container. Cross-user isolation was never at risk —
+   the object name derives from the authenticated principal — but one caller
+   could have spun up containers without limit. `isUsable()` now also requires
+   the marker `initialize` writes.
+2. **Request bodies cannot be streamed across the Durable Object RPC boundary.**
+   `wrangler tail` showed `ReadableStream received over RPC disconnected
+   prematurely`, which made uploads fail intermittently. `/files` now buffers
+   both directions, capped at 32 MiB on the Worker side.
+3. **Overriding `alarm()` hijacked the Container base class.** That class runs its
+   own alarm for sleep and activity bookkeeping; intercepting it ran the
+   8-hour-cap teardown seconds after a session started. Maximum lifetime is
+   checked on the request path now, and nothing competes with the base class.
+
 ## What is already verified
 
 The container half was built and exercised on an amd64 host before any Cloudflare

--- a/deploy/cloudflare/container/Dockerfile
+++ b/deploy/cloudflare/container/Dockerfile
@@ -1,0 +1,38 @@
+# hwp MCP session container.
+#
+# Runs `hwp serve` — the HTTP adapter over the same protocol core the stdio
+# server uses (docs/design/22-remote-mcp-deployment.md §3.2). There is no shell,
+# no bridge and no second process: the Worker is the only thing that can reach
+# this port, and `--root` confines every file the tools touch.
+#
+# Built from repository source because `hwp serve` is newer than the latest
+# release. Once a release carries it, replace the build stage with a
+# checksum-verified release tarball on the slim base — that cuts the image and
+# the cold start considerably. See ../README.md.
+
+FROM rust:1.93-bookworm AS build
+WORKDIR /src
+COPY . .
+RUN cargo build --release -p hwp-cli --bin hwp
+
+FROM debian:bookworm-slim
+# Rendering and PDF output need real font files; fonts-nanum matches the font
+# baseline CI already uses (glyf outlines, fast in debug builds).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends fonts-nanum \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /src/target/release/hwp /usr/local/bin/hwp
+
+RUN useradd --create-home --uid 10001 hwp \
+ && mkdir -p /work \
+ && chown hwp:hwp /work
+USER hwp
+WORKDIR /work
+
+EXPOSE 8080
+CMD ["hwp", "serve", \
+     "--addr", "0.0.0.0:8080", \
+     "--root", "/work", \
+     "--files", \
+     "--font-dir", "/usr/share/fonts/truetype/nanum"]

--- a/deploy/cloudflare/package-lock.json
+++ b/deploy/cloudflare/package-lock.json
@@ -1,0 +1,1626 @@
+{
+  "name": "hwp-mcp",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hwp-mcp",
+      "version": "0.0.0",
+      "dependencies": {
+        "@cloudflare/containers": "^0.3.7",
+        "@cloudflare/workers-oauth-provider": "^0.10.3"
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "^5.20260829.1",
+        "typescript": "^5.9.0",
+        "wrangler": "^4.127.1"
+      }
+    },
+    "node_modules/@cloudflare/containers": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@cloudflare/containers/-/containers-0.3.7.tgz",
+      "integrity": "sha512-DM9dm3FnIBSyiSJ1FLavKwl/lk3oAmTaynCzZQ9pZR0ncRPquSxkxd8Nu2MFILxmDDsPkxKsSNEh9mHHMty4Fw==",
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cloudflare/kv-asset-handler": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+      "integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@cloudflare/unenv-preset": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "peerDependencies": {
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "workerd": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260828.1.tgz",
+      "integrity": "sha512-CVd+xPhqUESg8Xhq09TZx0wl4FSirfJGOzvbPz2yHhBIvmNHFFQkSN3rkd7wEwnhQQk37Xi0/aD6ykPLJbmGiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-darwin-arm64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260828.1.tgz",
+      "integrity": "sha512-5HDPXRM152vU5JveByGFk34X57TVyIsfp4cabepAf45DC0MKvm52ucJqAjW1h8bvW4X+zRw9GU35OHF9FEC9Ww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260828.1.tgz",
+      "integrity": "sha512-MQ1Ll9P7F72HHUKizbb7BlDfbY8fRoNMpbIpZoU6uKsSkneFICWSKv6UlgU9EQZ+w0i7TMa12iUgJ8l29eRI9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-linux-arm64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260828.1.tgz",
+      "integrity": "sha512-FBTaUQ1xcU9jcp4OyBPcH8x0QiFvc1iuZL2GkD8zp2q1WyTVHYOptRDQUU+cuHjt0rQ2EIKVPBjahPxfa0joBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workerd-windows-64": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260828.1.tgz",
+      "integrity": "sha512-yvr77hC7dUbvK5K+SCg062kkPq3sx+drV1PcgHslzHDYcJBtT0V3X80qLE49LW1vq2svaeNmsVQS+vHsqWu8cQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@cloudflare/workers-oauth-provider": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-oauth-provider/-/workers-oauth-provider-0.10.3.tgz",
+      "integrity": "sha512-25ufMONJir9PllqVpK4GwOOoSFgpYm3+bM6NBedj7ufMCIfNf5jk4OI0LPuTJBaJgLl2lGCLqFqEPJXcSuPopQ==",
+      "license": "MIT"
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "5.20260829.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260829.1.tgz",
+      "integrity": "sha512-SsH4G9+JePvrBmz+b5Dl67LQ9w2/ycoIpAPcAkfg2aEs2SEisQHk7/AY0TymSXEBbDbWgcBqoLe4hNcuY3CxWA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.2.tgz",
+      "integrity": "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.2.tgz",
+      "integrity": "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.2.tgz",
+      "integrity": "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.1.tgz",
+      "integrity": "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.1.tgz",
+      "integrity": "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.1.tgz",
+      "integrity": "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.1.tgz",
+      "integrity": "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.1.tgz",
+      "integrity": "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.1.tgz",
+      "integrity": "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.1.tgz",
+      "integrity": "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.1.tgz",
+      "integrity": "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.1.tgz",
+      "integrity": "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.1.tgz",
+      "integrity": "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.2.tgz",
+      "integrity": "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.2.tgz",
+      "integrity": "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.2.tgz",
+      "integrity": "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.2.tgz",
+      "integrity": "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.2.tgz",
+      "integrity": "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.2.tgz",
+      "integrity": "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.2.tgz",
+      "integrity": "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.2.tgz",
+      "integrity": "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.2.tgz",
+      "integrity": "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==",
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.2.tgz",
+      "integrity": "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.2.tgz",
+      "integrity": "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.2.tgz",
+      "integrity": "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.2.tgz",
+      "integrity": "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.6.0.tgz",
+      "integrity": "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "kleur": "^4.1.5"
+      }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.24",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.24.tgz",
+      "integrity": "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/blake3-wasm": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
+      "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/miniflare": {
+      "version": "5.20260828.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260828.0-alpha.tgz",
+      "integrity": "sha512-6nbxhZEcz/UET3Y1OnYPsrAUjUmuFoib3ynUqteRdn1YnDxsLg8cwgZJZCk9QmtOmGzXwzXzgE/d/C0dJAPtVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "0.8.1",
+        "sharp": "0.35.2",
+        "undici": "7.29.0",
+        "workerd": "1.20260828.1",
+        "ws": "8.21.0",
+        "youch": "4.1.0-beta.10"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.2.tgz",
+      "integrity": "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.2",
+        "@img/sharp-darwin-x64": "0.35.2",
+        "@img/sharp-freebsd-wasm32": "0.35.2",
+        "@img/sharp-libvips-darwin-arm64": "1.3.1",
+        "@img/sharp-libvips-darwin-x64": "1.3.1",
+        "@img/sharp-libvips-linux-arm": "1.3.1",
+        "@img/sharp-libvips-linux-arm64": "1.3.1",
+        "@img/sharp-libvips-linux-ppc64": "1.3.1",
+        "@img/sharp-libvips-linux-riscv64": "1.3.1",
+        "@img/sharp-libvips-linux-s390x": "1.3.1",
+        "@img/sharp-libvips-linux-x64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.1",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.1",
+        "@img/sharp-linux-arm": "0.35.2",
+        "@img/sharp-linux-arm64": "0.35.2",
+        "@img/sharp-linux-ppc64": "0.35.2",
+        "@img/sharp-linux-riscv64": "0.35.2",
+        "@img/sharp-linux-s390x": "0.35.2",
+        "@img/sharp-linux-x64": "0.35.2",
+        "@img/sharp-linuxmusl-arm64": "0.35.2",
+        "@img/sharp-linuxmusl-x64": "0.35.2",
+        "@img/sharp-webcontainers-wasm32": "0.35.2",
+        "@img/sharp-win32-arm64": "0.35.2",
+        "@img/sharp-win32-ia32": "0.35.2",
+        "@img/sharp-win32-x64": "0.35.2"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unenv": {
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/workerd": {
+      "version": "1.20260828.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260828.1.tgz",
+      "integrity": "sha512-pB9yvt0kkwZDAGZHmpY59r0o3hM0DzdW6BJERqwZOhunZ3ssOyDSgQxOQer2cSZW4YCFeOTIQYN1qwhK5wv/Cw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "workerd": "bin/workerd"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@cloudflare/workerd-darwin-64": "1.20260828.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260828.1",
+        "@cloudflare/workerd-linux-64": "1.20260828.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260828.1",
+        "@cloudflare/workerd-windows-64": "1.20260828.1"
+      }
+    },
+    "node_modules/wrangler": {
+      "version": "4.127.1",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.127.1.tgz",
+      "integrity": "sha512-OzsiNgaI8i681L/+KnAKc+uEZ5D57xK5JuNvCOpRKICF4/5Q3Cu1oTGuUiT/f3GDUqQb3gzXNT0tfOHGMEtknw==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@cloudflare/kv-asset-handler": "0.5.0",
+        "@cloudflare/unenv-preset": "2.16.1",
+        "blake3-wasm": "2.1.5",
+        "esbuild": "0.28.1",
+        "miniflare": "5.20260828.0-alpha",
+        "path-to-regexp": "6.3.0",
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260828.1"
+      },
+      "bin": {
+        "cf-wrangler": "bin/cf-wrangler.js",
+        "wrangler": "bin/wrangler.js",
+        "wrangler2": "bin/wrangler.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.3"
+      },
+      "peerDependencies": {
+        "@cloudflare/workers-types": "^5.20260828.1"
+      },
+      "peerDependenciesMeta": {
+        "@cloudflare/workers-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/youch": {
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
+      }
+    },
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
+      }
+    }
+  }
+}

--- a/deploy/cloudflare/package.json
+++ b/deploy/cloudflare/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "hwp-mcp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "types": "wrangler types"
+  },
+  "dependencies": {
+    "@cloudflare/containers": "^0.3.7",
+    "@cloudflare/workers-oauth-provider": "^0.10.3"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^5.20260829.1",
+    "typescript": "^5.9.0",
+    "wrangler": "^4.127.1"
+  }
+}

--- a/deploy/cloudflare/public/style.css
+++ b/deploy/cloudflare/public/style.css
@@ -1,0 +1,36 @@
+:root {
+  color-scheme: light dark;
+  --fg: #16181d;
+  --muted: #5b6270;
+  --bg: #fbfbfc;
+  --accent: #2f5fd0;
+}
+@media (prefers-color-scheme: dark) {
+  :root { --fg: #e8eaef; --muted: #a0a7b4; --bg: #14161a; --accent: #7ea2f0; }
+}
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font: 16px/1.6 ui-sans-serif, system-ui, -apple-system, "Apple SD Gothic Neo", sans-serif;
+}
+main { max-width: 34rem; margin: 0 auto; padding: 3rem 1.25rem; }
+h1 { font-size: 1.5rem; letter-spacing: -0.01em; margin: 0 0 1rem; }
+p { color: var(--muted); margin: 0 0 1rem; }
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.9em;
+  background: color-mix(in srgb, var(--fg) 8%, transparent);
+  padding: 0.1em 0.35em;
+  border-radius: 4px;
+}
+button {
+  font: inherit;
+  color: #fff;
+  background: var(--accent);
+  border: 0;
+  border-radius: 8px;
+  padding: 0.6rem 1.1rem;
+  cursor: pointer;
+}
+button:hover { filter: brightness(1.08); }

--- a/deploy/cloudflare/src/audit.ts
+++ b/deploy/cloudflare/src/audit.ts
@@ -1,0 +1,47 @@
+/**
+ * Audit records carry metadata only — no tool arguments, no paths, no document
+ * content, no tokens (docs/design/20-remote-mcp.md §7).
+ */
+
+export interface AuditEvent {
+  requestId: string | null;
+  userId: string | null;
+  /** Raw session id; hashed here so the id itself never reaches storage. */
+  sessionId: string | null;
+  tool: string | null;
+  outcome: 'ok' | 'tool_error' | 'rejected' | 'timeout';
+  durationMs: number | null;
+  bytesIn: number | null;
+  bytesOut: number | null;
+}
+
+export async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function writeAudit(db: D1Database, event: AuditEvent): Promise<void> {
+  const sessionRef = event.sessionId ? await sha256Hex(event.sessionId) : null;
+  try {
+    await db
+      .prepare(
+        `INSERT INTO audit (ts, request_id, user_id, session_ref, tool, outcome, duration_ms, bytes_in, bytes_out)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        Date.now(),
+        event.requestId,
+        event.userId,
+        sessionRef,
+        event.tool,
+        event.outcome,
+        event.durationMs,
+        event.bytesIn,
+        event.bytesOut,
+      )
+      .run();
+  } catch (error) {
+    // An audit write must never take down a tool call that already succeeded.
+    console.error('audit write failed', error instanceof Error ? error.message : String(error));
+  }
+}

--- a/deploy/cloudflare/src/cookies.ts
+++ b/deploy/cloudflare/src/cookies.ts
@@ -1,0 +1,49 @@
+/**
+ * HMAC-signed cookie values. Used for the "skip the consent screen next time"
+ * marker; it carries no authority of its own, so signing is enough and there is
+ * nothing to encrypt.
+ */
+
+async function key(secret: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify'],
+  );
+}
+
+function b64url(bytes: ArrayBuffer): string {
+  return btoa(String.fromCharCode(...new Uint8Array(bytes)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+export async function sign(secret: string, value: string): Promise<string> {
+  const mac = await crypto.subtle.sign('HMAC', await key(secret), new TextEncoder().encode(value));
+  return `${value}.${b64url(mac)}`;
+}
+
+export async function verify(secret: string, signed: string | null): Promise<string | null> {
+  if (!signed) return null;
+  const dot = signed.lastIndexOf('.');
+  if (dot <= 0) return null;
+  const value = signed.slice(0, dot);
+  return (await sign(secret, value)) === signed ? value : null;
+}
+
+export function readCookie(request: Request, name: string): string | null {
+  const header = request.headers.get('cookie');
+  if (!header) return null;
+  for (const part of header.split(';')) {
+    const [k, ...rest] = part.trim().split('=');
+    if (k === name) return rest.join('=');
+  }
+  return null;
+}
+
+export function setCookie(name: string, value: string, maxAgeSeconds: number): string {
+  return `${name}=${value}; HttpOnly; Secure; SameSite=Lax; Path=/; Max-Age=${maxAgeSeconds}`;
+}

--- a/deploy/cloudflare/src/google-handler.ts
+++ b/deploy/cloudflare/src/google-handler.ts
@@ -1,0 +1,180 @@
+import { readCookie, setCookie, sign, verify } from './cookies';
+import { MCP_SCOPE } from './limits';
+import { upsertUser, type GoogleIdentity } from './users';
+import type { Env, Principal } from './types';
+import type { AuthRequest } from '@cloudflare/workers-oauth-provider';
+
+/**
+ * The browser-facing half of the service: the consent screen, the round trip to
+ * Google, and the callback that turns a Google identity into one of our users.
+ *
+ * Google is only the upstream identity provider. The token an MCP client ends up
+ * holding is one this Worker issued, which is what the MCP 2025-06-18
+ * third-party authorization flow requires — a Google access token must never
+ * reach the client or the document tools.
+ */
+
+const APPROVED_COOKIE = 'hwp_approved';
+const APPROVAL_TTL_SECONDS = 60 * 60 * 24 * 90;
+const STATE_TTL_SECONDS = 600;
+
+const GOOGLE_AUTHORIZE = 'https://accounts.google.com/o/oauth2/v2/auth';
+const GOOGLE_TOKEN = 'https://oauth2.googleapis.com/token';
+
+function html(body: string, status = 200): Response {
+  return new Response(
+    `<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">` +
+      `<link rel="stylesheet" href="/style.css"><title>hwp MCP</title><main>${body}</main>`,
+    { status, headers: { 'content-type': 'text/html; charset=utf-8' } },
+  );
+}
+
+function escape(text: string): string {
+  return text.replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]!,
+  );
+}
+
+/** Decodes a JWT payload. Signature verification is Google's job: the id_token
+ *  arrives over TLS on our own back-channel token exchange, not from the client. */
+function decodeIdToken(idToken: string): GoogleIdentity | null {
+  const parts = idToken.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const json = atob(parts[1]!.replace(/-/g, '+').replace(/_/g, '/'));
+    const claims = JSON.parse(json) as { sub?: string; email?: string; name?: string };
+    if (!claims.sub || !claims.email) return null;
+    return { sub: claims.sub, email: claims.email, name: claims.name };
+  } catch {
+    return null;
+  }
+}
+
+function redirectToGoogle(env: Env, url: URL, state: string): Response {
+  const target = new URL(GOOGLE_AUTHORIZE);
+  target.searchParams.set('client_id', env.GOOGLE_CLIENT_ID);
+  target.searchParams.set('redirect_uri', `${url.origin}/callback`);
+  target.searchParams.set('response_type', 'code');
+  target.searchParams.set('scope', 'openid email profile');
+  target.searchParams.set('state', state);
+  target.searchParams.set('access_type', 'online');
+  if (env.HOSTED_DOMAIN) target.searchParams.set('hd', env.HOSTED_DOMAIN);
+  return Response.redirect(target.toString(), 302);
+}
+
+/** Stores the in-flight authorization request; the state parameter is its key. */
+async function stashAuthRequest(env: Env, authRequest: AuthRequest): Promise<string> {
+  const state = crypto.randomUUID();
+  await env.OAUTH_KV.put(`state:${state}`, JSON.stringify(authRequest), {
+    expirationTtl: STATE_TTL_SECONDS,
+  });
+  return state;
+}
+
+async function takeAuthRequest(env: Env, state: string | null): Promise<AuthRequest | null> {
+  if (!state) return null;
+  const stored = await env.OAUTH_KV.get(`state:${state}`);
+  if (!stored) return null;
+  await env.OAUTH_KV.delete(`state:${state}`);
+  return JSON.parse(stored) as AuthRequest;
+}
+
+export const googleHandler: ExportedHandler<Env> = {
+  async fetch(request, env, _ctx): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/authorize') return authorize(request, env, url);
+    if (url.pathname === '/callback') return callback(request, env, url);
+    if (url.pathname === '/') return home();
+    return env.ASSETS.fetch(request);
+  },
+};
+
+async function authorize(request: Request, env: Env, url: URL): Promise<Response> {
+  const authRequest = await env.OAUTH_PROVIDER.parseAuthRequest(request);
+  const client = await env.OAUTH_PROVIDER.lookupClient(authRequest.clientId);
+  const state = await stashAuthRequest(env, authRequest);
+
+  // A client the user already approved skips straight to Google.
+  const approved = await verify(env.COOKIE_ENCRYPTION_KEY, readCookie(request, APPROVED_COOKIE));
+  if (approved === authRequest.clientId || request.method === 'POST') {
+    const response = redirectToGoogle(env, url, state);
+    if (request.method === 'POST') {
+      const headers = new Headers(response.headers);
+      headers.append(
+        'Set-Cookie',
+        setCookie(
+          APPROVED_COOKIE,
+          await sign(env.COOKIE_ENCRYPTION_KEY, authRequest.clientId),
+          APPROVAL_TTL_SECONDS,
+        ),
+      );
+      return new Response(null, { status: 302, headers });
+    }
+    return response;
+  }
+
+  const name = escape(client?.clientName ?? authRequest.clientId);
+  return html(
+    `<h1>Authorize ${name}</h1>
+     <p><strong>${name}</strong> wants to use your hwp documents through this service.
+        It will be able to read, convert, render and edit files inside its own
+        temporary workspace.</p>
+     <p>Signing in with Google creates your account if you do not have one yet.</p>
+     <form method="post"><button type="submit">Continue with Google</button></form>`,
+  );
+}
+
+async function callback(request: Request, env: Env, url: URL): Promise<Response> {
+  const code = url.searchParams.get('code');
+  const authRequest = await takeAuthRequest(env, url.searchParams.get('state'));
+  if (!code || !authRequest) {
+    return html('<h1>Sign-in failed</h1><p>The request expired. Start again from your client.</p>', 400);
+  }
+
+  const exchange = await fetch(GOOGLE_TOKEN, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      code,
+      client_id: env.GOOGLE_CLIENT_ID,
+      client_secret: env.GOOGLE_CLIENT_SECRET,
+      redirect_uri: `${url.origin}/callback`,
+      grant_type: 'authorization_code',
+    }),
+  });
+  if (!exchange.ok) {
+    return html('<h1>Sign-in failed</h1><p>Google rejected the exchange.</p>', 502);
+  }
+
+  const tokens = (await exchange.json()) as { id_token?: string };
+  const identity = tokens.id_token ? decodeIdToken(tokens.id_token) : null;
+  if (!identity) {
+    return html('<h1>Sign-in failed</h1><p>Google returned no usable identity.</p>', 502);
+  }
+  if (env.HOSTED_DOMAIN && !identity.email.endsWith(`@${env.HOSTED_DOMAIN}`)) {
+    return html('<h1>Sign-in refused</h1><p>This service is restricted to one domain.</p>', 403);
+  }
+
+  // First login is signup.
+  const userId = await upsertUser(env, identity);
+  const props: Principal = { userId, email: identity.email, via: 'oauth' };
+
+  const { redirectTo } = await env.OAUTH_PROVIDER.completeAuthorization({
+    request: authRequest,
+    userId,
+    metadata: { email: identity.email },
+    scope: [MCP_SCOPE],
+    props,
+  });
+  return Response.redirect(redirectTo, 302);
+}
+
+function home(): Response {
+  return html(
+    `<h1>hwp MCP</h1>
+     <p>An MCP server for HWP and HWPX documents. Point an MCP client at
+        <code>/mcp</code> and sign in with Google when it asks.</p>`,
+  );
+}

--- a/deploy/cloudflare/src/index.ts
+++ b/deploy/cloudflare/src/index.ts
@@ -1,0 +1,37 @@
+import OAuthProvider from '@cloudflare/workers-oauth-provider';
+
+import { googleHandler } from './google-handler';
+import { mcpApiHandler } from './mcp-api';
+import { handlePat, isPat } from './pat';
+import type { Env } from './types';
+
+export { HwpSession } from './session';
+
+/**
+ * hwp MCP — the Cloudflare tier of docs/design/22-remote-mcp-deployment.md.
+ *
+ * The Worker is this service's OAuth authorization server, not just a resource
+ * server: it registers clients dynamically, runs the consent screen, and issues
+ * its own tokens, with Google as the upstream identity provider. That is what
+ * lets any MCP client connect without an administrator provisioning anything.
+ */
+const provider = new OAuthProvider<Env>({
+  apiRoute: ['/mcp', '/files/'],
+  apiHandler: mcpApiHandler,
+  defaultHandler: googleHandler,
+  authorizeEndpoint: '/authorize',
+  tokenEndpoint: '/token',
+  clientRegistrationEndpoint: '/register',
+  scopesSupported: ['mcp:tools'],
+});
+
+export default {
+  fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> | Response {
+    // Personal access tokens bypass the OAuth machinery and reach the same MCP
+    // handler with the same principal shape (see pat.ts).
+    if (isPat(request.headers.get('authorization'))) {
+      return handlePat(request, env, ctx);
+    }
+    return provider.fetch(request, env, ctx);
+  },
+} satisfies ExportedHandler<Env>;

--- a/deploy/cloudflare/src/limits.ts
+++ b/deploy/cloudflare/src/limits.ts
@@ -1,0 +1,36 @@
+/**
+ * Operational limits, mirroring docs/design/20-remote-mcp.md §7 and doc 22 §3.2.
+ *
+ * The body cap is one byte below the 1 MiB the container's `hwp serve` enforces,
+ * so a request this Worker accepts can never be the one the container rejects.
+ */
+
+export const MAX_BODY_BYTES = 1024 * 1024 - 1;
+
+/** Default tool deadline (doc 20 §7). */
+export const TOOL_DEADLINE_MS = 120_000;
+
+/** Deadline for rendering, conversion and certification (doc 20 §7). */
+export const SLOW_TOOL_DEADLINE_MS = 300_000;
+
+/** Tools that get the longer deadline. */
+export const SLOW_TOOLS = new Set(['hwp_render', 'hwp_convert', 'hwp_certify', 'hwp_diff']);
+
+/** Idle lifetime before the container is stopped and the session invalidated. */
+export const IDLE_SLEEP_AFTER = '10m';
+
+/** Maximum session lifetime; after this the client must reinitialize (doc 20 §7). */
+export const MAX_SESSION_MS = 8 * 60 * 60 * 1000;
+
+/**
+ * Workspace file names. The charset excludes `/` and a leading `.`, so a name
+ * that passes cannot traverse out of the workspace. Percent-escapes are not
+ * decoded anywhere in the chain; `hwp serve` applies the identical rule.
+ */
+export const FILE_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+
+/** Personal access token prefix. Recognised before the OAuth provider sees the request. */
+export const PAT_PREFIX = 'hwp_pat_';
+
+/** The single scope this service issues. */
+export const MCP_SCOPE = 'mcp:tools';

--- a/deploy/cloudflare/src/limits.ts
+++ b/deploy/cloudflare/src/limits.ts
@@ -16,6 +16,16 @@ export const SLOW_TOOL_DEADLINE_MS = 300_000;
 /** Tools that get the longer deadline. */
 export const SLOW_TOOLS = new Set(['hwp_render', 'hwp_convert', 'hwp_certify', 'hwp_diff']);
 
+/**
+ * Worker-side cap for one `/files` transfer.
+ *
+ * The container enforces 64 MiB, but the Worker has to hold the bytes in memory:
+ * a request body cannot be streamed across the Durable Object RPC boundary
+ * without the stream disconnecting mid-transfer, so both directions are
+ * buffered. 32 MiB keeps that comfortably inside a Worker's 128 MB budget.
+ */
+export const MAX_FILE_TRANSFER_BYTES = 32 * 1024 * 1024;
+
 /** Idle lifetime before the container is stopped and the session invalidated. */
 export const IDLE_SLEEP_AFTER = '10m';
 

--- a/deploy/cloudflare/src/mcp-api.ts
+++ b/deploy/cloudflare/src/mcp-api.ts
@@ -53,6 +53,19 @@ function describe(body: ArrayBuffer): { method: string | null; tool: string | nu
 }
 
 /** `fetch` is required (not optional) so this satisfies the provider's handler type. */
+/**
+ * DNS-rebinding defense (docs/design/20-remote-mcp.md §2.2).
+ *
+ * Absent Origin is allowed, and that is the documented policy rather than an
+ * oversight: MCP clients are not browsers and send no Origin. A *present* Origin
+ * must be this deployment's own, because nothing here is meant to be called from
+ * another site's page.
+ */
+function originAllowed(request: Request, url: URL): boolean {
+  const origin = request.headers.get('origin');
+  return origin === null || origin === url.origin;
+}
+
 export const mcpApiHandler = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const principal = principalOf(ctx);
@@ -63,6 +76,9 @@ export const mcpApiHandler = {
     }
 
     const url = new URL(request.url);
+    if (!originAllowed(request, url)) {
+      return new Response('origin not allowed', { status: 403 });
+    }
     if (url.pathname === '/mcp') return handleMcp(request, env, ctx, principal);
     if (url.pathname.startsWith('/files/')) return handleFiles(request, env, principal, url);
     return new Response('not found', { status: 404 });

--- a/deploy/cloudflare/src/mcp-api.ts
+++ b/deploy/cloudflare/src/mcp-api.ts
@@ -1,0 +1,196 @@
+import { writeAudit } from './audit';
+import { FILE_NAME_RE, MAX_BODY_BYTES } from './limits';
+import type { Env, Principal } from './types';
+
+/**
+ * The authenticated MCP surface.
+ *
+ * Everything before this point established *who* is calling. This module decides
+ * *which session* they may talk to and forwards the raw JSON-RPC body to the
+ * container running `hwp serve`. It never interprets the protocol itself: the
+ * Rust core owns initialize, tools/list and tools/call, so the two transports
+ * cannot drift apart.
+ */
+
+function principalOf(ctx: ExecutionContext): Principal | null {
+  const props = (ctx as ExecutionContext & { props?: Principal }).props;
+  return props && typeof props.userId === 'string' ? props : null;
+}
+
+/** A session id is opaque and server-minted; reject anything that is not ours. */
+const SESSION_ID_RE = /^[0-9a-f-]{36}$/;
+
+function sessionStub(env: Env, principal: Principal, sessionId: string) {
+  // The principal is part of the name, so another user presenting this session id
+  // addresses a different object that was never initialized — and gets a plain
+  // 404 that reveals nothing about who owns the id.
+  const id = env.HWP_SESSION.idFromName(`${principal.userId}:${sessionId}`);
+  return env.HWP_SESSION.get(id);
+}
+
+/** Reads the body once, refusing anything over the cap before parsing it. */
+async function readBody(request: Request): Promise<{ bytes: ArrayBuffer } | { tooLarge: true }> {
+  const declared = request.headers.get('content-length');
+  if (declared !== null && Number(declared) > MAX_BODY_BYTES) return { tooLarge: true };
+  const bytes = await request.arrayBuffer();
+  if (bytes.byteLength > MAX_BODY_BYTES) return { tooLarge: true };
+  return { bytes };
+}
+
+/** Extracts the JSON-RPC method and tool name without validating the document. */
+function describe(body: ArrayBuffer): { method: string | null; tool: string | null } {
+  try {
+    const parsed = JSON.parse(new TextDecoder().decode(body)) as {
+      method?: unknown;
+      params?: { name?: unknown };
+    };
+    const method = typeof parsed.method === 'string' ? parsed.method : null;
+    const tool = typeof parsed.params?.name === 'string' ? parsed.params.name : null;
+    return { method, tool };
+  } catch {
+    return { method: null, tool: null };
+  }
+}
+
+/** `fetch` is required (not optional) so this satisfies the provider's handler type. */
+export const mcpApiHandler = {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const principal = principalOf(ctx);
+    if (!principal) {
+      // Reaching here without props means the composition in index.ts is wrong,
+      // not that the caller did anything. Fail closed rather than guess.
+      return new Response('unauthenticated', { status: 401 });
+    }
+
+    const url = new URL(request.url);
+    if (url.pathname === '/mcp') return handleMcp(request, env, ctx, principal);
+    if (url.pathname.startsWith('/files/')) return handleFiles(request, env, principal, url);
+    return new Response('not found', { status: 404 });
+  },
+};
+
+async function handleMcp(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  principal: Principal,
+): Promise<Response> {
+  const headerSessionId = request.headers.get('mcp-session-id');
+  const requestId = request.headers.get('cf-ray');
+
+  if (request.method === 'DELETE') {
+    if (!headerSessionId || !SESSION_ID_RE.test(headerSessionId)) {
+      return new Response('session not found', { status: 404 });
+    }
+    await sessionStub(env, principal, headerSessionId).terminate();
+    return new Response(null, { status: 204 });
+  }
+
+  if (request.method !== 'POST') {
+    // No server-to-client stream is offered, which the transport spec permits.
+    return new Response(null, { status: 405, headers: { Allow: 'POST, DELETE' } });
+  }
+
+  const body = await readBody(request);
+  if ('tooLarge' in body) {
+    ctx.waitUntil(
+      writeAudit(env.DB, {
+        requestId,
+        userId: principal.userId,
+        sessionId: headerSessionId,
+        tool: null,
+        outcome: 'rejected',
+        durationMs: null,
+        bytesIn: null,
+        bytesOut: null,
+      }),
+    );
+    return new Response('request body too large', { status: 413 });
+  }
+
+  const { method, tool } = describe(body.bytes);
+
+  // `initialize` mints the session; every other call must present one.
+  let sessionId: string;
+  let minted = false;
+  if (method === 'initialize') {
+    sessionId = crypto.randomUUID();
+    minted = true;
+  } else {
+    if (!headerSessionId || !SESSION_ID_RE.test(headerSessionId)) {
+      return new Response('session not found', { status: 404 });
+    }
+    sessionId = headerSessionId;
+  }
+
+  const stub = sessionStub(env, principal, sessionId);
+  if (minted) {
+    await stub.begin();
+  } else if (await stub.isDead()) {
+    return new Response('session not found', { status: 404 });
+  }
+
+  const started = Date.now();
+  const forwarded = new Request('http://container/mcp', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: body.bytes,
+  });
+  const response = await stub.proxy(forwarded, tool);
+
+  const out = await response.arrayBuffer();
+  ctx.waitUntil(
+    writeAudit(env.DB, {
+      requestId,
+      userId: principal.userId,
+      sessionId,
+      tool: tool ?? method,
+      outcome: response.ok ? 'ok' : response.status === 504 ? 'timeout' : 'tool_error',
+      durationMs: Date.now() - started,
+      bytesIn: body.bytes.byteLength,
+      bytesOut: out.byteLength,
+    }),
+  );
+
+  const headers = new Headers(response.headers);
+  if (minted) headers.set('Mcp-Session-Id', sessionId);
+  return new Response(out.byteLength === 0 ? null : out, {
+    status: response.status,
+    headers,
+  });
+}
+
+/**
+ * Workspace file transfer. This is the session-workspace model of doc 22 §7, not
+ * the artifact model of doc 20 §3.2: the bytes live in the container's private
+ * workspace and die with it.
+ */
+async function handleFiles(
+  request: Request,
+  env: Env,
+  principal: Principal,
+  url: URL,
+): Promise<Response> {
+  const sessionId = request.headers.get('mcp-session-id');
+  if (!sessionId || !SESSION_ID_RE.test(sessionId)) {
+    return new Response('session not found', { status: 404 });
+  }
+  const name = url.pathname.slice('/files/'.length);
+  if (!FILE_NAME_RE.test(name)) {
+    return new Response('invalid file name', { status: 400 });
+  }
+  if (request.method !== 'GET' && request.method !== 'POST') {
+    return new Response(null, { status: 405, headers: { Allow: 'GET, POST' } });
+  }
+
+  const stub = sessionStub(env, principal, sessionId);
+  if (await stub.isDead()) {
+    return new Response('session not found', { status: 404 });
+  }
+
+  const forwarded = new Request(`http://container/files/${name}`, {
+    method: request.method,
+    body: request.method === 'POST' ? request.body : undefined,
+  });
+  return stub.proxy(forwarded, null);
+}

--- a/deploy/cloudflare/src/mcp-api.ts
+++ b/deploy/cloudflare/src/mcp-api.ts
@@ -142,7 +142,7 @@ async function handleMcp(
   const stub = sessionStub(env, principal, sessionId);
   if (minted) {
     await stub.begin();
-  } else if (await stub.isDead()) {
+  } else if (!(await stub.isUsable())) {
     return new Response('session not found', { status: 404 });
   }
 
@@ -200,7 +200,7 @@ async function handleFiles(
   }
 
   const stub = sessionStub(env, principal, sessionId);
-  if (await stub.isDead()) {
+  if (!(await stub.isUsable())) {
     return new Response('session not found', { status: 404 });
   }
 

--- a/deploy/cloudflare/src/mcp-api.ts
+++ b/deploy/cloudflare/src/mcp-api.ts
@@ -1,5 +1,5 @@
 import { writeAudit } from './audit';
-import { FILE_NAME_RE, MAX_BODY_BYTES } from './limits';
+import { FILE_NAME_RE, MAX_BODY_BYTES, MAX_FILE_TRANSFER_BYTES } from './limits';
 import type { Env, Principal } from './types';
 
 /**
@@ -204,9 +204,30 @@ async function handleFiles(
     return new Response('session not found', { status: 404 });
   }
 
+  // Both directions are buffered rather than streamed. A ReadableStream sent
+  // across the Durable Object RPC boundary disconnects partway through, which
+  // surfaced as an intermittently failing upload, so the bytes are materialized
+  // on this side and handed over whole.
+  let body: ArrayBuffer | undefined;
+  if (request.method === 'POST') {
+    const declared = request.headers.get('content-length');
+    if (declared !== null && Number(declared) > MAX_FILE_TRANSFER_BYTES) {
+      return new Response('file too large', { status: 413 });
+    }
+    body = await request.arrayBuffer();
+    if (body.byteLength > MAX_FILE_TRANSFER_BYTES) {
+      return new Response('file too large', { status: 413 });
+    }
+  }
+
   const forwarded = new Request(`http://container/files/${name}`, {
     method: request.method,
-    body: request.method === 'POST' ? request.body : undefined,
+    body,
   });
-  return stub.proxy(forwarded, null);
+  const response = await stub.proxy(forwarded, null);
+  const out = await response.arrayBuffer();
+  return new Response(out.byteLength === 0 ? null : out, {
+    status: response.status,
+    headers: response.headers,
+  });
 }

--- a/deploy/cloudflare/src/pat.ts
+++ b/deploy/cloudflare/src/pat.ts
@@ -1,0 +1,52 @@
+import { sha256Hex } from './audit';
+import { mcpApiHandler } from './mcp-api';
+import { PAT_PREFIX } from './limits';
+import type { Env, Principal } from './types';
+
+/**
+ * Personal access tokens, for MCP clients configured with a static
+ * `Authorization` header rather than an OAuth flow.
+ *
+ * This runs ahead of the OAuth provider and, on a hit, calls the same MCP handler
+ * with an equivalent `Principal`. There is therefore exactly one authorization
+ * path downstream: nothing in mcp-api.ts knows or cares which door was used.
+ */
+export function isPat(authorization: string | null): boolean {
+  return authorization?.startsWith(`Bearer ${PAT_PREFIX}`) === true;
+}
+
+export async function handlePat(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response> {
+  const token = request.headers.get('authorization')!.slice('Bearer '.length);
+  const row = await env.DB.prepare(
+    `SELECT pats.id AS pat_id, users.id AS user_id, users.email AS email
+       FROM pats JOIN users ON users.id = pats.user_id
+      WHERE pats.token_hash = ? AND pats.revoked_at IS NULL`,
+  )
+    .bind(await sha256Hex(token))
+    .first<{ pat_id: string; user_id: string; email: string }>();
+
+  if (!row) {
+    return new Response('invalid token', {
+      status: 401,
+      headers: { 'WWW-Authenticate': 'Bearer error="invalid_token"' },
+    });
+  }
+
+  ctx.waitUntil(
+    env.DB.prepare('UPDATE pats SET last_used_at = ? WHERE id = ?')
+      .bind(Date.now(), row.pat_id)
+      .run()
+      .then(() => undefined),
+  );
+
+  const principal: Principal = { userId: row.user_id, email: row.email, via: 'pat' };
+  const withProps = Object.assign(Object.create(Object.getPrototypeOf(ctx) as object), ctx, {
+    props: principal,
+  }) as ExecutionContext;
+
+  return mcpApiHandler.fetch(request, env, withProps);
+}

--- a/deploy/cloudflare/src/pat.ts
+++ b/deploy/cloudflare/src/pat.ts
@@ -43,10 +43,12 @@ export async function handlePat(
       .then(() => undefined),
   );
 
+  // Attach the principal the same way the OAuth provider does: by assigning to
+  // `ctx.props` on the live context. Cloning the context instead would leave
+  // `waitUntil` — which lives on the prototype — behind, and the audit writes in
+  // mcp-api.ts depend on it.
   const principal: Principal = { userId: row.user_id, email: row.email, via: 'pat' };
-  const withProps = Object.assign(Object.create(Object.getPrototypeOf(ctx) as object), ctx, {
-    props: principal,
-  }) as ExecutionContext;
+  (ctx as ExecutionContext & { props?: Principal }).props = principal;
 
-  return mcpApiHandler.fetch(request, env, withProps);
+  return mcpApiHandler.fetch(request, env, ctx);
 }

--- a/deploy/cloudflare/src/session.ts
+++ b/deploy/cloudflare/src/session.ts
@@ -58,15 +58,27 @@ export class HwpSession extends Container<Env> {
    */
   async isUsable(): Promise<boolean> {
     if (await this.isDead()) return false;
-    return (await this.ctx.storage.get<number>('started')) !== undefined;
+    const started = await this.ctx.storage.get<number>('started');
+    if (started === undefined) return false;
+    if (Date.now() - started > MAX_SESSION_MS) {
+      await this.terminate();
+      return false;
+    }
+    return true;
   }
 
-  /** Records the creation time and arms the maximum-lifetime alarm. */
+  /**
+   * Records the creation time.
+   *
+   * Deliberately does not schedule an alarm. The Container base class runs its
+   * own alarm for sleep and activity bookkeeping, so setting one here clobbers
+   * its schedule and overriding `alarm()` hijacks its callback — which is how an
+   * 8-hour cap ended up terminating sessions seconds after they started. Maximum
+   * lifetime is enforced on the request path instead, in `isUsable()`.
+   */
   async begin(): Promise<void> {
-    const started = await this.ctx.storage.get<number>('started');
-    if (started === undefined) {
+    if ((await this.ctx.storage.get<number>('started')) === undefined) {
       await this.ctx.storage.put('started', Date.now());
-      await this.ctx.storage.setAlarm(Date.now() + MAX_SESSION_MS);
     }
   }
 
@@ -108,19 +120,14 @@ export class HwpSession extends Container<Env> {
     }
   }
 
-  /** Idempotent: stops the container, kills the alarm, and marks the session dead. */
+  /** Idempotent: stops the container and marks the session dead. */
   async terminate(): Promise<void> {
     await this.markDead();
-    await this.ctx.storage.deleteAlarm();
     try {
       await this.destroy();
     } catch {
       // Already gone; the dead flag is what callers read.
     }
-  }
-
-  override async alarm(): Promise<void> {
-    await this.terminate();
   }
 
   override onStop(): void | Promise<void> {

--- a/deploy/cloudflare/src/session.ts
+++ b/deploy/cloudflare/src/session.ts
@@ -91,15 +91,20 @@ export class HwpSession extends Container<Env> {
     try {
       return await this.containerFetch(deadlined);
     } catch (error) {
-      // A blown deadline ends the session: the container may still be mid-write,
-      // and the only guarantee worth keeping is that nothing partial survives.
-      // ponytail: deadline kills the session; per-request cancellation when a
-      // real user hits this.
-      await this.terminate();
       const timedOut = error instanceof Error && error.name === 'TimeoutError';
-      return new Response(timedOut ? 'tool deadline exceeded' : 'container unavailable', {
-        status: timedOut ? 504 : 502,
-      });
+      if (timedOut) {
+        // A blown deadline ends the session: the container may still be mid-write,
+        // and the only guarantee worth keeping is that nothing partial survives.
+        // ponytail: deadline kills the session; per-request cancellation when a
+        // real user hits this.
+        await this.terminate();
+        return new Response('tool deadline exceeded', { status: 504 });
+      }
+      // Anything else is this one request's problem, not the session's. Killing
+      // the session here made a transient RPC hiccup look like an expired
+      // session on the *next* call, which is a confusing way to lose a workspace.
+      console.error('container fetch failed', error instanceof Error ? error.message : error);
+      return new Response('container unavailable', { status: 502 });
     }
   }
 

--- a/deploy/cloudflare/src/session.ts
+++ b/deploy/cloudflare/src/session.ts
@@ -47,6 +47,20 @@ export class HwpSession extends Container<Env> {
     return (await this.ctx.storage.get<boolean>('dead')) === true;
   }
 
+  /**
+   * True only for a session that `initialize` actually created and that is still
+   * alive.
+   *
+   * Asking "is it dead?" is not enough: a never-initialized object has no dead
+   * flag either, so a caller who invents a well-formed session id would sail
+   * through and start a fresh container. The id must correspond to a session
+   * this service minted.
+   */
+  async isUsable(): Promise<boolean> {
+    if (await this.isDead()) return false;
+    return (await this.ctx.storage.get<number>('started')) !== undefined;
+  }
+
   /** Records the creation time and arms the maximum-lifetime alarm. */
   async begin(): Promise<void> {
     const started = await this.ctx.storage.get<number>('started');

--- a/deploy/cloudflare/src/session.ts
+++ b/deploy/cloudflare/src/session.ts
@@ -1,0 +1,117 @@
+import { Container } from '@cloudflare/containers';
+
+import {
+  IDLE_SLEEP_AFTER,
+  MAX_SESSION_MS,
+  SLOW_TOOLS,
+  SLOW_TOOL_DEADLINE_MS,
+  TOOL_DEADLINE_MS,
+} from './limits';
+import type { Env } from './types';
+
+/**
+ * One MCP session, backed by one container instance holding one workspace.
+ *
+ * Isolation comes from the platform, not from code here: the object name is
+ * derived from the authenticated principal plus a server-minted session id, so
+ * presenting someone else's session id resolves to a different object that was
+ * never initialized. `hwp serve --root /work` confines file access inside the
+ * container on top of that.
+ *
+ * A session is single-use in the strong sense: once the container stops for any
+ * reason — idle, deadline, crash, eviction, explicit delete — the workspace is
+ * gone, so the session is marked dead and every later request gets a 404. The
+ * client reinitializes and re-uploads. This is a deliberate simplification over
+ * doc 20 §3.2's artifact model, recorded in doc 22 §7.
+ */
+export class HwpSession extends Container<Env> {
+  defaultPort = 8080;
+  sleepAfter = IDLE_SLEEP_AFTER;
+  /** Document workers get no network egress (doc 20 §6). */
+  enableInternet = false;
+  envVars = { HWP_LANG: 'en' };
+
+  /**
+   * Serializes forwarded requests. `hwp serve` handles one request at a time, so
+   * overlapping fetches would only queue inside the container; keeping the queue
+   * here makes the deadline apply per request rather than per pile-up.
+   */
+  private chain: Promise<unknown> = Promise.resolve();
+
+  /** Marks this session unusable. Called on every path that destroys the workspace. */
+  private async markDead(): Promise<void> {
+    await this.ctx.storage.put('dead', true);
+  }
+
+  async isDead(): Promise<boolean> {
+    return (await this.ctx.storage.get<boolean>('dead')) === true;
+  }
+
+  /** Records the creation time and arms the maximum-lifetime alarm. */
+  async begin(): Promise<void> {
+    const started = await this.ctx.storage.get<number>('started');
+    if (started === undefined) {
+      await this.ctx.storage.put('started', Date.now());
+      await this.ctx.storage.setAlarm(Date.now() + MAX_SESSION_MS);
+    }
+  }
+
+  /** Proxies one request to the container under the deadline for `tool`. */
+  async proxy(request: Request, tool: string | null): Promise<Response> {
+    if (await this.isDead()) {
+      return new Response('session not found', { status: 404 });
+    }
+    const deadline = tool && SLOW_TOOLS.has(tool) ? SLOW_TOOL_DEADLINE_MS : TOOL_DEADLINE_MS;
+
+    const run = this.chain.then(() => this.forward(request, deadline));
+    // Keep the chain alive even when this call rejects, or one failure would
+    // wedge every later request on the same session.
+    this.chain = run.catch(() => undefined);
+    return run;
+  }
+
+  private async forward(request: Request, deadlineMs: number): Promise<Response> {
+    // `containerFetch` takes no options object, so the deadline rides on the
+    // request itself.
+    const deadlined = new Request(request, { signal: AbortSignal.timeout(deadlineMs) });
+    try {
+      return await this.containerFetch(deadlined);
+    } catch (error) {
+      // A blown deadline ends the session: the container may still be mid-write,
+      // and the only guarantee worth keeping is that nothing partial survives.
+      // ponytail: deadline kills the session; per-request cancellation when a
+      // real user hits this.
+      await this.terminate();
+      const timedOut = error instanceof Error && error.name === 'TimeoutError';
+      return new Response(timedOut ? 'tool deadline exceeded' : 'container unavailable', {
+        status: timedOut ? 504 : 502,
+      });
+    }
+  }
+
+  /** Idempotent: stops the container, kills the alarm, and marks the session dead. */
+  async terminate(): Promise<void> {
+    await this.markDead();
+    await this.ctx.storage.deleteAlarm();
+    try {
+      await this.destroy();
+    } catch {
+      // Already gone; the dead flag is what callers read.
+    }
+  }
+
+  override async alarm(): Promise<void> {
+    await this.terminate();
+  }
+
+  override onStop(): void | Promise<void> {
+    // Idle sleep, crash and eviction all land here. The workspace died with the
+    // instance, so the session cannot be resumed.
+    return this.markDead();
+  }
+
+  override onError(error: unknown): unknown {
+    void this.markDead();
+    return error;
+  }
+}

--- a/deploy/cloudflare/src/types.ts
+++ b/deploy/cloudflare/src/types.ts
@@ -1,0 +1,30 @@
+import type { OAuthHelpers } from '@cloudflare/workers-oauth-provider';
+
+import type { HwpSession } from './session';
+
+export interface Env {
+  HWP_SESSION: DurableObjectNamespace<HwpSession>;
+  OAUTH_KV: KVNamespace;
+  DB: D1Database;
+  ASSETS: Fetcher;
+
+  GOOGLE_CLIENT_ID: string;
+  GOOGLE_CLIENT_SECRET: string;
+  COOKIE_ENCRYPTION_KEY: string;
+  /** Optional: restrict sign-in to one Google Workspace domain. */
+  HOSTED_DOMAIN?: string;
+
+  /** Injected by the OAuth provider on the API handler's env. */
+  OAUTH_PROVIDER: OAuthHelpers;
+}
+
+/**
+ * The authenticated caller. The OAuth flow puts this in `ctx.props`; the
+ * personal-access-token path synthesizes the identical shape, so everything
+ * downstream has exactly one notion of "who is calling".
+ */
+export interface Principal {
+  userId: string;
+  email: string;
+  via: 'oauth' | 'pat';
+}

--- a/deploy/cloudflare/src/users.ts
+++ b/deploy/cloudflare/src/users.ts
@@ -1,0 +1,36 @@
+import type { Env } from './types';
+
+export interface GoogleIdentity {
+  sub: string;
+  email: string;
+  name?: string;
+}
+
+/**
+ * Upserts the user keyed on the Google `sub` claim and returns our own user id.
+ *
+ * This is the whole of "signup": the first successful Google login creates the
+ * record, so there is no separate registration step to build or to explain.
+ */
+export async function upsertUser(env: Env, identity: GoogleIdentity): Promise<string> {
+  const now = Date.now();
+  const existing = await env.DB.prepare('SELECT id FROM users WHERE google_sub = ?')
+    .bind(identity.sub)
+    .first<{ id: string }>();
+
+  if (existing) {
+    await env.DB.prepare('UPDATE users SET email = ?, name = ?, last_login_at = ? WHERE id = ?')
+      .bind(identity.email, identity.name ?? null, now, existing.id)
+      .run();
+    return existing.id;
+  }
+
+  const id = crypto.randomUUID();
+  await env.DB.prepare(
+    `INSERT INTO users (id, google_sub, email, name, created_at, last_login_at)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(id, identity.sub, identity.email, identity.name ?? null, now, now)
+    .run();
+  return id;
+}

--- a/deploy/cloudflare/tsconfig.json
+++ b/deploy/cloudflare/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2022"],
+    "module": "es2022",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/deploy/cloudflare/wrangler.jsonc
+++ b/deploy/cloudflare/wrangler.jsonc
@@ -27,13 +27,13 @@
   "migrations": [{ "tag": "v1", "new_sqlite_classes": ["HwpSession"] }],
 
   // The OAuth provider library requires this exact binding name.
-  "kv_namespaces": [{ "binding": "OAUTH_KV", "id": "PLACEHOLDER_RUN_WRANGLER_KV_NAMESPACE_CREATE" }],
+  "kv_namespaces": [{ "binding": "OAUTH_KV", "id": "6e717629e44a48b4afc8e2b52684cfe9" }],
 
   "d1_databases": [
     {
       "binding": "DB",
       "database_name": "hwp-mcp",
-      "database_id": "PLACEHOLDER_RUN_WRANGLER_D1_CREATE"
+      "database_id": "b8a7e5b9-7c14-4354-91a6-52e5c36d45c8"
     }
   ],
 

--- a/deploy/cloudflare/wrangler.jsonc
+++ b/deploy/cloudflare/wrangler.jsonc
@@ -1,0 +1,43 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "hwp-mcp",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-08-01",
+  "compatibility_flags": ["nodejs_compat"],
+
+  // The container runs `hwp serve` from the repository root, so the build context
+  // is the repo, not this directory.
+  "containers": [
+    {
+      "class_name": "HwpSession",
+      "image": "./container/Dockerfile",
+      "image_build_context": "../..",
+      // 1/4 vCPU, 1 GiB, 4 GB disk. Rendering is the memory-hungry path; raise
+      // this if the diagnostic corpus ever OOMs.
+      "instance_type": "basic",
+      // Budget guard: the owner's cap is $10/month and Workers Paid includes
+      // 25 GiB-hours of container memory.
+      "max_instances": 5
+    }
+  ],
+
+  "durable_objects": {
+    "bindings": [{ "name": "HWP_SESSION", "class_name": "HwpSession" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["HwpSession"] }],
+
+  // The OAuth provider library requires this exact binding name.
+  "kv_namespaces": [{ "binding": "OAUTH_KV", "id": "PLACEHOLDER_RUN_WRANGLER_KV_NAMESPACE_CREATE" }],
+
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "hwp-mcp",
+      "database_id": "PLACEHOLDER_RUN_WRANGLER_D1_CREATE"
+    }
+  ],
+
+  "assets": { "directory": "./public", "binding": "ASSETS" },
+
+  "observability": { "enabled": true }
+}


### PR DESCRIPTION
## Summary

Task A1 of #189, implementing [doc 22 §5](https://github.com/STAIxBWLB/hwp-cli/blob/main/docs/design/22-remote-mcp-deployment.md).
Adds `deploy/cloudflare/`: a Worker that fronts one container per MCP session, so anyone can sign in
with a Google account and drive the 20 tools from any MCP client.

**Nothing is deployed by this PR** and no Rust code changes. The only file outside `deploy/` is a
root `.dockerignore`, explained below.

## What the Worker is

It is this service's OAuth **authorization server**, not merely a resource server. Clients register
themselves at `/register`, the consent screen hands off to Google, and the callback issues a token
this Worker minted — a Google access token never reaches the client or the document tools, which is
what the MCP 2025-06-18 third-party flow requires. First Google login creates the user row, so
signup is not a separate feature.

Each session maps to one Durable Object named from the authenticated principal plus a server-minted
session id. Presenting someone else's session id therefore addresses an object that was never
initialized and gets a plain 404 that reveals nothing. That object owns one container running
`hwp serve --root /work` with no network egress; the workspace dies with the instance, which is why
idle sleep, a blown deadline, a crash and an explicit `DELETE` all mark the session dead.

Personal access tokens are recognised before the OAuth provider and reach the same handler with the
same principal shape, so exactly one authorization path exists downstream.

## Verification

The container half is fully exercised — built and run on an amd64 host before any Cloudflare account
exists, so the Worker is the only untested piece:

| Checked | Result |
|---|---|
| `docker build` from the repo root | 134 MB image, Rust release build in 38s |
| `GET /healthz`, initialize, `tools/list` | 200, correct handshake, exactly 20 tools |
| `GET /mcp` | 405 |
| `/files` upload/download, `.hidden` rejected | 200 byte-identical, 400 |
| `hwp_new` into `/work` then download it | created, 5,966 bytes retrieved |
| Tool writing outside `/work` | refused with the same message stdio gives |
| Process identity, fonts | runs as uid 10001, fonts-nanum present |

`wrangler deploy --dry-run` bundles the Worker (52 KiB gzipped) and resolves all four bindings plus
the container. `tsc --noEmit` is clean.

## Why a root `.dockerignore`

The image builds from the repository root because it needs the whole Cargo workspace. Without an
ignore file the build context would upload `target/` at roughly 17 GB, plus fixtures and fonts. With
it the context is about 8 MB. It also keeps documents out of any image by construction.

## Review notes

Two corrections are in the second commit and are worth a look:

- The PAT path originally cloned the `ExecutionContext` to attach the principal. `waitUntil` lives on
  the prototype, so the clone would have carried a broken one and silently dropped every audit write
  on that path. It now assigns `ctx.props` exactly as the OAuth provider does.
- Origin is validated per doc 20 §2.2. Absent Origin stays allowed — that is the documented policy,
  since MCP clients are not browsers — while a present Origin must be this deployment's own.

## Not in this PR

The four owner prerequisites (Workers Paid, an API token, a Google OAuth client, a $10 billing
notification) are listed in the README runbook; deployment waits on them. The dashboard and PAT
issuance UI are task A2. This tier uses the session-workspace model, not doc 20 §3.2's artifact
model — the amendment is recorded in doc 22 §7 and the README's *Known scope*.