### PR TITLE
feat(deploy): dashboard for issuing personal access tokens (#189 A2)

### DIFF
--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -129,6 +129,12 @@ sign-in, an access token this Worker issued (never a Google one), `initialize`
 starting a container, `tools/list` returning all 20 tools, `hwp_new` writing into
 the workspace, and the document coming back through `/files`.
 
+Personal access tokens work too, for clients that carry a fixed header instead of
+running an OAuth flow: `/dashboard` signs in with Google, mints a token shown
+once, drives `initialize` and `tools/list` with nothing but an `Authorization`
+header, records `last_used_at`, and returns `401` on the very next call after the
+token is revoked.
+
 Negative cases, all confirmed on the deployed service:
 
 | Case | Result |
@@ -201,6 +207,7 @@ Three guards keep this inside the $10 cap: `sleepAfter` is 10 minutes,
 | `src/session.ts` | `HwpSession` — one container per session, deadlines, idle and lifetime expiry |
 | `src/google-handler.ts` | Consent screen, Google round trip, and the callback where first login becomes signup |
 | `src/pat.ts` | Personal access tokens for header-configured clients |
+| `src/dashboard.ts` | The token dashboard: Google sign-in, create, list, revoke |
 | `src/users.ts` | The user upsert keyed on the Google `sub` claim |
 | `src/audit.ts` | Metadata-only audit writes |
 | `src/limits.ts` | Every limit in one place, mirroring doc 20 §7 |

--- a/deploy/cloudflare/public/style.css
+++ b/deploy/cloudflare/public/style.css
@@ -34,3 +34,26 @@ button {
   cursor: pointer;
 }
 button:hover { filter: brightness(1.08); }
+
+/* Dashboard */
+main { max-width: 44rem; }
+table { width: 100%; border-collapse: collapse; margin-top: 1.5rem; font-size: 0.94rem; }
+th, td { text-align: left; padding: 0.55rem 0.6rem; border-bottom: 1px solid color-mix(in srgb, var(--fg) 12%, transparent); }
+th { color: var(--muted); font-weight: 600; }
+form { display: flex; gap: 0.5rem; align-items: center; margin: 1rem 0 0; }
+input[type="text"], input:not([type]) {
+  font: inherit; flex: 1; padding: 0.55rem 0.7rem; border-radius: 8px;
+  border: 1px solid color-mix(in srgb, var(--fg) 20%, transparent);
+  background: transparent; color: var(--fg);
+}
+td form { margin: 0; }
+td button { background: transparent; color: var(--muted); border: 1px solid color-mix(in srgb, var(--fg) 20%, transparent); padding: 0.3rem 0.6rem; font-size: 0.85rem; }
+td button:hover { color: #c0392b; border-color: #c0392b; filter: none; }
+.token {
+  margin: 1.5rem 0; padding: 1rem 1.1rem; border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--accent) 45%, transparent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+.token code { display: block; margin: 0.5rem 0; padding: 0.6rem 0.7rem; word-break: break-all; line-height: 1.5; }
+.token p { color: var(--fg); }
+.empty { margin-top: 1.5rem; color: var(--muted); }

--- a/deploy/cloudflare/src/dashboard.ts
+++ b/deploy/cloudflare/src/dashboard.ts
@@ -1,0 +1,183 @@
+import { sha256Hex } from './audit';
+import { readCookie, setCookie, sign, verify } from './cookies';
+import { PAT_PREFIX } from './limits';
+import type { Env } from './types';
+
+/**
+ * The dashboard: where a person signs in with Google and mints a personal access
+ * token for MCP clients that carry a static `Authorization` header instead of
+ * running an OAuth flow.
+ *
+ * Sign-in reuses the same Google round trip the OAuth path uses. The difference
+ * is only where it lands: `/callback` sees a `dash` state and sets a session
+ * cookie here rather than completing an authorization it was never given.
+ */
+
+export const SESSION_COOKIE = 'hwp_dash';
+const SESSION_TTL_SECONDS = 60 * 60 * 12;
+const CSRF_COOKIE = 'hwp_csrf';
+
+/** Full token shown once; only its SHA-256 is stored. */
+function mintToken(): string {
+  const raw = crypto.getRandomValues(new Uint8Array(32));
+  const b64 = btoa(String.fromCharCode(...raw))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+  return `${PAT_PREFIX}${b64}`;
+}
+
+export async function currentUser(request: Request, env: Env): Promise<string | null> {
+  return verify(env.COOKIE_ENCRYPTION_KEY, readCookie(request, SESSION_COOKIE));
+}
+
+export async function startSession(env: Env, userId: string): Promise<string> {
+  return setCookie(
+    SESSION_COOKIE,
+    await sign(env.COOKIE_ENCRYPTION_KEY, userId),
+    SESSION_TTL_SECONDS,
+  );
+}
+
+function escape(text: string): string {
+  return text.replace(
+    /[&<>"']/g,
+    (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]!,
+  );
+}
+
+function page(body: string, extraHeaders: Record<string, string> = {}): Response {
+  return new Response(
+    `<!doctype html><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">` +
+      `<link rel="stylesheet" href="/style.css"><title>hwp MCP tokens</title><main>${body}</main>`,
+    { headers: { 'content-type': 'text/html; charset=utf-8', ...extraHeaders } },
+  );
+}
+
+interface PatRow {
+  id: string;
+  label: string | null;
+  created_at: number;
+  last_used_at: number | null;
+}
+
+function when(ms: number | null): string {
+  return ms ? new Date(ms).toISOString().slice(0, 16).replace('T', ' ') : 'never';
+}
+
+async function render(env: Env, userId: string, csrf: string, fresh?: string): Promise<string> {
+  const { results } = await env.DB.prepare(
+    `SELECT id, label, created_at, last_used_at FROM pats
+      WHERE user_id = ? AND revoked_at IS NULL ORDER BY created_at DESC`,
+  )
+    .bind(userId)
+    .all<PatRow>();
+
+  const rows = (results ?? [])
+    .map(
+      (r) => `<tr>
+        <td>${escape(r.label ?? '(no label)')}</td>
+        <td>${when(r.created_at)}</td>
+        <td>${when(r.last_used_at)}</td>
+        <td><form method="post" action="/dashboard/revoke">
+          <input type="hidden" name="csrf" value="${csrf}">
+          <input type="hidden" name="id" value="${escape(r.id)}">
+          <button type="submit">Revoke</button>
+        </form></td>
+      </tr>`,
+    )
+    .join('');
+
+  // Shown once, on the response that created it. It is never stored in plaintext,
+  // so a reload cannot bring it back.
+  const banner = fresh
+    ? `<div class="token">
+         <p><strong>Copy this now.</strong> It is not shown again.</p>
+         <code>${escape(fresh)}</code>
+         <p>Point a client at it with:</p>
+         <code>claude mcp add --transport http hwp https://hwp-mcp.staix.workers.dev/mcp --header "Authorization: Bearer ${escape(fresh)}"</code>
+       </div>`
+    : '';
+
+  return `<h1>Access tokens</h1>
+    <p>Use a token when an MCP client needs a fixed <code>Authorization</code> header
+       instead of signing in through a browser. Everything else should just use the
+       OAuth flow at <code>/mcp</code>.</p>
+    ${banner}
+    <form method="post" action="/dashboard/create">
+      <input type="hidden" name="csrf" value="${csrf}">
+      <input name="label" placeholder="What is this token for?" maxlength="60">
+      <button type="submit">Create token</button>
+    </form>
+    ${
+      rows
+        ? `<table><thead><tr><th>Label</th><th>Created</th><th>Last used</th><th></th></tr></thead><tbody>${rows}</tbody></table>`
+        : '<p class="empty">No tokens yet.</p>'
+    }`;
+}
+
+/** Double-submit CSRF: the cookie must match the field on every state change. */
+async function csrfToken(request: Request, env: Env): Promise<{ value: string; header?: string }> {
+  const existing = await verify(env.COOKIE_ENCRYPTION_KEY, readCookie(request, CSRF_COOKIE));
+  if (existing) return { value: existing };
+  const value = crypto.randomUUID();
+  return {
+    value,
+    header: setCookie(CSRF_COOKIE, await sign(env.COOKIE_ENCRYPTION_KEY, value), SESSION_TTL_SECONDS),
+  };
+}
+
+async function checkCsrf(request: Request, env: Env, form: FormData): Promise<boolean> {
+  const cookie = await verify(env.COOKIE_ENCRYPTION_KEY, readCookie(request, CSRF_COOKIE));
+  const field = form.get('csrf');
+  return typeof field === 'string' && cookie !== null && field === cookie;
+}
+
+export async function handleDashboard(request: Request, env: Env, url: URL): Promise<Response> {
+  const userId = await currentUser(request, env);
+  if (!userId) {
+    // Not signed in: bounce through the same Google round trip the OAuth path uses.
+    return Response.redirect(`${url.origin}/dashboard/login`, 302);
+  }
+
+  const csrf = await csrfToken(request, env);
+  const headers: Record<string, string> = {};
+  if (csrf.header) headers['set-cookie'] = csrf.header;
+
+  if (request.method === 'GET' && url.pathname === '/dashboard') {
+    return page(await render(env, userId, csrf.value), headers);
+  }
+
+  if (request.method === 'POST') {
+    const form = await request.formData();
+    if (!(await checkCsrf(request, env, form))) {
+      return new Response('bad csrf token', { status: 403 });
+    }
+
+    if (url.pathname === '/dashboard/create') {
+      const token = mintToken();
+      const label = (form.get('label') as string | null)?.slice(0, 60) || null;
+      await env.DB.prepare(
+        'INSERT INTO pats (id, user_id, token_hash, label, created_at) VALUES (?, ?, ?, ?, ?)',
+      )
+        .bind(crypto.randomUUID(), userId, await sha256Hex(token), label, Date.now())
+        .run();
+      return page(await render(env, userId, csrf.value, token), headers);
+    }
+
+    if (url.pathname === '/dashboard/revoke') {
+      const id = form.get('id');
+      if (typeof id === 'string') {
+        // Scoped to the owner, so a guessed id cannot revoke someone else's token.
+        await env.DB.prepare(
+          'UPDATE pats SET revoked_at = ? WHERE id = ? AND user_id = ? AND revoked_at IS NULL',
+        )
+          .bind(Date.now(), id, userId)
+          .run();
+      }
+      return page(await render(env, userId, csrf.value), headers);
+    }
+  }
+
+  return new Response('not found', { status: 404 });
+}

--- a/deploy/cloudflare/src/google-handler.ts
+++ b/deploy/cloudflare/src/google-handler.ts
@@ -1,4 +1,5 @@
 import { readCookie, setCookie, sign, verify } from './cookies';
+import { handleDashboard, startSession } from './dashboard';
 import { MCP_SCOPE } from './limits';
 import { upsertUser, type GoogleIdentity } from './users';
 import type { Env, Principal } from './types';
@@ -86,10 +87,27 @@ export const googleHandler: ExportedHandler<Env> = {
 
     if (url.pathname === '/authorize') return authorize(request, env, url);
     if (url.pathname === '/callback') return callback(request, env, url);
+    if (url.pathname === '/dashboard/login') return dashboardLogin(env, url);
+    if (url.pathname.startsWith('/dashboard')) return handleDashboard(request, env, url);
     if (url.pathname === '/') return home();
     return env.ASSETS.fetch(request);
   },
 };
+
+/**
+ * Sign-in for the dashboard.
+ *
+ * Reuses the OAuth path's Google round trip rather than adding a second one; the
+ * stored state carries a `dashboard` marker so `callback` knows to set a session
+ * cookie instead of completing an authorization nobody requested.
+ */
+async function dashboardLogin(env: Env, url: URL): Promise<Response> {
+  const state = crypto.randomUUID();
+  await env.OAUTH_KV.put(`state:${state}`, JSON.stringify({ dashboard: true }), {
+    expirationTtl: STATE_TTL_SECONDS,
+  });
+  return redirectToGoogle(env, url, state);
+}
 
 async function authorize(request: Request, env: Env, url: URL): Promise<Response> {
   const authRequest = await env.OAUTH_PROVIDER.parseAuthRequest(request);
@@ -128,8 +146,10 @@ async function authorize(request: Request, env: Env, url: URL): Promise<Response
 
 async function callback(request: Request, env: Env, url: URL): Promise<Response> {
   const code = url.searchParams.get('code');
-  const authRequest = await takeAuthRequest(env, url.searchParams.get('state'));
-  if (!code || !authRequest) {
+  const stored = await takeAuthRequest(env, url.searchParams.get('state'));
+  const toDashboard = (stored as { dashboard?: boolean } | null)?.dashboard === true;
+  const authRequest = toDashboard ? null : stored;
+  if (!code || (!authRequest && !toDashboard)) {
     return html('<h1>Sign-in failed</h1><p>The request expired. Start again from your client.</p>', 400);
   }
 
@@ -157,12 +177,19 @@ async function callback(request: Request, env: Env, url: URL): Promise<Response>
     return html('<h1>Sign-in refused</h1><p>This service is restricted to one domain.</p>', 403);
   }
 
-  // First login is signup.
+  // First login is signup, whichever door it came through.
   const userId = await upsertUser(env, identity);
-  const props: Principal = { userId, email: identity.email, via: 'oauth' };
 
+  if (toDashboard) {
+    return new Response(null, {
+      status: 302,
+      headers: { location: `${url.origin}/dashboard`, 'set-cookie': await startSession(env, userId) },
+    });
+  }
+
+  const props: Principal = { userId, email: identity.email, via: 'oauth' };
   const { redirectTo } = await env.OAUTH_PROVIDER.completeAuthorization({
-    request: authRequest,
+    request: authRequest!,
     userId,
     metadata: { email: identity.email },
     scope: [MCP_SCOPE],


### PR DESCRIPTION
## Summary

Task A2 of #189. The personal-access-token path shipped in A1 but nothing could mint one, so a
client that needs a fixed `Authorization` header had no way in. This adds the dashboard that
issues them.

## How it works

`/dashboard` signs the person in through **the same Google round trip the OAuth path already
uses**, rather than adding a second one. The stored state carries a `dashboard` marker, so the
callback knows to set a session cookie instead of completing an authorization nobody requested.
First Google login still creates the user row, so the two doors share one notion of identity.

From there: list your tokens, create one, revoke one.

## Safety notes for review

- A new token is shown **exactly once**, on the response that created it. Only its SHA-256 is
  stored, so a reload genuinely cannot bring it back.
- Revocation is scoped to the owner inside the `UPDATE` itself, so a guessed token id cannot
  revoke someone else's token.
- State-changing posts carry a double-submit CSRF token, signed with the same key as the session
  cookie.
- The dashboard mints tokens; it never validates them. That stays in `pat.ts`, which was already
  wired in A1, so there remains exactly one authorization path downstream.

## Verification, against the deployed service

| Step | Result |
|---|---|
| `/dashboard` unauthenticated | 302 to `/dashboard/login`, which redirects to Google |
| Sign in, then create a token | Token shown once with a ready-to-paste `claude mcp add` line |
| `initialize` with only the header | 200, session minted, no OAuth flow |
| `tools/list`, then `hwp_new` | 20 tools; document created |
| `last_used_at` in D1 | recorded |
| Revoke, then call again | token gone from the list; **401 with `WWW-Authenticate`** on the next call |
| D1 after revoke | `revoked_at` set |

## Note

A stale `origin/feat/cloudflare-worker` ref on the deploy host made a `git fetch` fail silently
inside an `&&` chain, so the first deploy attempt shipped the previous commit. Caught it by
checking the deployed code rather than trusting the "Deployed" line; `git remote prune` fixed it.
Worth remembering: the deploy output says a deploy happened, not that it deployed what you meant.