### PR TITLE
feat(deploy): rate limiting and bounded capacity (#189 A3, partial)

### DIFF
--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -143,6 +143,10 @@ Negative cases, all confirmed on the deployed service:
 | A session id this service never minted, on `/mcp` and on `/files` | `404`, revealing nothing |
 | `GET /mcp` | `405` — no server-push stream is offered |
 | Body over 1 MiB | `413` before parsing |
+| An upload over the 32 MiB sideband cap | `413` |
+| A spoofed `Origin`, versus this deployment's own | `403`, versus `200` |
+| More than 5 `initialize` calls a minute | `429` with `retry-after` |
+| No instance capacity left | `503` with `retry-after`, not a raw 500 |
 | File name outside the allowed charset | `400` |
 | Tool writing outside the workspace | refused, same message the stdio server gives |
 | `DELETE`, then reuse of that session | `204`, then `404` |
@@ -195,8 +199,18 @@ minutes and 200 GB-hours of disk. The `basic` instance type is 1 GiB, so roughly
 25 hours of *active* container time per month are included; beyond that it is
 about $0.009 per hour. Containers scale to zero, so idle sessions cost nothing.
 
-Three guards keep this inside the $10 cap: `sleepAfter` is 10 minutes,
-`max_instances` is 5, and the billing notification above fires at $10.
+Three guards keep this inside the $10 cap, and it is worth knowing which one does
+what. `sleepAfter` is **3 minutes** — that is the lever that actually bounds both
+spend and live instance count, because a session holds its container until it
+sleeps. `SESSION_LIMITER` allows 5 `initialize` calls per person per minute,
+capping how fast new containers can be created. `max_instances` is 20, a
+backstop rather than a budget control: set too low it turns ordinary concurrent
+use into capacity errors. The billing notification fires at $10 regardless.
+
+Logs and the audit table were checked against a call carrying a password and a
+document path: neither the password, the path, the file name, nor the access
+token appears in either. The audit row keeps the tool name, the outcome, byte
+counts, and a *hash* of the session id.
 
 ## Layout
 

--- a/deploy/cloudflare/src/limits.ts
+++ b/deploy/cloudflare/src/limits.ts
@@ -26,8 +26,17 @@ export const SLOW_TOOLS = new Set(['hwp_render', 'hwp_convert', 'hwp_certify', '
  */
 export const MAX_FILE_TRANSFER_BYTES = 32 * 1024 * 1024;
 
-/** Idle lifetime before the container is stopped and the session invalidated. */
-export const IDLE_SLEEP_AFTER = '10m';
+/**
+ * Idle lifetime before the container is stopped and the session invalidated.
+ *
+ * This is the lever that keeps live containers under `max_instances`, not the
+ * rate limiter: the limiter caps how fast sessions are *created*, but each one
+ * holds an instance for this long, so 5 new sessions a minute against a 10-minute
+ * hold reaches ten times the ceiling. Three minutes keeps a working session alive
+ * across normal think-time while returning capacity quickly, and it is the same
+ * lever that keeps the monthly container-hours bill down.
+ */
+export const IDLE_SLEEP_AFTER = '3m';
 
 /** Maximum session lifetime; after this the client must reinitialize (doc 20 §7). */
 export const MAX_SESSION_MS = 8 * 60 * 60 * 1000;

--- a/deploy/cloudflare/src/mcp-api.ts
+++ b/deploy/cloudflare/src/mcp-api.ts
@@ -52,7 +52,6 @@ function describe(body: ArrayBuffer): { method: string | null; tool: string | nu
   }
 }
 
-/** `fetch` is required (not optional) so this satisfies the provider's handler type. */
 /**
  * DNS-rebinding defense (docs/design/20-remote-mcp.md §2.2).
  *
@@ -66,6 +65,7 @@ function originAllowed(request: Request, url: URL): boolean {
   return origin === null || origin === url.origin;
 }
 
+/** `fetch` is required (not optional) so this satisfies the provider's handler type. */
 export const mcpApiHandler = {
   async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const principal = principalOf(ctx);
@@ -130,9 +130,27 @@ async function handleMcp(
   let sessionId: string;
   let minted = false;
   if (method === 'initialize') {
+    // The budget guard sits here rather than on the edge as a whole: this is the
+    // one call that starts a container, and container time is what the monthly
+    // cap actually buys. Ordinary traffic inside a session is far cheaper and
+    // gets the looser limit below.
+    const { success } = await env.SESSION_LIMITER.limit({ key: principal.userId });
+    if (!success) {
+      return new Response('too many sessions started; wait a minute', {
+        status: 429,
+        headers: { 'retry-after': '60' },
+      });
+    }
     sessionId = crypto.randomUUID();
     minted = true;
   } else {
+    const { success } = await env.CALL_LIMITER.limit({ key: principal.userId });
+    if (!success) {
+      return new Response('too many requests', {
+        status: 429,
+        headers: { 'retry-after': '60' },
+      });
+    }
     if (!headerSessionId || !SESSION_ID_RE.test(headerSessionId)) {
       return new Response('session not found', { status: 404 });
     }
@@ -197,6 +215,11 @@ async function handleFiles(
   }
   if (request.method !== 'GET' && request.method !== 'POST') {
     return new Response(null, { status: 405, headers: { Allow: 'GET, POST' } });
+  }
+
+  const { success } = await env.CALL_LIMITER.limit({ key: principal.userId });
+  if (!success) {
+    return new Response('too many requests', { status: 429, headers: { 'retry-after': '60' } });
   }
 
   const stub = sessionStub(env, principal, sessionId);

--- a/deploy/cloudflare/src/session.ts
+++ b/deploy/cloudflare/src/session.ts
@@ -115,7 +115,19 @@ export class HwpSession extends Container<Env> {
       // Anything else is this one request's problem, not the session's. Killing
       // the session here made a transient RPC hiccup look like an expired
       // session on the *next* call, which is a confusing way to lose a workspace.
-      console.error('container fetch failed', error instanceof Error ? error.message : error);
+      const detail = error instanceof Error ? error.message : String(error);
+      console.error('container fetch failed', detail);
+
+      // Running out of instance capacity is an ordinary, retryable condition, so
+      // it gets 503 rather than a 500 carrying Cloudflare's internal wording to
+      // the caller.
+      if (/max_instances|running container instances/i.test(detail)) {
+        await this.terminate();
+        return new Response('no capacity for a new session; try again shortly', {
+          status: 503,
+          headers: { 'retry-after': '60' },
+        });
+      }
       return new Response('container unavailable', { status: 502 });
     }
   }

--- a/deploy/cloudflare/src/types.ts
+++ b/deploy/cloudflare/src/types.ts
@@ -8,6 +8,11 @@ export interface Env {
   DB: D1Database;
   ASSETS: Fetcher;
 
+  /** Caps how often one principal may start a container (see wrangler.jsonc). */
+  SESSION_LIMITER: RateLimit;
+  /** Caps ordinary traffic once a session exists. */
+  CALL_LIMITER: RateLimit;
+
   GOOGLE_CLIENT_ID: string;
   GOOGLE_CLIENT_SECRET: string;
   COOKIE_ENCRYPTION_KEY: string;

--- a/deploy/cloudflare/wrangler.jsonc
+++ b/deploy/cloudflare/wrangler.jsonc
@@ -37,6 +37,16 @@
     }
   ],
 
+  // Rate limits. `period` may only be 10 or 60 seconds.
+  //
+  // SESSION_LIMITER is the budget guard: every initialize starts a container, and
+  // container time is what the $10/month cap actually buys. CALL_LIMITER is the
+  // much looser ceiling on ordinary traffic inside a session.
+  "ratelimits": [
+    { "name": "SESSION_LIMITER", "namespace_id": "1001", "simple": { "limit": 5, "period": 60 } },
+    { "name": "CALL_LIMITER", "namespace_id": "1002", "simple": { "limit": 120, "period": 60 } }
+  ],
+
   "assets": { "directory": "./public", "binding": "ASSETS" },
 
   "observability": { "enabled": true }

--- a/deploy/cloudflare/wrangler.jsonc
+++ b/deploy/cloudflare/wrangler.jsonc
@@ -15,9 +15,10 @@
       // 1/4 vCPU, 1 GiB, 4 GB disk. Rendering is the memory-hungry path; raise
       // this if the diagnostic corpus ever OOMs.
       "instance_type": "basic",
-      // Budget guard: the owner's cap is $10/month and Workers Paid includes
-      // 25 GiB-hours of container memory.
-      "max_instances": 5
+      // Raised from 5: each session holds an instance until it sleeps, so a
+      // ceiling that low turned ordinary concurrent use into capacity errors.
+      // Cost is still bounded by sleepAfter and the rate limiter, not by this.
+      "max_instances": 20
     }
   ],
 


### PR DESCRIPTION
## Summary

The hardening half of A3 in #189. **Three of the six A3 items are deliberately not in this PR**;
see the bottom for why, so the checkbox is not ticked on a partial job.

## What this adds

**Rate limiting, placed where the money is.** The service is public — anyone with a Google account
can sign up and start containers, and container time is what the $10/month cap buys. Until now
`max_instances` was the only guard, which caps concurrency but not spend. `SESSION_LIMITER` allows
five `initialize` calls per principal per minute, because that is the one call that starts a
container; `CALL_LIMITER` allows 120 other requests, covering ordinary in-session traffic and the
`/files` sideband.

**Capacity is now a legible condition.** Nine rapid `initialize` calls used to return
`500 Failed to start container: Maximum number of running container instances exceeded` —
Cloudflare's internal wording handed straight to the caller for what is an ordinary retryable
state. It answers `503` with `retry-after` now, and the half-created session is torn down.

**The guards are re-tuned so they can actually hold.** Testing showed the limiter cannot enforce
the instance ceiling, and expecting it to was my error: it caps how fast sessions are *created*,
while each holds an instance until it sleeps. Five sessions a minute against a ten-minute hold
reaches fifty live containers — ten times the old ceiling of five. So the idle timeout does that
job (10m → **3m**, still covering normal think-time), and `max_instances` rises 5 → 20 so ordinary
concurrent use is not mistaken for abuse. Spend stays bounded by the idle timeout and the limiter
together, which the README now states explicitly.

## Verification, on the deployed service

| Case | Result |
|---|---|
| 10 rapid `initialize` calls | six `200`, then `429` with `retry-after: 60` and a plain message |
| No instance capacity | `503` with `retry-after` (was a raw `500`) |
| Spoofed `Origin` vs. our own | `403` vs. `200` |
| Upload over the 32 MiB cap | `413` |
| Full A1 negative matrix rerun | `401` / `404` / `405` / `413` / `400` / `204→404`, all unchanged |
| Logs and audit table, after a call carrying a password and a document path | neither password, path, file name, nor token appears; audit keeps tool, outcome, byte counts and a *hashed* session reference |

## Deliberately not here

- **Slim release-tarball image** — blocked. The newest release is v0.14.0, which predates
  `hwp serve` (that shipped in #191, unreleased). Building it now would install a binary without
  the subcommand. It needs a release cut first.
- **Object-store artifact flow** — this is the start of real doc 20 §3.2 compliance and is a
  design change of its own size, not a hardening tweak. It deserves its own phase rather than
  being smuggled in here.
- **Custom domain and Google OAuth app verification** — the first is a choice (the workers.dev
  host was picked deliberately); the second is a multi-day external review that also needs a
  published privacy policy.