### PR TITLE
chore(release): v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,41 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.15.0]
+
+**Added**
+
+- `hwp serve` runs the MCP protocol over HTTP, so the same twenty tools are reachable from a
+  container instead of only from a local process. `POST /mcp` carries one JSON-RPC message capped
+  at 1 MiB (a request answers `200 application/json`, a notification `202` with no body),
+  `GET /mcp` answers `405` because the server never pushes, `GET /healthz` is the readiness probe,
+  and `--files` adds `POST|GET /files/{name}` under a 64 MiB per-file and 256 MiB per-workspace
+  cap. `--root` is mandatory here, unlike `hwp mcp` where omitting it only warns: a remote
+  deployment must never run with unrestricted filesystem access. An inbound `Mcp-Session-Id` is
+  accepted and ignored, because session affinity belongs to whatever sits in front.
+
+  The adapter is a private hop by design — it expects a trusted edge to have terminated TLS,
+  authenticated the caller and capped the body — which is what let it stay synchronous. The
+  dependency decision is recorded in `docs/design/22-remote-mcp-deployment.md` §4: `tiny_http`,
+  chosen over an async stack so the workspace keeps its no-tokio, no-SDK stance. The new subtree
+  is `ascii`, `chunked_transfer`, `httpdate` and `log`.
+
+**Changed**
+
+- `commands/mcp.rs` became `commands/mcp/{mod,authority,stdio,http}.rs`. The protocol core is now
+  transport-independent and expresses file authority through a `FileAuthority` trait, so the stdio
+  and HTTP adapters share one implementation rather than forking tool semantics. stdio behavior is
+  unchanged: `initialize` and `tools/list` output is byte-identical to v0.14.0 and the process test
+  still asserts exactly twenty tools.
+
+**Documentation**
+
+- `docs/design/22-remote-mcp-deployment.md` (and its Korean pair) specifies how the remote service
+  is built and hosted, resolving the dependency gate that `20-remote-mcp.md` §8 required. It
+  records two amendments to doc 20: the protocol core stays binary-internal for now, and §10's
+  writable-path criterion is narrowed for a single-session microVM workspace.
+- The bundled `hwp` skill documents the HTTP surface in both languages.
+
 ## [0.14.0]
 
 **Added**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hwp-cli"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "hwp-model",
  "hwpx",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-render"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "encoding_rs",
  "flate2",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "aes",
  "cfb",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"

--- a/README.ko.md
+++ b/README.ko.md
@@ -110,7 +110,7 @@ curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/inst
 기본 위치는 `~/.local/bin`이다(PATH에 없으면 안내를 출력한다). 위치·버전은 인자나 환경변수로 바꾼다:
 
 ```sh
-curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.14.0
+curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.15.0
 HWP_INSTALL_DIR=~/bin sh scripts/install.sh
 ```
 
@@ -151,7 +151,7 @@ RHEL/CentOS 7+ 및 그 이후 배포판에서 그대로 돌아간다. 빌드 러
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
-  | sh -s -- --tag v0.14.0 --dir ./bin
+  | sh -s -- --tag v0.15.0 --dir ./bin
 ```
 
 플랫폼이 배포 번들을 수집하기 전에 바이너리가 있어야 하므로(Vercel `includeFiles`, Next.js

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The default location is `~/.local/bin` (if it is not on PATH, the script says so
 location or version with arguments or environment variables:
 
 ```sh
-curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.14.0
+curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.15.0
 HWP_INSTALL_DIR=~/bin sh scripts/install.sh
 ```
 
@@ -167,7 +167,7 @@ to bump:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
-  | sh -s -- --tag v0.14.0 --dir ./bin
+  | sh -s -- --tag v0.15.0 --dir ./bin
 ```
 
 Run this from the build command (or a `prebuild` script) so the binary exists before the platform

--- a/deploy/cloudflare/container/Dockerfile.slim
+++ b/deploy/cloudflare/container/Dockerfile.slim
@@ -1,0 +1,52 @@
+# hwp MCP session container, built from a published release.
+#
+# Prefer this over ../Dockerfile once a release carries `hwp serve`: it skips the
+# Rust toolchain entirely, so the build is a download rather than a compile and
+# the image drops to roughly the size of the binary plus fonts.
+#
+# The build context is this directory, not the repository root — nothing from the
+# source tree is needed:
+#
+#     docker build -f Dockerfile.slim -t hwp-mcp .
+#
+# To move to a new release, bump HWP_VERSION and HWP_SHA256 together. The sha256
+# is published alongside the tarball as hwp-<version>-<target>.sha256; the build
+# fails loudly if it does not match, which is the point.
+
+FROM debian:bookworm-slim
+
+ARG HWP_VERSION=v0.15.0
+ARG HWP_TARGET=x86_64-unknown-linux-gnu
+ARG HWP_SHA256=REPLACE_WITH_PUBLISHED_SHA256
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl fonts-nanum \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    url="https://github.com/STAIxBWLB/hwp-cli/releases/download/${HWP_VERSION}/hwp-${HWP_VERSION}-${HWP_TARGET}.tar.gz"; \
+    curl -fsSL -o /tmp/hwp.tar.gz "$url"; \
+    echo "${HWP_SHA256}  /tmp/hwp.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/hwp.tar.gz -C /usr/local/bin hwp; \
+    chmod +x /usr/local/bin/hwp; \
+    rm -f /tmp/hwp.tar.gz; \
+    hwp --version; \
+    # A release without `serve` would otherwise fail only at runtime, inside a
+    # container nobody is watching.
+    hwp serve --help >/dev/null
+
+# curl was only needed for the download.
+RUN apt-get purge -y --auto-remove curl
+
+RUN useradd --create-home --uid 10001 hwp \
+ && mkdir -p /work \
+ && chown hwp:hwp /work
+USER hwp
+WORKDIR /work
+
+EXPOSE 8080
+CMD ["hwp", "serve", \
+     "--addr", "0.0.0.0:8080", \
+     "--root", "/work", \
+     "--files", \
+     "--font-dir", "/usr/share/fonts/truetype/nanum"]

--- a/skills/hwp/SKILL.ko.md
+++ b/skills/hwp/SKILL.ko.md
@@ -301,6 +301,27 @@ Quick 설정을 도와줄 때는 JSON 임포트를 선호하고, 인수 안에 �
 | `hwp_split` | `input`, `out_dir` | Section 단위(또는 `pages`)로 조각내고 발행된 조각 경로를 반환 |
 | `hwp_compare` | `a`, `b` | 읽기 전용 문단·구조 비교로 `hwp-compare-report-v1`을 반환. 차이가 있는 것은 정상 결과라 `isError`가 되지 않으므로 `identical`을 읽는다 |
 
+## 컨테이너용 HTTP 모드
+
+`hwp serve`는 `hwp mcp`와 같은 프로토콜을 stdio 대신 HTTP로 제공하므로, 같은 20종 도구를
+컨테이너에서 사용할 수 있습니다. 인터넷에 직접 노출하는 용도가 아니라, TLS 종단·인증·본문
+크기 제한을 이미 수행한 신뢰된 edge 뒤에 두는 것을 전제로 합니다.
+
+```bash
+hwp serve --addr 0.0.0.0:8080 --root /work --font-dir /usr/share/fonts/truetype/nanum
+```
+
+| 경로 | 동작 |
+|---|---|
+| `POST /mcp` | JSON-RPC 메시지 하나, 1 MiB 상한. request는 `200 application/json`, notification은 본문 없이 `202` |
+| `GET /mcp` | `405` — server가 push하지 않으므로 event stream을 제공하지 않습니다 |
+| `GET /healthz` | listener가 bind되면 `200`. container platform이 확인하는 지점입니다 |
+| `POST\|GET /files/{name}` | `--files`로만 활성화. 이름은 `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`를 만족해야 하며, 파일당 64 MiB·workspace당 256 MiB |
+
+`--root`는 여기서 필수입니다. 생략하면 경고만 하는 `hwp mcp`와 달리, 원격 배포는 파일 접근이
+제한되지 않은 상태로 실행되어서는 안 되기 때문입니다. 들어오는 `Mcp-Session-Id`는 받아들이되
+무시합니다. session affinity는 앞단 platform의 책임입니다.
+
 ## 안전 규칙 (반드시 준수)
 
 1. **쓰기 후에는 항상 검증하세요.** `new` / `edit` / `fill` / `compose` / `template` /

--- a/skills/hwp/SKILL.md
+++ b/skills/hwp/SKILL.md
@@ -303,6 +303,28 @@ Tools (20):
 | `hwp_split` | `input`, `out_dir` | Split into per-Section (or `pages`) fragments; returns the published fragment paths |
 | `hwp_compare` | `a`, `b` | Read-only paragraph/structure diff returning `hwp-compare-report-v1`. Differences are a normal result and never set `isError` — read `identical` |
 
+## HTTP mode for containers
+
+`hwp serve` speaks the same protocol as `hwp mcp`, over HTTP instead of stdio, so the same twenty
+tools are reachable from a container. It is meant to sit behind a trusted edge that has already
+terminated TLS, authenticated the caller and capped the request body — not to face the internet
+directly.
+
+```bash
+hwp serve --addr 0.0.0.0:8080 --root /work --font-dir /usr/share/fonts/truetype/nanum
+```
+
+| Route | Behavior |
+|---|---|
+| `POST /mcp` | One JSON-RPC message, capped at 1 MiB. A request answers `200 application/json`; a notification answers `202` with no body |
+| `GET /mcp` | `405` — the server never pushes, so no event stream is offered |
+| `GET /healthz` | `200` once the listener is bound; container platforms probe this |
+| `POST\|GET /files/{name}` | Only with `--files`. Names must match `^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`; 64 MiB per file, 256 MiB per workspace |
+
+`--root` is mandatory here, unlike `hwp mcp` where omitting it only warns: a remote deployment must
+never run with unrestricted filesystem access. An inbound `Mcp-Session-Id` is accepted and ignored,
+because session affinity belongs to the platform in front.
+
 ## Safety rules (must follow)
 
 1. **Validate after every write.** After `new` / `edit` / `fill` / `compose` / `template` /


### PR DESCRIPTION
## Summary

Cuts v0.15.0. The reason to cut it now is concrete: `hwp serve` shipped in #191 but no release
contains it, which blocks the release-tarball container image — building one today would install a
binary without the subcommand.

## What the release contains

- **`hwp serve`** (#191): the MCP protocol over HTTP, so the same twenty tools work from a
  container. `POST /mcp` capped at 1 MiB, `GET /mcp` → 405, `/healthz`, and `/files` behind
  `--files`. `--root` is mandatory, unlike `hwp mcp` where omitting it only warns.
- **The protocol-core split** (#190): `commands/mcp/{mod,authority,stdio,http}.rs` with a
  `FileAuthority` trait, so both adapters share one implementation. stdio output is byte-identical
  to v0.14.0 and the process test still asserts exactly twenty tools.
- **Deployment design** (#188) and the Cloudflare tier (#192, #193, #194), which live under
  `deploy/` and are not part of the binary.

## Checklist items this PR had to fix first

- The bundled skill did not document `hwp serve` at all — the readiness checklist requires it to
  cover every command a release ships, and an agent reading the skill would not have known the HTTP
  surface exists. Added in both languages.
- The README install examples were pinned to `--tag v0.14.0`.

## Also here

`deploy/cloudflare/container/Dockerfile.slim` builds the container from the published tarball with
a checksum check, which is what v0.15.0 unblocks. Its `HWP_SHA256` is a placeholder until the
release publishes; the image is not wired into `wrangler.jsonc` yet.

## Verification

`scripts/check.sh` → `check: OK (fmt/clippy/test/pdf-runner/structured-corpus/public-parity=skipped)`.
`scripts/release_notes.sh 0.15.0` extracts the CHANGELOG section cleanly.

Per the runbook the branch tag was deleted; the real tag goes on the merge commit once main is
green.