### PR TITLE
build(deploy): ship the container from the published release, not from source

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
-# The Cloudflare container image builds from the repository root (its Dockerfile
-# needs the whole Cargo workspace), so everything the build does not need must be
-# excluded here or it is uploaded as build context. `target/` alone is ~17 GB.
+# Only the source-build image (deploy/cloudflare/container/Dockerfile) uses the
+# repository root as its build context; the deployed slim image downloads a
+# released binary and needs none of it. Everything that build does not need must
+# be excluded here or it is uploaded as build context. `target/` alone is ~17 GB.
 
 target/
 **/target/

--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -86,7 +86,13 @@ npm ci
 npx wrangler deploy
 ```
 
-The first deploy takes several minutes: it compiles the Rust workspace inside the container image.
+The image is built from the published release tarball, so a deploy downloads a binary rather than
+compiling one: the build finishes in seconds and the image is 129 MB. Moving to a new `hwp` release
+means bumping `HWP_VERSION` and `HWP_SHA256` together in `container/Dockerfile.slim` - the checksum
+is published next to the tarball as `hwp-<version>-<target>.sha256`, and a mismatch fails the build.
+To try a change that is not released yet, point `wrangler.jsonc` at `container/Dockerfile` instead
+(source build, `image_build_context` `../..`, several minutes for the Rust compile).
+
 Rebuilding a secret is only needed if one is rotated:
 
 ```bash
@@ -225,7 +231,8 @@ counts, and a *hash* of the session id.
 | `src/users.ts` | The user upsert keyed on the Google `sub` claim |
 | `src/audit.ts` | Metadata-only audit writes |
 | `src/limits.ts` | Every limit in one place, mirroring doc 20 §7 |
-| `container/Dockerfile` | Builds `hwp` and runs `hwp serve` |
+| `container/Dockerfile.slim` | The deployed image: pinned release tarball, checksum-verified |
+| `container/Dockerfile` | Source build, for testing an unreleased change |
 | `schema.sql` | D1 tables |
 
 ## Known scope

--- a/deploy/cloudflare/container/Dockerfile.slim
+++ b/deploy/cloudflare/container/Dockerfile.slim
@@ -2,9 +2,9 @@
 #
 # Prefer this over ../Dockerfile once a release carries `hwp serve`: it skips the
 # Rust toolchain entirely, so the build is a download rather than a compile and
-# the image drops to roughly the size of the binary plus fonts.
+# the image is the runtime base plus fonts plus the binary, nothing else.
 #
-# The build context is this directory, not the repository root — nothing from the
+# The build context is this directory, not the repository root - nothing from the
 # source tree is needed:
 #
 #     docker build -f Dockerfile.slim -t hwp-mcp .
@@ -13,30 +13,35 @@
 # is published alongside the tarball as hwp-<version>-<target>.sha256; the build
 # fails loudly if it does not match, which is the point.
 
-FROM debian:bookworm-slim
-
 ARG HWP_VERSION=v0.15.0
 ARG HWP_TARGET=x86_64-unknown-linux-gnu
-ARG HWP_SHA256=REPLACE_WITH_PUBLISHED_SHA256
+ARG HWP_SHA256=884b762cbb005830e9f32f0862c84889e84fecb80e5e9b868b3db5b4b3b5fe76
 
-RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates curl fonts-nanum \
- && rm -rf /var/lib/apt/lists/*
-
+# Fetch stage. ADD downloads over the builder's own network stack, so no curl and
+# no CA bundle are ever installed; keeping it in a discarded stage also keeps the
+# archive itself out of the shipped layers.
+FROM debian:bookworm-slim AS fetch
+ARG HWP_VERSION
+ARG HWP_TARGET
+ARG HWP_SHA256
+ADD https://github.com/STAIxBWLB/hwp-cli/releases/download/${HWP_VERSION}/hwp-${HWP_VERSION}-${HWP_TARGET}.tar.gz /tmp/hwp.tar.gz
 RUN set -eux; \
-    url="https://github.com/STAIxBWLB/hwp-cli/releases/download/${HWP_VERSION}/hwp-${HWP_VERSION}-${HWP_TARGET}.tar.gz"; \
-    curl -fsSL -o /tmp/hwp.tar.gz "$url"; \
     echo "${HWP_SHA256}  /tmp/hwp.tar.gz" | sha256sum -c -; \
     tar -xzf /tmp/hwp.tar.gz -C /usr/local/bin hwp; \
     chmod +x /usr/local/bin/hwp; \
-    rm -f /tmp/hwp.tar.gz; \
     hwp --version; \
     # A release without `serve` would otherwise fail only at runtime, inside a
     # container nobody is watching.
     hwp serve --help >/dev/null
 
-# curl was only needed for the download.
-RUN apt-get purge -y --auto-remove curl
+FROM debian:bookworm-slim
+# Rendering and PDF output need real font files; fonts-nanum matches the font
+# baseline CI already uses (glyf outlines, fast in debug builds).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends fonts-nanum \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=fetch /usr/local/bin/hwp /usr/local/bin/hwp
 
 RUN useradd --create-home --uid 10001 hwp \
  && mkdir -p /work \

--- a/deploy/cloudflare/wrangler.jsonc
+++ b/deploy/cloudflare/wrangler.jsonc
@@ -10,8 +10,12 @@
   "containers": [
     {
       "class_name": "HwpSession",
-      "image": "./container/Dockerfile",
-      "image_build_context": "../..",
+      // Built from the published release tarball, not from source: the image is
+      // smaller, the build is seconds rather than a Rust compile, and the binary
+      // that ships is the one users install. ../Dockerfile still builds from
+      // source when a change has to be tried before it is released.
+      "image": "./container/Dockerfile.slim",
+      "image_build_context": "./container",
       // 1/4 vCPU, 1 GiB, 4 GB disk. Rendering is the memory-hungry path; raise
       // this if the diagnostic corpus ever OOMs.
       "instance_type": "basic",


### PR DESCRIPTION
Switches the Cloudflare session container to the v0.15.0 release tarball instead of compiling the workspace inside the image.

## Why

`hwp serve` shipped in v0.15.0, which is what the release-based image was waiting on. Building from the release makes the deployed binary the same artifact users install, and makes a deploy a download rather than a Rust compile.

## Measured on the deploy host (amd64, Docker 29.1.3)

| | source build | slim |
|---|---|---|
| image | 134 MB | **129 MB** |
| rebuild, no cache | several minutes | **6.7 s** |
| `hwp` binary in image | 22.8 MB | 18.6 MB |

Two layer details decide whether this is smaller or larger, and both were measured, not assumed:

- The first attempt installed curl, downloaded, then purged curl in a later layer: **144 MB**, larger than the source build, because a purge cannot reclaim bytes from an earlier layer.
- Merging install and purge into one layer got 138 MB, and dropping `curl` for `ADD` (which fetches over the builder network, so no CA bundle is installed either) got 137 MB - still larger, because `ADD` leaves the tarball in its own layer.
- Running the fetch in a discarded stage and copying only the binary out gives 129 MB.

## Verified on the built image

- `hwp --version` → 0.15.0, and the build itself runs `hwp serve --help`, so a release without the subcommand fails the build rather than the container.
- `/healthz` 200; `tools/list` → 20 tools.
- `hwp_new` → `hwp_render` (PDF, Korean text, fonts-nanum) → `GET /files/a.pdf` 200, 11156 bytes.
- Runs as uid 10001 `hwp`; no curl, no CA bundle, `/tmp` empty.

## Bumping the version later

`HWP_VERSION` and `HWP_SHA256` move together in `Dockerfile.slim`. The checksum is published next to the tarball as `hwp-<version>-<target>.sha256`, and a mismatch fails the build. `container/Dockerfile` still builds from source for testing a change before it is released; the README says how to switch back.

No Rust code is touched.