### PR TITLE
fix(deploy): make idle sessions actually stop, and forged ids cost nothing

### DIFF
--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -159,7 +159,7 @@ Negative cases, all confirmed on the deployed service:
 
 Five consecutive full round trips pass with no flakiness.
 
-### Three defects this verification caught
+### Five defects this verification caught
 
 Worth recording, because each one only appeared against the deployed service:
 
@@ -177,6 +177,21 @@ Worth recording, because each one only appeared against the deployed service:
    own alarm for sleep and activity bookkeeping; intercepting it ran the
    8-hour-cap teardown seconds after a session started. Maximum lifetime is
    checked on the request path now, and nothing competes with the base class.
+4. **Answering 404 still cost a container.** Defect 1's fix was incomplete:
+   `isUsable()` runs *inside* the object, and merely reaching the object starts a
+   container, so a forged id was rejected correctly and billed anyway. Measured
+   directly — one `404` for an invented id, and a container named after that id
+   appeared within 25 seconds. Session ids now carry an HMAC of themselves, so
+   `ourSessionId()` rejects a forged one at the edge and the object is never
+   touched. Without this an authenticated caller could hold the whole instance
+   ceiling with junk ids and lock real users out.
+5. **Idle containers never stopped.** The platform stops an idle container with
+   SIGTERM, and the kernel does not deliver a default-disposition signal to
+   PID 1, so `hwp serve` as PID 1 ignored it: `sleepAfter` looked configured and
+   did nothing. Nine containers had been running for close to four hours. The
+   image now runs tini as its init, which forwards the signal; `docker kill
+   --signal=TERM` exits the container in about a second, where before it stayed
+   up indefinitely.
 
 ## What is already verified
 
@@ -212,6 +227,28 @@ sleeps. `SESSION_LIMITER` allows 5 `initialize` calls per person per minute,
 capping how fast new containers can be created. `max_instances` is 20, a
 backstop rather than a budget control: set too low it turns ordinary concurrent
 use into capacity errors. The billing notification fires at $10 regardless.
+
+`sleepAfter` only works because the image runs tini as its init. The platform
+stops an idle container by sending SIGTERM, and the kernel does not deliver a
+signal with its default disposition to PID 1 - so with `hwp serve` as PID 1 the
+stop was silently discarded and containers stayed awake indefinitely. Nine of
+them ran for close to four hours before this was caught, which at 1 GiB each
+would have spent the monthly allowance in under three hours. If a future change
+touches the entrypoint, re-run the check below.
+
+To check that idle sessions really stop, watch the running instance count fall to
+zero within a few minutes of the last request:
+
+```bash
+curl -s "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/containers/applications/$APP_ID/instances" \
+  -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  | jq '[.result.instances[] | select(.status.state == "running")] | length'
+```
+
+A container that is still running ten minutes after its last request means the
+idle stop is not landing; `wrangler containers list` shows the same count. The
+image-level check is faster: `docker kill --signal=TERM <id>` must exit the
+container within a second or two.
 
 Logs and the audit table were checked against a call carrying a password and a
 document path: neither the password, the path, the file name, nor the access

--- a/deploy/cloudflare/container/Dockerfile
+++ b/deploy/cloudflare/container/Dockerfile
@@ -19,7 +19,7 @@ FROM debian:bookworm-slim
 # Rendering and PDF output need real font files; fonts-nanum matches the font
 # baseline CI already uses (glyf outlines, fast in debug builds).
 RUN apt-get update \
- && apt-get install -y --no-install-recommends fonts-nanum \
+ && apt-get install -y --no-install-recommends fonts-nanum tini \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /src/target/release/hwp /usr/local/bin/hwp
@@ -29,6 +29,14 @@ RUN useradd --create-home --uid 10001 hwp \
  && chown hwp:hwp /work
 USER hwp
 WORKDIR /work
+
+# `hwp serve` runs as PID 1, and the kernel does not deliver a signal with its
+# default disposition to PID 1 - so a plain SIGTERM is silently discarded and the
+# platform's idle stop never takes effect, leaving the container awake and billing.
+# tini installs real handlers, becomes PID 1, and forwards the signal to `hwp`,
+# which then terminates normally. Do not remove it: without an init the container
+# only stops when it is destroyed outright.
+ENTRYPOINT ["/usr/bin/tini", "--"]
 
 EXPOSE 8080
 CMD ["hwp", "serve", \

--- a/deploy/cloudflare/container/Dockerfile.slim
+++ b/deploy/cloudflare/container/Dockerfile.slim
@@ -38,7 +38,7 @@ FROM debian:bookworm-slim
 # Rendering and PDF output need real font files; fonts-nanum matches the font
 # baseline CI already uses (glyf outlines, fast in debug builds).
 RUN apt-get update \
- && apt-get install -y --no-install-recommends fonts-nanum \
+ && apt-get install -y --no-install-recommends fonts-nanum tini \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=fetch /usr/local/bin/hwp /usr/local/bin/hwp
@@ -48,6 +48,14 @@ RUN useradd --create-home --uid 10001 hwp \
  && chown hwp:hwp /work
 USER hwp
 WORKDIR /work
+
+# `hwp serve` runs as PID 1, and the kernel does not deliver a signal with its
+# default disposition to PID 1 - so a plain SIGTERM is silently discarded and the
+# platform's idle stop never takes effect, leaving the container awake and billing.
+# tini installs real handlers, becomes PID 1, and forwards the signal to `hwp`,
+# which then terminates normally. Do not remove it: without an init the container
+# only stops when it is destroyed outright.
+ENTRYPOINT ["/usr/bin/tini", "--"]
 
 EXPOSE 8080
 CMD ["hwp", "serve", \

--- a/deploy/cloudflare/src/mcp-api.ts
+++ b/deploy/cloudflare/src/mcp-api.ts
@@ -1,4 +1,5 @@
 import { writeAudit } from './audit';
+import { sign, verify } from './cookies';
 import { FILE_NAME_RE, MAX_BODY_BYTES, MAX_FILE_TRANSFER_BYTES } from './limits';
 import type { Env, Principal } from './types';
 
@@ -17,8 +18,28 @@ function principalOf(ctx: ExecutionContext): Principal | null {
   return props && typeof props.userId === 'string' ? props : null;
 }
 
-/** A session id is opaque and server-minted; reject anything that is not ours. */
-const SESSION_ID_RE = /^[0-9a-f-]{36}$/;
+/**
+ * A session id is opaque and server-minted: a random uuid carrying an HMAC of
+ * itself, so the edge can tell a real id from an invented one without asking
+ * storage.
+ *
+ * The check is not cosmetic. Reaching the Durable Object at all is what starts a
+ * container, and it starts even on the path that answers 404 - so validating the
+ * id only inside the object let anyone signed in burn a container per made-up id
+ * and pin the whole instance ceiling. Verifying the MAC here means a forged id
+ * never touches the object.
+ */
+const SESSION_ID_RE = /^[0-9a-f-]{36}\.[A-Za-z0-9_-]{43}$/;
+
+async function mintSessionId(env: Env): Promise<string> {
+  return sign(env.COOKIE_ENCRYPTION_KEY, crypto.randomUUID());
+}
+
+/** Returns the id when this service minted it, and null otherwise. */
+async function ourSessionId(env: Env, sessionId: string | null): Promise<string | null> {
+  if (!sessionId || !SESSION_ID_RE.test(sessionId)) return null;
+  return (await verify(env.COOKIE_ENCRYPTION_KEY, sessionId)) === null ? null : sessionId;
+}
 
 function sessionStub(env: Env, principal: Principal, sessionId: string) {
   // The principal is part of the name, so another user presenting this session id
@@ -95,10 +116,11 @@ async function handleMcp(
   const requestId = request.headers.get('cf-ray');
 
   if (request.method === 'DELETE') {
-    if (!headerSessionId || !SESSION_ID_RE.test(headerSessionId)) {
+    const known = await ourSessionId(env, headerSessionId);
+    if (!known) {
       return new Response('session not found', { status: 404 });
     }
-    await sessionStub(env, principal, headerSessionId).terminate();
+    await sessionStub(env, principal, known).terminate();
     return new Response(null, { status: 204 });
   }
 
@@ -141,7 +163,7 @@ async function handleMcp(
         headers: { 'retry-after': '60' },
       });
     }
-    sessionId = crypto.randomUUID();
+    sessionId = await mintSessionId(env);
     minted = true;
   } else {
     const { success } = await env.CALL_LIMITER.limit({ key: principal.userId });
@@ -151,10 +173,11 @@ async function handleMcp(
         headers: { 'retry-after': '60' },
       });
     }
-    if (!headerSessionId || !SESSION_ID_RE.test(headerSessionId)) {
+    const known = await ourSessionId(env, headerSessionId);
+    if (!known) {
       return new Response('session not found', { status: 404 });
     }
-    sessionId = headerSessionId;
+    sessionId = known;
   }
 
   const stub = sessionStub(env, principal, sessionId);
@@ -205,8 +228,8 @@ async function handleFiles(
   principal: Principal,
   url: URL,
 ): Promise<Response> {
-  const sessionId = request.headers.get('mcp-session-id');
-  if (!sessionId || !SESSION_ID_RE.test(sessionId)) {
+  const sessionId = await ourSessionId(env, request.headers.get('mcp-session-id'));
+  if (!sessionId) {
     return new Response('session not found', { status: 404 });
   }
   const name = url.pathname.slice('/files/'.length);

--- a/skills/hwp/SKILL.ko.md
+++ b/skills/hwp/SKILL.ko.md
@@ -322,6 +322,11 @@ hwp serve --addr 0.0.0.0:8080 --root /work --font-dir /usr/share/fonts/truetype/
 제한되지 않은 상태로 실행되어서는 안 되기 때문입니다. 들어오는 `Mcp-Session-Id`는 받아들이되
 무시합니다. session affinity는 앞단 platform의 책임입니다.
 
+PID 1로 직접 실행하지 말고 `tini` 같은 init 아래에서, 또는 `docker run --init`으로 실행하세요.
+`hwp serve`는 시그널 핸들러를 설치하지 않는데, 커널은 기본 처리 방식을 가진 시그널을 PID 1에
+전달하지 않습니다. 따라서 PID 1로 실행하면 SIGTERM을 무시하게 되고, 유휴 컨테이너를 그 방식으로
+정지시키는 플랫폼은 이 컨테이너를 영원히 정지시키지 못합니다.
+
 ## 안전 규칙 (반드시 준수)
 
 1. **쓰기 후에는 항상 검증하세요.** `new` / `edit` / `fill` / `compose` / `template` /

--- a/skills/hwp/SKILL.md
+++ b/skills/hwp/SKILL.md
@@ -325,6 +325,11 @@ hwp serve --addr 0.0.0.0:8080 --root /work --font-dir /usr/share/fonts/truetype/
 never run with unrestricted filesystem access. An inbound `Mcp-Session-Id` is accepted and ignored,
 because session affinity belongs to the platform in front.
 
+Run it under an init such as `tini`, or with `docker run --init`, rather than as PID 1. `hwp serve`
+installs no signal handlers, and the kernel does not deliver a signal with its default disposition
+to PID 1 — so as PID 1 it ignores SIGTERM, and a platform that stops idle containers that way will
+never stop it.
+
 ## Safety rules (must follow)
 
 1. **Validate after every write.** After `new` / `edit` / `fill` / `compose` / `template` /


### PR DESCRIPTION
Two cost defects found by watching the deployed service, not by reading the code. Both are live spend, so they are worth the detail.

## 1. Idle containers never stopped

`sleepAfter` is 3 minutes and the README called it "the lever that actually bounds both spend and live instance count." It was not bounding anything.

Cloudflare stops an idle container by sending SIGTERM. The kernel does not deliver a signal with its **default disposition to PID 1** — and `hwp serve` is PID 1 in this image, with no handler installed. The signal was silently discarded.

Measured on the image:

```
SigCgt (caught signals mask): 0000000100000440     # SIGTERM not among them
docker kill --signal=TERM <id>  ->  STILL RUNNING after 15s
```

And on the deployed service: a session whose last request was at 19:55:41 was still `running` at 20:03, and a monitor watching for eight minutes concluded `sleepAfter not taking effect`. Earlier, **nine containers had been running for close to four hours.** At 1 GiB each that spends the 25 GiB-h monthly allowance in under three hours, against a $10 cap.

Fix: both images run `tini` as init.

```
PID 1: /usr/bin/tini -- hwp serve --addr 0.0.0.0:8080 ...
docker kill --signal=TERM <id>  ->  exited after 1s (status=exited, exit=143)
```

Image cost: 129 MB -> 130 MB. Tools, `/healthz` and the PDF round trip all still pass.

## 2. Answering 404 still cost a container

The "invented session id" defect was fixed once already, by making `isUsable()` require the marker `initialize` writes. That check runs *inside* the Durable Object, and **reaching the object at all starts a container** — so the request was rejected correctly and billed anyway.

Measured against production:

```
BEFORE:  running: 9e323fd6-...            (a real session)
forged deadbeef-1111-4222-8333-444444444444 -> HTTP 404
AFTER 25s:
         running: 9e323fd6-...
         running: deadbeef-1111-4222-8333-444444444444
```

`CALL_LIMITER` allows 120 calls a minute, so an authenticated caller could hold all 20 instances with junk ids and lock real users out of a service that answers 503 when full.

Fix: session ids now carry an HMAC of themselves, reusing the `sign`/`verify` helpers the dashboard cookies already use. `ourSessionId()` verifies at the edge, so a forged id never reaches the object. The id stays opaque to clients; only its shape changes (`<uuid>.<mac>`).

## Verification

- `npx tsc --noEmit` clean.
- Image rebuilt and exercised: 20 tools, `hwp_new` -> `hwp_render` (PDF, Korean text) -> `/files` download, non-root uid 10001, SIGTERM exit in 1s.
- Post-deploy the negative matrix and an idle-stop observation need rerunning against the live service; the README now carries the one-liner for the instance-count check.

No Rust code is touched. Existing sessions are invalidated by the id format change, which is acceptable: sessions are single-use scratch workspaces and none are in production use.