### PR TITLE
docs(deploy): say why a retired session id is not the same risk as a forged one

### DIFF
--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -185,6 +185,16 @@ Worth recording, because each one only appeared against the deployed service:
    `ourSessionId()` rejects a forged one at the edge and the object is never
    touched. Without this an authenticated caller could hold the whole instance
    ceiling with junk ids and lock real users out.
+
+   A *retired* id — one this service really minted, whose session has since
+   stopped — still reaches the object and starts a container once, because the
+   edge cannot know a session died without asking. That is bounded and was left
+   alone: the id maps to one object, so retrying it cannot create more than one
+   container, obtaining ids is already capped at 5 `initialize` calls a minute,
+   and the container stops on the idle timer (measured: gone within a minute).
+   A forged id was different in kind — invented ids are unlimited. Do not add a
+   per-request KV lookup to close this; it would cost a network hop on every
+   call to save a container that stops by itself.
 5. **Idle containers never stopped.** The platform stops an idle container with
    SIGTERM, and the kernel does not deliver a default-disposition signal to
    PID 1, so `hwp serve` as PID 1 ignored it: `sleepAfter` looked configured and


### PR DESCRIPTION
Post-deploy verification of #198 turned up a sibling of the forged-id defect, and this records why it was left alone.

An id this service really minted, whose session has since stopped, still reaches the Durable Object and starts a container once — the edge cannot know a session died without asking someone. Observed directly: probing a session that had already been retired brought a container back up, and it stopped on its own within a minute.

It is bounded in a way the forged case was not:

- one id maps to one object, so retrying it cannot create more than one container, where invented ids were unlimited;
- obtaining ids is already capped at 5 `initialize` calls a minute, and each of those already cost a container;
- the idle timer stops it, which now works.

The note exists mostly to head off the fix it invites: a per-request KV lookup would put a network hop on every call to save a container that goes away by itself.

Docs only.