### PR TITLE
chore(release): v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.15.1]
+
 **Fixed**
 
 - `hwp serve` now stops on `SIGTERM` and `SIGINT` instead of ignoring them. The command exists for

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hwp-cli"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "hwp-model",
  "hwpx",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-render"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "encoding_rs",
  "flate2",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes",
  "cfb",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.15.0"
+version = "0.15.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"

--- a/README.ko.md
+++ b/README.ko.md
@@ -110,7 +110,7 @@ curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/inst
 기본 위치는 `~/.local/bin`이다(PATH에 없으면 안내를 출력한다). 위치·버전은 인자나 환경변수로 바꾼다:
 
 ```sh
-curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.15.0
+curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.15.1
 HWP_INSTALL_DIR=~/bin sh scripts/install.sh
 ```
 
@@ -151,7 +151,7 @@ RHEL/CentOS 7+ 및 그 이후 배포판에서 그대로 돌아간다. 빌드 러
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
-  | sh -s -- --tag v0.15.0 --dir ./bin
+  | sh -s -- --tag v0.15.1 --dir ./bin
 ```
 
 플랫폼이 배포 번들을 수집하기 전에 바이너리가 있어야 하므로(Vercel `includeFiles`, Next.js

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The default location is `~/.local/bin` (if it is not on PATH, the script says so
 location or version with arguments or environment variables:
 
 ```sh
-curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.15.0
+curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.15.1
 HWP_INSTALL_DIR=~/bin sh scripts/install.sh
 ```
 
@@ -167,7 +167,7 @@ to bump:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
-  | sh -s -- --tag v0.15.0 --dir ./bin
+  | sh -s -- --tag v0.15.1 --dir ./bin
 ```
 
 Run this from the build command (or a `prebuild` script) so the binary exists before the platform


### PR DESCRIPTION
Patch release: one shipped-binary fix since v0.15.0.

## What ships

`hwp serve` stops on SIGTERM and SIGINT instead of ignoring them (#199). The command exists for container deployment, where it is usually PID 1, and the kernel does not deliver a signal that still has its default disposition to PID 1 — so a process installing no handler discarded the stop signal outright. On Cloudflare Containers that left nine instances running for close to four hours with `sleepAfter` set to three minutes and doing nothing.

An in-flight request still runs to completion; a second signal exits immediately so a long tool call cannot make the process unkillable. Windows is unchanged.

Everything else merged since v0.15.0 (#197, #198, #200) is deployment infrastructure under `deploy/cloudflare/` and does not ship in the release artifacts.

## Release prep

- `CHANGELOG.md`: Unreleased section closed as `[0.15.1]`; `scripts/release_notes.sh 0.15.1` extracts it cleanly.
- `README.md` / `README.ko.md`: `install.sh --tag` pins moved to v0.15.1.
- `scripts/release.sh 0.15.1` bumped `[workspace.package] version` and relocked the workspace crates offline.
- `tools/list` returns 20, matching every "twenty tools" claim in the docs.
- `scripts/check.sh` run on this tree.

Patch rather than minor: the only shipped change is a fix, and the repo has patch-release precedent (v0.12.1, v0.8.x).

Tag goes on the merge commit once main CI is green.