### PR TITLE
build(deploy): pin the container to v0.15.1 and drop the init

### DIFF
--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -199,10 +199,10 @@ Worth recording, because each one only appeared against the deployed service:
    SIGTERM, and the kernel does not deliver a default-disposition signal to
    PID 1, so `hwp serve` as PID 1 ignored it: `sleepAfter` looked configured and
    did nothing. Nine containers had been running for close to four hours. Fixed
-   twice over: `hwp serve` installs a handler and exits cleanly even as PID 1,
-   and the image runs tini for the releases that predate it. `docker kill
-   --signal=TERM` exits the container in about a second either way, where before
-   it stayed up indefinitely.
+   in the binary: `hwp serve` installs a handler and exits cleanly even as PID 1,
+   released as 0.15.1 and pinned here. `docker kill --signal=TERM` now exits the
+   container in about two seconds, where before it stayed up indefinitely. tini
+   carried the image between the discovery and the release, and is gone again.
 
 ## What is already verified
 
@@ -244,10 +244,10 @@ The platform asks with SIGTERM, and the kernel does not deliver a signal with it
 default disposition to PID 1 - so with `hwp serve` as PID 1 and no handler, the
 stop was silently discarded and containers stayed awake indefinitely. Nine of
 them ran for close to four hours before this was caught, which at 1 GiB each
-would have spent the monthly allowance in under three hours. `hwp serve` now
-installs the handler itself, and the image also runs tini as its init because
-`HWP_VERSION` still pins 0.15.0, which predates that. If a future change touches
-the entrypoint or the pinned version, re-run the check below.
+would have spent the monthly allowance in under three hours. `hwp serve` installs
+the handler itself since 0.15.1, which is what `HWP_VERSION` pins, so the image
+needs no init. Moving `HWP_VERSION` below 0.15.1 would reintroduce the defect;
+re-run the check below after any change to the pin or the entrypoint.
 
 To check that idle sessions really stop, watch the running instance count fall to
 zero within a few minutes of the last request:

--- a/deploy/cloudflare/container/Dockerfile
+++ b/deploy/cloudflare/container/Dockerfile
@@ -19,7 +19,7 @@ FROM debian:bookworm-slim
 # Rendering and PDF output need real font files; fonts-nanum matches the font
 # baseline CI already uses (glyf outlines, fast in debug builds).
 RUN apt-get update \
- && apt-get install -y --no-install-recommends fonts-nanum tini \
+ && apt-get install -y --no-install-recommends fonts-nanum \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build /src/target/release/hwp /usr/local/bin/hwp
@@ -30,14 +30,8 @@ RUN useradd --create-home --uid 10001 hwp \
 USER hwp
 WORKDIR /work
 
-# The platform stops an idle container with SIGTERM, and the kernel does not
-# deliver a signal with its default disposition to PID 1 - so a PID 1 that
-# installs no handler discards it and the container stays awake and billing.
-# `hwp serve` handles SIGTERM itself, so this image would stop correctly without
-# an init; tini stays only to keep the two images identical in how they run, and
-# to reap should `hwp` ever spawn a child.
-ENTRYPOINT ["/usr/bin/tini", "--"]
-
+# No init: `hwp serve` handles SIGTERM itself, so it stops correctly even as PID 1,
+# where the kernel delivers no signal that still has its default disposition.
 EXPOSE 8080
 CMD ["hwp", "serve", \
      "--addr", "0.0.0.0:8080", \

--- a/deploy/cloudflare/container/Dockerfile.slim
+++ b/deploy/cloudflare/container/Dockerfile.slim
@@ -13,9 +13,9 @@
 # is published alongside the tarball as hwp-<version>-<target>.sha256; the build
 # fails loudly if it does not match, which is the point.
 
-ARG HWP_VERSION=v0.15.0
+ARG HWP_VERSION=v0.15.1
 ARG HWP_TARGET=x86_64-unknown-linux-gnu
-ARG HWP_SHA256=884b762cbb005830e9f32f0862c84889e84fecb80e5e9b868b3db5b4b3b5fe76
+ARG HWP_SHA256=0c8f92a91eae1e6c8bb2932afbd5084ab918c6a1397ab68acbd3dc6a8cc9284d
 
 # Fetch stage. ADD downloads over the builder's own network stack, so no curl and
 # no CA bundle are ever installed; keeping it in a discarded stage also keeps the
@@ -38,7 +38,7 @@ FROM debian:bookworm-slim
 # Rendering and PDF output need real font files; fonts-nanum matches the font
 # baseline CI already uses (glyf outlines, fast in debug builds).
 RUN apt-get update \
- && apt-get install -y --no-install-recommends fonts-nanum tini \
+ && apt-get install -y --no-install-recommends fonts-nanum \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=fetch /usr/local/bin/hwp /usr/local/bin/hwp
@@ -49,15 +49,11 @@ RUN useradd --create-home --uid 10001 hwp \
 USER hwp
 WORKDIR /work
 
-# The platform stops an idle container with SIGTERM, and the kernel does not
-# deliver a signal with its default disposition to PID 1 - so a PID 1 that
-# installs no handler discards it and the container stays awake and billing.
-# `hwp serve` handles SIGTERM itself from the release after 0.15.0 onward, but
-# HWP_VERSION still pins 0.15.0, which does not. tini becomes PID 1 and forwards
-# the signal, so the image is correct either way. Once HWP_VERSION moves past
-# 0.15.0 this is redundant and may go.
-ENTRYPOINT ["/usr/bin/tini", "--"]
-
+# No init: `hwp serve` handles SIGTERM itself since 0.15.1, so it stops correctly
+# even as PID 1, where the kernel delivers no signal that still has its default
+# disposition. If HWP_VERSION is ever moved back below 0.15.1, put tini back -
+# without one, the platform's idle stop is discarded and the container bills
+# until it is destroyed outright.
 EXPOSE 8080
 CMD ["hwp", "serve", \
      "--addr", "0.0.0.0:8080", \


### PR DESCRIPTION
Moves the session container onto the release that carries the SIGTERM handler, and removes the workaround that stood in for it.

## Why the init can go

#198 added tini because `hwp serve` ignored SIGTERM as PID 1. #199 fixed that in the binary, and v0.15.1 ships it — so tini has no job left. It existed only to carry the image between finding the defect and releasing the fix.

## Verified on the built image

```
version: hwp 0.15.1
PID 1:   hwp serve --addr 0.0.0.0:8080 --root /work ...      # no init in front
SigCgt:  0000000100004442                                     # SIGTERM caught
healthz 200, 20 tools, hwp_new ok, PDF via /files 200 (10304 bytes)
docker kill --signal=TERM  ->  exited after 2s (exit=0)
hwp serve: shutting down
```

Image stays 129 MB; the build is 8.2 s.

## Checksum

`HWP_SHA256` is the published `hwp-v0.15.1-x86_64-unknown-linux-gnu.sha256`, independently recomputed from the downloaded tarball before it was written in:

```
published: 0c8f92a91eae1e6c8bb2932afbd5084ab918c6a1397ab68acbd3dc6a8cc9284d
computed : 0c8f92a91eae1e6c8bb2932afbd5084ab918c6a1397ab68acbd3dc6a8cc9284d
```

## Not a trap for the next reader

The comment replacing the ENTRYPOINT says what to restore if `HWP_VERSION` is ever moved back below 0.15.1 — without an init on an older binary, the platform's idle stop is discarded and the container bills until destroyed outright. The README says the same and keeps the instance-count check.