### PR TITLE
feat(release): publish an aarch64-unknown-linux-gnu binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,11 @@ jobs:
           - target: x86_64-unknown-linux-gnu.2.17
             os: ubuntu-latest
             build-tool: cargo-zigbuild
+          # Same treatment for arm64, which AgentCore requires. glibc's aarch64 port
+          # starts at 2.17, so the same floor is both valid and the lowest meaningful one.
+          - target: aarch64-unknown-linux-gnu.2.17
+            os: ubuntu-latest
+            build-tool: cargo-zigbuild
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-apple-darwin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+**Added**
+
+- A `aarch64-unknown-linux-gnu` release archive, cross-built against the same glibc 2.17 floor as
+  the x86_64 Linux one, so `install.sh` and `hwp update` now serve arm64 Linux instead of sending it
+  to a source build. Homebrew is unchanged: it does not run on arm64 Linux.
+
 ## [0.15.1]
 
 **Fixed**

--- a/README.ko.md
+++ b/README.ko.md
@@ -135,6 +135,7 @@ hwp --version
 | 플랫폼 | 아카이브 |
 |---|---|
 | Linux x86_64 | `hwp-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux arm64 | `hwp-vX.Y.Z-aarch64-unknown-linux-gnu.tar.gz` |
 | macOS Apple Silicon | `hwp-vX.Y.Z-aarch64-apple-darwin.tar.gz` |
 | macOS Intel | `hwp-vX.Y.Z-x86_64-apple-darwin.tar.gz` |
 | Windows x86_64 | `hwp-vX.Y.Z-x86_64-pc-windows-msvc.zip` |

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Every [release](https://github.com/STAIxBWLB/hwp-cli/releases) attaches per-plat
 | Platform | Archive |
 |---|---|
 | Linux x86_64 | `hwp-vX.Y.Z-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux arm64 | `hwp-vX.Y.Z-aarch64-unknown-linux-gnu.tar.gz` |
 | macOS Apple Silicon | `hwp-vX.Y.Z-aarch64-apple-darwin.tar.gz` |
 | macOS Intel | `hwp-vX.Y.Z-x86_64-apple-darwin.tar.gz` |
 | Windows x86_64 | `hwp-vX.Y.Z-x86_64-pc-windows-msvc.zip` |

--- a/crates/hwp-cli/src/commands/update.rs
+++ b/crates/hwp-cli/src/commands/update.rs
@@ -54,6 +54,7 @@ pub fn target_triple(os: &str, arch: &str) -> Option<(&'static str, Archive)> {
         ("macos", "aarch64") => Some(("aarch64-apple-darwin", Archive::TarGz)),
         ("macos", "x86_64") => Some(("x86_64-apple-darwin", Archive::TarGz)),
         ("linux", "x86_64") => Some(("x86_64-unknown-linux-gnu", Archive::TarGz)),
+        ("linux", "aarch64") => Some(("aarch64-unknown-linux-gnu", Archive::TarGz)),
         ("windows", "x86_64") => Some(("x86_64-pc-windows-msvc", Archive::Zip)),
         _ => None,
     }
@@ -456,7 +457,10 @@ mod tests {
             Some(("x86_64-pc-windows-msvc", Archive::Zip))
         );
         // 릴리스가 없는 조합은 소스 설치로 안내해야 하므로 None이어야 한다.
-        assert_eq!(target_triple("linux", "aarch64"), None);
+        assert_eq!(
+            target_triple("linux", "aarch64"),
+            Some(("aarch64-unknown-linux-gnu", Archive::TarGz))
+        );
         assert_eq!(target_triple("freebsd", "x86_64"), None);
     }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -40,6 +40,7 @@ case "$os/$arch" in
   Darwin/arm64)  target="aarch64-apple-darwin" ;;
   Darwin/x86_64) target="x86_64-apple-darwin" ;;
   Linux/x86_64)  target="x86_64-unknown-linux-gnu" ;;
+  Linux/aarch64) target="aarch64-unknown-linux-gnu" ;;
   *) die "사전 빌드 바이너리가 없는 플랫폼입니다: $os/$arch
   소스에서 설치하세요: cargo install --git https://github.com/$REPO hwp-cli" ;;
 esac


### PR DESCRIPTION
Adds the Linux arm64 release artifact (#189 B1, first half). The AgentCore image needs a published arm64 tarball to pin; none existed.

## The build risk was retired first

The only C in the dependency graph is `zstd-sys`, pulled by `zip`'s default features. Rather than find out on a tag, this was reproduced in a `rust:1.93` container running exactly what the action runs:

```
cargo zigbuild --release -p hwp-cli --bin hwp --target aarch64-unknown-linux-gnu.2.17
    Finished `release` profile [optimized] target(s) in 39.90s

hwp: ELF 64-bit LSB pie executable, ARM aarch64, ... interpreter /lib/ld-linux-aarch64.so.1, stripped
glibc floor: GLIBC_2.17
17,136,824 bytes
```

`zstd-sys` cross-compiles without complaint. The `.2.17` floor is valid on aarch64 — glibc's aarch64 port starts there, so it is also the lowest meaningful one.

## The change

- **`release.yml`** — one matrix entry. The `pip3 install cargo-zigbuild` step is already gated on `matrix.build-tool`, and the action strips `.2.17` when naming, so the asset is `hwp-vX.Y.Z-aarch64-unknown-linux-gnu.tar.gz`. `skill-bundle` downloads a literal x86_64 pattern and is unaffected.
- **`update.rs`** — the target table gains the arm. Its test asserted `target_triple("linux","aarch64") == None`, so that assertion is **inverted, not deleted**; `("freebsd","x86_64")` still covers the `None` branch. Without the flip `cargo test` goes red.
- **`install.sh`** — one `case` arm. Only `aarch64`: `arm64` from `uname -m` is a Darwin-ism, already handled by the `Darwin/arm64` arm.
- Platform tables in both READMEs, and a CHANGELOG `**Added**` bullet.

## Deliberately not touched

`Formula/hwp.rb` and `scripts/update_formula.sh`. They are all-or-nothing — adding the triple to `TARGETS` without a formula stanza fails `update-formula` with `치환 실패: aarch64-unknown-linux-gnu` on the next release — and **Homebrew does not run on arm64 Linux**, so a stanza would advertise what cannot be exercised. The brew sentences in both READMEs stay true as written.

## One consequence, accepted knowingly

`skill-bundle` has `needs: upload-assets`, which fails if any matrix job fails. So a future arm64 build failure leaves a release in **draft** — every release becomes contingent on arm64 building. That is the correct behaviour; `continue-on-error` would instead publish a release whose platform table advertises an asset that is not there.

## Verification

`cargo fmt --check` clean; `cargo test -p hwp-cli --bins` 223 passed, including the flipped assertion. The workflow parses and the matrix now lists 5 targets. The release path itself is exercised on the next tag.