### PR TITLE
feat(deploy): serve on hwp-mcp.staix.net

### DIFF
--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -22,7 +22,7 @@ All four are satisfied; nothing here needs repeating for a first deploy.
 |---|---|
 | Workers Paid | Active. `wrangler containers list` succeeds, which is the authoritative test |
 | API token `hwp-mcp deploy` | Created, scoped to the `entelecheia` account with Workers Scripts, Workers KV Storage, D1 and Containers all at Edit. Verified against `/user/tokens/verify` and stored on the deploy host at `~/.config/hwp-mcp-deploy.env` (mode 600) |
-| Google OAuth client `hwp MCP` | Web application in project `chu-rise`, redirect URI `https://hwp-mcp.staix.workers.dev/callback`. Its id and secret are Worker secrets already |
+| Google OAuth client `hwp MCP` | Web application in project `chu-rise`. **Both** redirect URIs are registered: `https://hwp-mcp.staix.net/callback` and `https://hwp-mcp.staix.workers.dev/callback`. Both are required while two hostnames serve the Worker, because `google-handler.ts` builds the redirect from `url.origin`, so whichever host the user arrived on is the one sent to Google. Its id and secret are Worker secrets already |
 | Budget notification | Cloudflare's auto-created budget alert is already exactly $10 USD to yj.lee@me.com |
 
 Two things about the Google side are worth knowing before anyone else tries to sign in:
@@ -60,9 +60,16 @@ EOF
 
 ## Already provisioned
 
-Account `entelecheia` (`b378caab1c7aea09cb77db791fe5f3f8`), workers.dev subdomain
-`staix`, so the service URL is
-`https://hwp-mcp.staix.workers.dev`.
+Account `entelecheia` (`b378caab1c7aea09cb77db791fe5f3f8`). The service URL is
+`https://hwp-mcp.staix.net`, a Custom Domain on the `staix.net` zone declared in
+`wrangler.jsonc`; Cloudflare owns its DNS record and certificate.
+
+`https://hwp-mcp.staix.workers.dev` still answers and is meant to. Nothing stored
+is tied to a hostname - the OAuth provider keys KV as `client:`/`grant:`/`token:`
+with no origin, and PATs are SHA-256 hashes in D1 - so every registered client,
+grant, token and PAT works on both. Rolling back is deleting the `routes` block
+and deploying, which costs no client anything because none was ever forced off
+the old host.
 
 These exist and their ids are already in `wrangler.jsonc` — do not recreate them:
 
@@ -107,12 +114,12 @@ image. The Worker URL may answer before container routes do.
 ```bash
 # 1. Protocol, from a machine with a browser.
 npx @modelcontextprotocol/inspector
-#    Transport: Streamable HTTP → https://hwp-mcp.staix.workers.dev/mcp
+#    Transport: Streamable HTTP → https://hwp-mcp.staix.net/mcp
 #    Expect: dynamic registration → Google sign-in → initialize returns
 #    Mcp-Session-Id → tools/list shows exactly 20 tools.
 
 # 2. A real client.
-claude mcp add --transport http hwp https://hwp-mcp.staix.workers.dev/mcp
+claude mcp add --transport http hwp https://hwp-mcp.staix.net/mcp
 ```
 
 Then check the negatives, which are the parts worth distrusting:
@@ -129,7 +136,8 @@ After testing, confirm the container count returns to zero in the dashboard.
 
 ## Deployed and verified
 
-Live at `https://hwp-mcp.staix.workers.dev`. The whole path was exercised against
+Live at `https://hwp-mcp.staix.net` (and still at `https://hwp-mcp.staix.workers.dev`).
+The whole path was exercised against
 the real service: dynamic client registration, the consent screen, Google
 sign-in, an access token this Worker issued (never a Google one), `initialize`
 starting a container, `tools/list` returning all 20 tools, `hwp_new` writing into

--- a/deploy/cloudflare/src/dashboard.ts
+++ b/deploy/cloudflare/src/dashboard.ts
@@ -65,7 +65,13 @@ function when(ms: number | null): string {
   return ms ? new Date(ms).toISOString().slice(0, 16).replace('T', ' ') : 'never';
 }
 
-async function render(env: Env, userId: string, csrf: string, fresh?: string): Promise<string> {
+async function render(
+  env: Env,
+  origin: string,
+  userId: string,
+  csrf: string,
+  fresh?: string,
+): Promise<string> {
   const { results } = await env.DB.prepare(
     `SELECT id, label, created_at, last_used_at FROM pats
       WHERE user_id = ? AND revoked_at IS NULL ORDER BY created_at DESC`,
@@ -95,7 +101,7 @@ async function render(env: Env, userId: string, csrf: string, fresh?: string): P
          <p><strong>Copy this now.</strong> It is not shown again.</p>
          <code>${escape(fresh)}</code>
          <p>Point a client at it with:</p>
-         <code>claude mcp add --transport http hwp https://hwp-mcp.staix.workers.dev/mcp --header "Authorization: Bearer ${escape(fresh)}"</code>
+         <code>claude mcp add --transport http hwp ${escape(origin)}/mcp --header "Authorization: Bearer ${escape(fresh)}"</code>
        </div>`
     : '';
 
@@ -145,7 +151,7 @@ export async function handleDashboard(request: Request, env: Env, url: URL): Pro
   if (csrf.header) headers['set-cookie'] = csrf.header;
 
   if (request.method === 'GET' && url.pathname === '/dashboard') {
-    return page(await render(env, userId, csrf.value), headers);
+    return page(await render(env, url.origin, userId, csrf.value), headers);
   }
 
   if (request.method === 'POST') {
@@ -162,7 +168,7 @@ export async function handleDashboard(request: Request, env: Env, url: URL): Pro
       )
         .bind(crypto.randomUUID(), userId, await sha256Hex(token), label, Date.now())
         .run();
-      return page(await render(env, userId, csrf.value, token), headers);
+      return page(await render(env, url.origin, userId, csrf.value, token), headers);
     }
 
     if (url.pathname === '/dashboard/revoke') {
@@ -175,7 +181,7 @@ export async function handleDashboard(request: Request, env: Env, url: URL): Pro
           .bind(Date.now(), id, userId)
           .run();
       }
-      return page(await render(env, userId, csrf.value), headers);
+      return page(await render(env, url.origin, userId, csrf.value), headers);
     }
   }
 

--- a/deploy/cloudflare/wrangler.jsonc
+++ b/deploy/cloudflare/wrangler.jsonc
@@ -52,6 +52,14 @@
     { "name": "CALL_LIMITER", "namespace_id": "1002", "simple": { "limit": 120, "period": 60 } }
   ],
 
+  // A Custom Domain rather than a route: Cloudflare provisions the DNS record and
+  // the certificate itself, where a plain route would need both done by hand first.
+  // workers.dev stays on deliberately. Every credential is host-independent - the
+  // OAuth provider keys KV as client:/grant:/token: with no origin, and PATs are
+  // SHA-256 hashes in D1 - so clients configured before the move keep working on
+  // the old hostname instead of breaking on a date nobody told them about.
+  "routes": [{ "pattern": "hwp-mcp.staix.net", "custom_domain": true }],
+
   "assets": { "directory": "./public", "binding": "ASSETS" },
 
   "observability": { "enabled": true }


### PR DESCRIPTION
Puts the service on a Custom Domain instead of only a workers.dev hostname (#189 A3). The `staix.net` zone is already on the account, so this is a hostname choice, not a purchase.

## ⚠️ Do not deploy this before adding the Google redirect URI

`google-handler.ts:58` and `:163` build `redirect_uri` from `url.origin`, so the first sign-in on the new host sends Google a URI it has never seen and fails with `redirect_uri_mismatch`. **Add `https://hwp-mcp.staix.net/callback` to the `hwp MCP` client first, keeping the existing `https://hwp-mcp.staix.workers.dev/callback`.** Both are needed while two hostnames serve the Worker.

## The cutover is additive, not a migration

This was the assumption worth checking, and it holds. `@cloudflare/workers-oauth-provider` keys KV as `client:${clientId}`, `grant:${userId}:${grantId}`, `token:${userId}:${grantId}:${tokenId}` — **no origin anywhere** — and PATs are SHA-256 hashes in D1. So:

| Artifact | Survives? |
|---|---|
| Registered OAuth clients, grants, access tokens | Yes, keys carry no origin |
| PATs | Yes, host never involved |
| User records (keyed on `google_sub`) | Yes |
| Clients configured with the old URL | Yes, while workers.dev is on |

`workers_dev` therefore stays on deliberately: two hostnames cost nothing and no client breaks on a date nobody told it about. Rollback is deleting the `routes` block and deploying — zero client impact, because nobody was forced off the old host.

`custom_domain: true` rather than a plain route with `zone_name`: Cloudflare then provisions the DNS record and the certificate itself, where a route needs both done by hand first.

## `dashboard.ts`

The fresh-token banner was the only place in shipped code that hardcoded the hostname. It now takes the origin the request arrived on — `handleDashboard` already holds `url` — so it prints the host the token was actually minted on, correct on both hostnames at once. Hardcoding the new host would be the same line count and re-plant the bug for the next rename.

## Verification after deploy

- Certificate provisioning is asynchronous; **525/526 for a few minutes is normal, retry ~15 min before rolling back.**
- `curl -sI https://hwp-mcp.staix.net/` → 200
- `/.well-known/oauth-authorization-server` reports the new host in every endpoint
- MCP Inspector: registration → Google sign-in → `initialize` → `tools/list` = 20
- Dashboard on the new host mints a PAT and the banner prints `hwp-mcp.staix.net`
- Spoofed `Origin` → 403; correct one → not 403
- The **old** hostname still serves an existing PAT

`npx tsc --noEmit` is clean, which is what catches the `render()` signature change.