### PR TITLE
feat(mcp): inline base64 file transfer for remote sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 **Added**
 
+- `hwp_put_file` and `hwp_get_file` move documents in and out of a session workspace as base64,
+  capped at 512 KiB decoded. Remote deployments could author documents from text but could not
+  ingest an existing one: no tool accepted document bytes, and the `/files` route needs an
+  out-of-band HTTP request an MCP client cannot make. AgentCore, which exposes `/mcp` and nothing
+  else, has no sideband at all. The tool count is now 22; the twenty existing schemas are unchanged.
 - A `aarch64-unknown-linux-gnu` release archive, cross-built against the same glibc 2.17 floor as
   the x86_64 Linux one, so `install.sh` and `hwp update` now serve arm64 Linux instead of sending it
   to a source build. Homebrew is unchanged: it does not run on arm64 Linux.

--- a/README.ko.md
+++ b/README.ko.md
@@ -466,7 +466,7 @@ Amazon Quick Web은 로컬 stdio 프로세스를 시작할 수 없다. 이제 `h
 edge가 있다고 전제하는 private hop이다. 인증된 Streamable HTTP, tenant 격리, artifact 전송은
 여전히 [Remote MCP transport](docs/design/20-remote-mcp.ko.md)의 후속 작업이다.
 
-### 노출 도구 (20종)
+### 노출 도구 (22종)
 
 | 도구 | 필수 인자 | 기능 |
 |---|---|---|
@@ -490,6 +490,8 @@ edge가 있다고 전제하는 private hop이다. 인증된 Streamable HTTP, ten
 | `hwp_merge` | `inputs`, `output` | 문서 두 개 이상을 합치고 보존 손실 원장을 반환 |
 | `hwp_split` | `input`, `out_dir` | Section 단위(또는 `pages` 범위)로 나누고 발행된 조각 경로를 반환 |
 | `hwp_compare` | `a`, `b` | 읽기 전용 문단·구조 비교를 `hwp-compare-report-v1`으로 반환. 차이가 있어도 `isError`가 아니므로 `identical`을 읽는다 |
+| `hwp_put_file` | `name`, `content` | base64 콘텐츠를 세션 워크스페이스에 저장. 원격 배포에 기존 문서를 넣는 유일한 경로다. 도구 인자는 경로를 받으므로 먼저 올린 뒤 그 이름을 넘긴다. 복호 512 KiB 상한 |
+| `hwp_get_file` | `path` | 워크스페이스 파일을 base64로 반환(영수증 블록 + embedded resource). 상한을 넘으면 자르지 않고 거절한다. 중간 산출물은 워크스페이스에 두고 최종 결과물만 받는다. 반환된 base64는 클라이언트 메시지 스트림에 쌓인다 |
 
 ### 클라이언트 설정 예
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ and in CI.
 - **Document-level workflows** Merge several documents into one (`hwp merge`, one Section per
   input), split one into per-section or per-page-range fragments (`hwp split`), and report the
   paragraph and structural differences between two documents (`hwp compare`).
-- **MCP server** A dependency-free (serde_json only) stdio MCP server exposing 20 tools to
+- **MCP server** A dependency-free (serde_json only) stdio MCP server exposing 22 tools to
   desktop clients, including Amazon Quick Desktop.
 
 ## Implementation status
@@ -61,7 +61,7 @@ and in CI.
 | Certification (`certify`) and structured corpus gate (`corpus`) | Implemented |
 | Document-level workflows (`merge`, `split`, `compare`) | Implemented; spot-checked in Hancom on 2026-08-29 (see [12-feature-gaps](docs/design/12-feature-gaps.md) GM-3/GM-4/GM-8) |
 | Official-document authoring (profiles, templates, frames, lint, table styling) | Implemented |
-| MCP server (20 tools) | Implemented |
+| MCP server (22 tools) | Implemented |
 | Distribution documents (배포용문서) | Read |
 | HTML conversion | Structural parity with markdown; CSS mapping of character and paragraph shapes is still coarse |
 | Equations | Approximated as a box plus the script |
@@ -480,7 +480,7 @@ The copy-paste Windows setup, create/validate acceptance test, reusable agent in
 symptom-driven recovery are in the dedicated
 [Amazon Quick Desktop runbook](docs/manual/amazon-quick-desktop.md).
 
-Amazon Quick Desktop can launch this local stdio server and expose all 20 tools. Install the
+Amazon Quick Desktop can launch this local stdio server and expose all 22 tools. Install the
 publish-safe skill into its active profile with:
 
 ```sh
@@ -524,6 +524,8 @@ tenant isolation and artifact transfer remain future work in
 | `hwp_merge` | `inputs`, `output` | Combine two or more documents; returns the preservation ledger |
 | `hwp_split` | `input`, `out_dir` | Split per Section (or per `pages` range); returns the published fragment paths |
 | `hwp_compare` | `a`, `b` | Read-only paragraph/structure diff as `hwp-compare-report-v1`. Differences never set `isError` — read `identical` |
+| `hwp_put_file` | `name`, `content` | Write base64 content into the session workspace. The only way to hand an existing document to a remote deployment: tool arguments take paths, so upload first and pass the name. 512 KiB decoded |
+| `hwp_get_file` | `path` | Return a workspace file as base64 (a receipt block plus an embedded resource). Refuses above 512 KiB rather than truncating. Keep intermediates in the workspace and fetch only the final artifact - the base64 lands in the client's message stream |
 
 ### Client configuration example
 

--- a/crates/hwp-cli/src/commands/mcp/mod.rs
+++ b/crates/hwp-cli/src/commands/mcp/mod.rs
@@ -32,6 +32,16 @@ const MAX_REQUEST_LINE_BYTES: usize = 1024 * 1024;
 const DEFAULT_READ_BYTES: usize = 256 * 1024;
 const MAX_READ_BYTES: usize = 1024 * 1024;
 
+/// 인라인 전송 한 건의 복호 후 상한 (doc 22 §3.3).
+///
+/// base64는 3바이트를 4문자로 부풀리므로 512 KiB는 약 699 KB로 인코딩되고, 1 MiB인
+/// `MAX_REQUEST_LINE_BYTES` 안에 JSON-RPC 봉투가 들어갈 여유가 남는다. Tier A의
+/// `/files`는 64 MiB까지 받으므로, 이 상한은 사이드밴드가 없는 Tier B의 제약이다.
+const MAX_INLINE_CONTENT_BYTES: usize = 512 * 1024;
+/// 복호 전에 거절하기 위한 인코딩 길이 상한. `decode`는 출력 전체를 할당하므로
+/// 먼저 막지 않으면 요청 하나로 상한을 훨씬 넘는 메모리를 잡을 수 있다.
+const MAX_INLINE_CONTENT_B64_CHARS: usize = MAX_INLINE_CONTENT_BYTES.div_ceil(3) * 4;
+
 /// 한 줄 JSON-RPC 요청 → 응답 JSON 문자열. 알림(id 없음)이면 None.
 pub fn handle_request(line: &str, ctx: &dyn FileAuthority) -> Option<String> {
     let mut req: Value = match serde_json::from_str(line) {
@@ -267,6 +277,10 @@ fn call_tool(name: &str, args: &mut Value, ctx: &dyn FileAuthority) -> Value {
             .and_then(|_| tool_lint(args, ctx).map_err(Into::into)),
         "hwp_certify" => reject_password_outside_scope(args)
             .and_then(|_| tool_certify(args, ctx).map_err(Into::into)),
+        "hwp_put_file" => reject_password_outside_scope(args)
+            .and_then(|_| tool_put_file(args, ctx).map_err(Into::into)),
+        "hwp_get_file" => reject_password_outside_scope(args)
+            .and_then(|_| tool_get_file(args, ctx).map_err(Into::into)),
         other => Err(McpToolError::from(format!("알 수 없는 도구: {other}"))),
     };
     match result {
@@ -704,6 +718,159 @@ fn tool_certify(args: &Value, ctx: &dyn FileAuthority) -> Result<Vec<Value>, Str
         return Err(summary);
     }
     Ok(vec![text_content(&summary)])
+}
+
+/// 워크스페이스 파일 하나의 SHA-256 16진 표기.
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest as _, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher
+        .finalize()
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+/// 확장자로 추정한 MIME 타입. 모르면 octet-stream이다.
+fn mime_for(path: &Path) -> &'static str {
+    match path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("hwp") => "application/x-hwp",
+        Some("hwpx") => "application/hwp+zip",
+        Some("pdf") => "application/pdf",
+        Some("png") => "image/png",
+        Some("jpg" | "jpeg") => "image/jpeg",
+        Some("svg") => "image/svg+xml",
+        Some("json") => "application/json",
+        Some("md") => "text/markdown",
+        Some("html") => "text/html",
+        Some("csv") => "text/csv",
+        Some("txt") => "text/plain",
+        Some("docx") => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        Some("odt") => "application/vnd.oasis.opendocument.text",
+        _ => "application/octet-stream",
+    }
+}
+
+/// base64 콘텐츠를 워크스페이스 파일로 쓴다.
+///
+/// Tier B(AgentCore)는 `/mcp` 외의 경로를 제공하지 않으므로 문서가 JSON-RPC 안으로
+/// 들어와야 한다. Tier A에도 필요한데, `/files`는 `Mcp-Session-Id`를 실은 별도 HTTP
+/// 요청이라 MCP 클라이언트가 호출할 수 없기 때문이다. 이 도구가 생기기 전까지 원격
+/// 서비스는 텍스트에서 문서를 **만들 수는** 있어도 기존 문서를 **받을 수는** 없었다.
+///
+/// 이름 검사는 `checked_write_path`에 맡긴다. `/files` 라우트의 `valid_file_name`을
+/// 재사용하지 않는데, 그 정규식은 URL 경로 조각이 canonicalize 검사 없이 root에
+/// 이어붙는 라우트에서 **그 자체가 봉쇄 수단**이라 존재한다. 여기서는
+/// `checked_write_path`가 더 강한 검사를 하며, ASCII 전용 문자셋을 씌우면 다른 모든
+/// 도구가 받는 한글 파일명을 이 도구만 거절하게 된다.
+fn tool_put_file(args: &Value, ctx: &dyn FileAuthority) -> Result<Vec<Value>, String> {
+    let object = args
+        .as_object()
+        .ok_or_else(|| "arguments는 객체여야 합니다".to_string())?;
+    if let Some(unknown) = object
+        .keys()
+        .find(|key| !matches!(key.as_str(), "name" | "content"))
+    {
+        return Err(format!("알 수 없는 hwp_put_file 인자: {unknown}"));
+    }
+    let path = checked_write_path(ctx, arg_str(args, "name")?)?;
+    let content = arg_str(args, "content")?;
+    if content.len() > MAX_INLINE_CONTENT_B64_CHARS {
+        return Err(format!(
+            "content가 너무 큽니다: base64 {}자 (상한 {}자, 복호 {} KiB). \
+             더 작은 파일로 나누거나 Tier A의 /files 경로를 쓰세요.",
+            content.len(),
+            MAX_INLINE_CONTENT_B64_CHARS,
+            MAX_INLINE_CONTENT_BYTES / 1024
+        ));
+    }
+    let bytes = hwp_convert::base64::decode(content)?;
+    // decode는 공백과 패딩을 무시하므로 위 검사만으로는 복호 크기를 보장하지 못한다.
+    if bytes.len() > MAX_INLINE_CONTENT_BYTES {
+        return Err(format!(
+            "content가 너무 큽니다: 복호 {}바이트 (상한 {}바이트)",
+            bytes.len(),
+            MAX_INLINE_CONTENT_BYTES
+        ));
+    }
+    // 스테이징·fsync·재읽기 검증은 다른 모든 출력 경로와 같은 헬퍼가 처리한다.
+    crate::commands::output::write_validated(
+        &path,
+        None,
+        |staged| {
+            std::fs::write(staged, &bytes)?;
+            Ok(())
+        },
+        |staged, _| {
+            let written = std::fs::read(staged)?;
+            if written != bytes {
+                anyhow::bail!("업로드 검증 중 바이트 불일치: {}", staged.display());
+            }
+            Ok(())
+        },
+    )
+    .map_err(|error| format!("{error:#}"))?;
+
+    let summary = serde_json::to_string_pretty(&json!({
+        "path": path.display().to_string(),
+        "bytes": bytes.len(),
+        "sha256": sha256_hex(&bytes),
+    }))
+    .map_err(|error| error.to_string())?;
+    Ok(vec![text_content(&summary)])
+}
+
+/// 워크스페이스 파일을 base64로 돌려준다.
+///
+/// 반환은 두 블록이다. 영수증 역할의 텍스트 블록은 알 수 없는 블록 타입을 버리는
+/// 클라이언트에도 무엇이 생겼는지 남기고, embedded resource 블록이 실제 바이트를
+/// 나른다. `tool_read_scoped`·`tool_render_scoped`가 이미 쓰는 두 블록 관례와 같다.
+///
+/// 상한을 넘으면 잘라내지 않고 거절한다. 반쪽 문서는 오류보다 나쁘고, 파일은 그대로
+/// 남으므로 더 작은 포맷으로 변환하거나 Tier A의 `/files`로 받으면 된다.
+fn tool_get_file(args: &Value, ctx: &dyn FileAuthority) -> Result<Vec<Value>, String> {
+    let object = args
+        .as_object()
+        .ok_or_else(|| "arguments는 객체여야 합니다".to_string())?;
+    if let Some(unknown) = object.keys().find(|key| key.as_str() != "path") {
+        return Err(format!("알 수 없는 hwp_get_file 인자: {unknown}"));
+    }
+    let path = checked_read_path(ctx, arg_str(args, "path")?)?;
+    let size = std::fs::metadata(&path)
+        .map_err(|error| format!("{}: {error}", path.display()))?
+        .len();
+    if size > MAX_INLINE_CONTENT_BYTES as u64 {
+        return Err(format!(
+            "파일이 인라인 상한을 넘습니다: {size}바이트 (상한 {}바이트). \
+             파일은 워크스페이스에 그대로 있으니 더 작은 포맷으로 변환하거나 \
+             Tier A의 /files 경로로 받으세요.",
+            MAX_INLINE_CONTENT_BYTES
+        ));
+    }
+    let bytes = std::fs::read(&path).map_err(|error| format!("{}: {error}", path.display()))?;
+    let summary = serde_json::to_string_pretty(&json!({
+        "path": path.display().to_string(),
+        "bytes": bytes.len(),
+        "sha256": sha256_hex(&bytes),
+    }))
+    .map_err(|error| error.to_string())?;
+    Ok(vec![
+        text_content(&summary),
+        json!({
+            "type": "resource",
+            "resource": {
+                "uri": format!("file://{}", path.display()),
+                "mimeType": mime_for(&path),
+                "blob": hwp_convert::base64::encode(&bytes),
+            }
+        }),
+    ])
 }
 
 /// `hwp merge` over MCP. Every input, the output and the optional loss report
@@ -2260,6 +2427,31 @@ fn tool_defs() -> Vec<Value> {
                     "report": {"type": "string", "description": "존재하지 않는 artifact 디렉터리 경로"}
                 },
                 "required": ["input", "policy", "report"]
+            }
+        }),
+        json!({
+            "name": "hwp_put_file",
+            "description": "base64 콘텐츠를 세션 워크스페이스의 파일로 저장한다. 원격 배포에서 기존 문서를 넣는 유일한 경로다(도구 인자는 경로를 받으므로, 먼저 이 도구로 올린 뒤 그 이름을 넘긴다). 복호 512 KiB 상한.",
+            "inputSchema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "name": {"type": "string", "description": "워크스페이스 안의 파일명 또는 상대 경로"},
+                    "content": {"type": "string", "description": "파일 내용의 base64. 복호 512 KiB 상한"}
+                },
+                "required": ["name", "content"]
+            }
+        }),
+        json!({
+            "name": "hwp_get_file",
+            "description": "워크스페이스 파일을 base64로 돌려준다(영수증 JSON + embedded resource 두 블록). 512 KiB 상한이며 초과 시 자르지 않고 거절한다. 중간 산출물은 워크스페이스에 두고 최종 결과물만 받는 것이 좋다 — 반환된 base64는 클라이언트의 메시지 스트림에 그대로 쌓인다.",
+            "inputSchema": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "path": {"type": "string", "description": "워크스페이스 안의 파일 경로"}
+                },
+                "required": ["path"]
             }
         }),
         json!({
@@ -4857,5 +5049,136 @@ mod tests {
         assert_eq!(capped["count"], 3);
         assert_eq!(capped["truncated"], true);
         assert_eq!(capped["matches"].as_array().unwrap().len(), 2);
+    }
+
+    /// 인라인 전송 왕복. 이 흐름이 R3의 존재 이유다 — 이 도구들이 생기기 전에는
+    /// 원격 세션에 기존 문서를 넣을 방법이 프로토콜 안에 없었다.
+    #[test]
+    fn 인라인_전송_왕복() {
+        let root = temp_file("inline-roundtrip");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let ctx = ctx_with_roots(vec![root.canonicalize().unwrap()]);
+
+        let source = root.join("source.hwpx");
+        create_hwpx(&source, "# 인라인 왕복\n\n본문 한 줄.");
+        let original = std::fs::read(&source).unwrap();
+        let encoded = hwp_convert::base64::encode(&original);
+
+        let put = tool_put_file(
+            &json!({"name": root.join("uploaded.hwpx").display().to_string(), "content": encoded}),
+            &ctx,
+        )
+        .expect("put");
+        let receipt: Value = serde_json::from_str(put[0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(receipt["bytes"], original.len());
+
+        // 올린 파일이 다른 도구에 그대로 보인다: 경로 인자를 유지한다는 doc 22 §7의 모델.
+        let info = tool_info(
+            &json!({"path": root.join("uploaded.hwpx").display().to_string()}),
+            &ctx,
+        );
+        assert!(info.is_ok(), "업로드한 문서를 hwp_info가 읽지 못했습니다");
+
+        let got = tool_get_file(
+            &json!({"path": root.join("uploaded.hwpx").display().to_string()}),
+            &ctx,
+        )
+        .expect("get");
+        assert_eq!(got.len(), 2, "영수증과 resource 두 블록이어야 합니다");
+        assert_eq!(got[1]["resource"]["mimeType"], "application/hwp+zip");
+        let blob = got[1]["resource"]["blob"].as_str().unwrap();
+        assert_eq!(
+            hwp_convert::base64::decode(blob).unwrap(),
+            original,
+            "왕복 후 바이트가 달라졌습니다"
+        );
+        let got_receipt: Value = serde_json::from_str(got[0]["text"].as_str().unwrap()).unwrap();
+        assert_eq!(got_receipt["sha256"], receipt["sha256"]);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// 상한 초과는 복호 **전에** 걸러야 한다. 걸러지지 않으면 요청 하나가 상한을
+    /// 훨씬 넘는 메모리를 잡으므로, 파일이 생기지 않았다는 것이 그 증거다.
+    #[test]
+    fn 인라인_업로드_상한() {
+        let root = temp_file("inline-cap");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let ctx = ctx_with_roots(vec![root.canonicalize().unwrap()]);
+        let destination = root.join("too-big.bin");
+
+        let oversized = "A".repeat(MAX_INLINE_CONTENT_B64_CHARS + 1);
+        let error = tool_put_file(
+            &json!({"name": destination.display().to_string(), "content": oversized}),
+            &ctx,
+        )
+        .expect_err("상한을 넘겼는데 통과했습니다");
+        assert!(error.contains("너무 큽니다"), "{error}");
+        assert!(
+            !destination.exists(),
+            "복호 전에 거절해야 하므로 파일이 생기면 안 됩니다"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// 상한을 넘는 파일은 잘라내지 않고 거절하며, 파일 자체는 남는다.
+    #[test]
+    fn 인라인_다운로드_상한() {
+        let root = temp_file("inline-get-cap");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let ctx = ctx_with_roots(vec![root.canonicalize().unwrap()]);
+
+        let big = root.join("big.bin");
+        std::fs::write(&big, vec![0u8; MAX_INLINE_CONTENT_BYTES + 1]).unwrap();
+        let error = tool_get_file(&json!({"path": big.display().to_string()}), &ctx)
+            .expect_err("상한을 넘겼는데 통과했습니다");
+        assert!(error.contains("인라인 상한"), "{error}");
+        assert!(big.exists(), "거절이 파일을 지우면 안 됩니다");
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// 잘못된 인자와 sandbox 이탈은 다른 도구와 같은 방식으로 거절한다.
+    #[test]
+    fn 인라인_전송_인자와_sandbox_검사() {
+        let root = temp_file("inline-guards");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let ctx = ctx_with_roots(vec![root.canonicalize().unwrap()]);
+
+        let unknown = tool_put_file(
+            &json!({"name": "a.bin", "content": "QQ==", "extra": 1}),
+            &ctx,
+        )
+        .expect_err("알 수 없는 인자를 통과시켰습니다");
+        assert!(
+            unknown.contains("알 수 없는 hwp_put_file 인자"),
+            "{unknown}"
+        );
+
+        let bad_base64 = tool_put_file(
+            &json!({"name": root.join("a.bin").display().to_string(), "content": "not base64!"}),
+            &ctx,
+        )
+        .expect_err("잘못된 base64를 통과시켰습니다");
+        assert!(!bad_base64.is_empty());
+
+        // root 밖으로 나가는 이름은 checked_write_path 가 막는다.
+        for escape in ["../escape.bin", "/tmp/escape.bin"] {
+            assert!(
+                tool_put_file(&json!({"name": escape, "content": "QQ=="}), &ctx).is_err(),
+                "sandbox 이탈이 허용되었습니다: {escape}"
+            );
+        }
+        assert!(
+            tool_get_file(&json!({"path": "../escape.bin"}), &ctx).is_err(),
+            "읽기에서 sandbox 이탈이 허용되었습니다"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/crates/hwp-cli/src/commands/mcp/mod.rs
+++ b/crates/hwp-cli/src/commands/mcp/mod.rs
@@ -732,6 +732,64 @@ fn sha256_hex(bytes: &[u8]) -> String {
         .collect()
 }
 
+/// base64 문자열의 구조를 검사한다.
+///
+/// 공유 디코더는 `=`와 공백을 건너뛰고 남는 비트를 버리므로 `"A"`나 `"===="` 같은
+/// 입력이 빈 벡터로 조용히 통과한다. 전송 도구에서 그것은 0바이트 파일을 업로드
+/// 성공으로 보고한다는 뜻이라 여기서 먼저 막는다.
+///
+/// 잡아내지 못하는 것도 적어 둔다. 4문자 경계에 딱 맞게 잘린 페이로드는 인코딩만
+/// 봐서는 온전한 것과 구분할 수 없다. 그래서 두 도구 모두 영수증에 sha256을 담는다.
+fn validate_base64_structure(text: &str) -> Result<(), String> {
+    let compact: Vec<u8> = text
+        .bytes()
+        .filter(|byte| !byte.is_ascii_whitespace())
+        .collect();
+    let padding = compact.iter().rev().take_while(|&&b| b == b'=').count();
+    if padding > 2 {
+        return Err("잘못된 base64: 패딩이 2자를 넘습니다".to_string());
+    }
+    let payload = &compact[..compact.len() - padding];
+    if payload.contains(&b'=') {
+        return Err("잘못된 base64: 패딩이 끝이 아닌 위치에 있습니다".to_string());
+    }
+    if !compact.is_empty() && !compact.len().is_multiple_of(4) {
+        return Err(format!(
+            "잘못된 base64: 공백을 제외한 길이가 4의 배수가 아닙니다 ({}자)",
+            compact.len()
+        ));
+    }
+    // 길이 %4 == 1 은 어떤 바이트열도 만들어낼 수 없는 형태다.
+    if payload.len() % 4 == 1 {
+        return Err("잘못된 base64: 잘린 페이로드입니다".to_string());
+    }
+    Ok(())
+}
+
+/// 파일 경로를 `file://` URI로 만든다.
+///
+/// `format!("file://{}", path.display())`는 공백·`#`·비ASCII·윈도우 드라이브 경로에서
+/// 유효한 URI가 아니다. MCP 클라이언트가 resource `uri`를 URI로 파싱하면 멀쩡한 blob을
+/// 거절하거나 잘못 해석할 수 있다.
+fn file_uri(path: &Path) -> String {
+    const UNRESERVED_EXTRA: &[u8] = b"-._~/";
+    let text = path.display().to_string().replace('\\', "/");
+    let mut encoded = String::with_capacity(text.len());
+    for byte in text.bytes() {
+        if byte.is_ascii_alphanumeric() || UNRESERVED_EXTRA.contains(&byte) {
+            encoded.push(byte as char);
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    // 윈도우의 `C:/...`처럼 슬래시로 시작하지 않는 경로는 빈 authority 뒤에 루트가 온다.
+    if encoded.starts_with('/') {
+        format!("file://{encoded}")
+    } else {
+        format!("file:///{encoded}")
+    }
+}
+
 /// 확장자로 추정한 MIME 타입. 모르면 octet-stream이다.
 fn mime_for(path: &Path) -> &'static str {
     match path
@@ -790,6 +848,7 @@ fn tool_put_file(args: &Value, ctx: &dyn FileAuthority) -> Result<Vec<Value>, St
             MAX_INLINE_CONTENT_BYTES / 1024
         ));
     }
+    validate_base64_structure(content)?;
     let bytes = hwp_convert::base64::decode(content)?;
     // decode는 공백과 패딩을 무시하므로 위 검사만으로는 복호 크기를 보장하지 못한다.
     if bytes.len() > MAX_INLINE_CONTENT_BYTES {
@@ -841,19 +900,35 @@ fn tool_get_file(args: &Value, ctx: &dyn FileAuthority) -> Result<Vec<Value>, St
     if let Some(unknown) = object.keys().find(|key| key.as_str() != "path") {
         return Err(format!("알 수 없는 hwp_get_file 인자: {unknown}"));
     }
+    use std::io::Read as _;
     let path = checked_read_path(ctx, arg_str(args, "path")?)?;
-    let size = std::fs::metadata(&path)
-        .map_err(|error| format!("{}: {error}", path.display()))?
-        .len();
-    if size > MAX_INLINE_CONTENT_BYTES as u64 {
-        return Err(format!(
-            "파일이 인라인 상한을 넘습니다: {size}바이트 (상한 {}바이트). \
-             파일은 워크스페이스에 그대로 있으니 더 작은 포맷으로 변환하거나 \
-             Tier A의 /files 경로로 받으세요.",
-            MAX_INLINE_CONTENT_BYTES
-        ));
+    let file =
+        std::fs::File::open(&path).map_err(|error| format!("{}: {error}", path.display()))?;
+    let metadata = file
+        .metadata()
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    // 일반 파일만 받는다. 문자 장치는 metadata가 0바이트라고 보고하므로 크기 검사만
+    // 믿으면 /dev/zero 같은 경로에서 읽기가 끝나지 않는다(root 제한이 없는 stdio에서).
+    if !metadata.is_file() {
+        return Err(format!("일반 파일이 아닙니다: {}", path.display()));
     }
-    let bytes = std::fs::read(&path).map_err(|error| format!("{}: {error}", path.display()))?;
+    let too_big = format!(
+        "파일이 인라인 상한을 넘습니다 (상한 {}바이트). \
+         파일은 워크스페이스에 그대로 있으니 더 작은 포맷으로 변환하거나 \
+         Tier A의 /files 경로로 받으세요.",
+        MAX_INLINE_CONTENT_BYTES
+    );
+    if metadata.len() > MAX_INLINE_CONTENT_BYTES as u64 {
+        return Err(too_big);
+    }
+    // 읽기 자체도 묶는다. metadata 이후에 파일이 자라도 상한을 넘길 수 없다.
+    let mut bytes = Vec::new();
+    file.take(MAX_INLINE_CONTENT_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("{}: {error}", path.display()))?;
+    if bytes.len() > MAX_INLINE_CONTENT_BYTES {
+        return Err(too_big);
+    }
     let summary = serde_json::to_string_pretty(&json!({
         "path": path.display().to_string(),
         "bytes": bytes.len(),
@@ -865,7 +940,7 @@ fn tool_get_file(args: &Value, ctx: &dyn FileAuthority) -> Result<Vec<Value>, St
         json!({
             "type": "resource",
             "resource": {
-                "uri": format!("file://{}", path.display()),
+                "uri": file_uri(&path),
                 "mimeType": mime_for(&path),
                 "blob": hwp_convert::base64::encode(&bytes),
             }
@@ -5180,5 +5255,74 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// 공유 디코더는 `"A"`와 `"===="`를 빈 벡터로 통과시킨다. 전송 도구에서 그것은
+    /// 0바이트 파일을 업로드 성공으로 보고한다는 뜻이므로 구조 검사가 먼저 막는다.
+    #[test]
+    fn 인라인_업로드_잘못된_base64_거절() {
+        let root = temp_file("inline-b64");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let ctx = ctx_with_roots(vec![root.canonicalize().unwrap()]);
+
+        // 디코더 자체는 이것들을 조용히 통과시킨다는 사실을 먼저 고정한다.
+        assert_eq!(hwp_convert::base64::decode("A").unwrap(), Vec::<u8>::new());
+        assert_eq!(
+            hwp_convert::base64::decode("====").unwrap(),
+            Vec::<u8>::new()
+        );
+
+        for bad in ["A", "====", "QQ", "QUJD="] {
+            let destination = root.join(format!("bad-{}.bin", bad.len()));
+            let error = tool_put_file(
+                &json!({"name": destination.display().to_string(), "content": bad}),
+                &ctx,
+            )
+            .unwrap_err();
+            assert!(error.contains("잘못된 base64"), "{bad}: {error}");
+            assert!(!destination.exists(), "{bad}: 파일이 생기면 안 됩니다");
+        }
+
+        // 정상 입력은 그대로 통과한다.
+        assert!(validate_base64_structure("QUJD").is_ok());
+        assert!(validate_base64_structure("QQ==").is_ok());
+        assert!(validate_base64_structure("QUJ=").is_ok());
+        assert!(validate_base64_structure("QUJD\nRUZH").is_ok());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// 문자 장치는 metadata가 0바이트라고 보고하므로, 크기 검사만 믿으면 읽기가
+    /// 끝나지 않는다. root 제한이 없는 stdio에서 실제로 도달 가능한 경로였다.
+    #[test]
+    #[cfg(unix)]
+    fn 인라인_다운로드_일반_파일만() {
+        // roots가 비어 있으면 checked_read_path가 아무 경로나 통과시킨다 — 이것이
+        // 이 검사가 필요한 조건 그대로다.
+        let ctx = ctx_with_roots(Vec::new());
+        let error = tool_get_file(&json!({"path": "/dev/zero"}), &ctx)
+            .expect_err("/dev/zero 를 읽으려 시도했습니다");
+        assert!(error.contains("일반 파일이 아닙니다"), "{error}");
+    }
+
+    /// resource uri는 클라이언트가 URI로 파싱하므로 공백·비ASCII·윈도우 경로에서도
+    /// 유효해야 한다.
+    #[test]
+    fn 인라인_다운로드_uri_인코딩() {
+        assert_eq!(
+            file_uri(Path::new("/work/보고서 최종.hwpx")),
+            "file:///work/%EB%B3%B4%EA%B3%A0%EC%84%9C%20%EC%B5%9C%EC%A2%85.hwpx"
+        );
+        assert_eq!(
+            file_uri(Path::new("/work/a#b.pdf")),
+            "file:///work/a%23b.pdf"
+        );
+        // 슬래시로 시작하지 않는 경로는 빈 authority 뒤에 루트를 세운다.
+        let windows = file_uri(Path::new(r"C:\work\out.hwpx"));
+        assert!(
+            windows == "file:///C%3A/work/out.hwpx",
+            "윈도우 경로 URI: {windows}"
+        );
     }
 }

--- a/crates/hwp-cli/tests/cli_surface.rs
+++ b/crates/hwp-cli/tests/cli_surface.rs
@@ -274,6 +274,7 @@ fn mcp_stdio_session() {
         "hwp_diff",
         "hwp_edit",
         "hwp_fill",
+        "hwp_get_file",
         "hwp_grep",
         "hwp_info",
         "hwp_lint",
@@ -281,6 +282,7 @@ fn mcp_stdio_session() {
         "hwp_list_fields",
         "hwp_merge",
         "hwp_new",
+        "hwp_put_file",
         "hwp_read",
         "hwp_render",
         "hwp_slots",
@@ -291,7 +293,7 @@ fn mcp_stdio_session() {
     .iter()
     .map(|s| s.to_string())
     .collect();
-    assert_eq!(names, expect, "도구 20종");
+    assert_eq!(names, expect, "도구 22종");
 
     send(
         serde_json::json!({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{

--- a/crates/hwp-cli/tests/golden/mcp-tools-list.json
+++ b/crates/hwp-cli/tests/golden/mcp-tools-list.json
@@ -1416,6 +1416,45 @@
     "name": "hwp_certify"
   },
   {
+    "description": "base64 콘텐츠를 세션 워크스페이스의 파일로 저장한다. 원격 배포에서 기존 문서를 넣는 유일한 경로다(도구 인자는 경로를 받으므로, 먼저 이 도구로 올린 뒤 그 이름을 넘긴다). 복호 512 KiB 상한.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "description": "파일 내용의 base64. 복호 512 KiB 상한",
+          "type": "string"
+        },
+        "name": {
+          "description": "워크스페이스 안의 파일명 또는 상대 경로",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "content"
+      ],
+      "type": "object"
+    },
+    "name": "hwp_put_file"
+  },
+  {
+    "description": "워크스페이스 파일을 base64로 돌려준다(영수증 JSON + embedded resource 두 블록). 512 KiB 상한이며 초과 시 자르지 않고 거절한다. 중간 산출물은 워크스페이스에 두고 최종 결과물만 받는 것이 좋다 — 반환된 base64는 클라이언트의 메시지 스트림에 그대로 쌓인다.",
+    "inputSchema": {
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "description": "워크스페이스 안의 파일 경로",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ],
+      "type": "object"
+    },
+    "name": "hwp_get_file"
+  },
+  {
     "description": "여러 HWP5/HWPX 문서를 인자 순서대로 하나로 합친다 (입력 하나당 Section 하나). 출력 포맷은 output 확장자(.hwp/.hwpx)로 정한다. 쪽/각주/개요 번호는 각 입력의 시작·계속 설정을 그대로 유지하므로 병합 후 수동 조정이 필요할 수 있다.",
     "inputSchema": {
       "additionalProperties": false,

--- a/crates/hwp-cli/tests/mcp_schema.rs
+++ b/crates/hwp-cli/tests/mcp_schema.rs
@@ -70,8 +70,23 @@ fn tools_list() -> serde_json::Value {
     send(serde_json::json!({"jsonrpc":"2.0","id":2,"method":"tools/list"}));
     let list = recv("tools/list");
 
+    // Bounded shutdown, the same shape cli_surface.rs uses. An unconditional wait()
+    // turns a regression where `hwp mcp` stops exiting on stdin EOF into a test that
+    // hangs until the CI job's own timeout, which reports as a stuck workspace rather
+    // than as the MCP defect it is.
     drop(stdin);
-    let _ = child.wait();
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            assert!(status.success(), "MCP 종료 코드: {status}");
+            break;
+        }
+        if std::time::Instant::now() > deadline {
+            let _ = child.kill();
+            panic!("MCP가 stdin EOF 후 30s 내 종료하지 않음");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
 
     let tools = list["result"]["tools"].clone();
     assert!(

--- a/crates/hwp-cli/tests/serve_http.rs
+++ b/crates/hwp-cli/tests/serve_http.rs
@@ -14,8 +14,8 @@ use std::net::TcpStream;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 
-/// The 20 tools the MCP surface publishes; must agree with `cli_surface.rs`.
-const EXPECTED_TOOLS: [&str; 20] = [
+/// The 22 tools the MCP surface publishes; must agree with `cli_surface.rs`.
+const EXPECTED_TOOLS: [&str; 22] = [
     "hwp_certify",
     "hwp_compare",
     "hwp_compose",
@@ -23,6 +23,7 @@ const EXPECTED_TOOLS: [&str; 20] = [
     "hwp_diff",
     "hwp_edit",
     "hwp_fill",
+    "hwp_get_file",
     "hwp_grep",
     "hwp_info",
     "hwp_lint",
@@ -30,6 +31,7 @@ const EXPECTED_TOOLS: [&str; 20] = [
     "hwp_list_fields",
     "hwp_merge",
     "hwp_new",
+    "hwp_put_file",
     "hwp_read",
     "hwp_render",
     "hwp_slots",
@@ -329,4 +331,61 @@ fn serve_exits_on_sigterm() {
         std::thread::sleep(std::time::Duration::from_millis(50));
     };
     assert!(exit.success(), "정상 종료가 아닙니다: {exit:?}");
+}
+
+/// Inline transfer over HTTP: the flow Tier B has to use, where `/mcp` is the entire
+/// contract and no `/files` sideband exists. Proves a document can enter and leave a
+/// session without any route but this one.
+#[test]
+fn serve_inline_transfer_roundtrip() {
+    let server = spawn("inline", false);
+
+    // Build a real document inside the workspace, then read its bytes back out so the
+    // test has something with genuine structure to send, not a synthetic blob.
+    let made = call_tool(
+        &server.addr,
+        "hwp_new",
+        serde_json::json!({
+            "output": server.root.join("made.hwpx").to_string_lossy(),
+            "markdown": "# 인라인 전송\n\n본문.",
+        }),
+    );
+    assert_eq!(made["isError"], false, "{made}");
+    let original = std::fs::read(server.root.join("made.hwpx")).unwrap();
+
+    let fetched = call_tool(
+        &server.addr,
+        "hwp_get_file",
+        serde_json::json!({"path": server.root.join("made.hwpx").to_string_lossy()}),
+    );
+    assert_eq!(fetched["isError"], false, "{fetched}");
+    let blob = fetched["content"][1]["resource"]["blob"].as_str().unwrap();
+
+    // Round the bytes back in under a different name, then confirm the copy is usable
+    // by a normal path-taking tool — the doc 22 §7 model, where inline transfer feeds
+    // the workspace rather than replacing path arguments.
+    let put = call_tool(
+        &server.addr,
+        "hwp_put_file",
+        serde_json::json!({
+            "name": server.root.join("copy.hwpx").to_string_lossy(),
+            "content": blob,
+        }),
+    );
+    assert_eq!(put["isError"], false, "{put}");
+    assert_eq!(
+        std::fs::read(server.root.join("copy.hwpx")).unwrap(),
+        original,
+        "HTTP 왕복 후 바이트가 달라졌습니다"
+    );
+
+    let info = call_tool(
+        &server.addr,
+        "hwp_info",
+        serde_json::json!({"path": server.root.join("copy.hwpx").to_string_lossy()}),
+    );
+    assert_eq!(
+        info["isError"], false,
+        "왕복한 문서를 읽지 못했습니다: {info}"
+    );
 }

--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -116,7 +116,7 @@ image. The Worker URL may answer before container routes do.
 npx @modelcontextprotocol/inspector
 #    Transport: Streamable HTTP → https://hwp-mcp.staix.net/mcp
 #    Expect: dynamic registration → Google sign-in → initialize returns
-#    Mcp-Session-Id → tools/list shows exactly 20 tools.
+#    Mcp-Session-Id → tools/list shows exactly 22 tools.
 
 # 2. A real client.
 claude mcp add --transport http hwp https://hwp-mcp.staix.net/mcp
@@ -140,7 +140,7 @@ Live at `https://hwp-mcp.staix.net` (and still at `https://hwp-mcp.staix.workers
 The whole path was exercised against
 the real service: dynamic client registration, the consent screen, Google
 sign-in, an access token this Worker issued (never a Google one), `initialize`
-starting a container, `tools/list` returning all 20 tools, `hwp_new` writing into
+starting a container, `tools/list` returning all 22 tools, `hwp_new` writing into
 the workspace, and the document coming back through `/files`.
 
 Personal access tokens work too, for clients that carry a fixed header instead of
@@ -222,7 +222,7 @@ against real Cloudflare services.
 |---|---|
 | `docker build` from the repo root | 134 MB image; the Rust release build takes well under a minute on a large host |
 | `hwp serve` startup | binds and prints `hwp serve: listening on http://0.0.0.0:8080` |
-| `GET /healthz`, `POST /mcp` initialize, `tools/list` | 200, correct handshake, exactly 20 tools |
+| `GET /healthz`, `POST /mcp` initialize, `tools/list` | 200, correct handshake, exactly 22 tools |
 | `GET /mcp` | 405 |
 | `/files` upload, download, and a rejected `.hidden` name | 200, byte-identical, 400 |
 | `hwp_new` into `/work`, then `GET /files/made.hwpx` | created and downloadable |

--- a/docs/design/20-remote-mcp.md
+++ b/docs/design/20-remote-mcp.md
@@ -236,14 +236,14 @@ security tests pass without recreating an unsafe framework.
 ## 9. Phased follow-up backlog
 
 1. **Core extraction:** introduce typed JSON-RPC values and authority contexts; keep stdio output and
-   all 20 tools byte/behavior compatible.
+   all 22 tools byte/behavior compatible.
 2. **Artifact model:** implement tenant-owned uploads, immutable outputs, remote-safe schemas, quotas,
    and cleanup without opening a network listener.
 3. **Transport and auth:** add the selected HTTP adapter, protocol headers, SSE/session lifecycle,
    OAuth resource-server validation, proxy boundary, and audit events behind an explicit build or
    deployment mode.
 4. **Quick Web pilot:** register a non-production connector, verify initialization and remote-safe
-   parity for all 20 tools, then test upload, edit, render, convert, download, expiry, and reconnect.
+   parity for all 22 tools, then test upload, edit, render, convert, download, expiry, and reconnect.
 5. **Security gate:** complete cross-tenant, rebinding, proxy-bypass, archive-bomb, race, timeout,
    cancellation, and load tests; obtain an independent review before general availability.
 6. **Operations:** define SLOs, capacity, key rotation, incident response, deletion verification,
@@ -261,7 +261,7 @@ artifact model of §3.2 remains required and unimplemented.
 
 A Remote MCP implementation is acceptable only when all of the following are demonstrated:
 
-- stdio remains the default and its existing process test still exposes exactly 20 tools;
+- stdio remains the default and its existing process test still exposes exactly 22 tools;
 - HTTP conformance covers `POST`, `GET`, `DELETE`, both response media types, version negotiation,
   notifications, session creation/termination, reconnect, and disconnect behavior;
 - invalid origin, host, content type, protocol version, token, scope, session, or artifact ownership

--- a/docs/design/22-remote-mcp-deployment.ko.md
+++ b/docs/design/22-remote-mcp-deployment.ko.md
@@ -111,15 +111,32 @@ adapter가 강제하는 규칙은 다음과 같다.
 
 ### 3.3 Remote-safe inline content
 
-Tier B는 `/mcp` 외의 route를 노출하지 않으므로 문서가 JSON-RPC 안으로 이동해야 한다. 이에 따라
-tool schema에 inline mode를 추가한다. 문서 입력이나 출력을 path 대신 크기 제한이 있는 base64
-content로 주고받는 방식이다. 이 패턴은 현재 server에 이미 존재한다. `hwp_compose`는 `spec`을
-inline이나 `spec_path`로 받고, `hwp_template`은 `inline_contract_input`으로 template과 data를
-inline으로 받는다.
+Tier B는 `/mcp` 외의 route를 노출하지 않으므로 문서가 JSON-RPC 안으로 이동해야 한다. 이를
+도구 두 개가 담당한다. `hwp_put_file {name, content}`은 base64 콘텐츠를 세션 워크스페이스의
+파일로 쓰고, `hwp_get_file {path}`은 워크스페이스 파일을 base64로 반환한다. 상한은 복호 기준
+512 KiB이며, 인코딩하면 약 699 KB라서 1 MiB인 줄 상한 안에 JSON-RPC 봉투가 들어갈 여유가 남는다.
 
-이는 doc 20 §3.2가 요구하는 remote schema의 첫 부분이다. tenant 소유 upload, immutable output,
-보존 기간, object store 기반 signed download URL을 포함하는 완전한 artifact model은 두 tier
-모두에서 후속 phase로 남는다.
+**이 절은 원래 기존 tool schema에 inline mode를 추가하는 방식을 규정했으나, 구현 단계에서
+기각되었다.** 도구별 inline은 17개 도구에 인자 약 30개를 더하고, 각 인자를 그 도구의 알 수 없는
+인자 배열에도 넣어야 하며, 비밀번호 범위 도구 6개에서는 `take_scoped_password` 허용 목록에도
+추가해야 한다. 여기에 crate에서 가장 안전이 중요한 파일 안에 발행하지 않고 스테이징만 하는 경로가
+필요했다. 그러고도 `hwp_split`·`hwp_certify`·다중 페이지 `hwp_render`·`hwp_convert --media-dir`의
+디렉터리 및 다중 파일 출력은 표현하지 못해 모두 제외해야 했다. 도구 두 개는 파일 하나로 끝나고,
+기존 20개 스키마를 한 바이트도 바꾸지 않으며, 모든 경로 인자를 균일하게 다룬다. doc 20 §3.2가
+열거하는 이미지·폰트·정책·부품 경로까지 포함되는데, 문서 입출력만 다루는 도구별 범위였다면
+이것들은 빠졌을 것이다. §7이 이미 이 형태를 규정하고 있다. 도구는 계속 경로 인자를 받고, 경로는
+하나의 사설 워크스페이스 안의 상대 이름이다.
+
+이 도구들은 Tier A의 공백도 함께 메운다. `/files`는 `Mcp-Session-Id`를 실은 별도 HTTP 요청이
+필요한 경로이고 MCP 클라이언트는 그런 요청을 보낼 수 없다. 따라서 이 도구들이 생기기 전까지
+배포된 서비스는 텍스트에서 문서를 만들 수는 있어도 기존 문서를 받을 수는 없었다.
+
+우회하지 말고 명시해 둘 제약이 둘 있다. 512 KiB는 이미지가 많은 문서에는 작다. Tier A의
+`/files`는 64 MiB까지 받지만 Tier B에는 대응물이 없다. 그리고 받아 온 문서의 base64는 클라이언트
+메시지 스트림에 그대로 쌓이며 대부분의 클라이언트가 이를 모델에 넘긴다. 상한을 올리려면 분할
+전송이 필요하고, 분할 전송은 곧 doc 20 §3.2의 artifact model이다. tenant 소유 upload, immutable
+output, 보존 기간, object store 기반 signed download URL을 포함하는 그 모델은 두 tier 모두에서
+후속 phase로 남으며, 여기서 즉석으로 만들 프로토콜이 아니다.
 
 ## 4. Dependency 결정 기록
 

--- a/docs/design/22-remote-mcp-deployment.md
+++ b/docs/design/22-remote-mcp-deployment.md
@@ -111,15 +111,33 @@ Rules the adapter enforces:
 
 ### 3.3 Remote-safe inline content
 
-Tier B exposes no route other than `/mcp`, so documents must travel inside JSON-RPC. Tool schemas
-gain an inline mode in which a document input or output is base64 content with a size cap rather
-than a path. The pattern already exists in the current server: `hwp_compose` accepts a `spec`
-inline or as `spec_path`, and `hwp_template` accepts inline template and data through
-`inline_contract_input`.
+Tier B exposes no route other than `/mcp`, so documents must travel inside JSON-RPC. Two tools do
+this: `hwp_put_file {name, content}` writes base64 content into the session workspace, and
+`hwp_get_file {path}` returns a workspace file as base64. The cap is 512 KiB decoded, which encodes
+to roughly 699 KB and leaves the JSON-RPC envelope room inside the 1 MiB line limit.
 
-This is the first slice of the doc 20 §3.2 remote schema requirement. The complete artifact model,
-meaning tenant-owned uploads, immutable outputs, retention, and signed download URLs backed by an
-object store, is a later phase in both tiers.
+**This section originally specified an inline mode added to the existing tool schemas, and that was
+rejected during implementation.** Per-tool inline would have added around thirty keys across
+seventeen tools, each also needing an entry in that tool's unknown-argument array and, for the six
+password-scoped tools, in its `take_scoped_password` allow-list, plus a stage-without-publishing
+path inside the crate's most safety-critical file. It still could not express the directory and
+multi-file outputs of `hwp_split`, `hwp_certify`, multi-page `hwp_render` and `hwp_convert
+--media-dir`, all of which would have been excluded. Two tools are one file, leave all twenty
+existing schemas byte-identical, and cover every path argument uniformly - including the image,
+font, policy and parts paths doc 20 §3.2 enumerates and that a per-tool document-only scope would
+have missed. §7 already commits to this shape: tools keep taking path arguments, and a path is a
+relative name inside one private workspace.
+
+It also closes a gap in Tier A. `/files` is a separate HTTP route requiring an out-of-band request
+that carries `Mcp-Session-Id`, which an MCP client cannot make, so before these tools the deployed
+service could author documents from text but could not ingest an existing one through the protocol.
+
+Two limits are worth stating rather than engineering around. 512 KiB is small for an image-heavy
+document; Tier A's `/files` handles 64 MiB, and Tier B has no equivalent. And a fetched document
+puts its base64 into the client's message stream, which most clients feed to the model. Raising the
+ceiling means chunking, and chunking is the doc 20 §3.2 artifact model - tenant-owned uploads,
+immutable outputs, retention, and signed download URLs backed by an object store - which remains a
+later phase in both tiers, not a protocol invented here.
 
 ## 4. Dependency decision record
 
@@ -348,7 +366,7 @@ Satisfied by the first implementation, with the point that enforces each:
 
 | Criterion | Enforcement |
 |---|---|
-| stdio stays the default and still exposes exactly 20 tools | The existing stdio process test gates the core split |
+| stdio stays the default and exposes the same tools as the HTTP adapter | The existing stdio process test gates the core split |
 | Authentication precedes tool execution | Tier A: the OAuth provider and the token middleware both reject before the handler. Tier B: the runtime's JWT authorizer rejects before the container |
 | Sessions bind to a principal and cross-principal access fails closed | Tier A: the object name derives from the principal, so a foreign session identifier yields an uninformative `404`. Tier B: the platform scopes sessions to the authorized caller |
 | Request, upload, workspace, and deadline limits with deterministic cleanup | Body rejection before parsing at the edge and again in `hwp serve`; file and workspace caps in the adapter; deadlines and termination at the edge |

--- a/docs/manual/ai-integrations.ko.md
+++ b/docs/manual/ai-integrations.ko.md
@@ -169,7 +169,7 @@ claude.ai 코드 실행 샌드박스는 네트워크가 레지스트리로 제�
 
 ## Amazon Quick Desktop
 
-Amazon Quick Desktop은 `hwp mcp`를 로컬 stdio 커넥터로 실행할 수 있다. HWP 도구 20개가
+Amazon Quick Desktop은 `hwp mcp`를 로컬 stdio 커넥터로 실행할 수 있다. HWP 도구 22개가
 모두 노출되는 연결을 실기 확인했다. Quick 릴리스에 따라 UI 이름은 달라질 수 있으며 아래 명칭은
 현재 Desktop 흐름 기준이다.
 
@@ -211,8 +211,8 @@ Apple Silicon Homebrew에서는 흔히 `/opt/homebrew/bin/hwp`가 나온다. 이
 모든 root를 생략하지 않는다.
 
 **Test connection**을 선택하고 Quick의 명령 실행 확인 창에서 **Add server**를 승인한다. 테스트는
-**Connected**, **20 tools available**을 표시해야 한다. 이어서 **Add MCP**를 선택하고 확인 창을
-다시 승인한 뒤 연결을 새로고침한다. `Hwp`가 활성화되어 있고 **20 tools, Connected**로 표시되는지
+**Connected**, **22 tools available**을 표시해야 한다. 이어서 **Add MCP**를 선택하고 확인 창을
+다시 승인한 뒤 연결을 새로고침한다. `Hwp`가 활성화되어 있고 **22 tools, Connected**로 표시되는지
 확인한다.
 
 같은 설정의 import JSON:
@@ -275,7 +275,7 @@ Quick의 **Local folders and access permissions**는 내장 읽기·검색 도�
 승인된 목적 폴더로 복사한다.
 
 자동 비활성화된 커넥터의 설정을 바꾼 뒤에는 명시적으로 다시 활성화한다. 복구되면
-**Connected**, **20 tools available**가 표시되고 새로고침 뒤에도 활성 상태를 유지한다.
+**Connected**, **22 tools available**가 표시되고 새로고침 뒤에도 활성 상태를 유지한다.
 
 ### 3. publish-safe HWP 스킬 설치
 
@@ -329,8 +329,8 @@ HTML로 오인할 수 있는 angle-bracket markup을 포함하지 않는다.
 ### Desktop 확인 체크리스트
 
 - `hwp --version`이 의도한 최신 바이너리를 표시함
-- 커넥터 테스트가 **Connected**, **20 tools available**을 표시함
-- 새로고침 뒤에도 커넥터가 활성화되어 있고 **20 tools, Connected**를 표시함
+- 커넥터 테스트가 **Connected**, **22 tools available**을 표시함
+- 새로고침 뒤에도 커넥터가 활성화되어 있고 **22 tools, Connected**를 표시함
 - 테스트 HWPX에서 `hwp_new`, `hwp_read`, `hwp_validate`, `hwp_render`가 성공함(Windows에서는
   설정된 LocalLow root 아래에서 테스트. 예: `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace`)
 - 같은 root 아래에 둔 그 문서의 사본 두 개로 `hwp_merge`, `hwp_split`, `hwp_compare`가 성공하며,

--- a/docs/manual/ai-integrations.md
+++ b/docs/manual/ai-integrations.md
@@ -4,7 +4,7 @@
 
 `hwp` ships two integration surfaces for AI clients:
 
-- an **MCP stdio server** (`hwp mcp`, 20 tools) for clients that speak the Model Context
+- an **MCP stdio server** (`hwp mcp`, 22 tools) for clients that speak the Model Context
   Protocol, and
 - an **agent skill** (the `skills/hwp/` tree in this repo) that teaches an agent the CLI and
   MCP usage. It is embedded in the binary, and `hwp skill export` materializes it as a
@@ -216,8 +216,8 @@ location the tools may legitimately access. Do not omit all roots unless unrestr
 access is intentional.
 
 Select **Test connection**, review Quick's command-execution confirmation, and approve **Add
-server**. The test should report **Connected** and **20 tools available**. Select **Add MCP**, approve
-the confirmation again, refresh connections, and verify that `Hwp` is enabled and shows **20 tools,
+server**. The test should report **Connected** and **22 tools available**. Select **Add MCP**, approve
+the confirmation again, refresh connections, and verify that `Hwp` is enabled and shows **22 tools,
 Connected**.
 
 Equivalent import JSON:
@@ -281,7 +281,7 @@ without broad ACL changes. Move or copy inputs into that dedicated root, keep MC
 outputs under it, and copy validated artifacts to the approved destination afterward.
 
 After changing an auto-disabled connector, explicitly enable it again. A successful recovery
-reports **Connected** and **20 tools available** and remains enabled after refresh.
+reports **Connected** and **22 tools available** and remains enabled after refresh.
 
 ### 3. Install the publish-safe HWP skill
 
@@ -336,8 +336,8 @@ contain no angle-bracket markup that Quick can misclassify as HTML.
 ### Desktop acceptance checklist
 
 - `hwp --version` reports the intended current binary.
-- Connector test reports **Connected** and **20 tools available**.
-- After refresh, the connector remains enabled and reports **20 tools, Connected**.
+- Connector test reports **Connected** and **22 tools available**.
+- After refresh, the connector remains enabled and reports **22 tools, Connected**.
 - `hwp_new`, `hwp_read`, `hwp_validate`, and `hwp_render` succeed on a test HWPX document (under
   the configured LocalLow root, e.g. `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace`, on Windows).
 - `hwp_merge`, `hwp_split` and `hwp_compare` succeed on two copies of that document under the same

--- a/docs/manual/amazon-quick-desktop.ko.md
+++ b/docs/manual/amazon-quick-desktop.ko.md
@@ -22,13 +22,13 @@ Windows 절차 자체를 다시 실행하지는 않았다. 아래에 적은 `hwp
 | 구성요소 | 역할 | Windows 확인값 |
 |---|---|---|
 | `hwp.exe` | MCP stdio 서버 실행 | 안정된 절대 경로의 최신 바이너리 하나 |
-| HWP MCP 커넥터 | HWP 도구 20개 노출 | `hwp.exe mcp ...` |
+| HWP MCP 커넥터 | HWP 도구 22개 노출 | `hwp.exe mcp ...` |
 | HWP 스킬 | Quick 에이전트에게 도구 사용 시점과 방법 안내 | 활성 Quick 프로필의 `skills/hwp/SKILL.md` |
 | 교환 root | Low 무결성 MCP 자식과 파일을 주고받는 경계 | `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace` |
 | 폰트 디렉터리 | Windows 렌더링 폰트 공급 | `C:\Windows\Fonts` |
 
 커넥터와 스킬은 서로 별개다. 스킬 설치는 바이너리를 설치하거나 커넥터를 만들지 않는다. 커넥터에
-도구 20개가 표시된 뒤에도 파일 쓰기는 실패할 수 있으므로, 실제 생성·검증 smoke test까지 해야 한다.
+도구 22개가 표시된 뒤에도 파일 쓰기는 실패할 수 있으므로, 실제 생성·검증 smoke test까지 해야 한다.
 
 ## 1. 최신 `hwp.exe` 하나 설치하고 확인
 
@@ -72,7 +72,7 @@ Quick에도 이 경로를 그대로 입력한다. 다른 터미널의 PATH에 �
 Quick 내장 파일 도구와 로컬 MCP 자식 프로세스는 같은 파일 권한을 받지 않는다. 확인한 Windows
 빌드에서 Quick은 `hwp.exe`를 Low mandatory integrity(`S-1-16-4096`)로 시작한다. `C:\TEMP`와
 `%LOCALAPPDATA%\Temp` 같은 일반 폴더는 보통 Medium 무결성이다. 이 경로에서는 MCP 커넥터가
-시작하고 도구 20개를 노출해도, `hwp_new`가 private staging 디렉터리를 만드는 첫 쓰기에서
+시작하고 도구 22개를 노출해도, `hwp_new`가 private staging 디렉터리를 만드는 첫 쓰기에서
 `Access is denied (os error 5)`가 발생할 수 있다.
 
 Windows가 기본 제공하는 `LocalLow` 아래에 전용 자식 디렉터리를 만든다. 관리자 권한 없이 Low
@@ -172,13 +172,13 @@ Quick은 이 따옴표를 제거하지 않고 그대로 넘길 수 있다. 그�
 찾고, root 확인에 실패해 즉시 종료하며 MCP handshake가 닫힌다. JSON 형식은 각 token을 배열의 별도
 항목으로 유지해 이 문제를 피한다.
 
-**Test connection**을 선택하고 Quick의 명령 실행 확인을 승인한다. **Connected**, **20 tools
+**Test connection**을 선택하고 Quick의 명령 실행 확인을 승인한다. **Connected**, **22 tools
 available**이 표시되어야 한다. 이어서 **Add MCP**를 선택하고 다시 승인한 뒤 연결을 새로고침한다.
-`hwp`가 활성화되어 있고 **20 tools, Connected**로 표시되는지 확인한다.
+`hwp`가 활성화되어 있고 **22 tools, Connected**로 표시되는지 확인한다.
 
 ## 5. 실제 end-to-end smoke test 실행
 
-“20 tools available”에서 멈추지 않는다. 새 Quick 대화를 열고 다음 prompt를 붙여넣는다.
+“22 tools available”에서 멈추지 않는다. 새 Quick 대화를 열고 다음 prompt를 붙여넣는다.
 
 ```text
 셸 명령이 아니라 HWP MCP 도구를 사용하라.
@@ -272,7 +272,7 @@ passthrough를 항상 버리므로, 무손실이라고 가정하지 말고 응�
 |---|---|---|
 | `hwp.exe`가 시작하지 않거나 `--version`이 실패함 | 잘못된 바이너리·아키텍처, 차단되거나 불완전한 압축 해제 | 다시 다운로드하고 SHA-256을 확인한 뒤 Windows x86_64 아카이브를 풀고 정확한 절대 command를 테스트한다 |
 | Test connection에 도구가 없거나 서버가 즉시 종료함 | 없거나 읽을 수 없는 `--root`, 바꾸지 않은 `YOUR_NAME`, Arguments 안의 따옴표 문자, 오타, 오래된 command 경로 | `LocalLow` 자식 생성, 실제 계정 절대 경로 치환, 위 JSON import, 셸 따옴표 제거, `hwp.exe --version` 검증 |
-| **Connected, 20 tools**인데 `hwp_new`가 `Access is denied (os error 5)`를 반환함 | 탐색에는 읽기 권한만 필요했다. 요청 목적지가 Medium 무결성(대표적으로 `C:\TEMP`, `%LOCALAPPDATA%\Temp`)이거나 구버전이 `\\?\...`를 전달함 | `--root`와 모든 도구 경로를 전용 `LocalLow` 자식으로 지정, `icacls`로 Low 레이블 확인, hwp-cli v0.8.2 이상 사용, 재시작 뒤 smoke test |
+| **Connected, 22 tools**인데 `hwp_new`가 `Access is denied (os error 5)`를 반환함 | 탐색에는 읽기 권한만 필요했다. 요청 목적지가 Medium 무결성(대표적으로 `C:\TEMP`, `%LOCALAPPDATA%\Temp`)이거나 구버전이 `\\?\...`를 전달함 | `--root`와 모든 도구 경로를 전용 `LocalLow` 자식으로 지정, `icacls`로 Low 레이블 확인, hwp-cli v0.8.2 이상 사용, 재시작 뒤 smoke test |
 | **Local folders and access permissions**에 추가한 경로도 실패함 | 이 설정은 Quick 내장 읽기·검색 도구를 제어하며 Medium 폴더를 Low 무결성 MCP 자식이 쓸 수 있게 만들지 않음 | 내장 도구나 Explorer로 파일을 설정된 `LocalLow` 교환 root에 복사한 뒤 HWP 도구 호출 |
 | `os error 2` | 경로가 실제로 없거나 `YOUR_NAME`을 바꾸지 않았거나 Desktop이 OneDrive로 파일을 이동함 | 실제 절대 경로 확인, 목적 디렉터리 생성, 또는 설정된 교환 root에 staging |
 | 반복 실패 뒤 커넥터가 비활성화됨 | 시작·handshake 실패가 반복되어 Quick이 자동 비활성화함 | command/root 수정·저장, 커넥터를 명시적으로 다시 활성화, 새로고침, 필요하면 Quick 재시작 |
@@ -315,7 +315,7 @@ Get-Content "$env:LOCALAPPDATA\Temp\quickwork-backend.log" -Tail 300 |
   Select-String "UserMCP|Loaded.*servers|total tools|hwp"
 ```
 
-정상 기동 시 “Started ... with 20 tools”, “Loaded 1/1 servers (0 failed), 20 total tools”와 같은
+정상 기동 시 “Started ... with 22 tools”, “Loaded 1/1 servers (0 failed), 22 total tools”와 같은
 메시지가 보인다. 로그 문구와 위치는 안정된 API 계약이 아니다.
 
 ## 완료 체크리스트
@@ -324,7 +324,7 @@ Get-Content "$env:LOCALAPPDATA\Temp\quickwork-backend.log" -Tail 300 |
 - 커넥터가 분리된 JSON 인자를 사용하며 셸 따옴표가 들어 있지 않음
 - `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace`가 존재하고 Low 레이블을 상속하며 Windows MCP root로 설정됨
 - 현재 HWP 스킬이 활성 Quick 프로필에 설치됨
-- Test connection이 **Connected**, **20 tools available**을 표시함
+- Test connection이 **Connected**, **22 tools available**을 표시함
 - 새로고침·재시작 뒤에도 커넥터가 활성 상태임
 - 절대 `LocalLow` smoke-test 경로에서 `hwp_new`, `hwp_validate`, `hwp_read`가 성공함
 - 같은 root 아래에 둔 그 smoke-test 문서의 사본 두 개로 `hwp_merge`, `hwp_split`,

--- a/docs/manual/amazon-quick-desktop.md
+++ b/docs/manual/amazon-quick-desktop.md
@@ -29,7 +29,7 @@ v0.8.2 or later` floor stated below still holds.
 | Font directory | Supplies Windows fonts for rendering | `C:\Windows\Fonts` |
 
 The connector and the skill are separate. Installing the skill does not install the binary or
-create the connector. A connector can also show 20 tools while later file writes fail, so a real
+create the connector. A connector can also show 22 tools while later file writes fail, so a real
 create-and-validate smoke test is required.
 
 ## 1. Install and verify one current `hwp.exe`
@@ -76,7 +76,7 @@ Windows verbatim path such as `\\?\C:\...`, confirm that `hwp --version` reports
 Quick's built-in file tools and its local MCP child do not receive the same filesystem permissions.
 On the tested Windows build, Quick starts `hwp.exe` at Low mandatory integrity
 (`S-1-16-4096`). Ordinary folders such as `C:\TEMP` and `%LOCALAPPDATA%\Temp` are normally Medium
-integrity: the MCP connector can start and expose 20 tools there, but the first write can fail with
+integrity: the MCP connector can start and expose 22 tools there, but the first write can fail with
 `Access is denied (os error 5)` when `hwp_new` creates its private staging directory.
 
 Use a dedicated child of Windows' existing `LocalLow` directory. It inherits the Low-integrity
@@ -183,12 +183,12 @@ contains quotes. The root then fails fast and the MCP handshake closes. The JSON
 failure by keeping every token as a separate array item.
 
 Select **Test connection**, approve Quick's command-execution confirmation, and expect
-**Connected** and **20 tools available**. Then select **Add MCP**, approve the confirmation, refresh
-connections, and verify that `hwp` is enabled and reports **20 tools, Connected**.
+**Connected** and **22 tools available**. Then select **Add MCP**, approve the confirmation, refresh
+connections, and verify that `hwp` is enabled and reports **22 tools, Connected**.
 
 ## 5. Run an end-to-end smoke test
 
-Do not stop at “20 tools available.” Start a new Quick chat and paste this prompt:
+Do not stop at “22 tools available.” Start a new Quick chat and paste this prompt:
 
 ```text
 Use the HWP MCP tools, not a shell command.
@@ -285,7 +285,7 @@ assuming a lossless run.
 |---|---|---|
 | `hwp.exe` does not start or `--version` fails | Wrong binary, wrong architecture, blocked or incomplete extraction | Re-download, verify SHA-256, extract the Windows x86_64 archive, and test the exact absolute command path |
 | Test connection shows no tools or the server exits immediately | Missing/unreadable `--root`, literal `YOUR_NAME`, quote characters in Arguments, typo, or stale command path | Create the `LocalLow` child, substitute the absolute account path, import the JSON above, remove shell quotes, and verify `hwp.exe --version` |
-| **Connected, 20 tools** but `hwp_new` returns `Access is denied (os error 5)` | Discovery only needed read access; the requested destination is Medium integrity (commonly `C:\TEMP` or `%LOCALAPPDATA%\Temp`), or an older binary still passes `\\?\...` | Point `--root` and every tool path at the dedicated `LocalLow` child; verify its Low label with `icacls`; use hwp-cli v0.8.2 or later; restart and run the smoke test |
+| **Connected, 22 tools** but `hwp_new` returns `Access is denied (os error 5)` | Discovery only needed read access; the requested destination is Medium integrity (commonly `C:\TEMP` or `%LOCALAPPDATA%\Temp`), or an older binary still passes `\\?\...` | Point `--root` and every tool path at the dedicated `LocalLow` child; verify its Low label with `icacls`; use hwp-cli v0.8.2 or later; restart and run the smoke test |
 | A path added to **Local folders and access permissions** still fails | That setting controls Quick's built-in read/search tools; it does not make a Medium-integrity folder writable by the Low-integrity MCP child | Use the built-in tool or Explorer to copy the file into the configured `LocalLow` exchange root, then call HWP tools there |
 | `os error 2` | The path does not exist, `YOUR_NAME` was not replaced, or Desktop moved the file to OneDrive | Check the real absolute path, create the intended directory, or stage the file under the configured exchange root |
 | Connector becomes disabled after repeated failures | Quick auto-disabled a connector whose startup/handshake repeatedly failed | Correct the command/root, save, explicitly enable the connector, refresh, and restart Quick if needed |
@@ -328,8 +328,8 @@ Get-Content "$env:LOCALAPPDATA\Temp\quickwork-backend.log" -Tail 300 |
   Select-String "UserMCP|Loaded.*servers|total tools|hwp"
 ```
 
-A healthy startup contains messages equivalent to “Started ... with 20 tools” and “Loaded 1/1
-servers (0 failed), 20 total tools.” Log wording and location are not stable API contracts.
+A healthy startup contains messages equivalent to “Started ... with 22 tools” and “Loaded 1/1
+servers (0 failed), 22 total tools.” Log wording and location are not stable API contracts.
 
 ## Completion checklist
 
@@ -337,7 +337,7 @@ servers (0 failed), 20 total tools.” Log wording and location are not stable A
 - The connector uses separate JSON arguments and has no embedded shell quotes.
 - `%USERPROFILE%\AppData\LocalLow\hwp-quick-workspace` exists, inherits the Low label, and is the Windows MCP root.
 - The current HWP skill is installed in the active Quick profile.
-- Test connection reports **Connected** and **20 tools available**.
+- Test connection reports **Connected** and **22 tools available**.
 - The connector stays enabled after refresh or restart.
 - `hwp_new`, `hwp_validate`, and `hwp_read` succeed on the absolute `LocalLow` smoke-test path.
 - `hwp_merge`, `hwp_split` and `hwp_compare` succeed on two copies of that smoke-test document

--- a/skills/hwp/SKILL.ko.md
+++ b/skills/hwp/SKILL.ko.md
@@ -300,10 +300,12 @@ Quick 설정을 도와줄 때는 JSON 임포트를 선호하고, 인수 안에 �
 | `hwp_merge` | `inputs`, `output` | 문서 두 개 이상을 합침 (입력 하나당 Section 하나); 보존 손실 원장을 반환 |
 | `hwp_split` | `input`, `out_dir` | Section 단위(또는 `pages`)로 조각내고 발행된 조각 경로를 반환 |
 | `hwp_compare` | `a`, `b` | 읽기 전용 문단·구조 비교로 `hwp-compare-report-v1`을 반환. 차이가 있는 것은 정상 결과라 `isError`가 되지 않으므로 `identical`을 읽는다 |
+| `hwp_put_file` | `name`, `content` | base64 콘텐츠를 세션 워크스페이스에 저장. 원격 배포에 기존 문서를 넣는 유일한 경로다. 도구 인자는 경로를 받으므로 먼저 올린 뒤 그 이름을 넘긴다. 복호 512 KiB 상한 |
+| `hwp_get_file` | `path` | 워크스페이스 파일을 base64로 반환(영수증 블록 + embedded resource). 상한을 넘으면 자르지 않고 거절한다. 중간 산출물은 워크스페이스에 두고 최종 결과물만 받는다. 반환된 base64는 클라이언트 메시지 스트림에 쌓인다 |
 
 ## 컨테이너용 HTTP 모드
 
-`hwp serve`는 `hwp mcp`와 같은 프로토콜을 stdio 대신 HTTP로 제공하므로, 같은 20종 도구를
+`hwp serve`는 `hwp mcp`와 같은 프로토콜을 stdio 대신 HTTP로 제공하므로, 같은 22종 도구를
 컨테이너에서 사용할 수 있습니다. 인터넷에 직접 노출하는 용도가 아니라, TLS 종단·인증·본문
 크기 제한을 이미 수행한 신뢰된 edge 뒤에 두는 것을 전제로 합니다.
 

--- a/skills/hwp/SKILL.md
+++ b/skills/hwp/SKILL.md
@@ -270,7 +270,7 @@ of it, and re-enable the connector if repeated startup failures caused Quick to 
 
 When helping someone configure Quick, prefer JSON import and never put shell quote characters
 inside an argument. Verify three layers in order: the exact absolute binary returns a version;
-Quick reports 20 tools and stays enabled after refresh; then `hwp_new` followed by `hwp_validate`
+Quick reports 22 tools and stays enabled after refresh; then `hwp_new` followed by `hwp_validate`
 succeeds on an absolute path under the configured LocalLow root (for example
 `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\quick-hwp-smoke.hwpx`). Do not claim
 that discovery alone proves file access.
@@ -302,6 +302,8 @@ Tools (20):
 | `hwp_merge` | `inputs`, `output` | Combine two or more documents, one Section per input; returns the preservation ledger |
 | `hwp_split` | `input`, `out_dir` | Split into per-Section (or `pages`) fragments; returns the published fragment paths |
 | `hwp_compare` | `a`, `b` | Read-only paragraph/structure diff returning `hwp-compare-report-v1`. Differences are a normal result and never set `isError` — read `identical` |
+| `hwp_put_file` | `name`, `content` | Write base64 content into the session workspace. The only way to hand an existing document to a remote deployment: tool arguments take paths, so upload first and pass the name. 512 KiB decoded |
+| `hwp_get_file` | `path` | Return a workspace file as base64 (a receipt block plus an embedded resource). Refuses above 512 KiB rather than truncating. Keep intermediates in the workspace and fetch only the final artifact - the base64 lands in the client's message stream |
 
 ## HTTP mode for containers
 


### PR DESCRIPTION
Closes #189 R3. Adds `hwp_put_file` and `hwp_get_file`.

## The gap this closes

A remote deployment could **author** documents from text but could not **ingest** an existing one:

- No tool accepted document bytes. `base64` appears in the whole 20-tool surface only in `hwp_render`'s PNG return and `hwp_convert`'s `embed_bin`.
- `/files` needs an out-of-band HTTP request carrying `Mcp-Session-Id`, which an MCP client cannot make.
- AgentCore exposes `/mcp` and nothing else (doc 22 §6.1), so it has no sideband at all.

So this is a Tier B prerequisite that also fixes Tier A today.

## Why not the shape §3.3 specified

doc 22 §3.3 called for an inline mode added to the existing tool schemas. **§3.3 is amended in this PR with the reason**, rather than left contradicting the code.

Per-tool inline would have added ~30 keys across 17 tools. Each needs a schema property, an entry in that tool's `const ALLOWED` unknown-argument array, and for the six password-scoped tools an entry in its `take_scoped_password` allow-list — plus a stage-without-publishing path inside `commands/output.rs`, the crate's most safety-critical file. And it still could not express the directory and multi-file outputs of `hwp_split`, `hwp_certify`, multi-page `hwp_render` and `hwp_convert --media-dir`, all of which would have been excluded.

Two tools are one file, cover **every** path argument uniformly — including the image, font, policy and parts paths doc 20 §3.2 enumerates and that a document-only per-tool scope would have missed — and match what §7 already committed to: tools keep taking path arguments, and a path is a relative name inside one private workspace.

## The cost, measured

The golden snapshot from #204 exists for exactly this:

```
39      0       crates/hwp-cli/tests/golden/mcp-tools-list.json
```

**39 added, 0 removed.** The twenty existing schemas are byte-identical.

## Design

- Containment is `checked_write_path` / `checked_read_path`. `/files`'s `valid_file_name` is **deliberately not reused**: that regex exists because the route joins a URL segment onto the root with no canonicalize-and-contain check, so its charset *is* the containment there. `checked_write_path` is stronger, and the ASCII-only charset would ban the Korean filenames every other tool accepts.
- Publishing goes through `write_validated` — atomic staging, fsync, read-back — the same helper every other output path uses. Not modified.
- base64 is `hwp_convert::base64`, already called at `mod.rs:293`. **No dependency added**; the external `base64` crate stays dev-only.
- `MAX_INLINE_CONTENT_BYTES = 512 KiB` decoded, enforced three times: before decode (it allocates the whole output), after decode (it ignores whitespace, so the first check is not sufficient), and on `metadata().len()` before reading. Over-cap is **refused, not truncated**, and the file survives so you can convert it smaller or use `/files` on Tier A.
- `hwp_get_file` returns two blocks — a receipt and an embedded resource — the convention `tool_read_scoped` and `tool_render_scoped` already use.

## Also fixes #204's review finding

The unbounded `child.wait()` is now the same 30s `try_wait`-and-`kill` loop `cli_surface.rs:329` uses, so a regression where `hwp mcp` stops exiting on stdin EOF fails as itself rather than hanging until the CI job's timeout. I merged #204 before reading that thread; that was my error, and the fix lands here.

## Verification

`scripts/check.sh` passes. Four unit tests (round trip with byte-identical output and matching sha256; over-cap put asserting **no file was created**, which is what proves the pre-decode guard fired; over-cap get; unknown-argument, bad-base64 and sandbox-escape refusals) plus an HTTP round trip in `serve_http.rs` that puts, gets and re-reads through `/mcp` alone — the flow Tier B has to use.

## Docs

Tool count 20 → 22 across the live surface: both READMEs, both SKILL files, both `ai-integrations`, both `amazon-quick-desktop`, the deploy README, doc 20. **Deliberately left at 20**: `CHANGELOG.md`'s historical release notes, and doc 22 lines 81 and 135, which record a past gate and a rejected alternative's cost.

## Stated, not engineered around

512 KiB is small for an image-heavy document, and a fetched document's base64 lands in the client's message stream. Raising the ceiling means chunking, and chunking is the doc 20 §3.2 artifact model — still a later phase, not a protocol invented here. Both are written into §3.3 and the tool descriptions.