### PR TITLE
docs(deploy): privacy policy and a homepage that describes the service

### DIFF
--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -36,6 +36,51 @@ Two things about the Google side are worth knowing before anyone else tries to s
   `chu-rise` project, so a dedicated project is the clean fix if this service ever needs its own
   branding.
 
+## Google verification
+
+The app is in **Testing** publishing status, which caps it at 100 listed test users.
+That cap, not a review queue, is what stops anyone but the owner from using the
+service. Moving to production is the unblock.
+
+The scopes are `openid email profile` (`google-handler.ts:60`), all **non-sensitive**.
+That matters: this app does not enter the sensitive or restricted path, so there is no
+CASA assessment and no third-party penetration test. Check the console before planning
+around a multi-day review that may not apply here.
+
+What the repo now provides, both served from the verified domain:
+
+| Requirement | Where |
+|---|---|
+| A homepage saying what the app does | `/`, from `home()` in `src/google-handler.ts` |
+| A privacy policy | `/privacy`, from `public/privacy.html` — no route needed, the unmatched-path fallthrough to `env.ASSETS` serves it |
+| A contact address | `yj.lee@chu.ac.kr`, on both pages |
+
+The privacy policy is written from `schema.sql` and `src/audit.ts` rather than from a
+template, so it names the actual columns and states what is deliberately absent from
+the audit table. Keep it that way: if either file gains a field, the page is wrong
+until it is updated.
+
+Owner steps, none of which are in this repo:
+
+1. **Decide the Google Cloud project.** The consent screen's privacy-policy URL,
+   authorized domains and publishing status are all *project-scoped*. Verifying the
+   shared `chu-rise` project would point every other client's consent screen at this
+   service's privacy policy, which is wrong for those apps' users. A dedicated project
+   costs a new client id and secret, two `wrangler secret put` calls and a deploy.
+2. **Verify domain ownership.** A DNS TXT record on `staix.net` as a Search Console
+   Domain property, added in the Cloudflare zone the account already owns. It covers
+   `hwp-mcp.staix.net` and every future subdomain.
+3. **Fill the consent screen.** One field cannot follow the usual contact convention:
+   Google's **User support email** must be a Google account or a Group you own, and
+   `yj.lee@chu.ac.kr` is not one — it was already rejected as a test user for that
+   reason. That field has to be `hello@jeju.ai` unless a Group is created on
+   `staix.net`. The privacy-policy contact and the developer contact field both take
+   `yj.lee@chu.ac.kr` normally.
+4. **At submission, drop the workers.dev redirect URI** rather than verifying it.
+   `workers.dev` is on the Public Suffix List and its DNS is not ours. This stops *new
+   sign-ins* on the old hostname; already-issued tokens and PATs keep working there,
+   because Google is only involved at sign-in.
+
 ## Where to deploy from
 
 `wrangler deploy` builds the container image locally, so the deploy host needs a

--- a/deploy/cloudflare/public/privacy.html
+++ b/deploy/cloudflare/public/privacy.html
@@ -33,6 +33,14 @@
      name of the tool or method called, whether it succeeded, how long it took, and how
      many bytes moved in and out. It contains <strong>no tool arguments, no file names,
      no paths, no document content and no tokens</strong>.</p>
+  <p><strong>Authorization records for connected clients.</strong> When an MCP client
+     connects through the OAuth flow, the service stores a registration for that client,
+     a grant recording that you authorized it, and a record per access token it holds.
+     Each grant carries your account identifier and your email address, and the tokens
+     are stored so they can be checked and revoked. These are what let a client keep
+     working without asking you to sign in again, and they are deleted when the grant
+     is revoked. A short-lived entry also exists during sign-in itself and expires
+     within ten minutes.</p>
   <p><strong>Sign-in cookies.</strong> A signed dashboard session cookie lasting twelve
      hours, a cookie preventing cross-site request forgery, and a signed cookie
      recording which client you already approved, lasting ninety days. All are signed

--- a/deploy/cloudflare/public/privacy.html
+++ b/deploy/cloudflare/public/privacy.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<link rel="stylesheet" href="/style.css">
+<title>Privacy policy — hwp MCP</title>
+<main>
+  <h1>Privacy policy</h1>
+  <p>hwp MCP is an MCP server for HWP and HWPX documents, operated by Young Joon Lee.
+     Contact: <a href="mailto:yj.lee@chu.ac.kr">yj.lee@chu.ac.kr</a>.</p>
+  <p>This page describes exactly what the service stores. Where it says something is
+     not stored, that is enforced in code, not policy.</p>
+
+  <h2>What Google gives us</h2>
+  <p>Signing in requests only the <code>openid</code>, <code>email</code> and
+     <code>profile</code> scopes. From the resulting token the service reads three
+     claims and nothing else: your Google account identifier (<code>sub</code>), your
+     email address, and your display name. They identify your account. They are never
+     sold, never shared, never used for advertising, and never used to train models.
+     Use of information received from Google APIs follows the
+     <a href="https://developers.google.com/terms/api-services-user-data-policy">Google
+     API Services User Data Policy</a>, including its Limited Use requirements.</p>
+
+  <h2>What the service stores</h2>
+  <p><strong>Your account.</strong> An internal identifier, the Google
+     <code>sub</code>, your email address, your display name, and the times you first
+     signed in and last signed in. Identity is keyed on <code>sub</code> rather than on
+     the email address, because an address can be reassigned to a different person.</p>
+  <p><strong>Access tokens you create.</strong> An identifier, a label you chose, a
+     SHA-256 hash of the token, and the times it was created, last used and revoked.
+     The token itself is shown once at creation and is never stored.</p>
+  <p><strong>An activity log, metadata only.</strong> A timestamp, a request
+     identifier, your account identifier, a SHA-256 hash of the session identifier, the
+     name of the tool or method called, whether it succeeded, how long it took, and how
+     many bytes moved in and out. It contains <strong>no tool arguments, no file names,
+     no paths, no document content and no tokens</strong>.</p>
+  <p><strong>Sign-in cookies.</strong> A signed dashboard session cookie lasting twelve
+     hours, a cookie preventing cross-site request forgery, and a signed cookie
+     recording which client you already approved, lasting ninety days. All are signed
+     rather than tracking, and there are no third-party cookies and no analytics.</p>
+
+  <h2>Your documents</h2>
+  <p>Documents you upload or generate exist only inside a container created for your
+     session. That container has no network access to anywhere, is private to your
+     session, and is destroyed when the session ends. Document content is never written
+     to durable storage, never logged, and never read by the operator.</p>
+
+  <h2>Who else is involved</h2>
+  <p>Cloudflare provides the infrastructure the service runs on, and Google provides
+     sign-in. No one else receives your data.</p>
+
+  <h2>Retention and deletion</h2>
+  <p>Your account record and your tokens are deleted on request to
+     <a href="mailto:yj.lee@chu.ac.kr">yj.lee@chu.ac.kr</a>; there is no self-service
+     deletion page today. The metadata-only activity log described above is currently
+     retained without a fixed expiry. Documents need no deletion request because they
+     do not outlive the session that created them.</p>
+
+  <h2>Changes</h2>
+  <p>Material changes to this page will be reflected here before they take effect in
+     the service.</p>
+  <p><a href="/">Back</a></p>
+</main>

--- a/deploy/cloudflare/src/google-handler.ts
+++ b/deploy/cloudflare/src/google-handler.ts
@@ -199,9 +199,22 @@ async function callback(request: Request, env: Env, url: URL): Promise<Response>
 }
 
 function home(): Response {
+  // Google's verification review reads this page: it wants a homepage on the verified
+  // domain that says what the app does and links the privacy policy. It is also the
+  // first thing a person sees, so it says what the service is for, not just that it
+  // exists.
   return html(
     `<h1>hwp MCP</h1>
-     <p>An MCP server for HWP and HWPX documents. Point an MCP client at
-        <code>/mcp</code> and sign in with Google when it asks.</p>`,
+     <p>An MCP server for HWP and HWPX documents. It reads, renders, converts, edits
+        and creates Korean word-processor files, so an AI assistant can work with them
+        directly instead of asking you to open Hangul.</p>
+     <p>Point an MCP client at <code>/mcp</code> and sign in with Google when it asks.
+        For a client that needs a fixed <code>Authorization</code> header instead, sign
+        in at <a href="/dashboard">the dashboard</a> and create a token there.</p>
+     <p>Each session gets its own container with no network access, and it is destroyed
+        when the session ends. What is stored, and what deliberately is not, is set out
+        in the <a href="/privacy">privacy policy</a>.</p>
+     <p>Operated by Young Joon Lee. Contact
+        <a href="mailto:yj.lee@chu.ac.kr">yj.lee@chu.ac.kr</a>.</p>`,
   );
 }


### PR DESCRIPTION
Everything Google's verification review asks for that lives in this repo (#189 A3). The remaining steps are console work and are written down rather than done here.

## What was missing

`public/` held only `style.css`, and `home()` was one sentence. Verification wants a homepage on the verified domain that says what the app does, a privacy policy on that domain, and a contact address.

## The privacy page needs no route

`google-handler.ts:93` already falls through unmatched paths to `env.ASSETS.fetch(request)`, so `public/privacy.html` is served at `/privacy` with **zero code change**. It repeats the chrome from `html()` and links the existing `/style.css`; no CSS was added.

## The policy is written from the schema, not from a template

Checked against `schema.sql` and `src/audit.ts` before a word was written, so it names actual columns:

- Only three id_token claims are read (`sub`, `email`, `name`), and identity is keyed on `sub` **not** the email, because an address can be reassigned — the schema comment says so and now the policy does too.
- PATs are SHA-256 hashes; the plaintext is shown once and never stored.
- The audit table is metadata only, and the page states what is deliberately absent: **no tool arguments, no file names, no paths, no document content, no tokens.**
- Documents live in a per-session container with no network access, destroyed with the session.

**Retention says what is true**, not what sounds reassuring: deletion is by request to `yj.lee@chu.ac.kr`, there is no self-service page today, and the metadata log has no fixed expiry. Building `/dashboard/delete` and audit pruning is the follow-up if the service ever has users other than the owner.

If `schema.sql` or `audit.ts` gains a field, this page is wrong until updated. The README section says so.

## Two decisions left to the owner, both recorded

- **Which Google Cloud project.** The consent screen's privacy-policy URL, authorized domains and publishing status are all *project-scoped*, so verifying the shared `chu-rise` project would point every other client's consent screen at this service's privacy policy — wrong for those apps' users, not merely untidy. A dedicated project costs a new client id and secret, two `wrangler secret put` calls and a deploy.
- **The support-email conflict.** Google's **User support email** must be a Google account or a Group you own. `yj.lee@chu.ac.kr` is not one — the README already records it being rejected as a test user for exactly that reason — so that one field has to be `hello@jeju.ai` unless a Group is created on `staix.net`. Flagging it rather than quietly using the wrong address on a page that says it is the contact.

## Worth knowing before scheduling

The scopes are `openid email profile`, all **non-sensitive**, so no CASA assessment and no third-party pentest. The real gate on public use is the **Testing publishing status and its 100-test-user cap**, currently holding one user. This PR and #206 are prerequisites for lifting it, not the lifting itself.

`npx tsc --noEmit` clean. Verify after deploy: `curl https://hwp-mcp.staix.net/privacy` returns the page and `/` links to it.