### PR TITLE
chore(release): v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.16.0]
+
 **Added**
 
 - `hwp_put_file` and `hwp_get_file` move documents in and out of a session workspace as base64,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hwp-cli"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "hwp-model",
  "hwpx",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-render"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "encoding_rs",
  "flate2",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "aes",
  "cfb",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.15.1"
+version = "0.16.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"

--- a/README.ko.md
+++ b/README.ko.md
@@ -110,7 +110,7 @@ curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/inst
 기본 위치는 `~/.local/bin`이다(PATH에 없으면 안내를 출력한다). 위치·버전은 인자나 환경변수로 바꾼다:
 
 ```sh
-curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.15.1
+curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.16.0
 HWP_INSTALL_DIR=~/bin sh scripts/install.sh
 ```
 
@@ -152,7 +152,7 @@ RHEL/CentOS 7+ 및 그 이후 배포판에서 그대로 돌아간다. 빌드 러
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
-  | sh -s -- --tag v0.15.1 --dir ./bin
+  | sh -s -- --tag v0.16.0 --dir ./bin
 ```
 
 플랫폼이 배포 번들을 수집하기 전에 바이너리가 있어야 하므로(Vercel `includeFiles`, Next.js

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The default location is `~/.local/bin` (if it is not on PATH, the script says so
 location or version with arguments or environment variables:
 
 ```sh
-curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.15.1
+curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.16.0
 HWP_INSTALL_DIR=~/bin sh scripts/install.sh
 ```
 
@@ -168,7 +168,7 @@ to bump:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
-  | sh -s -- --tag v0.15.1 --dir ./bin
+  | sh -s -- --tag v0.16.0 --dir ./bin
 ```
 
 Run this from the build command (or a `prebuild` script) so the binary exists before the platform


### PR DESCRIPTION
Minor release: two new MCP tools and a new platform artifact.

## What ships

**`hwp_put_file` and `hwp_get_file`** (#204, #207). A remote deployment could author documents from text but could not ingest an existing one: no tool accepted document bytes, and `/files` needs an out-of-band HTTP request an MCP client cannot make. AgentCore, which exposes `/mcp` and nothing else, has no sideband at all. Cap is 512 KiB decoded. **Tool count 20 → 22; the twenty existing schemas are byte-identical**, which the golden snapshot proves — its diff was 39 added, 0 removed.

**A `aarch64-unknown-linux-gnu` archive** (#205), cross-built against the same glibc 2.17 floor as the x86_64 Linux one. `install.sh` and `hwp update` now serve arm64 Linux instead of sending it to a source build. This is the **first release to publish that target**, so it is the one to watch. Homebrew is unchanged: it does not run on arm64 Linux.

Also merged since v0.15.1 but not shipped in the binary: #206 (custom domain) and #208 (privacy policy and homepage), both under `deploy/cloudflare/`.

## Release prep

- `CHANGELOG.md` Unreleased closed as `[0.16.0]`; `scripts/release_notes.sh 0.16.0` extracts it cleanly.
- `install.sh --tag` pins moved to v0.16.0 in both READMEs.
- `scripts/release.sh 0.16.0` bumped `[workspace.package] version` and relocked workspace crates offline.
- `tools/list` returns **22**, matching every claim in the docs. The only remaining "20 tools" strings are `CHANGELOG.md` history and doc 22 lines 81 and 153, which record a past gate and a rejected alternative — deliberately left.
- `scripts/check.sh` passes.

Minor rather than patch: both changelog entries are additions.

## What to watch on the tag

The arm64 job is new. Its risk was retired before the PR that added it — the cross-compile was reproduced in a `rust:1.93` container (40s, ELF ARM aarch64, `GLIBC_2.17`, `zstd-sys` fine) and an arm64 image built from that binary was exercised under binfmt (22 tools on port 8000, `/files` absent, SIGTERM exit 0 in 2s). What the tag proves is the remaining half: that the action names and uploads the asset correctly.

Note `skill-bundle` has `needs: upload-assets`, so if arm64 fails the release stays a **draft** rather than publishing with a missing advertised asset.