### PR TITLE
build(deploy): arm64 image for AgentCore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+**Added**
+
+- `deploy/aws/Dockerfile.agentcore` builds the arm64 image AWS Bedrock AgentCore requires, pinned to
+  the v0.16.0 release tarball with its published sha256 verified at build time. It serves
+  `0.0.0.0:8000` and omits `--files`, because AgentCore exposes no route but `/mcp`; documents move
+  through `hwp_put_file` and `hwp_get_file` instead. Deploying to AgentCore is separate work.
+
 ## [0.16.0]
 
 **Added**

--- a/deploy/aws/Dockerfile.agentcore
+++ b/deploy/aws/Dockerfile.agentcore
@@ -1,0 +1,82 @@
+# hwp MCP container for AWS Bedrock AgentCore Runtime.
+#
+# Deliberately a separate file from ../cloudflare/container/Dockerfile.slim rather
+# than a build-arg on it. The two differences that matter live in CMD - port 8000
+# and the absence of --files - and an exec-form CMD cannot take an ARG. Making it
+# configurable means shell-form CMD, which puts `sh` at PID 1 and reintroduces the
+# defect #199 and #203 fixed: `hwp serve` handles SIGTERM *because* it is PID 1, and
+# `sh` would not forward it. That file is also pinned by wrangler.jsonc and built by
+# a live deploy, so it is the wrong place to experiment.
+#
+# AgentCore requires arm64 and Streamable HTTP on 0.0.0.0:8000/mcp, and it exposes no
+# other route, so the /files sideband cannot exist there (docs/design/22-remote-mcp-deployment.md
+# §6.1). Documents travel inline through hwp_put_file and hwp_get_file instead.
+#
+# Build and verify (the host may be x86_64; binfmt supplies the emulation):
+#
+#     docker run --privileged --rm tonistiigi/binfmt --install arm64
+#     docker buildx build --platform linux/arm64 -f Dockerfile.agentcore -t hwp-agentcore:arm64 .
+#     docker run -d --name t --platform linux/arm64 -p 8000:8000 hwp-agentcore:arm64
+#     # initialize + tools/list == 22 on :8000; /files/x is NOT 200
+#     time docker stop t    # ~2s, not the 10s kill timeout - the #199 regression check
+#
+# To move to a new release, bump HWP_VERSION and HWP_SHA256 together. The sha256 is
+# published beside the tarball as hwp-<version>-<target>.sha256, and a mismatch fails
+# the build, which is the point.
+
+# The platform is pinned, and through an ARG of our own name rather than buildkit's
+# predefined TARGETPLATFORM, which buildkit overrides so a default there would do
+# nothing. Dropping the pin is worse than the lint it avoids: a build that forgets
+# --platform would produce an image labelled for the host arch holding an aarch64
+# binary, which AgentCore rejects. Override only to test another architecture.
+ARG HWP_PLATFORM=linux/arm64
+
+ARG HWP_VERSION=v0.16.0
+ARG HWP_TARGET=aarch64-unknown-linux-gnu
+ARG HWP_SHA256=54d56d339febd220a444c8fc06a6002095ac95c9d3bdfbcc3fd1b40b70c7a7d1
+
+# Fetch stage. ADD downloads over the builder's own network stack, so no curl and
+# no CA bundle are ever installed; keeping it in a discarded stage also keeps the
+# archive itself out of the shipped layers.
+FROM --platform=${HWP_PLATFORM} debian:bookworm-slim AS fetch
+ARG HWP_VERSION
+ARG HWP_TARGET
+ARG HWP_SHA256
+ADD https://github.com/STAIxBWLB/hwp-cli/releases/download/${HWP_VERSION}/hwp-${HWP_VERSION}-${HWP_TARGET}.tar.gz /tmp/hwp.tar.gz
+RUN set -eux; \
+    echo "${HWP_SHA256}  /tmp/hwp.tar.gz" | sha256sum -c -; \
+    tar -xzf /tmp/hwp.tar.gz -C /usr/local/bin hwp; \
+    chmod +x /usr/local/bin/hwp; \
+    hwp --version; \
+    # A release without `serve` would otherwise fail only at runtime, inside a
+    # container nobody is watching.
+    hwp serve --help >/dev/null
+
+ARG HWP_PLATFORM
+FROM --platform=${HWP_PLATFORM} debian:bookworm-slim
+# Rendering and PDF output need real font files; fonts-nanum matches the font
+# baseline CI already uses (glyf outlines, fast in debug builds).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends fonts-nanum \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=fetch /usr/local/bin/hwp /usr/local/bin/hwp
+
+RUN useradd --create-home --uid 10001 hwp \
+ && mkdir -p /work \
+ && chown hwp:hwp /work
+USER hwp
+WORKDIR /work
+
+# No init: `hwp serve` handles SIGTERM itself since 0.15.1, so it stops correctly
+# even as PID 1, where the kernel delivers no signal that still has its default
+# disposition. If HWP_VERSION is ever moved back below 0.15.1, put tini back -
+# without one, an idle-stop signal is discarded and the container bills until it
+# is destroyed outright.
+
+EXPOSE 8000
+# No --files: AgentCore exposes only /mcp, so the sideband has nowhere to live.
+CMD ["hwp", "serve", \
+     "--addr", "0.0.0.0:8000", \
+     "--root", "/work", \
+     "--font-dir", "/usr/share/fonts/truetype/nanum"]

--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -336,6 +336,7 @@ counts, and a *hash* of the session id.
 | `src/limits.ts` | Every limit in one place, mirroring doc 20 §7 |
 | `container/Dockerfile.slim` | The deployed image: pinned release tarball, checksum-verified |
 | `container/Dockerfile` | Source build, for testing an unreleased change |
+| `../aws/Dockerfile.agentcore` | arm64 image for AWS Bedrock AgentCore: port 8000, no `/files`. Not used by this deployment |
 | `schema.sql` | D1 tables |
 
 ## Known scope


### PR DESCRIPTION
Completes #189 B1. The image AgentCore needs, pinned to the v0.16.0 release that first publishes an arm64 Linux tarball.

## Contract

AgentCore requires arm64 and Streamable HTTP on `0.0.0.0:8000/mcp`, and exposes **no other route** (doc 22 §6.1), so `--files` has nowhere to live. Documents move inline through `hwp_put_file` and `hwp_get_file`, which v0.16.0 ships — that is why R3 was a Tier B prerequisite.

## Why a separate file, not a build-arg on `Dockerfile.slim`

The differences that matter live in `CMD` — the port and the missing `--files` — and an **exec-form `CMD` cannot take an `ARG`**. Making it configurable means shell-form `CMD`, which puts `sh` at PID 1 and reintroduces exactly the defect #199 and #203 fixed: `hwp serve` handles SIGTERM *because* it is PID 1, and `sh` would not forward it. `Dockerfile.slim` is also pinned by `wrangler.jsonc` and built by a live deploy, so it is the wrong file to experiment in.

## The platform pin, and a lint that was almost a bug

First attempt hardcoded `FROM --platform=linux/arm64`, which buildkit warns about. Second attempt used `ARG TARGETPLATFORM=linux/arm64` — and that **silently does nothing**, because `TARGETPLATFORM` is predefined and buildkit overrides it. The default I thought was protecting the build was inert.

It now uses `ARG HWP_PLATFORM=linux/arm64`, an unreserved name. Verified both ways:

```
with --platform:     0 warning lines
without --platform:  0 warning lines,  uname -m -> aarch64
```

Dropping the pin would be worse than the lint: a build that forgets `--platform` would produce an image labelled for the host arch holding an aarch64 binary, which AgentCore rejects.

## Verified under binfmt on the x86_64 build host, against the published tarball

```
arch: aarch64   version: hwp 0.16.0   user: hwp (uid 10001)
22 tools on :8000; hwp_put_file and hwp_get_file present
/files/x -> 404                       # the sideband is genuinely absent
hwp_new -> hwp_get_file -> hwp_put_file  -> round trip byte-identical
SIGTERM -> exited after 2s (exit=0)   # the #199 regression check
image 149 MB, build 4.3 s
```

The checksum was independently recomputed from the downloaded tarball before it was written in:

```
published: 54d56d339febd220a444c8fc06a6002095ac95c9d3bdfbcc3fd1b40b70c7a7d1
computed : 54d56d339febd220a444c8fc06a6002095ac95c9d3bdfbcc3fd1b40b70c7a7d1
```

**What emulation does not prove:** anything about timing (qemu is 5-20x slower), and nothing about AgentCore's own runtime — its networking, its `Mcp-Session-Id` injection, the JWT authorizer. That is B2 and out of scope here.

No Rust code is touched. `deploy/cloudflare/` is unaffected except for one Layout row.