### PR TITLE
fix(deploy): keep workers.dev on, which routes silently turned off

### DIFF
--- a/deploy/cloudflare/README.md
+++ b/deploy/cloudflare/README.md
@@ -109,12 +109,17 @@ Account `entelecheia` (`b378caab1c7aea09cb77db791fe5f3f8`). The service URL is
 `https://hwp-mcp.staix.net`, a Custom Domain on the `staix.net` zone declared in
 `wrangler.jsonc`; Cloudflare owns its DNS record and certificate.
 
-`https://hwp-mcp.staix.workers.dev` still answers and is meant to. Nothing stored
-is tied to a hostname - the OAuth provider keys KV as `client:`/`grant:`/`token:`
-with no origin, and PATs are SHA-256 hashes in D1 - so every registered client,
-grant, token and PAT works on both. Rolling back is deleting the `routes` block
-and deploying, which costs no client anything because none was ever forced off
-the old host.
+`https://hwp-mcp.staix.workers.dev` still answers, and it takes an explicit
+`"workers_dev": true` in `wrangler.jsonc` to keep it that way. **Once `routes`
+exists, wrangler disables workers.dev by default**, which is not obvious and is
+not what the first deploy of the custom domain was expected to do: it took the
+old hostname to 404 until the flag was added back. Keeping it on costs nothing
+and matters because nothing stored is tied to a hostname - the OAuth provider
+keys KV as `client:`/`grant:`/`token:` with no origin, and PATs are SHA-256
+hashes in D1 - so every registered client, grant, token and PAT works on both.
+Turn it off deliberately, once the old hostname is advertised nowhere.
+
+Rolling back the custom domain is deleting the `routes` block and deploying.
 
 These exist and their ids are already in `wrangler.jsonc` — do not recreate them:
 

--- a/deploy/cloudflare/container/Dockerfile.slim
+++ b/deploy/cloudflare/container/Dockerfile.slim
@@ -13,9 +13,9 @@
 # is published alongside the tarball as hwp-<version>-<target>.sha256; the build
 # fails loudly if it does not match, which is the point.
 
-ARG HWP_VERSION=v0.15.1
+ARG HWP_VERSION=v0.16.0
 ARG HWP_TARGET=x86_64-unknown-linux-gnu
-ARG HWP_SHA256=0c8f92a91eae1e6c8bb2932afbd5084ab918c6a1397ab68acbd3dc6a8cc9284d
+ARG HWP_SHA256=633fefcf0d23af6fe5d727f76284565021f185b8b63176424d5beb4f32a5cba6
 
 # Fetch stage. ADD downloads over the builder's own network stack, so no curl and
 # no CA bundle are ever installed; keeping it in a discarded stage also keeps the

--- a/deploy/cloudflare/wrangler.jsonc
+++ b/deploy/cloudflare/wrangler.jsonc
@@ -54,11 +54,16 @@
 
   // A Custom Domain rather than a route: Cloudflare provisions the DNS record and
   // the certificate itself, where a plain route would need both done by hand first.
-  // workers.dev stays on deliberately. Every credential is host-independent - the
-  // OAuth provider keys KV as client:/grant:/token: with no origin, and PATs are
-  // SHA-256 hashes in D1 - so clients configured before the move keep working on
-  // the old hostname instead of breaking on a date nobody told them about.
   "routes": [{ "pattern": "hwp-mcp.staix.net", "custom_domain": true }],
+
+  // Required, and not the default. Once `routes` exists, wrangler disables
+  // workers.dev unless this says otherwise - the first deploy of the custom domain
+  // took the old hostname down for that reason. Keep it true: every credential is
+  // host-independent (the OAuth provider keys KV as client:/grant:/token: with no
+  // origin, and PATs are SHA-256 hashes in D1), so clients configured before the
+  // move keep working instead of breaking on a date nobody told them about. Turn it
+  // off only deliberately, when the old hostname is no longer advertised anywhere.
+  "workers_dev": true,
 
   "assets": { "directory": "./public", "binding": "ASSETS" },
 


### PR DESCRIPTION
Deploying #206 took `hwp-mcp.staix.workers.dev` to **404**.

## What I got wrong

#206 stated, in the commit message, the PR body and the README: *"adding `routes` does not disable it."* That is false. **Once `routes` exists, wrangler disables workers.dev unless the config says otherwise**, and it says so only in a deploy warning:

```
▲ [WARNING] Because 'workers_dev' is not in your Wrangler file, it will be disabled for this deployment by default.
```

Measured right after the deploy:

```
hwp-mcp.staix.net                HTTP 200
hwp-mcp.staix.workers.dev        HTTP 404
```

So the one thing #206 promised would not happen — breaking clients that hold the old URL — is exactly what happened, for the minutes between that deploy and this fix.

## The fix

`"workers_dev": true`, explicit rather than assumed, with a comment saying it is **required and not the default** so it does not get deleted later as redundant. The README passage that made the wrong claim now records the real behaviour and what the first deploy actually did.

Verified after redeploy: both hostnames serve.