### PR TITLE
fix(mcp): refuse empty inline content instead of calling it a successful upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+**Fixed**
+
+- `hwp_put_file` refuses empty `content` instead of reporting a successful upload of a zero-byte
+  file. Found in live verification, where a shell step produced an empty string and the tool said it
+  had worked; the failure then surfaced as a confusing error from whatever tool read the file next.
+
 **Added**
 
 - `deploy/aws/Dockerfile.agentcore` builds the arm64 image AWS Bedrock AgentCore requires, pinned to

--- a/crates/hwp-cli/src/commands/mcp/mod.rs
+++ b/crates/hwp-cli/src/commands/mcp/mod.rs
@@ -745,6 +745,13 @@ fn validate_base64_structure(text: &str) -> Result<(), String> {
         .bytes()
         .filter(|byte| !byte.is_ascii_whitespace())
         .collect();
+    // 빈 입력은 0바이트 파일을 업로드 성공으로 보고하게 만든다. 문서를 옮기는
+    // 도구에서 그것은 거의 언제나 호출부의 인코딩이 조용히 실패한 흔적이고,
+    // 실제로 라이브 검증 중에 그렇게 물렸다. 다음 도구에서 이해하기 어려운
+    // 오류로 드러나느니 여기서 말하는 편이 낫다.
+    if compact.is_empty() {
+        return Err("content가 비어 있습니다".to_string());
+    }
     let padding = compact.iter().rev().take_while(|&&b| b == b'=').count();
     if padding > 2 {
         return Err("잘못된 base64: 패딩이 2자를 넘습니다".to_string());
@@ -753,7 +760,7 @@ fn validate_base64_structure(text: &str) -> Result<(), String> {
     if payload.contains(&b'=') {
         return Err("잘못된 base64: 패딩이 끝이 아닌 위치에 있습니다".to_string());
     }
-    if !compact.is_empty() && !compact.len().is_multiple_of(4) {
+    if !compact.len().is_multiple_of(4) {
         return Err(format!(
             "잘못된 base64: 공백을 제외한 길이가 4의 배수가 아닙니다 ({}자)",
             compact.len()
@@ -5273,14 +5280,17 @@ mod tests {
             Vec::<u8>::new()
         );
 
-        for bad in ["A", "====", "QQ", "QUJD="] {
-            let destination = root.join(format!("bad-{}.bin", bad.len()));
+        for bad in ["", "   ", "A", "====", "QQ", "QUJD="] {
+            let destination = root.join(format!("bad-{}.bin", bad.escape_debug()));
             let error = tool_put_file(
                 &json!({"name": destination.display().to_string(), "content": bad}),
                 &ctx,
             )
             .unwrap_err();
-            assert!(error.contains("잘못된 base64"), "{bad}: {error}");
+            assert!(
+                error.contains("잘못된 base64") || error.contains("비어 있습니다"),
+                "{bad}: {error}"
+            );
             assert!(!destination.exists(), "{bad}: 파일이 생기면 안 됩니다");
         }
 


### PR DESCRIPTION
Found by live verification, not by review, which is the part worth noting.

A shell step in my own end-to-end check produced an empty string, `hwp_put_file` reported **success**, and a 0-byte file appeared with the sha256 of nothing:

```
hwp_put_file isError: False | { "bytes": 0, "path": "/work/uploaded.hwpx", "sha256": "e3b0c442..." }
remote can read the uploaded document: False
```

The failure then surfaced one call later as a confusing error from `hwp_info`, pointing at the wrong place.

## Why the earlier fix missed it

This is the same shape review flagged for `"A"` and `"===="` in #207, and I fixed those while leaving the empty string through: the length check was written as `!compact.is_empty() && !len.is_multiple_of(4)`, which *skips* an empty input rather than rejecting it. For a tool whose job is moving documents, empty content means the caller's encoding silently failed, and saying so at the call that failed beats reporting success and breaking somewhere less obvious.

The existing test now covers `""` and `"   "` alongside the previous cases.

`scripts/check.sh` passes.