### PR TITLE
fix(deploy): log Google's error when the token exchange fails

### DIFF
--- a/deploy/cloudflare/src/google-handler.ts
+++ b/deploy/cloudflare/src/google-handler.ts
@@ -171,7 +171,31 @@ async function callback(request: Request, env: Env, url: URL): Promise<Response>
     // no token: on failure Google returns {error, error_description} only.
     const detail = await exchange.text().catch(() => '');
     console.error('google token exchange failed', exchange.status, detail.slice(0, 300));
-    return html('<h1>Sign-in failed</h1><p>Google rejected the exchange.</p>', 502);
+    // Google's `error` field is a short fixed enum -- invalid_client, invalid_grant,
+    // redirect_uri_mismatch and so on -- and carries no secret. Showing it turns four
+    // indistinguishable failures into one that names its own cause, which matters
+    // because the alternative is reading Worker logs that need a token scope the
+    // deploy credentials do not have.
+    let reason = '';
+    try {
+      const parsed = JSON.parse(detail) as { error?: unknown };
+      const description =
+        typeof (parsed as { error_description?: unknown }).error_description === 'string'
+          ? (parsed as { error_description: string }).error_description
+          : '';
+      if (typeof parsed.error === 'string' && /^[a-z_]{1,40}$/.test(parsed.error)) {
+        // The description names the offending parameter, which is the whole point:
+        // invalid_request alone does not say *which* field Google refused.
+        reason = description
+          ? ` (${parsed.error}: ${description.slice(0, 200)})`
+          : ` (${parsed.error})`;
+      }
+    } catch {
+      // A non-JSON body means Google is not answering the way it documents; the
+      // status alone is then the only honest signal.
+      reason = ` (HTTP ${exchange.status})`;
+    }
+    return html(`<h1>Sign-in failed</h1><p>Google rejected the exchange${escape(reason)}.</p>`, 502);
   }
 
   const tokens = (await exchange.json()) as { id_token?: string };

--- a/deploy/cloudflare/src/google-handler.ts
+++ b/deploy/cloudflare/src/google-handler.ts
@@ -165,6 +165,12 @@ async function callback(request: Request, env: Env, url: URL): Promise<Response>
     }),
   });
   if (!exchange.ok) {
+    // Log Google's own error code. Without it the only signal is "rejected", which is
+    // indistinguishable between a wrong secret, a redirect_uri mismatch and a code
+    // already spent -- three very different fixes. The body carries no user data and
+    // no token: on failure Google returns {error, error_description} only.
+    const detail = await exchange.text().catch(() => '');
+    console.error('google token exchange failed', exchange.status, detail.slice(0, 300));
     return html('<h1>Sign-in failed</h1><p>Google rejected the exchange.</p>', 502);
   }
 


### PR DESCRIPTION
Written while diagnosing a live sign-in failure that this line would have answered in one step.

`"Google rejected the exchange"` is the identical message for:

- a wrong client secret,
- a `redirect_uri` mismatch,
- an authorization code already spent,
- an OAuth client that has not finished propagating on Google's side.

Four different fixes, no way to tell them apart from the outside. I guessed twice and was wrong both times.

Google returns `{error, error_description}` on failure and nothing else — no user data, no token — so the status plus a bounded slice of the body is safe to log and is exactly what makes the next failure a lookup instead of a bisect.

Deploy-only change; `npx tsc --noEmit` clean.