### PR TITLE
chore(release): v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.16.1]
+
 **Fixed**
 
 - `hwp_put_file` refuses empty `content` instead of reporting a successful upload of a zero-byte

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hwp-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "aes",
  "anyhow",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "hwp-model",
  "hwpx",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-render"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "encoding_rs",
  "flate2",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "aes",
  "cfb",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.16.0"
+version = "0.16.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"


### PR DESCRIPTION
Closes the gap between "fixed" and "deployed" for the empty-inline-content defect.

`hwp_put_file` refusing empty `content` (#213) is merged to main but not in any release, so the live Cloudflare service -- pinned to the v0.16.0 tarball -- still reports a successful upload of a zero-byte file. Cutting this release is what lets the container pin move.

Contents are #213 plus the AgentCore Dockerfile from #211; the Dockerfile is deploy-only and does not change the binary.

Local gate green: fmt, clippy `-D warnings`, `cargo test --workspace`, the PDF-runner tests and the structured corpus. Public PDF parity skipped on this host (needs the pinned `pdfinfo 24.02.0`); CI runs it on ubuntu-24.04.

After merge: tag `v0.16.1` on the merge commit, then bump `HWP_VERSION` and `HWP_SHA256` in `deploy/cloudflare/container/Dockerfile.slim` together and redeploy.