### PR TITLE
build(deploy): pin both images to v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+**Changed**
+
+- Both deployment images pin the v0.16.1 tarball instead of v0.16.0, so the live service gets the
+  `hwp_put_file` empty-content fix. `deploy/cloudflare/container/Dockerfile.slim` is the one that
+  ships; `deploy/aws/Dockerfile.agentcore` moves with it to keep the two from drifting.
+
 ## [0.16.1]
 
 **Fixed**

--- a/deploy/aws/Dockerfile.agentcore
+++ b/deploy/aws/Dockerfile.agentcore
@@ -31,9 +31,9 @@
 # binary, which AgentCore rejects. Override only to test another architecture.
 ARG HWP_PLATFORM=linux/arm64
 
-ARG HWP_VERSION=v0.16.0
+ARG HWP_VERSION=v0.16.1
 ARG HWP_TARGET=aarch64-unknown-linux-gnu
-ARG HWP_SHA256=54d56d339febd220a444c8fc06a6002095ac95c9d3bdfbcc3fd1b40b70c7a7d1
+ARG HWP_SHA256=03f0b8b2f6de11dcc0c4672da947d400ca1ab2557160a351c546e941af5a0805
 
 # Fetch stage. ADD downloads over the builder's own network stack, so no curl and
 # no CA bundle are ever installed; keeping it in a discarded stage also keeps the

--- a/deploy/cloudflare/container/Dockerfile.slim
+++ b/deploy/cloudflare/container/Dockerfile.slim
@@ -13,9 +13,9 @@
 # is published alongside the tarball as hwp-<version>-<target>.sha256; the build
 # fails loudly if it does not match, which is the point.
 
-ARG HWP_VERSION=v0.16.0
+ARG HWP_VERSION=v0.16.1
 ARG HWP_TARGET=x86_64-unknown-linux-gnu
-ARG HWP_SHA256=633fefcf0d23af6fe5d727f76284565021f185b8b63176424d5beb4f32a5cba6
+ARG HWP_SHA256=dd7145b73dd3d3b20aa1386e691e5ed2d16dafa8654772407c4a5d18f955b702
 
 # Fetch stage. ADD downloads over the builder's own network stack, so no curl and
 # no CA bundle are ever installed; keeping it in a discarded stage also keeps the


### PR DESCRIPTION
Closes the gap between "fixed" and "deployed".

The live service ran v0.16.0, which predates the `hwp_put_file` empty-content fix (#213), so the deployed tool still reported a successful upload of a zero-byte file. The image pins a published tarball by design, so releasing v0.16.1 is what made the fix reachable at all.

`Dockerfile.slim` is the one wrangler builds and deploys. `Dockerfile.agentcore` pins the same binary for arm64 and is not deployed anywhere yet; it moves in the same commit so the two cannot drift into pinning different releases of the same tool.

Both sha256 values were fetched from the published `.sha256` assets rather than computed locally -- computing them locally would make the build-time check verify my arithmetic instead of the release.

Verified on the deploy host, which is the only machine here with Docker:

```
build OK
hwp 0.16.1
MCP HTTP server for container deployment: the same tools over POST /mcp
size: 123 MB
```

The build passing is itself the checksum check: a wrong `HWP_SHA256` fails `sha256sum -c` in the discarded fetch stage.