### PR TITLE
fix(compare): name and quote table-cell paragraphs in the diff report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 - Both deployment images pin the v0.16.1 tarball instead of v0.16.0, so the live service gets the
   `hwp_put_file` empty-content fix. `deploy/cloudflare/container/Dockerfile.slim` is the one that
   ships; `deploy/aws/Dockerfile.agentcore` moves with it to keep the two from drifting.
+- Every paragraph entry of the `hwp compare --json` report gains a `text` string and a `location`
+  object naming where that paragraph lives; a replaced pair also carries `b_text` and `b_location`.
+  The change is purely additive - the report contract string stays `hwp-compare-report-v1` and every
+  key present before is still present with the same meaning, so existing consumers need no change
+  (#223).
+
+**Fixed**
+
+- `hwp compare` names and quotes paragraphs inside table cells instead of printing a blank line. The
+  report used to look each paragraph's text up in a flat list of top-level paragraphs while the
+  index came from the engine's deep walk, so past the first table the two index spaces diverged. A
+  cell difference now prints as `표 0 셀 (1,1) 문단 1: text`, using the same 0-based table numbering
+  `hwp edit --set-cell` takes. The structure summary counts paragraph insertions and deletions
+  inside tables and states a table-count change instead of silently dropping the surplus tables
+  (#223).
 
 ## [0.16.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 - Both deployment images pin the v0.16.1 tarball instead of v0.16.0, so the live service gets the
   `hwp_put_file` empty-content fix. `deploy/cloudflare/container/Dockerfile.slim` is the one that
   ships; `deploy/aws/Dockerfile.agentcore` moves with it to keep the two from drifting.
-- Every paragraph entry of the `hwp compare --json` report gains a `text` string and a `location`
-  object naming where that paragraph lives; a replaced pair also carries `b_text` and `b_location`.
-  The change is purely additive - the report contract string stays `hwp-compare-report-v1` and every
-  key present before is still present with the same meaning, so existing consumers need no change
-  (#223).
+- Every paragraph entry of the `hwp compare --json` report gains a `text` string carrying the
+  paragraph's full text and a `location` object naming where that paragraph lives; a replaced pair
+  also carries `b_text` and `b_location`. A nested location additionally carries the `path` of
+  owning paragraph / control / list steps down to it, which is what makes it unique. The structure
+  block gains `cell_paragraphs` (`{a, b}`, how many paragraphs live in a table cell on each side)
+  and `table_count` (`{a, b}`). The change is purely additive - the report contract string stays
+  `hwp-compare-report-v1` and every key present before is still present with the same meaning, so
+  existing consumers need no change (#223).
 
 **Fixed**
 
@@ -27,9 +30,11 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
   report used to look each paragraph's text up in a flat list of top-level paragraphs while the
   index came from the engine's deep walk, so past the first table the two index spaces diverged. A
   cell difference now prints as `표 0 셀 (1,1) 문단 1: text`, using the same 0-based table numbering
-  `hwp edit --set-cell` takes. The structure summary counts paragraph insertions and deletions
-  inside tables and states a table-count change instead of silently dropping the surplus tables
-  (#223).
+  `hwp edit --set-cell` takes - a table nested inside a caption is unreachable for that editor, so
+  it consumes no table number and cannot shift the ones that follow. The structure summary states
+  each side's own count of paragraphs inside table cells (`표 내부 문단 4→5 (+1)`), which is
+  unmoved by a paragraph that merely migrates between cells, and states a table-count change
+  instead of silently dropping the surplus tables (#223).
 
 ## [0.16.1]
 

--- a/crates/hwp-cli/src/commands/compare.rs
+++ b/crates/hwp-cli/src/commands/compare.rs
@@ -25,8 +25,9 @@
 use std::path::Path;
 
 use hwp_cli::cli::{CompareFormat, PasswordArgs};
-use hwp_convert::document_compare::{CharOp, CharRun, DocumentDiff, ParagraphOp};
-use hwp_model::{Document, HwpChar, Paragraph};
+use hwp_convert::document_compare::{
+    CharOp, CharRun, DocumentDiff, ParagraphLocation, ParagraphOp,
+};
 
 use crate::commands::cat::{LoadOptions, load_document_with_options, resolve_password_args};
 
@@ -57,7 +58,7 @@ pub fn run(
         .map_err(|error| anyhow::anyhow!("비교 실패: {error}"))?;
 
     match format {
-        CompareFormat::Text => print_text_report(a, b, &doc_a, &doc_b, &diff),
+        CompareFormat::Text => print_text_report(a, b, &diff),
         CompareFormat::Json => {
             let json = compare_report_json(a, b, &diff);
             println!("{}", serde_json::to_string_pretty(&json)?);
@@ -87,60 +88,66 @@ pub(crate) fn execute(
     Ok(compare_report_json(a, b, &diff))
 }
 
-/// Plain text extraction identical in shape to `commands/grep.rs`'s `para_text`
-/// (this file has no reuse path across binaries, so the small helper is
-/// duplicated rather than shared).
-fn para_text(para: &Paragraph) -> String {
-    let mut text = String::new();
-    for ch in &para.chars {
-        match ch {
-            HwpChar::Text(c) => text.push(*c),
-            HwpChar::CharCtrl(10) => text.push(' '),
-            _ => {}
+/// The Korean location label for one paragraph. Body paragraphs render as an
+/// empty string — they are addressed by their bracketed index alone, which is
+/// what `hwp compare` printed before locations existed.
+fn location_str(location: &ParagraphLocation) -> String {
+    match location {
+        ParagraphLocation::Body { .. } => String::new(),
+        ParagraphLocation::Cell {
+            table,
+            row,
+            col,
+            index,
+            ..
+        } => format!("표 {table} 셀 ({row},{col}) 문단 {index}"),
+        ParagraphLocation::Caption { table, index, .. } => format!("표 {table} 캡션 문단 {index}"),
+        ParagraphLocation::Nested { ctrl_id, index, .. } => {
+            format!("개체 {} 문단 {index}", ctrl_id_str(ctrl_id))
         }
     }
-    text.trim().to_string()
 }
 
-fn flat_paragraphs(doc: &Document) -> Vec<&Paragraph> {
-    doc.sections.iter().flat_map(|s| &s.paragraphs).collect()
+/// One report line: the operation sign, the bracketed flattened index, the
+/// location when there is one, then the paragraph's excerpt.
+fn entry_line(sign: char, index: usize, location: &ParagraphLocation, text: &str) -> String {
+    let location = location_str(location);
+    if location.is_empty() {
+        format!("{sign} [{index}] {text}")
+    } else {
+        format!("{sign} [{index}] {location}: {text}")
+    }
 }
 
 /// Unified-diff-style text report: a header naming both paths, one line per
 /// non-equal paragraph operation, then a short structural summary.
-fn print_text_report(a: &Path, b: &Path, doc_a: &Document, doc_b: &Document, diff: &DocumentDiff) {
+///
+/// Every printed value comes off the [`ParagraphEntry`], never from a second
+/// walk of the source documents: the report's old flat top-level paragraph
+/// list and the engine's deep walk indexed different sequences, so past the
+/// first table the lookup either missed or named the wrong paragraph (#223).
+fn print_text_report(a: &Path, b: &Path, diff: &DocumentDiff) {
     println!("--- {}", a.display());
     println!("+++ {}", b.display());
-
-    let a_paras = flat_paragraphs(doc_a);
-    let b_paras = flat_paragraphs(doc_b);
 
     for entry in &diff.paragraphs {
         match entry.op {
             ParagraphOp::Equal => {}
             ParagraphOp::Insert => {
                 let index = entry.b_index.unwrap_or_default();
-                let text = b_paras.get(index).map(|p| para_text(p)).unwrap_or_default();
-                println!("+ [{index}] {text}");
+                println!("{}", entry_line('+', index, &entry.location, &entry.text));
             }
             ParagraphOp::Delete => {
                 let index = entry.a_index.unwrap_or_default();
-                let text = a_paras.get(index).map(|p| para_text(p)).unwrap_or_default();
-                println!("- [{index}] {text}");
+                println!("{}", entry_line('-', index, &entry.location, &entry.text));
             }
             ParagraphOp::Replace => {
                 let a_index = entry.a_index.unwrap_or_default();
                 let b_index = entry.b_index.unwrap_or_default();
-                let a_text = a_paras
-                    .get(a_index)
-                    .map(|p| para_text(p))
-                    .unwrap_or_default();
-                let b_text = b_paras
-                    .get(b_index)
-                    .map(|p| para_text(p))
-                    .unwrap_or_default();
-                println!("- [{a_index}] {a_text}");
-                println!("+ [{b_index}] {b_text}");
+                println!("{}", entry_line('-', a_index, &entry.location, &entry.text));
+                let b_location = entry.b_location.as_ref().unwrap_or(&entry.location);
+                let b_text = entry.b_text.as_deref().unwrap_or_default();
+                println!("{}", entry_line('+', b_index, b_location, b_text));
             }
         }
     }
@@ -165,6 +172,11 @@ fn print_text_report(a: &Path, b: &Path, doc_a: &Document, doc_b: &Document, dif
         diff.structure.tables.len(),
         changed_controls,
     );
+}
+
+/// A `ctrl_id` as its four printable characters (e.g. `gso `).
+fn ctrl_id_str(ctrl_id: &[u8; 4]) -> String {
+    String::from_utf8_lossy(ctrl_id).into_owned()
 }
 
 fn paragraph_op_str(op: ParagraphOp) -> &'static str {

--- a/crates/hwp-cli/src/commands/compare.rs
+++ b/crates/hwp-cli/src/commands/compare.rs
@@ -196,6 +196,54 @@ fn char_op_str(op: CharOp) -> &'static str {
     }
 }
 
+/// Serializes a [`ParagraphLocation`] by hand into a `kind`-discriminated
+/// object carrying that variant's numbers. Hand-rolled rather than derived so
+/// the engine types stay free of a serde dependency and the emitted shape is
+/// explicit and reviewable.
+fn location_json(location: &ParagraphLocation) -> serde_json::Value {
+    match location {
+        ParagraphLocation::Body { section, index } => serde_json::json!({
+            "kind": "body",
+            "section": section,
+            "index": index,
+        }),
+        ParagraphLocation::Cell {
+            section,
+            table,
+            row,
+            col,
+            index,
+        } => serde_json::json!({
+            "kind": "cell",
+            "section": section,
+            "table": table,
+            "row": row,
+            "col": col,
+            "index": index,
+        }),
+        ParagraphLocation::Caption {
+            section,
+            table,
+            index,
+        } => serde_json::json!({
+            "kind": "caption",
+            "section": section,
+            "table": table,
+            "index": index,
+        }),
+        ParagraphLocation::Nested {
+            section,
+            ctrl_id,
+            index,
+        } => serde_json::json!({
+            "kind": "nested",
+            "section": section,
+            "ctrl_id": ctrl_id_str(ctrl_id),
+            "index": index,
+        }),
+    }
+}
+
 fn char_run_json(run: &CharRun) -> serde_json::Value {
     serde_json::json!({
         "op": char_op_str(run.op),
@@ -213,11 +261,23 @@ pub(crate) fn compare_report_json(a: &Path, b: &Path, diff: &DocumentDiff) -> se
         .paragraphs
         .iter()
         .map(|entry| {
+            // `text` and `location` are additive (D-17): every key below was
+            // present before them and keeps its meaning, and the contract
+            // string is unchanged, so a consumer that ignores unknown keys
+            // needs no change.
             let mut value = serde_json::json!({
                 "op": paragraph_op_str(entry.op),
                 "a_index": entry.a_index,
                 "b_index": entry.b_index,
+                "text": entry.text,
+                "location": location_json(&entry.location),
             });
+            if let Some(b_text) = &entry.b_text {
+                value["b_text"] = serde_json::json!(b_text);
+            }
+            if let Some(b_location) = &entry.b_location {
+                value["b_location"] = location_json(b_location);
+            }
             if let Some(chars) = &entry.chars {
                 value["chars"] =
                     serde_json::json!(chars.iter().map(char_run_json).collect::<Vec<_>>());
@@ -282,6 +342,36 @@ mod tests {
         )
     }
 
+    /// A pair whose only difference is one paragraph appended inside a table
+    /// cell — the #223 shape.
+    fn diff_with_cell_insertion() -> (std::path::PathBuf, std::path::PathBuf, DocumentDiff) {
+        use hwp_model::{Control, HwpChar};
+
+        let markdown = "본문 문단\n\n| 항목 | 내용 |\n| - | - |\n| 하나 | 둘 |\n";
+        let doc_a = hwp_convert::from_markdown::from_markdown(markdown);
+        let mut doc_b = doc_a.clone();
+        let cell = doc_b
+            .sections
+            .iter_mut()
+            .flat_map(|s| s.paragraphs.iter_mut())
+            .flat_map(|p| p.controls.iter_mut())
+            .find_map(|control| match control {
+                Control::Table(table) => table.cells.iter_mut().find(|c| c.row == 1 && c.col == 1),
+                _ => None,
+            })
+            .expect("셀 (1,1)이 있어야 함");
+        let mut added = cell.paragraphs[0].clone();
+        added.chars = "○ 둘째 항목 BBB".chars().map(HwpChar::Text).collect();
+        cell.paragraphs.push(added);
+
+        let diff = hwp_convert::document_compare::compare_documents(&doc_a, &doc_b).unwrap();
+        (
+            std::path::PathBuf::from("a.hwpx"),
+            std::path::PathBuf::from("b.hwpx"),
+            diff,
+        )
+    }
+
     #[test]
     fn json_report_contract() {
         let (a, b, diff) = diff_a_vs_a();
@@ -293,6 +383,40 @@ mod tests {
         assert!(v["structure"]["sections"].is_object());
         assert!(v["structure"]["controls"].is_array());
         assert!(v["structure"]["tables"].is_array());
+
+        // The `text` and `location` keys are additive: every key the report
+        // carried before them is still present with the same meaning, on
+        // every entry, so a consumer that ignores unknown keys keeps working.
+        for entry in v["paragraphs"].as_array().unwrap() {
+            assert!(entry["op"].is_string());
+            assert!(entry.get("a_index").is_some());
+            assert!(entry.get("b_index").is_some());
+            assert!(entry["text"].is_string());
+            assert!(entry["location"]["kind"].is_string());
+        }
+    }
+
+    /// #223: a paragraph inside a table cell must be addressable from the
+    /// JSON report, with the same 0-based table number `--set-cell` uses.
+    #[test]
+    fn json_report_locates_a_cell_paragraph() {
+        let (a, b, diff) = diff_with_cell_insertion();
+        let v = compare_report_json(&a, &b, &diff);
+        assert_eq!(v["contract"], "hwp-compare-report-v1");
+
+        let inserted = v["paragraphs"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["op"] == "insert")
+            .expect("추가된 셀 문단이 있어야 함");
+        assert_eq!(inserted["text"], "○ 둘째 항목 BBB");
+        assert_eq!(inserted["location"]["kind"], "cell");
+        assert_eq!(inserted["location"]["section"], 0);
+        assert_eq!(inserted["location"]["table"], 0);
+        assert_eq!(inserted["location"]["row"], 1);
+        assert_eq!(inserted["location"]["col"], 1);
+        assert_eq!(inserted["location"]["index"], 1);
     }
 
     /// Both inputs go in as `.json` IR (no hwp5/hwpx container writer touches

--- a/crates/hwp-cli/src/commands/compare.rs
+++ b/crates/hwp-cli/src/commands/compare.rs
@@ -122,7 +122,7 @@ fn location_str(location: &ParagraphLocation) -> String {
 }
 
 /// One report line: the operation sign, the bracketed flattened index, the
-/// location when there is one, then the paragraph's excerpt.
+/// location when there is one, then the paragraph's full text.
 fn entry_line(sign: char, index: usize, location: &ParagraphLocation, text: &str) -> String {
     let location = location_str(location);
     if location.is_empty() {

--- a/crates/hwp-cli/src/commands/compare.rs
+++ b/crates/hwp-cli/src/commands/compare.rs
@@ -164,17 +164,19 @@ fn print_text_report(a: &Path, b: &Path, diff: &DocumentDiff) {
         .filter(|(a, b)| a != b)
         .count();
     // The existing fields keep their order; the D-18 additions are appended,
-    // and the table count only when the two sides actually differ.
+    // and the table count only when the two sides actually differ. The cell
+    // paragraph figure is each side's own count, so it reads like every other
+    // a→b pair on the line.
+    let (a_cells, b_cells) = diff.structure.cell_paragraphs;
+    let cell_delta = b_cells as isize - a_cells as isize;
     let mut summary = format!(
-        "구조: 구역 {}→{}, 문단 {}→{}, 표 변경 {}건, 컨트롤 종류 변경 {}건, 표 내부 문단 +{} -{}",
+        "구조: 구역 {}→{}, 문단 {}→{}, 표 변경 {}건, 컨트롤 종류 변경 {}건, 표 내부 문단 {a_cells}→{b_cells} ({cell_delta:+})",
         diff.structure.sections.0,
         diff.structure.sections.1,
         diff.structure.paragraphs.0,
         diff.structure.paragraphs.1,
         diff.structure.tables.len(),
         changed_controls,
-        diff.structure.cell_paragraphs.0,
-        diff.structure.cell_paragraphs.1,
     );
     let (a_tables, b_tables) = diff.structure.table_counts;
     if a_tables != b_tables {
@@ -332,9 +334,11 @@ pub(crate) fn compare_report_json(a: &Path, b: &Path, diff: &DocumentDiff) -> se
             "paragraphs": {"a": diff.structure.paragraphs.0, "b": diff.structure.paragraphs.1},
             "controls": controls,
             "tables": tables,
+            // Per-side counts, like every other pair in this block: how many
+            // paragraphs live in a table cell on each side.
             "cell_paragraphs": {
-                "inserted": diff.structure.cell_paragraphs.0,
-                "deleted": diff.structure.cell_paragraphs.1,
+                "a": diff.structure.cell_paragraphs.0,
+                "b": diff.structure.cell_paragraphs.1,
             },
             "table_count": {"a": diff.structure.table_counts.0, "b": diff.structure.table_counts.1},
         },

--- a/crates/hwp-cli/src/commands/compare.rs
+++ b/crates/hwp-cli/src/commands/compare.rs
@@ -26,7 +26,7 @@ use std::path::Path;
 
 use hwp_cli::cli::{CompareFormat, PasswordArgs};
 use hwp_convert::document_compare::{
-    CharOp, CharRun, DocumentDiff, ParagraphLocation, ParagraphOp,
+    CharOp, CharRun, DocumentDiff, ListKind, LocationStep, ParagraphLocation, ParagraphOp,
 };
 
 use crate::commands::cat::{LoadOptions, load_document_with_options, resolve_password_args};
@@ -102,8 +102,21 @@ fn location_str(location: &ParagraphLocation) -> String {
             ..
         } => format!("표 {table} 셀 ({row},{col}) 문단 {index}"),
         ParagraphLocation::Caption { table, index, .. } => format!("표 {table} 캡션 문단 {index}"),
-        ParagraphLocation::Nested { ctrl_id, index, .. } => {
-            format!("개체 {} 문단 {index}", ctrl_id_str(ctrl_id))
+        ParagraphLocation::Nested {
+            ctrl_id,
+            index,
+            path,
+            ..
+        } => {
+            // The innermost step says which of the control's lists this is;
+            // without it two sibling lists print the same label.
+            let list = match path.last().map(|step| step.list) {
+                Some(ListKind::Cell { row, col }) => format!(" 셀 ({row},{col})"),
+                Some(ListKind::Caption) => " 캡션".to_string(),
+                Some(ListKind::List(n)) => format!(" 목록 {n}"),
+                None => String::new(),
+            };
+            format!("개체 {}{list} 문단 {index}", ctrl_id_str(ctrl_id))
         }
     }
 }
@@ -246,13 +259,40 @@ fn location_json(location: &ParagraphLocation) -> serde_json::Value {
             section,
             ctrl_id,
             index,
+            path,
         } => serde_json::json!({
             "kind": "nested",
             "section": section,
             "ctrl_id": ctrl_id_str(ctrl_id),
             "index": index,
+            // The owner path: one entry per nesting level, from the section's
+            // own paragraph list down to the list holding this paragraph.
+            // `ctrl_id` alone repeats between sibling controls, so this is
+            // what makes a nested location unique.
+            "path": path.iter().map(location_step_json).collect::<Vec<_>>(),
         }),
     }
+}
+
+/// One [`LocationStep`] of a nested location's owner path.
+fn location_step_json(step: &LocationStep) -> serde_json::Value {
+    let mut value = serde_json::json!({
+        "paragraph": step.paragraph,
+        "control": step.control,
+    });
+    match step.list {
+        ListKind::Cell { row, col } => {
+            value["list"] = serde_json::json!("cell");
+            value["row"] = serde_json::json!(row);
+            value["col"] = serde_json::json!(col);
+        }
+        ListKind::Caption => value["list"] = serde_json::json!("caption"),
+        ListKind::List(index) => {
+            value["list"] = serde_json::json!("list");
+            value["list_index"] = serde_json::json!(index);
+        }
+    }
+    value
 }
 
 fn char_run_json(run: &CharRun) -> serde_json::Value {

--- a/crates/hwp-cli/src/commands/compare.rs
+++ b/crates/hwp-cli/src/commands/compare.rs
@@ -163,15 +163,24 @@ fn print_text_report(a: &Path, b: &Path, diff: &DocumentDiff) {
         .values()
         .filter(|(a, b)| a != b)
         .count();
-    println!(
-        "구조: 구역 {}→{}, 문단 {}→{}, 표 변경 {}건, 컨트롤 종류 변경 {}건",
+    // The existing fields keep their order; the D-18 additions are appended,
+    // and the table count only when the two sides actually differ.
+    let mut summary = format!(
+        "구조: 구역 {}→{}, 문단 {}→{}, 표 변경 {}건, 컨트롤 종류 변경 {}건, 표 내부 문단 +{} -{}",
         diff.structure.sections.0,
         diff.structure.sections.1,
         diff.structure.paragraphs.0,
         diff.structure.paragraphs.1,
         diff.structure.tables.len(),
         changed_controls,
+        diff.structure.cell_paragraphs.0,
+        diff.structure.cell_paragraphs.1,
     );
+    let (a_tables, b_tables) = diff.structure.table_counts;
+    if a_tables != b_tables {
+        summary.push_str(&format!(", 표 개수 {a_tables}→{b_tables}"));
+    }
+    println!("{summary}");
 }
 
 /// A `ctrl_id` as its four printable characters (e.g. `gso `).
@@ -323,6 +332,11 @@ pub(crate) fn compare_report_json(a: &Path, b: &Path, diff: &DocumentDiff) -> se
             "paragraphs": {"a": diff.structure.paragraphs.0, "b": diff.structure.paragraphs.1},
             "controls": controls,
             "tables": tables,
+            "cell_paragraphs": {
+                "inserted": diff.structure.cell_paragraphs.0,
+                "deleted": diff.structure.cell_paragraphs.1,
+            },
+            "table_count": {"a": diff.structure.table_counts.0, "b": diff.structure.table_counts.1},
         },
     })
 }

--- a/crates/hwp-cli/tests/compare_exit_codes.rs
+++ b/crates/hwp-cli/tests/compare_exit_codes.rs
@@ -37,6 +37,41 @@ fn write_json_doc(path: &Path, markdown: &str) {
     std::fs::write(path, json).unwrap();
 }
 
+/// Same as [`write_json_doc`], plus one extra paragraph appended inside the
+/// first table's `(row, col)` cell — the #223 shape, where the two documents'
+/// top-level paragraphs are identical and the only difference is in a cell.
+fn write_json_doc_with_cell_paragraph(path: &Path, markdown: &str, row: u16, col: u16, text: &str) {
+    use hwp_model::{Control, HwpChar};
+
+    let mut doc = hwp_convert::from_markdown::from_markdown(markdown);
+    let mut done = false;
+    for para in doc
+        .sections
+        .iter_mut()
+        .flat_map(|s| s.paragraphs.iter_mut())
+    {
+        for control in &mut para.controls {
+            if let Control::Table(table) = control {
+                let cell = table
+                    .cells
+                    .iter_mut()
+                    .find(|c| c.row == row && c.col == col)
+                    .expect("셀이 있어야 함");
+                let mut added = cell.paragraphs[0].clone();
+                added.chars = text.chars().map(HwpChar::Text).collect();
+                cell.paragraphs.push(added);
+                done = true;
+                break;
+            }
+        }
+        if done {
+            break;
+        }
+    }
+    assert!(done, "표가 있는 문서여야 함");
+    std::fs::write(path, hwp_convert::to_json(&doc, true, false).unwrap()).unwrap();
+}
+
 fn sha256(path: &Path) -> Vec<u8> {
     Sha256::digest(std::fs::read(path).unwrap()).to_vec()
 }
@@ -67,6 +102,32 @@ fn differing_documents_exit_one() {
     assert!(
         stdout.contains("고유텍스트마커삽입됨"),
         "stdout에 변경된 문단 텍스트가 있어야 함: {stdout}"
+    );
+}
+
+/// #223: a paragraph added inside a table cell used to print as a blank line,
+/// because the report re-looked-up the text in a flat list of top-level
+/// paragraphs while the index came from the engine's deep walk. The entry now
+/// carries its own text and its own location, so the line names the cell.
+#[test]
+fn added_cell_paragraph_prints_its_cell_and_its_text() {
+    let dir = tmp_dir("cell_paragraph");
+    let a = dir.join("a.json");
+    let b = dir.join("b.json");
+    let table = "본문 문단\n\n| 항목 | 내용 |\n| - | - |\n| 하나 | 둘 |\n";
+    write_json_doc(&a, table);
+    write_json_doc_with_cell_paragraph(&b, table, 1, 1, "○ 둘째 항목 BBB");
+
+    let output = hwp().arg("compare").arg(&a).arg(&b).output().unwrap();
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("표 0 셀 (1,1) 문단 1"),
+        "stdout에 셀 위치가 있어야 함: {stdout}"
+    );
+    assert!(
+        stdout.contains("○ 둘째 항목 BBB"),
+        "stdout에 추가된 문단 텍스트가 있어야 함: {stdout}"
     );
 }
 

--- a/crates/hwp-cli/tests/compare_exit_codes.rs
+++ b/crates/hwp-cli/tests/compare_exit_codes.rs
@@ -129,6 +129,12 @@ fn added_cell_paragraph_prints_its_cell_and_its_text() {
         stdout.contains("○ 둘째 항목 BBB"),
         "stdout에 추가된 문단 텍스트가 있어야 함: {stdout}"
     );
+    // The structure summary states each side's own count of paragraphs living
+    // in a table cell, not a tally of the diff's own insert/delete operations.
+    assert!(
+        stdout.contains("표 내부 문단 4→5 (+1)"),
+        "stdout에 표 내부 문단 집계가 있어야 함: {stdout}"
+    );
 }
 
 /// Catches a regression where the "differences found" path starts returning

--- a/crates/hwp-convert/src/document_compare.rs
+++ b/crates/hwp-convert/src/document_compare.rs
@@ -49,12 +49,6 @@ use hwp_model::{Control, Document, HwpChar, Paragraph};
 /// a weaker comparison (FLOW-03 `precision` probe, planner decision A-11).
 pub const MAX_LCS_CELLS: usize = 25_000_000;
 
-/// How much of a paragraph's text a [`ParagraphEntry`] carries, counted in
-/// `char`s (Unicode scalar values), never bytes — a Korean paragraph yields
-/// this many Hangul syllables and never a split UTF-8 sequence. The cap also
-/// stops one pathologically long paragraph from inflating the whole report.
-pub const TEXT_EXCERPT_CHARS: usize = 60;
-
 /// The full result of comparing two documents.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DocumentDiff {
@@ -163,9 +157,10 @@ pub struct ParagraphEntry {
     pub a_index: Option<usize>,
     pub b_index: Option<usize>,
     pub chars: Option<Vec<CharRun>>,
-    /// The paragraph's own text, the first [`TEXT_EXCERPT_CHARS`] `char`s of
-    /// [`para_text`]. Taken from the a-side, except for a pure `Insert`,
-    /// which has no a-side and therefore reports the b-side.
+    /// The paragraph's own text in full, as [`para_text`] extracts it — never
+    /// truncated, so a difference past any fixed excerpt length is still
+    /// visible. Taken from the a-side, except for a pure `Insert`, which has
+    /// no a-side and therefore reports the b-side.
     pub text: String,
     /// Where [`text`](Self::text) lives — same side as `text`.
     pub location: ParagraphLocation,
@@ -286,7 +281,7 @@ pub fn para_text(para: &Paragraph) -> String {
     text.trim().to_string()
 }
 
-/// One flattened paragraph's reportable identity: its excerpt and where it
+/// One flattened paragraph's reportable identity: its full text and where it
 /// lives. Collected in the same single walk that flattens the `chars`
 /// sequences, so the two can never drift out of index alignment.
 struct ParagraphMeta {
@@ -304,10 +299,7 @@ fn flatten_paragraphs(document: &Document) -> (Vec<Vec<HwpChar>>, Vec<ParagraphM
     walk_paragraphs(document, &mut |paragraph, location| {
         chars.push(paragraph.chars.clone());
         meta.push(ParagraphMeta {
-            text: para_text(paragraph)
-                .chars()
-                .take(TEXT_EXCERPT_CHARS)
-                .collect(),
+            text: para_text(paragraph),
             location,
         });
     });
@@ -1099,26 +1091,24 @@ mod tests {
         ));
     }
 
+    /// #227 finding D: the text is carried in full. A 60-char excerpt hid
+    /// every difference past that point behind two identical-looking lines.
     #[test]
-    fn excerpt_is_capped_in_chars_not_bytes() {
-        let a = doc("머리\n");
-        let mut b = doc("머리\n\n{}\n");
-        b.sections[0]
-            .paragraphs
-            .last_mut()
-            .unwrap()
-            .chars
-            .splice(.., "가".repeat(80).chars().map(HwpChar::Text));
+    fn paragraph_text_is_never_truncated() {
+        let long = |tail: &str| format!("{}{tail}", "가".repeat(80));
+        let a = doc(&format!("머리\n\n{}\n", long("앞")));
+        let b = doc(&format!("머리\n\n{}\n", long("뒤")));
 
         let diff = compare_documents(&a, &b).unwrap();
         let changed = diff
             .paragraphs
             .iter()
-            .find(|e| e.op != ParagraphOp::Equal)
-            .expect("the long paragraph differs");
-        let excerpt = changed.b_text.as_deref().unwrap_or(&changed.text);
-        assert_eq!(excerpt.chars().count(), TEXT_EXCERPT_CHARS);
-        assert_eq!(excerpt, "가".repeat(TEXT_EXCERPT_CHARS));
+            .find(|entry| entry.op == ParagraphOp::Replace)
+            .expect("the long paragraph is replaced");
+        assert_eq!(changed.text, long("앞"));
+        assert_eq!(changed.b_text.as_deref(), Some(long("뒤").as_str()));
+        // The two report lines differ even though the first 80 chars match.
+        assert_ne!(Some(changed.text.as_str()), changed.b_text.as_deref());
     }
 
     #[test]

--- a/crates/hwp-convert/src/document_compare.rs
+++ b/crates/hwp-convert/src/document_compare.rs
@@ -186,10 +186,16 @@ pub struct StructureDiff {
     /// `b"tbl "`). Only kinds present on at least one side appear.
     pub controls: BTreeMap<[u8; 4], (usize, usize)>,
     pub tables: Vec<TableGeometryDelta>,
-    /// Paragraphs inserted and deleted inside table cells (D-18). Counted
-    /// from the paragraph entries whose location is the cell variant, so a
-    /// difference that lives only inside a table is a reported fact rather
-    /// than something the summary has to be read between the lines for.
+    /// How many paragraphs live in a table cell on each side (D-18) — the
+    /// paragraphs whose location is [`ParagraphLocation::Cell`], counted
+    /// independently per document rather than tallied from the diff's own
+    /// operations. A difference that lives only inside a table is therefore a
+    /// reported fact rather than something to read between the lines of the
+    /// summary.
+    ///
+    /// Cells of a table nested inside a caption are not in this bucket: they
+    /// have no `--set-cell` address and report as
+    /// [`ParagraphLocation::Nested`].
     pub cell_paragraphs: (usize, usize),
     /// How many tables each document has. `tables` above only pairs the
     /// tables both sides have; before this field the surplus was dropped by a
@@ -203,7 +209,7 @@ impl StructureDiff {
             && self.paragraphs.0 == self.paragraphs.1
             && self.controls.values().all(|(a, b)| a == b)
             && self.tables.is_empty()
-            && self.cell_paragraphs == (0, 0)
+            && self.cell_paragraphs.0 == self.cell_paragraphs.1
             && self.table_counts.0 == self.table_counts.1
     }
 }
@@ -218,7 +224,7 @@ pub fn compare_documents(a: &Document, b: &Document) -> Result<DocumentDiff, Str
     let ops = paragraph_lcs(&a_paras, &b_paras)?;
     let paragraphs = fold_paragraph_ops(ops, &a_paras, &b_paras, &a_meta, &b_meta)?;
 
-    let structure = structure_diff(a, b, a_paras.len(), b_paras.len(), &paragraphs);
+    let structure = structure_diff(a, b, &a_meta, &b_meta);
 
     let identical =
         paragraphs.iter().all(|e| e.op == ParagraphOp::Equal) && structure.is_identical();
@@ -643,9 +649,8 @@ fn char_lcs_runs(a: &[HwpChar], b: &[HwpChar]) -> Result<Vec<CharRun>, String> {
 fn structure_diff(
     a: &Document,
     b: &Document,
-    a_paragraph_count: usize,
-    b_paragraph_count: usize,
-    paragraphs: &[ParagraphEntry],
+    a_meta: &[ParagraphMeta],
+    b_meta: &[ParagraphMeta],
 ) -> StructureDiff {
     let a_controls = control_inventory(a);
     let b_controls = control_inventory(b);
@@ -671,23 +676,23 @@ fn structure_diff(
         })
         .collect();
 
-    let is_cell = |location: &ParagraphLocation| matches!(location, ParagraphLocation::Cell { .. });
-    let count_cell = |op| {
-        paragraphs
-            .iter()
-            .filter(|entry| entry.op == op && is_cell(&entry.location))
+    // Per-side inventory, not a tally of the diff's own operations: a
+    // paragraph moved from one cell to another, or replaced across the body /
+    // cell boundary, produces no net change here, which is the truth. Deriving
+    // the number from Insert/Delete ops instead reported such a move as one
+    // gain and one loss.
+    let cells = |meta: &[ParagraphMeta]| {
+        meta.iter()
+            .filter(|entry| matches!(entry.location, ParagraphLocation::Cell { .. }))
             .count()
     };
 
     StructureDiff {
         sections: (a.sections.len(), b.sections.len()),
-        paragraphs: (a_paragraph_count, b_paragraph_count),
+        paragraphs: (a_meta.len(), b_meta.len()),
         controls,
         tables,
-        cell_paragraphs: (
-            count_cell(ParagraphOp::Insert),
-            count_cell(ParagraphOp::Delete),
-        ),
+        cell_paragraphs: (cells(a_meta), cells(b_meta)),
         table_counts: (a_tables.len(), b_tables.len()),
     }
 }
@@ -1071,18 +1076,35 @@ mod tests {
         assert!(diff.paragraphs.iter().any(|e| e.op != ParagraphOp::Equal));
     }
 
+    /// #227 finding B: the same paragraph in a different cell is a move, not
+    /// a gain plus a loss. The count is a per-side inventory, so it stays
+    /// equal; the Insert/Delete tally it replaced reported `(1, 1)` here.
     #[test]
-    fn cell_paragraph_changes_are_counted_and_never_look_identical() {
-        // One paragraph added inside a cell on each side, in different cells,
-        // so the pair reports one insertion and one deletion inside tables.
+    fn a_paragraph_moved_between_cells_keeps_the_cell_paragraph_count() {
         let table = "| 항목 | 내용 |\n| - | - |\n| 하나 | 둘 |\n";
         let mut a = doc(table);
         let mut b = doc(table);
-        push_cell_paragraph(&mut a, 0, 0, "a쪽 추가");
+        push_cell_paragraph(&mut a, 0, 0, "옮긴 문단");
+        push_cell_paragraph(&mut b, 1, 1, "옮긴 문단");
+
+        let diff = compare_documents(&a, &b).unwrap();
+        assert_eq!(diff.structure.cell_paragraphs, (5, 5));
+        // The chars-only LCS still sees a deletion and an insertion, so the
+        // pair is not identical. Teaching the diff to recognize a move is
+        // Phase 3 (D-11/D-12) and deliberately out of scope here.
+        assert!(!diff.identical);
+    }
+
+    /// A paragraph added on one side only does move the count.
+    #[test]
+    fn an_added_cell_paragraph_moves_the_cell_paragraph_count() {
+        let table = "| 항목 | 내용 |\n| - | - |\n| 하나 | 둘 |\n";
+        let a = doc(table);
+        let mut b = doc(table);
         push_cell_paragraph(&mut b, 1, 1, "b쪽 추가");
 
         let diff = compare_documents(&a, &b).unwrap();
-        assert_eq!(diff.structure.cell_paragraphs, (1, 1));
+        assert_eq!(diff.structure.cell_paragraphs, (4, 5));
         assert!(!diff.structure.is_identical());
         assert!(!diff.identical);
     }
@@ -1097,11 +1119,11 @@ mod tests {
     }
 
     #[test]
-    fn identical_structure_reports_zero_for_the_new_counts() {
+    fn identical_structure_reports_matching_new_counts() {
         let a = doc("| a | b |\n| - | - |\n| 1 | 2 |\n");
         let b = doc("| a | b |\n| - | - |\n| 1 | 2 |\n");
         let diff = compare_documents(&a, &b).unwrap();
-        assert_eq!(diff.structure.cell_paragraphs, (0, 0));
+        assert_eq!(diff.structure.cell_paragraphs, (4, 4));
         assert_eq!(diff.structure.table_counts, (1, 1));
         assert!(diff.structure.is_identical());
         assert!(diff.identical);

--- a/crates/hwp-convert/src/document_compare.rs
+++ b/crates/hwp-convert/src/document_compare.rs
@@ -80,17 +80,19 @@ pub enum ParagraphOp {
 /// source `Document` a second time — the divergent second index space that
 /// made cell paragraphs print blank (#223).
 ///
-/// `table` is the 0-based depth-first document-order table number
-/// `hwp_convert::edit`'s `with_nth_table` uses, so a printed cell location is
-/// a valid `hwp edit --set-cell "table:row:col=..."` address.
+/// `table` is the 0-based document-order table number `hwp_convert::edit`'s
+/// `with_nth_table` uses, so a printed cell location is a valid
+/// `hwp edit --set-cell "table:row:col=..."` address. The two counters are
+/// kept in lockstep by construction: only tables that walker can reach get a
+/// number at all (see [`walk_nested_paragraphs`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ParagraphLocation {
     /// A section's own paragraph: the 0-based section index and the 0-based
     /// index within that section's paragraph list.
     Body { section: usize, index: usize },
-    /// A paragraph inside a table cell: the section, the document-order table
-    /// number, the cell's `row` and `col`, and the 0-based index within the
-    /// cell's paragraph list.
+    /// A paragraph inside the cell of an addressable table: the section, the
+    /// document-order table number, the cell's `row` and `col`, and the
+    /// 0-based index within the cell's paragraph list.
     Cell {
         section: usize,
         table: usize,
@@ -98,16 +100,20 @@ pub enum ParagraphLocation {
         col: u16,
         index: usize,
     },
-    /// A paragraph inside a table caption: the section, the table number, and
-    /// the 0-based index within the caption's paragraph list.
+    /// A paragraph inside the caption of an addressable table: the section,
+    /// the table number, and the 0-based index within the caption's
+    /// paragraph list.
     Caption {
         section: usize,
         table: usize,
         index: usize,
     },
-    /// A paragraph inside any other nested list (picture caption, generic
-    /// control paragraph list or caption): the section, the owning control's
-    /// `ctrl_id`, and the 0-based index within that list.
+    /// A paragraph inside any other nested list: a picture caption, a generic
+    /// control's paragraph list or caption, or anything below a caption —
+    /// including the cells of a table nested inside one, which `--set-cell`
+    /// cannot address and which therefore carries no table number. The
+    /// section, the owning control's `ctrl_id`, and the 0-based index within
+    /// that list.
     Nested {
         section: usize,
         ctrl_id: [u8; 4],
@@ -278,110 +284,128 @@ fn flatten_paragraphs(document: &Document) -> (Vec<Vec<HwpChar>>, Vec<ParagraphM
 /// depend on that binary crate, so the traversal shape is mirrored rather
 /// than shared).
 ///
-/// The table counter is document-global and increments on every
-/// `Control::Table` **before** that table's own nested content is walked,
-/// which is the pre-order `edit.rs`'s `with_nth_table` counts in. Its one
-/// known divergence: `with_nth_table` does not descend into captions, so a
-/// table nested inside a caption is counted here but is not addressable by
-/// `--set-cell` at all. No such document is known, and caption coverage for
-/// the editing walkers is already tracked as deferred work.
+/// The table counter is document-global; see [`walk_nested_paragraphs`] for
+/// how it is kept identical to `edit.rs`'s `with_nth_table` numbering.
 fn walk_paragraphs(document: &Document, visit: &mut impl FnMut(&Paragraph, ParagraphLocation)) {
     let mut tables = 0usize;
     for (section, sec) in document.sections.iter().enumerate() {
         for (index, paragraph) in sec.paragraphs.iter().enumerate() {
             visit(paragraph, ParagraphLocation::Body { section, index });
-            walk_nested_paragraphs(paragraph, section, &mut tables, visit);
+            let scope = Scope {
+                section,
+                addressable: true,
+            };
+            walk_nested_paragraphs(paragraph, scope, &mut tables, visit);
         }
     }
 }
 
+/// What a nested paragraph inherits from the list it lives in.
+#[derive(Debug, Clone, Copy)]
+struct Scope {
+    section: usize,
+    /// Whether `edit.rs`'s `walk_nth_table` can reach this list at all.
+    addressable: bool,
+}
+
 /// Visits the paragraphs nested in `paragraph`'s controls: table cells and
 /// caption, picture caption, and generic paragraph lists and caption.
+///
+/// **Table numbering.** The counter must produce exactly the index
+/// `edit.rs`'s `with_nth_table` takes, or a printed `--set-cell` address
+/// edits the wrong table. That walker increments on a `Control::Table`
+/// **before** descending into its cells, and it descends only through
+/// section paragraphs, table cells and generic paragraph lists — never
+/// through a caption. So the counter here increments in the same pre-order
+/// and only while `scope.addressable` holds; every caption clears the flag
+/// for its whole subtree, and a table found there gets no number and
+/// consumes none, keeping later tables correctly numbered.
 fn walk_nested_paragraphs(
     paragraph: &Paragraph,
-    section: usize,
+    scope: Scope,
     tables: &mut usize,
     visit: &mut impl FnMut(&Paragraph, ParagraphLocation),
 ) {
+    let section = scope.section;
+    let caption_scope = Scope {
+        addressable: false,
+        ..scope
+    };
     for control in &paragraph.controls {
+        let ctrl_id = control.ctrl_id();
+        let nested = move |index| ParagraphLocation::Nested {
+            section,
+            ctrl_id,
+            index,
+        };
         match control {
             Control::Table(table) => {
-                let table_index = *tables;
-                *tables += 1;
+                let number = scope.addressable.then(|| {
+                    let number = *tables;
+                    *tables += 1;
+                    number
+                });
                 for cell in &table.cells {
-                    for (index, nested) in cell.paragraphs.iter().enumerate() {
-                        visit(
-                            nested,
-                            ParagraphLocation::Cell {
+                    walk_list(
+                        &cell.paragraphs,
+                        scope,
+                        tables,
+                        visit,
+                        |index| match number {
+                            Some(table) => ParagraphLocation::Cell {
                                 section,
-                                table: table_index,
+                                table,
                                 row: cell.row,
                                 col: cell.col,
                                 index,
                             },
-                        );
-                        walk_nested_paragraphs(nested, section, tables, visit);
-                    }
+                            None => nested(index),
+                        },
+                    );
                 }
                 if let Some(caption) = &table.caption {
-                    for (index, nested) in caption.paragraphs.iter().enumerate() {
-                        visit(
-                            nested,
-                            ParagraphLocation::Caption {
+                    walk_list(&caption.paragraphs, caption_scope, tables, visit, |index| {
+                        match number {
+                            Some(table) => ParagraphLocation::Caption {
                                 section,
-                                table: table_index,
+                                table,
                                 index,
                             },
-                        );
-                        walk_nested_paragraphs(nested, section, tables, visit);
-                    }
+                            None => nested(index),
+                        }
+                    });
                 }
             }
             Control::Picture(picture) => {
                 if let Some(caption) = &picture.caption {
-                    for (index, nested) in caption.paragraphs.iter().enumerate() {
-                        visit(
-                            nested,
-                            ParagraphLocation::Nested {
-                                section,
-                                ctrl_id: control.ctrl_id(),
-                                index,
-                            },
-                        );
-                        walk_nested_paragraphs(nested, section, tables, visit);
-                    }
+                    walk_list(&caption.paragraphs, caption_scope, tables, visit, nested);
                 }
             }
             Control::Generic(generic) => {
                 for list in &generic.paragraph_lists {
-                    for (index, nested) in list.paragraphs.iter().enumerate() {
-                        visit(
-                            nested,
-                            ParagraphLocation::Nested {
-                                section,
-                                ctrl_id: control.ctrl_id(),
-                                index,
-                            },
-                        );
-                        walk_nested_paragraphs(nested, section, tables, visit);
-                    }
+                    walk_list(&list.paragraphs, scope, tables, visit, nested);
                 }
                 if let Some(caption) = &generic.caption {
-                    for (index, nested) in caption.paragraphs.iter().enumerate() {
-                        visit(
-                            nested,
-                            ParagraphLocation::Nested {
-                                section,
-                                ctrl_id: control.ctrl_id(),
-                                index,
-                            },
-                        );
-                        walk_nested_paragraphs(nested, section, tables, visit);
-                    }
+                    walk_list(&caption.paragraphs, caption_scope, tables, visit, nested);
                 }
             }
             Control::SectionDef(_) => {}
         }
+    }
+}
+
+/// Visits one nested paragraph list: each paragraph with the location
+/// `locate` builds for it, then that paragraph's own nested lists.
+fn walk_list(
+    paragraphs: &[Paragraph],
+    scope: Scope,
+    tables: &mut usize,
+    visit: &mut impl FnMut(&Paragraph, ParagraphLocation),
+    mut locate: impl FnMut(usize) -> ParagraphLocation,
+) {
+    for (index, nested) in paragraphs.iter().enumerate() {
+        visit(nested, locate(index));
+        walk_nested_paragraphs(nested, scope, tables, visit);
     }
 }
 
@@ -730,6 +754,108 @@ mod tests {
             }
         }
         panic!("the document has no table");
+    }
+
+    /// The `n`th table directly under a section paragraph. Test-only: it does
+    /// not recurse, so it stays independent of the walker under test.
+    fn nth_top_level_table(document: &mut Document, n: usize) -> &mut hwp_model::Table {
+        document.sections[0]
+            .paragraphs
+            .iter_mut()
+            .flat_map(|para| para.controls.iter_mut())
+            .filter_map(|control| match control {
+                Control::Table(table) => Some(table),
+                _ => None,
+            })
+            .nth(n)
+            .expect("the table exists")
+    }
+
+    /// Gives table `n` a caption holding a copy of itself, so the document has
+    /// a table `edit`'s `with_nth_table` can never reach.
+    fn add_caption_table(document: &mut Document, n: usize) {
+        let inner = nth_top_level_table(document, n).clone();
+        nth_top_level_table(document, n).caption = Some(hwp_model::Caption {
+            side: hwp_model::CaptionSide::Bottom,
+            direction: hwp_model::CaptionDirection::Horizontal,
+            gap: 283,
+            width: None,
+            last_width: 0,
+            paragraphs: vec![Paragraph {
+                controls: vec![Control::Table(inner)],
+                ..Paragraph::default()
+            }],
+        });
+    }
+
+    /// #227 finding A: `with_nth_table` never descends into a caption, so a
+    /// table nested in one must not consume a table number — otherwise every
+    /// later table is off by one and the printed cell address edits the wrong
+    /// table.
+    #[test]
+    fn a_caption_nested_table_does_not_shift_the_set_cell_numbering() {
+        let one = "| a | b |\n| - | - |\n| 1 | 2 |\n";
+        let mut a = doc(&format!("{one}\n첫 본문\n\n{one}\n둘째 본문\n\n{one}"));
+        add_caption_table(&mut a, 0);
+
+        let mut b = a.clone();
+        let cell = nth_top_level_table(&mut b, 2)
+            .cells
+            .iter_mut()
+            .find(|c| c.row == 1 && c.col == 1)
+            .expect("the cell exists");
+        let mut added = cell.paragraphs[0].clone();
+        added.chars = "셋째 표 셀 추가".chars().map(HwpChar::Text).collect();
+        cell.paragraphs.push(added);
+
+        let diff = compare_documents(&a, &b).unwrap();
+        let inserted = diff
+            .paragraphs
+            .iter()
+            .find(|e| e.op == ParagraphOp::Insert)
+            .expect("the added cell paragraph is one insertion");
+        let ParagraphLocation::Cell {
+            table: reported,
+            row,
+            col,
+            ..
+        } = inserted.location
+        else {
+            panic!("a cell paragraph reports a cell location: {:?}", inserted);
+        };
+        assert_eq!(reported, 2, "the caption table must not take a number");
+
+        // The reported number is a real `--set-cell` address: driving the
+        // editor with it lands in that same table.
+        let mut edited = a.clone();
+        crate::edit::set_cell(&mut edited, reported, row, col, "찍었다").unwrap();
+        let landed = nth_top_level_table(&mut edited, 2)
+            .cells
+            .iter()
+            .find(|c| c.row == row && c.col == col)
+            .expect("the cell exists");
+        assert_eq!(para_text(&landed.paragraphs[0]), "찍었다");
+    }
+
+    /// Everything below a caption is unaddressable, cells included.
+    #[test]
+    fn a_caption_nested_table_cell_reports_a_nested_location() {
+        let mut a = doc("| a | b |\n| - | - |\n| 1 | 2 |\n");
+        add_caption_table(&mut a, 0);
+        let mut locations = Vec::new();
+        walk_paragraphs(&a, &mut |_, location| locations.push(location));
+        assert!(
+            locations.iter().any(
+                |l| matches!(l, ParagraphLocation::Nested { ctrl_id, .. } if ctrl_id == b"tbl ")
+            ),
+            "a caption table's cells are nested, not addressable: {locations:?}"
+        );
+        assert!(
+            !locations
+                .iter()
+                .any(|l| matches!(l, ParagraphLocation::Cell { table, .. } if *table != 0)),
+            "only table 0 is addressable here: {locations:?}"
+        );
     }
 
     #[test]

--- a/crates/hwp-convert/src/document_compare.rs
+++ b/crates/hwp-convert/src/document_compare.rs
@@ -112,13 +112,45 @@ pub enum ParagraphLocation {
     /// control's paragraph list or caption, or anything below a caption —
     /// including the cells of a table nested inside one, which `--set-cell`
     /// cannot address and which therefore carries no table number. The
-    /// section, the owning control's `ctrl_id`, and the 0-based index within
-    /// that list.
+    /// section, the owning control's `ctrl_id`, the 0-based index within that
+    /// list, and the `path` down to it.
+    ///
+    /// The other three variants are unique on their own numbers: a section
+    /// index plus a paragraph index, or a table number that is unique per
+    /// document. `ctrl_id` is not — two generic controls in one paragraph
+    /// share it — so this variant carries the full owner `path` and is unique
+    /// through that.
     Nested {
         section: usize,
         ctrl_id: [u8; 4],
         index: usize,
+        path: Vec<LocationStep>,
     },
+}
+
+/// One step from a paragraph list down into a nested one: which paragraph of
+/// the current list owns the control, which control of that paragraph it is,
+/// and which of that control's paragraph lists was entered. A chain of these
+/// from the section's own paragraph list names any nested list in a document
+/// exactly once, however deeply it nests.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LocationStep {
+    /// 0-based index of the owning paragraph within its own list.
+    pub paragraph: usize,
+    /// 0-based ordinal of the control within that paragraph's `controls`.
+    pub control: usize,
+    pub list: ListKind,
+}
+
+/// Which paragraph list of a control a [`LocationStep`] enters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ListKind {
+    /// A table cell, named by its `(row, col)`.
+    Cell { row: u16, col: u16 },
+    /// The control's caption.
+    Caption,
+    /// A generic control's `paragraph_lists[n]`.
+    List(usize),
 }
 
 /// One paragraph-level operation. `a_index`/`b_index` are indices into the
@@ -300,18 +332,23 @@ fn walk_paragraphs(document: &Document, visit: &mut impl FnMut(&Paragraph, Parag
             let scope = Scope {
                 section,
                 addressable: true,
+                paragraph: index,
             };
-            walk_nested_paragraphs(paragraph, scope, &mut tables, visit);
+            walk_nested_paragraphs(paragraph, &[], scope, &mut tables, visit);
         }
     }
 }
 
-/// What a nested paragraph inherits from the list it lives in.
+/// What a paragraph inherits from the list it lives in. The list's own
+/// [`LocationStep`] path travels beside it as a slice, so a caller can extend
+/// it with one local `Vec` per nested list.
 #[derive(Debug, Clone, Copy)]
 struct Scope {
     section: usize,
     /// Whether `edit.rs`'s `walk_nth_table` can reach this list at all.
     addressable: bool,
+    /// 0-based index of the current paragraph within its own list.
+    paragraph: usize,
 }
 
 /// Visits the paragraphs nested in `paragraph`'s controls: table cells and
@@ -328,6 +365,7 @@ struct Scope {
 /// consumes none, keeping later tables correctly numbered.
 fn walk_nested_paragraphs(
     paragraph: &Paragraph,
+    path: &[LocationStep],
     scope: Scope,
     tables: &mut usize,
     visit: &mut impl FnMut(&Paragraph, ParagraphLocation),
@@ -337,12 +375,17 @@ fn walk_nested_paragraphs(
         addressable: false,
         ..scope
     };
-    for control in &paragraph.controls {
+    for (control_index, control) in paragraph.controls.iter().enumerate() {
         let ctrl_id = control.ctrl_id();
-        let nested = move |index| ParagraphLocation::Nested {
-            section,
-            ctrl_id,
-            index,
+        // The path down to one of this control's paragraph lists.
+        let descend = |list| {
+            let mut path = path.to_vec();
+            path.push(LocationStep {
+                paragraph: scope.paragraph,
+                control: control_index,
+                list,
+            });
+            path
         };
         match control {
             Control::Table(table) => {
@@ -352,8 +395,13 @@ fn walk_nested_paragraphs(
                     number
                 });
                 for cell in &table.cells {
+                    let path = descend(ListKind::Cell {
+                        row: cell.row,
+                        col: cell.col,
+                    });
                     walk_list(
                         &cell.paragraphs,
+                        &path,
                         scope,
                         tables,
                         visit,
@@ -365,34 +413,84 @@ fn walk_nested_paragraphs(
                                 col: cell.col,
                                 index,
                             },
-                            None => nested(index),
+                            None => ParagraphLocation::Nested {
+                                section,
+                                ctrl_id,
+                                index,
+                                path: path.clone(),
+                            },
                         },
                     );
                 }
                 if let Some(caption) = &table.caption {
-                    walk_list(&caption.paragraphs, caption_scope, tables, visit, |index| {
-                        match number {
+                    let path = descend(ListKind::Caption);
+                    walk_list(
+                        &caption.paragraphs,
+                        &path,
+                        caption_scope,
+                        tables,
+                        visit,
+                        |index| match number {
                             Some(table) => ParagraphLocation::Caption {
                                 section,
                                 table,
                                 index,
                             },
-                            None => nested(index),
-                        }
-                    });
+                            None => ParagraphLocation::Nested {
+                                section,
+                                ctrl_id,
+                                index,
+                                path: path.clone(),
+                            },
+                        },
+                    );
                 }
             }
             Control::Picture(picture) => {
                 if let Some(caption) = &picture.caption {
-                    walk_list(&caption.paragraphs, caption_scope, tables, visit, nested);
+                    let path = descend(ListKind::Caption);
+                    walk_list(
+                        &caption.paragraphs,
+                        &path,
+                        caption_scope,
+                        tables,
+                        visit,
+                        |index| ParagraphLocation::Nested {
+                            section,
+                            ctrl_id,
+                            index,
+                            path: path.clone(),
+                        },
+                    );
                 }
             }
             Control::Generic(generic) => {
-                for list in &generic.paragraph_lists {
-                    walk_list(&list.paragraphs, scope, tables, visit, nested);
+                for (list_index, list) in generic.paragraph_lists.iter().enumerate() {
+                    let path = descend(ListKind::List(list_index));
+                    walk_list(&list.paragraphs, &path, scope, tables, visit, |index| {
+                        ParagraphLocation::Nested {
+                            section,
+                            ctrl_id,
+                            index,
+                            path: path.clone(),
+                        }
+                    });
                 }
                 if let Some(caption) = &generic.caption {
-                    walk_list(&caption.paragraphs, caption_scope, tables, visit, nested);
+                    let path = descend(ListKind::Caption);
+                    walk_list(
+                        &caption.paragraphs,
+                        &path,
+                        caption_scope,
+                        tables,
+                        visit,
+                        |index| ParagraphLocation::Nested {
+                            section,
+                            ctrl_id,
+                            index,
+                            path: path.clone(),
+                        },
+                    );
                 }
             }
             Control::SectionDef(_) => {}
@@ -400,10 +498,12 @@ fn walk_nested_paragraphs(
     }
 }
 
-/// Visits one nested paragraph list: each paragraph with the location
-/// `locate` builds for it, then that paragraph's own nested lists.
+/// Visits one nested paragraph list reached by `path`: each paragraph with
+/// the location `locate` builds for it, then that paragraph's own nested
+/// lists.
 fn walk_list(
     paragraphs: &[Paragraph],
+    path: &[LocationStep],
     scope: Scope,
     tables: &mut usize,
     visit: &mut impl FnMut(&Paragraph, ParagraphLocation),
@@ -411,7 +511,11 @@ fn walk_list(
 ) {
     for (index, nested) in paragraphs.iter().enumerate() {
         visit(nested, locate(index));
-        walk_nested_paragraphs(nested, scope, tables, visit);
+        let scope = Scope {
+            paragraph: index,
+            ..scope
+        };
+        walk_nested_paragraphs(nested, path, scope, tables, visit);
     }
 }
 
@@ -840,6 +944,74 @@ mod tests {
             .find(|c| c.row == row && c.col == col)
             .expect("the cell exists");
         assert_eq!(para_text(&landed.paragraphs[0]), "찍었다");
+    }
+
+    /// A generic control holding one paragraph list of `texts`.
+    fn generic_with_list(texts: &[&str]) -> Control {
+        Control::Generic(hwp_model::GenericControl {
+            ctrl_id: *b"gso ",
+            data: Vec::new(),
+            paragraph_lists: vec![hwp_model::ParagraphList {
+                header_data: Vec::new(),
+                paragraphs: texts
+                    .iter()
+                    .map(|text| Paragraph {
+                        chars: text.chars().map(HwpChar::Text).collect(),
+                        ..Paragraph::default()
+                    })
+                    .collect(),
+            }],
+            extras: Vec::new(),
+            raw_children: Vec::new(),
+            gso_shapes: Vec::new(),
+            equation: None,
+            column_def: None,
+            caption: None,
+            hwpx_raw_xml: None,
+            container_box: None,
+        })
+    }
+
+    /// #227 finding C: `section` + `ctrl_id` + `index` repeats between two
+    /// sibling generic controls in one paragraph. The owner path separates
+    /// them.
+    #[test]
+    fn sibling_generic_paragraph_lists_get_distinct_locations() {
+        let mut document = doc("본문\n");
+        document.sections[0].paragraphs[0].controls = vec![
+            generic_with_list(&["첫 상자"]),
+            generic_with_list(&["둘 상자"]),
+        ];
+
+        let mut locations = Vec::new();
+        walk_paragraphs(&document, &mut |_, location| locations.push(location));
+        let nested: Vec<_> = locations
+            .iter()
+            .filter(|l| matches!(l, ParagraphLocation::Nested { .. }))
+            .collect();
+        assert_eq!(nested.len(), 2, "one paragraph per box: {locations:?}");
+        assert_ne!(nested[0], nested[1], "sibling boxes must not collide");
+    }
+
+    /// Uniqueness is not a two-control special case: every location in a
+    /// document with sibling boxes, a table and a caption is distinct.
+    #[test]
+    fn every_location_in_a_nested_document_is_unique() {
+        let mut document = doc("| a | b |\n| - | - |\n| 1 | 2 |\n");
+        add_caption_table(&mut document, 0);
+        document.sections[0].paragraphs[0].controls.extend([
+            generic_with_list(&["첫 상자"]),
+            generic_with_list(&["둘 상자"]),
+        ]);
+
+        let mut locations = Vec::new();
+        walk_paragraphs(&document, &mut |_, location| locations.push(location));
+        for (index, location) in locations.iter().enumerate() {
+            assert!(
+                !locations[index + 1..].contains(location),
+                "duplicate location {location:?} in {locations:?}"
+            );
+        }
     }
 
     /// Everything below a caption is unaddressable, cells included.

--- a/crates/hwp-convert/src/document_compare.rs
+++ b/crates/hwp-convert/src/document_compare.rs
@@ -49,6 +49,12 @@ use hwp_model::{Control, Document, HwpChar, Paragraph};
 /// a weaker comparison (FLOW-03 `precision` probe, planner decision A-11).
 pub const MAX_LCS_CELLS: usize = 25_000_000;
 
+/// How much of a paragraph's text a [`ParagraphEntry`] carries, counted in
+/// `char`s (Unicode scalar values), never bytes — a Korean paragraph yields
+/// this many Hangul syllables and never a split UTF-8 sequence. The cap also
+/// stops one pathologically long paragraph from inflating the whole report.
+pub const TEXT_EXCERPT_CHARS: usize = 60;
+
 /// The full result of comparing two documents.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DocumentDiff {
@@ -69,6 +75,46 @@ pub enum ParagraphOp {
     Replace,
 }
 
+/// Where a paragraph sits in its document (D-16). Carried on every
+/// [`ParagraphEntry`] so a report can name the paragraph without walking the
+/// source `Document` a second time — the divergent second index space that
+/// made cell paragraphs print blank (#223).
+///
+/// `table` is the 0-based depth-first document-order table number
+/// `hwp_convert::edit`'s `with_nth_table` uses, so a printed cell location is
+/// a valid `hwp edit --set-cell "table:row:col=..."` address.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParagraphLocation {
+    /// A section's own paragraph: the 0-based section index and the 0-based
+    /// index within that section's paragraph list.
+    Body { section: usize, index: usize },
+    /// A paragraph inside a table cell: the section, the document-order table
+    /// number, the cell's `row` and `col`, and the 0-based index within the
+    /// cell's paragraph list.
+    Cell {
+        section: usize,
+        table: usize,
+        row: u16,
+        col: u16,
+        index: usize,
+    },
+    /// A paragraph inside a table caption: the section, the table number, and
+    /// the 0-based index within the caption's paragraph list.
+    Caption {
+        section: usize,
+        table: usize,
+        index: usize,
+    },
+    /// A paragraph inside any other nested list (picture caption, generic
+    /// control paragraph list or caption): the section, the owning control's
+    /// `ctrl_id`, and the 0-based index within that list.
+    Nested {
+        section: usize,
+        ctrl_id: [u8; 4],
+        index: usize,
+    },
+}
+
 /// One paragraph-level operation. `a_index`/`b_index` are indices into the
 /// flattened paragraph sequence of each document (top-level plus nested
 /// cell/caption paragraphs; not WCHAR offsets). `chars` is populated only for
@@ -79,6 +125,18 @@ pub struct ParagraphEntry {
     pub a_index: Option<usize>,
     pub b_index: Option<usize>,
     pub chars: Option<Vec<CharRun>>,
+    /// The paragraph's own text, the first [`TEXT_EXCERPT_CHARS`] `char`s of
+    /// [`para_text`]. Taken from the a-side, except for a pure `Insert`,
+    /// which has no a-side and therefore reports the b-side.
+    pub text: String,
+    /// Where [`text`](Self::text) lives — same side as `text`.
+    pub location: ParagraphLocation,
+    /// The b-side text of a `Replace`, which is the one operation with a
+    /// paragraph on both sides; `None` for every other operation, mirroring
+    /// how `chars` is populated only for `Replace`.
+    pub b_text: Option<String>,
+    /// Where [`b_text`](Self::b_text) lives; `None` whenever `b_text` is.
+    pub b_location: Option<ParagraphLocation>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -137,11 +195,11 @@ impl StructureDiff {
 /// rendering. Returns `Err` naming the [`MAX_LCS_CELLS`] ceiling when either
 /// the paragraph-level or a character-level LCS table would exceed it.
 pub fn compare_documents(a: &Document, b: &Document) -> Result<DocumentDiff, String> {
-    let a_paras = flatten_paragraph_chars(a);
-    let b_paras = flatten_paragraph_chars(b);
+    let (a_paras, a_meta) = flatten_paragraphs(a);
+    let (b_paras, b_meta) = flatten_paragraphs(b);
 
     let ops = paragraph_lcs(&a_paras, &b_paras)?;
-    let paragraphs = fold_paragraph_ops(ops, &a_paras, &b_paras)?;
+    let paragraphs = fold_paragraph_ops(ops, &a_paras, &b_paras, &a_meta, &b_meta)?;
 
     let structure = structure_diff(a, b, a_paras.len(), b_paras.len());
 
@@ -155,67 +213,159 @@ pub fn compare_documents(a: &Document, b: &Document) -> Result<DocumentDiff, Str
     })
 }
 
+/// Plain text of one paragraph: text characters kept, the `LINE_BREAK`
+/// control character mapped to a space, every other element dropped, then
+/// trimmed. Moved here from `hwp-cli`'s `commands/compare.rs` so the compare
+/// report can read a paragraph's text off its [`ParagraphEntry`] instead of
+/// indexing back into the source document (D-16). The near-identical copies
+/// in `commands/grep.rs` and `commands/fill.rs` are deliberately left alone.
+pub fn para_text(para: &Paragraph) -> String {
+    let mut text = String::new();
+    for ch in &para.chars {
+        match ch {
+            HwpChar::Text(c) => text.push(*c),
+            HwpChar::CharCtrl(hwp_model::ctrl_char::LINE_BREAK) => text.push(' '),
+            _ => {}
+        }
+    }
+    text.trim().to_string()
+}
+
+/// One flattened paragraph's reportable identity: its excerpt and where it
+/// lives. Collected in the same single walk that flattens the `chars`
+/// sequences, so the two can never drift out of index alignment.
+struct ParagraphMeta {
+    text: String,
+    location: ParagraphLocation,
+}
+
 /// Flattens every section's paragraphs — top-level plus the paragraphs
 /// nested in table cells/captions, picture captions, and generic control
 /// paragraph lists/captions — into one ordered `chars` sequence per
-/// paragraph, in depth-first document order.
-fn flatten_paragraph_chars(document: &Document) -> Vec<Vec<HwpChar>> {
-    let mut out = Vec::new();
-    walk_paragraphs(document, &mut |paragraph| out.push(paragraph.chars.clone()));
-    out
+/// paragraph plus its [`ParagraphMeta`], in depth-first document order.
+fn flatten_paragraphs(document: &Document) -> (Vec<Vec<HwpChar>>, Vec<ParagraphMeta>) {
+    let mut chars = Vec::new();
+    let mut meta = Vec::new();
+    walk_paragraphs(document, &mut |paragraph, location| {
+        chars.push(paragraph.chars.clone());
+        meta.push(ParagraphMeta {
+            text: para_text(paragraph)
+                .chars()
+                .take(TEXT_EXCERPT_CHARS)
+                .collect(),
+            location,
+        });
+    });
+    (chars, meta)
 }
 
-/// Visits every paragraph of the document in depth-first document order:
-/// each top-level paragraph, then the paragraphs nested in its controls.
+/// Visits every paragraph of the document in depth-first document order —
+/// each top-level paragraph, then the paragraphs nested in its controls —
+/// handing the visitor the paragraph's [`ParagraphLocation`].
 /// The nested traversal mirrors hwp-cli's
 /// `commands/preservation.rs::collect_paragraph_controls` (this crate cannot
 /// depend on that binary crate, so the traversal shape is mirrored rather
 /// than shared).
-fn walk_paragraphs(document: &Document, visit: &mut impl FnMut(&Paragraph)) {
-    for paragraph in document.sections.iter().flat_map(|s| s.paragraphs.iter()) {
-        visit(paragraph);
-        walk_nested_paragraphs(paragraph, visit);
+///
+/// The table counter is document-global and increments on every
+/// `Control::Table` **before** that table's own nested content is walked,
+/// which is the pre-order `edit.rs`'s `with_nth_table` counts in. Its one
+/// known divergence: `with_nth_table` does not descend into captions, so a
+/// table nested inside a caption is counted here but is not addressable by
+/// `--set-cell` at all. No such document is known, and caption coverage for
+/// the editing walkers is already tracked as deferred work.
+fn walk_paragraphs(document: &Document, visit: &mut impl FnMut(&Paragraph, ParagraphLocation)) {
+    let mut tables = 0usize;
+    for (section, sec) in document.sections.iter().enumerate() {
+        for (index, paragraph) in sec.paragraphs.iter().enumerate() {
+            visit(paragraph, ParagraphLocation::Body { section, index });
+            walk_nested_paragraphs(paragraph, section, &mut tables, visit);
+        }
     }
 }
 
 /// Visits the paragraphs nested in `paragraph`'s controls: table cells and
 /// caption, picture caption, and generic paragraph lists and caption.
-fn walk_nested_paragraphs(paragraph: &Paragraph, visit: &mut impl FnMut(&Paragraph)) {
+fn walk_nested_paragraphs(
+    paragraph: &Paragraph,
+    section: usize,
+    tables: &mut usize,
+    visit: &mut impl FnMut(&Paragraph, ParagraphLocation),
+) {
     for control in &paragraph.controls {
         match control {
             Control::Table(table) => {
+                let table_index = *tables;
+                *tables += 1;
                 for cell in &table.cells {
-                    for nested in &cell.paragraphs {
-                        visit(nested);
-                        walk_nested_paragraphs(nested, visit);
+                    for (index, nested) in cell.paragraphs.iter().enumerate() {
+                        visit(
+                            nested,
+                            ParagraphLocation::Cell {
+                                section,
+                                table: table_index,
+                                row: cell.row,
+                                col: cell.col,
+                                index,
+                            },
+                        );
+                        walk_nested_paragraphs(nested, section, tables, visit);
                     }
                 }
                 if let Some(caption) = &table.caption {
-                    for nested in &caption.paragraphs {
-                        visit(nested);
-                        walk_nested_paragraphs(nested, visit);
+                    for (index, nested) in caption.paragraphs.iter().enumerate() {
+                        visit(
+                            nested,
+                            ParagraphLocation::Caption {
+                                section,
+                                table: table_index,
+                                index,
+                            },
+                        );
+                        walk_nested_paragraphs(nested, section, tables, visit);
                     }
                 }
             }
             Control::Picture(picture) => {
                 if let Some(caption) = &picture.caption {
-                    for nested in &caption.paragraphs {
-                        visit(nested);
-                        walk_nested_paragraphs(nested, visit);
+                    for (index, nested) in caption.paragraphs.iter().enumerate() {
+                        visit(
+                            nested,
+                            ParagraphLocation::Nested {
+                                section,
+                                ctrl_id: control.ctrl_id(),
+                                index,
+                            },
+                        );
+                        walk_nested_paragraphs(nested, section, tables, visit);
                     }
                 }
             }
             Control::Generic(generic) => {
                 for list in &generic.paragraph_lists {
-                    for nested in &list.paragraphs {
-                        visit(nested);
-                        walk_nested_paragraphs(nested, visit);
+                    for (index, nested) in list.paragraphs.iter().enumerate() {
+                        visit(
+                            nested,
+                            ParagraphLocation::Nested {
+                                section,
+                                ctrl_id: control.ctrl_id(),
+                                index,
+                            },
+                        );
+                        walk_nested_paragraphs(nested, section, tables, visit);
                     }
                 }
                 if let Some(caption) = &generic.caption {
-                    for nested in &caption.paragraphs {
-                        visit(nested);
-                        walk_nested_paragraphs(nested, visit);
+                    for (index, nested) in caption.paragraphs.iter().enumerate() {
+                        visit(
+                            nested,
+                            ParagraphLocation::Nested {
+                                section,
+                                ctrl_id: control.ctrl_id(),
+                                index,
+                            },
+                        );
+                        walk_nested_paragraphs(nested, section, tables, visit);
                     }
                 }
             }
@@ -287,53 +437,51 @@ fn fold_paragraph_ops(
     ops: Vec<AtomicOp>,
     a: &[Vec<HwpChar>],
     b: &[Vec<HwpChar>],
+    a_meta: &[ParagraphMeta],
+    b_meta: &[ParagraphMeta],
 ) -> Result<Vec<ParagraphEntry>, String> {
+    // Text and location come from the a-side, except for a pure Insert, which
+    // has no a-side; a Replace additionally carries its b-side explicitly.
+    let entry = |op, a_index: Option<usize>, b_index: Option<usize>, chars| {
+        let primary = a_index
+            .map(|i| &a_meta[i])
+            .unwrap_or_else(|| &b_meta[b_index.expect("an entry has at least one side")]);
+        let b_side = (op == ParagraphOp::Replace).then(|| &b_meta[b_index.unwrap()]);
+        ParagraphEntry {
+            op,
+            a_index,
+            b_index,
+            chars,
+            text: primary.text.clone(),
+            location: primary.location.clone(),
+            b_text: b_side.map(|meta| meta.text.clone()),
+            b_location: b_side.map(|meta| meta.location.clone()),
+        }
+    };
+
     let mut out = Vec::with_capacity(ops.len());
     let mut iter = ops.into_iter().peekable();
     while let Some(op) = iter.next() {
         match op {
-            AtomicOp::Equal(ai, bi) => out.push(ParagraphEntry {
-                op: ParagraphOp::Equal,
-                a_index: Some(ai),
-                b_index: Some(bi),
-                chars: None,
-            }),
+            AtomicOp::Equal(ai, bi) => {
+                out.push(entry(ParagraphOp::Equal, Some(ai), Some(bi), None))
+            }
             AtomicOp::Delete(ai) => {
                 if let Some(AtomicOp::Insert(bi)) = iter.peek().copied() {
                     iter.next();
                     let chars = Some(char_lcs_runs(&a[ai], &b[bi])?);
-                    out.push(ParagraphEntry {
-                        op: ParagraphOp::Replace,
-                        a_index: Some(ai),
-                        b_index: Some(bi),
-                        chars,
-                    });
+                    out.push(entry(ParagraphOp::Replace, Some(ai), Some(bi), chars));
                 } else {
-                    out.push(ParagraphEntry {
-                        op: ParagraphOp::Delete,
-                        a_index: Some(ai),
-                        b_index: None,
-                        chars: None,
-                    });
+                    out.push(entry(ParagraphOp::Delete, Some(ai), None, None));
                 }
             }
             AtomicOp::Insert(bi) => {
                 if let Some(AtomicOp::Delete(ai)) = iter.peek().copied() {
                     iter.next();
                     let chars = Some(char_lcs_runs(&a[ai], &b[bi])?);
-                    out.push(ParagraphEntry {
-                        op: ParagraphOp::Replace,
-                        a_index: Some(ai),
-                        b_index: Some(bi),
-                        chars,
-                    });
+                    out.push(entry(ParagraphOp::Replace, Some(ai), Some(bi), chars));
                 } else {
-                    out.push(ParagraphEntry {
-                        op: ParagraphOp::Insert,
-                        a_index: None,
-                        b_index: Some(bi),
-                        chars: None,
-                    });
+                    out.push(entry(ParagraphOp::Insert, None, Some(bi), None));
                 }
             }
         }
@@ -503,7 +651,7 @@ fn structure_diff(
 /// than shared).
 fn control_inventory(document: &Document) -> BTreeMap<[u8; 4], usize> {
     let mut counts = BTreeMap::new();
-    walk_paragraphs(document, &mut |paragraph| {
+    walk_paragraphs(document, &mut |paragraph, _location| {
         for control in &paragraph.controls {
             *counts.entry(control.ctrl_id()).or_default() += 1;
         }
@@ -515,7 +663,7 @@ fn control_inventory(document: &Document) -> BTreeMap<[u8; 4], usize> {
 /// including tables nested in cells and captions.
 fn table_geometries(document: &Document) -> Vec<(u16, u16)> {
     let mut out = Vec::new();
-    walk_paragraphs(document, &mut |paragraph| {
+    walk_paragraphs(document, &mut |paragraph, _location| {
         for control in &paragraph.controls {
             if let Control::Table(table) = control {
                 out.push((table.rows, table.cols));
@@ -531,6 +679,118 @@ mod tests {
 
     fn doc(md: &str) -> Document {
         crate::from_markdown::from_markdown(md)
+    }
+
+    /// Appends a paragraph inside the first table's `(row, col)` cell — the
+    /// #223 shape, where both documents' top-level paragraphs are identical
+    /// and the only difference lives inside a cell.
+    fn push_cell_paragraph(document: &mut Document, row: u16, col: u16, text: &str) {
+        for para in document
+            .sections
+            .iter_mut()
+            .flat_map(|s| s.paragraphs.iter_mut())
+        {
+            for control in &mut para.controls {
+                if let Control::Table(table) = control {
+                    let cell = table
+                        .cells
+                        .iter_mut()
+                        .find(|c| c.row == row && c.col == col)
+                        .expect("the cell exists");
+                    let mut added = cell.paragraphs[0].clone();
+                    added.chars = text.chars().map(HwpChar::Text).collect();
+                    cell.paragraphs.push(added);
+                    return;
+                }
+            }
+        }
+        panic!("the document has no table");
+    }
+
+    #[test]
+    fn inserted_cell_paragraph_carries_its_cell_location_and_text() {
+        let a = doc("| a | b |\n| - | - |\n| 1 | 2 |\n");
+        let mut b = a.clone();
+        push_cell_paragraph(&mut b, 1, 1, "○ 둘째 항목 BBB");
+
+        let diff = compare_documents(&a, &b).unwrap();
+        let inserted = diff
+            .paragraphs
+            .iter()
+            .find(|e| e.op == ParagraphOp::Insert)
+            .expect("the added cell paragraph is one insertion");
+        assert_eq!(inserted.text, "○ 둘째 항목 BBB");
+        assert_eq!(
+            inserted.location,
+            ParagraphLocation::Cell {
+                section: 0,
+                table: 0,
+                row: 1,
+                col: 1,
+                index: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn two_equal_adjacent_cell_paragraphs_stay_two_entries() {
+        // The diff is index-based over the deep walk, so byte-equal
+        // neighbours never merge into one entry or collide on one location.
+        let a = doc("| a | b |\n| - | - |\n| 1 | 2 |\n");
+        let mut b = a.clone();
+        push_cell_paragraph(&mut b, 1, 1, "같은 문단");
+        push_cell_paragraph(&mut b, 1, 1, "같은 문단");
+
+        let diff = compare_documents(&a, &b).unwrap();
+        let inserted: Vec<_> = diff
+            .paragraphs
+            .iter()
+            .filter(|e| e.op == ParagraphOp::Insert)
+            .collect();
+        assert_eq!(inserted.len(), 2);
+        assert_ne!(inserted[0].location, inserted[1].location);
+        assert_ne!(inserted[0].b_index, inserted[1].b_index);
+    }
+
+    #[test]
+    fn empty_cell_paragraph_still_carries_a_full_location() {
+        let a = doc("| a | b |\n| - | - |\n| 1 | 2 |\n");
+        let mut b = a.clone();
+        push_cell_paragraph(&mut b, 1, 1, "");
+
+        let diff = compare_documents(&a, &b).unwrap();
+        let inserted = diff
+            .paragraphs
+            .iter()
+            .find(|e| e.op == ParagraphOp::Insert)
+            .expect("an empty added paragraph is still an insertion");
+        assert_eq!(inserted.text, "");
+        assert!(matches!(
+            inserted.location,
+            ParagraphLocation::Cell { row: 1, col: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn excerpt_is_capped_in_chars_not_bytes() {
+        let a = doc("머리\n");
+        let mut b = doc("머리\n\n{}\n");
+        b.sections[0]
+            .paragraphs
+            .last_mut()
+            .unwrap()
+            .chars
+            .splice(.., "가".repeat(80).chars().map(HwpChar::Text));
+
+        let diff = compare_documents(&a, &b).unwrap();
+        let changed = diff
+            .paragraphs
+            .iter()
+            .find(|e| e.op != ParagraphOp::Equal)
+            .expect("the long paragraph differs");
+        let excerpt = changed.b_text.as_deref().unwrap_or(&changed.text);
+        assert_eq!(excerpt.chars().count(), TEXT_EXCERPT_CHARS);
+        assert_eq!(excerpt, "가".repeat(TEXT_EXCERPT_CHARS));
     }
 
     #[test]

--- a/crates/hwp-convert/src/document_compare.rs
+++ b/crates/hwp-convert/src/document_compare.rs
@@ -180,6 +180,15 @@ pub struct StructureDiff {
     /// `b"tbl "`). Only kinds present on at least one side appear.
     pub controls: BTreeMap<[u8; 4], (usize, usize)>,
     pub tables: Vec<TableGeometryDelta>,
+    /// Paragraphs inserted and deleted inside table cells (D-18). Counted
+    /// from the paragraph entries whose location is the cell variant, so a
+    /// difference that lives only inside a table is a reported fact rather
+    /// than something the summary has to be read between the lines for.
+    pub cell_paragraphs: (usize, usize),
+    /// How many tables each document has. `tables` above only pairs the
+    /// tables both sides have; before this field the surplus was dropped by a
+    /// positional `zip` without a word (D-18).
+    pub table_counts: (usize, usize),
 }
 
 impl StructureDiff {
@@ -188,6 +197,8 @@ impl StructureDiff {
             && self.paragraphs.0 == self.paragraphs.1
             && self.controls.values().all(|(a, b)| a == b)
             && self.tables.is_empty()
+            && self.cell_paragraphs == (0, 0)
+            && self.table_counts.0 == self.table_counts.1
     }
 }
 
@@ -201,7 +212,7 @@ pub fn compare_documents(a: &Document, b: &Document) -> Result<DocumentDiff, Str
     let ops = paragraph_lcs(&a_paras, &b_paras)?;
     let paragraphs = fold_paragraph_ops(ops, &a_paras, &b_paras, &a_meta, &b_meta)?;
 
-    let structure = structure_diff(a, b, a_paras.len(), b_paras.len());
+    let structure = structure_diff(a, b, a_paras.len(), b_paras.len(), &paragraphs);
 
     let identical =
         paragraphs.iter().all(|e| e.op == ParagraphOp::Equal) && structure.is_identical();
@@ -610,6 +621,7 @@ fn structure_diff(
     b: &Document,
     a_paragraph_count: usize,
     b_paragraph_count: usize,
+    paragraphs: &[ParagraphEntry],
 ) -> StructureDiff {
     let a_controls = control_inventory(a);
     let b_controls = control_inventory(b);
@@ -635,11 +647,24 @@ fn structure_diff(
         })
         .collect();
 
+    let is_cell = |location: &ParagraphLocation| matches!(location, ParagraphLocation::Cell { .. });
+    let count_cell = |op| {
+        paragraphs
+            .iter()
+            .filter(|entry| entry.op == op && is_cell(&entry.location))
+            .count()
+    };
+
     StructureDiff {
         sections: (a.sections.len(), b.sections.len()),
         paragraphs: (a_paragraph_count, b_paragraph_count),
         controls,
         tables,
+        cell_paragraphs: (
+            count_cell(ParagraphOp::Insert),
+            count_cell(ParagraphOp::Delete),
+        ),
+        table_counts: (a_tables.len(), b_tables.len()),
     }
 }
 
@@ -918,6 +943,42 @@ mod tests {
         let diff = compare_documents(&a, &b).unwrap();
         assert!(!diff.identical);
         assert!(diff.paragraphs.iter().any(|e| e.op != ParagraphOp::Equal));
+    }
+
+    #[test]
+    fn cell_paragraph_changes_are_counted_and_never_look_identical() {
+        // One paragraph added inside a cell on each side, in different cells,
+        // so the pair reports one insertion and one deletion inside tables.
+        let table = "| 항목 | 내용 |\n| - | - |\n| 하나 | 둘 |\n";
+        let mut a = doc(table);
+        let mut b = doc(table);
+        push_cell_paragraph(&mut a, 0, 0, "a쪽 추가");
+        push_cell_paragraph(&mut b, 1, 1, "b쪽 추가");
+
+        let diff = compare_documents(&a, &b).unwrap();
+        assert_eq!(diff.structure.cell_paragraphs, (1, 1));
+        assert!(!diff.structure.is_identical());
+        assert!(!diff.identical);
+    }
+
+    #[test]
+    fn differing_table_counts_are_reported_not_truncated() {
+        let a = doc("| a | b |\n| - | - |\n| 1 | 2 |\n");
+        let b = doc("| a | b |\n| - | - |\n| 1 | 2 |\n\n본문\n\n| c | d |\n| - | - |\n| 3 | 4 |\n");
+        let diff = compare_documents(&a, &b).unwrap();
+        assert_eq!(diff.structure.table_counts, (1, 2));
+        assert!(!diff.structure.is_identical());
+    }
+
+    #[test]
+    fn identical_structure_reports_zero_for_the_new_counts() {
+        let a = doc("| a | b |\n| - | - |\n| 1 | 2 |\n");
+        let b = doc("| a | b |\n| - | - |\n| 1 | 2 |\n");
+        let diff = compare_documents(&a, &b).unwrap();
+        assert_eq!(diff.structure.cell_paragraphs, (0, 0));
+        assert_eq!(diff.structure.table_counts, (1, 1));
+        assert!(diff.structure.is_identical());
+        assert!(diff.identical);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`hwp compare` printed a blank line for a paragraph added inside a table cell (#223). The root cause
is two divergent index spaces: the report re-looked-up each paragraph's text in `flat_paragraphs`, a
flat list of top-level paragraphs only, while the entry index came from the engine's deep walk over
top-level *and* nested paragraphs. Past the first table the two sequences no longer line up, so the
lookup either missed (blank line) or named the wrong paragraph. The fix deletes the second index
space rather than patching the lookup: every `ParagraphEntry` now carries its own text and its own
location, and the report prints what it is given.

Reproduction from the issue: edit a form document's cell with `hwp edit --set-cell`, then
`hwp compare` the original against the edited copy. Before, the added paragraph showed as `+ [104] `.
Now:

```
+ [6] 표 0 셀 (1,1) 문단 1: ○ 둘째 항목 BBB
구조: 구역 1→1, 문단 6→7, 표 변경 0건, 컨트롤 종류 변경 0건, 표 내부 문단 4→5 (+1)
```

The table number is the same 0-based document-order index `hwp edit --set-cell t:r:c` uses, so a
printed location pastes straight into an edit command.

What changed:

- `hwp-convert::document_compare` gains `ParagraphLocation` (body / table cell / table caption /
  other nested list), threaded through `walk_paragraphs` with a document-global table counter.
- The counter increments only for tables `edit.rs`'s `with_nth_table` can reach: section
  paragraphs, table cells and generic paragraph lists, never a caption. A table nested inside a
  caption therefore consumes no number and cannot shift the ones after it, and its own cell
  paragraphs report as `Nested` rather than as a cell address that would edit the wrong table.
- `ParagraphEntry` gains `text` (the paragraph's full text, never truncated) and `location`, plus
  `b_text` / `b_location` for `Replace`, the one operation with a paragraph on both sides.
- A `Nested` location carries the owner `path` down to its list: one `LocationStep` per level, each
  naming the owning paragraph's index, the control's ordinal in that paragraph and which of the
  control's lists was entered. `section` + `ctrl_id` + `index` alone repeated between two sibling
  generic boxes in one paragraph; the path makes every location in a document unique. Body, cell
  and caption locations keep their fields unchanged - a table number is unique per document and a
  section plus paragraph index is unique on its own.
- `para_text` moved from `commands/compare.rs` into `hwp-convert` and is public. The near-identical
  copies in `grep.rs` and `fill.rs` are deliberately untouched.
- `commands/compare.rs` drops `flat_paragraphs` and `print_text_report`'s two `&Document`
  parameters, so nothing on the reporting path can index back into a source document.
- `StructureDiff` gains `cell_paragraphs` and `table_counts`. `cell_paragraphs` is a per-side
  inventory - how many paragraphs live in a table cell on each side - taken from the same walk that
  flattens the paragraphs, not a tally of the diff's own Insert/Delete operations. A paragraph that
  moves between two cells therefore leaves it unchanged, which is the truth. Both feed
  `is_identical`, and a table-count change is stated instead of being dropped by the positional
  `zip`.

**The JSON change is additive and the contract string is unchanged.** `hwp-compare-report-v1` stays
exactly as it was; entries gain `text` and `location` (and `b_text` / `b_location` on a replace),
a `nested` location carries `path`, and `structure` gains `cell_paragraphs` (`{a, b}`) and
`table_count` (`{a, b}`). Every key present before is still present with the same meaning, so a
consumer that ignores unknown keys needs no change. `json_report_contract` now asserts that property
instead of leaving it assumed. The MCP `hwp_compare` tool shares this body and takes no schema
change, so no golden or `cli-reference` regeneration was needed.

Known limitation: the paragraph LCS compares `chars` sequences only and has no notion of a move, so
a paragraph relocated between cells is still reported as a deletion plus an insertion and the pair
is not `identical`. The structural count no longer misrepresents it, but teaching the diff about
moves is Phase 3 (D-11 / D-12) and out of scope here.

Tests added:

- `hwp-convert`: `a_caption_nested_table_does_not_shift_the_set_cell_numbering` (builds T0, a table
  inside T0's caption, then T1 and T2, asserts the reported number for T2's cell is 2 and drives
  `set_cell` with it to prove the text lands in T2), `a_caption_nested_table_cell_reports_a_nested_location`,
  `sibling_generic_paragraph_lists_get_distinct_locations`,
  `every_location_in_a_nested_document_is_unique`,
  `a_paragraph_moved_between_cells_keeps_the_cell_paragraph_count`,
  `an_added_cell_paragraph_moves_the_cell_paragraph_count`, `paragraph_text_is_never_truncated`,
  `inserted_cell_paragraph_carries_its_cell_location_and_text`,
  `two_equal_adjacent_cell_paragraphs_stay_two_entries`,
  `empty_cell_paragraph_still_carries_a_full_location`,
  `differing_table_counts_are_reported_not_truncated`,
  `identical_structure_reports_matching_new_counts`.
- `hwp-cli`: `json_report_locates_a_cell_paragraph` (unit) and
  `added_cell_paragraph_prints_its_cell_and_its_text` (subprocess, asserts the cell location, the
  added text and the `표 내부 문단 4→5 (+1)` summary reach stdout). No test asserts on glyphs or
  page counts.

## Checklist

- [x] `scripts/check.sh` passes (fmt -> clippy --all-targets -D warnings -> test; the same gates as CI).
      The public PDF-parity gate skipped locally (this host has no `pdfinfo version 24.02.0`); CI runs
      it on ubuntu-24.04.
- [x] Does this change need verification in Hancom Office? (writer or compatibility-rule impact)
  - If it does not: [x] read-only. `hwp compare` loads both inputs and writes nothing; no writer,
    no compatibility rule and no serialized byte is touched by this PR.
- [x] Data policy respected (no fixtures committed; the tests build their documents from markdown
      through `from_markdown` and compare `.json` IR)
- [x] Design documents updated where applicable: none apply - no feature gap status, structure map,
      README or CLAUDE.md statement changes.
- [x] New features come with tests (engine unit tests plus a CLI subprocess regression)
- [x] User-facing documentation updated on both sides: not applicable - no clap flag, help string, KO
      overlay entry or MCP schema changed, so `docs/manual/cli-reference{,.ko}.md` are unchanged.
      `CHANGELOG.md` carries the English `[Unreleased]` entry.

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fZ11gwTiyWETK6tmMJ6n8
