### PR TITLE
chore(release): v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+## [0.17.0]
+
 **Added**
 
 - `hwp edit --set-cell-para "표:행:열=>키:값[,키:값]"` applies a paragraph shape to every

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hwp-cli"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-convert"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "hwp-model",
  "hwpx",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-model"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -777,7 +777,7 @@ dependencies = [
 
 [[package]]
 name = "hwp-render"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "encoding_rs",
  "flate2",
@@ -797,7 +797,7 @@ dependencies = [
 
 [[package]]
 name = "hwp5"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "aes",
  "cfb",
@@ -816,7 +816,7 @@ dependencies = [
 
 [[package]]
 name = "hwpx"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "aes",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "3"
 members = ["crates/*"]
 
 [workspace.package]
-version = "0.16.1"
+version = "0.17.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 rust-version = "1.93"

--- a/README.ko.md
+++ b/README.ko.md
@@ -110,7 +110,7 @@ curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/inst
 기본 위치는 `~/.local/bin`이다(PATH에 없으면 안내를 출력한다). 위치·버전은 인자나 환경변수로 바꾼다:
 
 ```sh
-curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.16.0
+curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.17.0
 HWP_INSTALL_DIR=~/bin sh scripts/install.sh
 ```
 
@@ -152,7 +152,7 @@ RHEL/CentOS 7+ 및 그 이후 배포판에서 그대로 돌아간다. 빌드 러
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
-  | sh -s -- --tag v0.16.0 --dir ./bin
+  | sh -s -- --tag v0.17.0 --dir ./bin
 ```
 
 플랫폼이 배포 번들을 수집하기 전에 바이너리가 있어야 하므로(Vercel `includeFiles`, Next.js

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The default location is `~/.local/bin` (if it is not on PATH, the script says so
 location or version with arguments or environment variables:
 
 ```sh
-curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.16.0
+curl -fsSL .../install.sh | sh -s -- --dir /usr/local/bin --tag v0.17.0
 HWP_INSTALL_DIR=~/bin sh scripts/install.sh
 ```
 
@@ -168,7 +168,7 @@ to bump:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/STAIxBWLB/hwp-cli/main/scripts/install.sh \
-  | sh -s -- --tag v0.16.0 --dir ./bin
+  | sh -s -- --tag v0.17.0 --dir ./bin
 ```
 
 Run this from the build command (or a `prebuild` script) so the binary exists before the platform


### PR DESCRIPTION
Cuts v0.17.0: closes the `[Unreleased]` CHANGELOG section, bumps the workspace version (0.16.1 -> 0.17.0) and the pinned `install.sh --tag` examples in both READMEs.

## What ships

Issues #220 through #225, the cell-paragraph fidelity series (PRs #226, #227, #228, #229):

- **Added** `hwp edit --set-cell-para` with an `align` key, and a matching MCP `set_cell_para`. `--set-para` gains `align` and comma-separated key lists through the shared parser.
- **Changed (behaviour)** `--set-cell` splits its value on blank lines into one paragraph per block; `hwp fill`, `--data tables`, `--set-cell-by-label` and the MCP typed `set_cell` share it.
- **Changed** the `hwp compare --json` report gains `text`, `location`, `cell_paragraphs` and `table_count` (additive; contract string unchanged).
- **Fixed** cell-aware `--insert-para`/`--delete-para`, source-preserving cell splice, nested line-layout synthesis, multi-paragraph table height, cloned control mask, compare naming cell paragraphs, cell-paragraph render overlap, `line-spacing:150%` parsing, hwp5 line-spacing persistence and its `--verify` projection.

Minor bump rather than patch: a new flag, a new MCP argument, and one documented behaviour change.

## Gates

- `scripts/check.sh` green locally (public PDF parity skipped: this host lacks the pinned `pdfinfo version 24.02.0`; CI runs it on ubuntu-24.04).
- Tool count unchanged at 22, so the "22 tools" claims in the docs still hold.
- Every merged PR was CI-green on ubuntu, macOS and Windows, and carries a Codex adversarial review whose findings were fixed and answered on the PR.

## Not done, and it gates publication

No Hancom open verification receipt (`hancom-verification-receipt-v1`) exists for this release. #226 changes the PARA_SHAPE emission and #229 changes the hwp5 table splice, the nested line-layout synthesis and the multi-paragraph table height, all of which alter bytes Hangul reads. The release-readiness checklist requires that receipt. Merging this PR only prepares the version; whoever tags should record the receipt first or accept the gap knowingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)