### PR TITLE
build(deploy): pin both images to v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 ## [Unreleased]
 
+**Changed**
+
+- Both deployment images pin the v0.17.0 tarball instead of v0.16.1, so the live service gets the
+  cell-paragraph series (issues #220 through #225). `deploy/cloudflare/container/Dockerfile.slim`
+  is the one that ships; `deploy/aws/Dockerfile.agentcore` moves with it to keep the two from
+  drifting.
+
 ## [0.17.0]
 
 **Added**

--- a/deploy/aws/Dockerfile.agentcore
+++ b/deploy/aws/Dockerfile.agentcore
@@ -31,9 +31,9 @@
 # binary, which AgentCore rejects. Override only to test another architecture.
 ARG HWP_PLATFORM=linux/arm64
 
-ARG HWP_VERSION=v0.16.1
+ARG HWP_VERSION=v0.17.0
 ARG HWP_TARGET=aarch64-unknown-linux-gnu
-ARG HWP_SHA256=03f0b8b2f6de11dcc0c4672da947d400ca1ab2557160a351c546e941af5a0805
+ARG HWP_SHA256=ecaa404650bc5e3c1c1a437caa8d1de95928bc5df7cb3202482a2e65d3138124
 
 # Fetch stage. ADD downloads over the builder's own network stack, so no curl and
 # no CA bundle are ever installed; keeping it in a discarded stage also keeps the

--- a/deploy/cloudflare/container/Dockerfile.slim
+++ b/deploy/cloudflare/container/Dockerfile.slim
@@ -13,9 +13,9 @@
 # is published alongside the tarball as hwp-<version>-<target>.sha256; the build
 # fails loudly if it does not match, which is the point.
 
-ARG HWP_VERSION=v0.16.1
+ARG HWP_VERSION=v0.17.0
 ARG HWP_TARGET=x86_64-unknown-linux-gnu
-ARG HWP_SHA256=dd7145b73dd3d3b20aa1386e691e5ed2d16dafa8654772407c4a5d18f955b702
+ARG HWP_SHA256=842c05600b70cb04639958269426e5ffe83ef390a069df7936286c6081ac0f1b
 
 # Fetch stage. ADD downloads over the builder's own network stack, so no curl and
 # no CA bundle are ever installed; keeping it in a discarded stage also keeps the


### PR DESCRIPTION
Moves the two deployment images from the v0.16.1 tarball to v0.17.0, so the live service gets the cell-paragraph series (issues #220 through #225).

- `deploy/cloudflare/container/Dockerfile.slim` -> `v0.17.0`, x86_64 sha256 `842c0560...ac0f1b`
- `deploy/aws/Dockerfile.agentcore` -> `v0.17.0`, aarch64 sha256 `ecaa4046...138124`

Both checksums are copied from the release's own `hwp-v0.17.0-<target>.sha256` assets, and the aarch64-apple-darwin tarball was verified locally against its published checksum with the extracted binary reporting `hwp 0.17.0`.

Deploying the images themselves is a separate, manual step; this PR only moves the pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)