### PR TITLE
feat(release): gate release copy on claim, doc-surface and verification-block checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ name: CI
 # gate input is re-included: skills/hwp/SKILL.md (include_str! into the binary),
 # docs/manual/** (cli-reference{,.ko}.md are compared byte-for-byte by tests/cli_reference.rs,
 # and the whole directory is scanned by check-claims.sh and check-doc-surface.sh), README{,.ko}.md,
-# CHANGELOG.md, skills/hwp/SKILL.ko.md and scripts/** — every path those two gates read. A file
+# CHANGELOG.md, skills/hwp/SKILL.ko.md and scripts/**: every path those two gates read. A file
 # a gate scans but the filter excludes is a gate that never sees the change that breaks it.
 # The same list must be kept identical under push and pull_request (GitHub Actions does not
 # support YAML anchors).
@@ -103,6 +103,10 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: bash scripts/check-doc-surface.sh --self-test
+      - name: Verification block fixtures
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: bash scripts/release_verification_block.sh --self-test
 
   pdf-parity:
     name: pdf-parity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
 name: CI
 
 # Path filter: documentation-only and formula-only changes skip CI entirely — no Rust
-# input changes, so fmt/clippy/test outcomes cannot change. Three .md files are re-included
-# because they ARE build/test inputs: skills/hwp/SKILL.md (include_str! into the binary) and
-# docs/manual/cli-reference{,.ko}.md (compared byte-for-byte by tests/cli_reference.rs).
+# input changes, so fmt/clippy/test outcomes cannot change. Markdown that IS a build, test or
+# gate input is re-included: skills/hwp/SKILL.md (include_str! into the binary),
+# docs/manual/** (cli-reference{,.ko}.md are compared byte-for-byte by tests/cli_reference.rs,
+# and the whole directory is scanned by check-claims.sh and check-doc-surface.sh), README{,.ko}.md,
+# CHANGELOG.md, skills/hwp/SKILL.ko.md and scripts/** — every path those two gates read. A file
+# a gate scans but the filter excludes is a gate that never sees the change that breaks it.
 # The same list must be kept identical under push and pull_request (GitHub Actions does not
 # support YAML anchors).
 on:
@@ -13,17 +16,25 @@ on:
       - "**"
       - "!**.md"
       - "!Formula/**"
+      - "README.md"
+      - "README.ko.md"
+      - "CHANGELOG.md"
+      - "docs/manual/**"
       - "skills/hwp/SKILL.md"
-      - "docs/manual/cli-reference.md"
-      - "docs/manual/cli-reference.ko.md"
+      - "skills/hwp/SKILL.ko.md"
+      - "scripts/**"
   pull_request:
     paths:
       - "**"
       - "!**.md"
       - "!Formula/**"
+      - "README.md"
+      - "README.ko.md"
+      - "CHANGELOG.md"
+      - "docs/manual/**"
       - "skills/hwp/SKILL.md"
-      - "docs/manual/cli-reference.md"
-      - "docs/manual/cli-reference.ko.md"
+      - "skills/hwp/SKILL.ko.md"
+      - "scripts/**"
 
 env:
   CARGO_TERM_COLOR: always
@@ -69,6 +80,29 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: bash scripts/check-structured-corpus.sh
+      # The doc-surface gate compares the documented tool count against a live `hwp mcp`
+      # tools/list session, so it needs a runnable binary; clippy only type-checks.
+      - name: Build hwp (the doc-surface gate drives the real MCP server)
+        if: ${{ !cancelled() }}
+        run: cargo build --locked -p hwp-cli
+      # The release-copy gates, same files scripts/check.sh runs locally. Separate steps so a
+      # failure in one still reports the others.
+      - name: Release copy claim lint
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: bash scripts/check-claims.sh
+      - name: Release copy claim lint fixtures
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: bash scripts/check-claims.sh --self-test
+      - name: Documentation surface (tool count, skill coverage)
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: bash scripts/check-doc-surface.sh
+      - name: Documentation surface fixtures
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: bash scripts/check-doc-surface.sh --self-test
 
   pdf-parity:
     name: pdf-parity

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ permissions:
   contents: write
   pull-requests: write
   checks: read # verify-ci reads the tagged commit's check runs
+  actions: read # verify-ci reads the readiness run cited by the CHANGELOG
 
 env:
   CARGO_TERM_COLOR: always
@@ -29,6 +30,7 @@ jobs:
   verify-ci:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
       - name: Tagged commit has green CI
         env:
           GH_TOKEN: ${{ github.token }}
@@ -48,6 +50,16 @@ jobs:
             echo "::error::Tagged commit $GITHUB_SHA has no green CI. Let the CI workflow pass on main, then re-run this workflow."
             exit 1
           fi
+
+      # Second half of the same gate: the release BODY must carry the marker-bounded
+      # Verification block, and the release-readiness run it cites must be a successful run of
+      # release-readiness.yml against this very commit. scripts/release.sh runs the same script
+      # before it tags, so a release cannot acquire evidence between the branch and the tag.
+      - name: Tagged version cites a verified readiness run
+        if: ${{ !cancelled() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/check-verification-block.sh "${GITHUB_REF_NAME#v}" "$GITHUB_SHA"
 
   # Version gate — the tag must match the Cargo.toml [workspace.package] version.
   verify-version:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,23 +19,35 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
 
 **Added**
 
-- `scripts/check-claims.sh` fails the local gate when release-facing copy acquires one of the
-  four claim families `docs/release-readiness.md` forbids, in English or Korean. A negated or
-  quoted occurrence is exempted through `scripts/claim-allowlist.txt` one exact sentence at a
-  time, so an entry can never widen into a file-level or pattern-level exemption. The script
-  itself carries the enumeration, one alternative per line with the checklist sentence it
-  enforces.
+- `scripts/check-claims.sh` fails the gate when release-facing copy acquires one of the four
+  claim families `docs/release-readiness.md` forbids, in English or Korean, in either word order
+  and in the documented equivalents of each family. A sentence that negates the phrase before
+  saying it is not a finding; a negation after it still is. Anything else is exempted through
+  `scripts/claim-allowlist.txt` as an exact `<path><TAB><line>` pair, so appending a claim to an
+  exempted line changes the line and the exemption lapses. `--self-test` runs adversarial
+  fixtures, positive and negative, over the shape list, the negation rule and the allowlist.
 - `scripts/check-doc-surface.sh` ties the documentation to the running server: every tool-count
   claim in `README*.md`, `docs/manual/*.md` and `skills/hwp/SKILL*.md` must equal the length of
   the live `hwp mcp` `tools/list` response, and both skill files must name every CLI subcommand
-  and every MCP tool. Counts are matched in each shape the documents use and across a line wrap,
-  and a `--self-test` mode seeds every shape so the pattern cannot be narrowed unnoticed. Nine
-  stale counts and the previously undocumented `hwp dump` command are corrected with it.
+  and every MCP tool. Counts are matched in every shape the documents use - numeral, counter,
+  parenthesised, labelled with a colon, spelled out in English, and Korean native numerals -
+  across up to three wrapped lines, and `--self-test` drives a table of every shape against
+  several stale values plus the live one, so neither the shapes nor the window can shrink
+  unnoticed. Nine stale counts and the previously undocumented `hwp dump` command are corrected
+  with it.
 - `scripts/release_verification_block.sh` writes the `**Verification**` block into a version's
-  CHANGELOG section, naming the four excluded parity gates with the distances measured in
-  `docs/design/21-pdf-parity.md` sections 4.5 and 4.6 and the release-readiness run URL. It is
-  idempotent per version, and `scripts/release.sh` now refuses to bump, commit or tag without a
-  readiness run URL and that block.
+  CHANGELOG section between `<!-- verification:begin -->` and `<!-- verification:end -->`, naming
+  the four excluded parity gates with the distances measured in `docs/design/21-pdf-parity.md`
+  sections 4.5 and 4.6 and the release-readiness run URL. A rerun replaces exactly that region,
+  so anything an editor added around it survives, and a missing, duplicated or unmarked block is
+  refused rather than guessed at.
+- `scripts/check-verification-block.sh` is the release boundary both ends share: it requires the
+  version's section to carry one marked block citing one Actions run URL of this repository, and
+  the GitHub API to report that run as a successful `release-readiness.yml` run whose head_sha is
+  the commit being released. `scripts/release.sh` runs it before the version bump and
+  `.github/workflows/release.yml` runs it against the tagged commit. There is no override flag.
+- The CI `lint` job now runs the claim lint, the doc-surface gate and both fixture suites, and
+  the workflow's path filters no longer exclude the documents those gates read.
 
 ## [0.17.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
   is the one that ships; `deploy/aws/Dockerfile.agentcore` moves with it to keep the two from
   drifting.
 
+**Added**
+
+- `scripts/check-claims.sh` fails the local gate when release-facing copy acquires one of the
+  four claim families `docs/release-readiness.md` forbids, in English or Korean. A negated or
+  quoted occurrence is exempted through `scripts/claim-allowlist.txt` one exact sentence at a
+  time, so an entry can never widen into a file-level or pattern-level exemption. The script
+  itself carries the enumeration, one alternative per line with the checklist sentence it
+  enforces.
+- `scripts/check-doc-surface.sh` ties the documentation to the running server: every tool-count
+  claim in `README*.md`, `docs/manual/*.md` and `skills/hwp/SKILL*.md` must equal the length of
+  the live `hwp mcp` `tools/list` response, and both skill files must name every CLI subcommand
+  and every MCP tool. Counts are matched in each shape the documents use and across a line wrap,
+  and a `--self-test` mode seeds every shape so the pattern cannot be narrowed unnoticed. Nine
+  stale counts and the previously undocumented `hwp dump` command are corrected with it.
+- `scripts/release_verification_block.sh` writes the `**Verification**` block into a version's
+  CHANGELOG section, naming the four excluded parity gates with the distances measured in
+  `docs/design/21-pdf-parity.md` sections 4.5 and 4.6 and the release-readiness run URL. It is
+  idempotent per version, and `scripts/release.sh` now refuses to bump, commit or tag without a
+  readiness run URL and that block.
+
 ## [0.17.0]
 
 **Added**

--- a/README.ko.md
+++ b/README.ko.md
@@ -41,7 +41,7 @@ Linux/macOS 서버와 CI에서 그대로 돈다.
   구역별·쪽 범위별 조각으로 나누며(`hwp split`), 문서 두 개의 문단·구조 차이를 보고한다
   (`hwp compare`).
 - **MCP 서버** 의존성 없는(serde_json만) stdio MCP 서버로 Amazon Quick Desktop을 포함한
-  데스크톱 클라이언트에 20개 도구를 노출한다.
+  데스크톱 클라이언트에 22개 도구를 노출한다.
 
 ## 구현 상태
 
@@ -55,7 +55,7 @@ Linux/macOS 서버와 CI에서 그대로 돈다.
 | 인증(certify) · 구조 코퍼스 게이트(corpus) | 구현 완료 |
 | 문서 단위 작업(`merge`·`split`·`compare`) | 구현 완료. 2026-08-29 한글에서 표본 확인([12-feature-gaps](docs/design/12-feature-gaps.ko.md) GM-3·GM-4·GM-8) |
 | 공문서 저작 (프로파일·템플릿·문서 틀·lint·표 서식) | 구현 완료 |
-| MCP 서버 (20 도구) | 구현 완료 |
+| MCP 서버 (22 도구) | 구현 완료 |
 | 배포용문서 | 읽기 지원 |
 | HTML 변환 | 구조는 markdown과 동등. 글자·문단 모양의 CSS 매핑은 아직 거칠다 |
 | 수식 | 상자+스크립트 근사 렌더 |
@@ -447,7 +447,7 @@ Amazon Quick Desktop)과 번들 에이전트 스킬(`hwp skill export`):
 Windows 복사·실행 설정, 생성·검증 acceptance test, 재사용 가능한 에이전트 지침, 증상별 복구는 전용
 [Amazon Quick Desktop 가이드](docs/manual/amazon-quick-desktop.ko.md)에 정리했다.
 
-Amazon Quick Desktop은 로컬 stdio 서버를 실행해 20개 도구를 모두 노출할 수 있다. publish-safe
+Amazon Quick Desktop은 로컬 stdio 서버를 실행해 22개 도구를 모두 노출할 수 있다. publish-safe
 스킬은 활성 프로필에 다음과 같이 설치한다.
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ but it is a private hop that expects a trusted edge in front of it: authenticate
 tenant isolation and artifact transfer remain future work in
 [Remote MCP transport](docs/design/20-remote-mcp.md).
 
-### Exposed tools (20)
+### Exposed tools (22)
 
 | Tool | Required arguments | Purpose |
 |---|---|---|

--- a/docs/manual/ai-integrations.ko.md
+++ b/docs/manual/ai-integrations.ko.md
@@ -4,7 +4,7 @@
 
 `hwp`는 AI 클라이언트용 연동 표면을 두 가지 제공한다.
 
-- MCP를 구사하는 클라이언트용 **MCP stdio 서버**(`hwp mcp`, 20개 도구)
+- MCP를 구사하는 클라이언트용 **MCP stdio 서버**(`hwp mcp`, 22개 도구)
 - CLI와 MCP 사용법을 에이전트에게 가르치는 **에이전트 스킬**(이 저장소의 `skills/hwp/` 트리).
   바이너리에 임베드되어 있으며 `hwp skill export`로 디렉터리 형태로 풀어낼 수 있다:
   `SKILL.md`, `SKILL.ko.md`, 공문서 가이드(`official-documents(.ko).md`), `references/`,

--- a/scripts/check-claims.sh
+++ b/scripts/check-claims.sh
@@ -1,88 +1,227 @@
 #!/usr/bin/env bash
 # Forbidden-claim lint over release-facing copy (docs/release-readiness.md lines 26-27, 40-41).
+#
+#   scripts/check-claims.sh              scan the working tree
+#   scripts/check-claims.sh --self-test  prove the pattern, the negation rule and the allowlist
+#
 # The release must not claim Hancom parity, pixel parity, full coverage of every real document
 # form, or cross-platform-identical raster bytes. It states the excluded gates and their measured
 # distance instead (docs/design/21-pdf-parity.md sections 4.5 and 4.6).
 #
-# Legitimate occurrences (a negated or quoted sentence) are exempted one exact sentence at a time
-# through scripts/claim-allowlist.txt. Never exempt a file, a directory or a pattern.
+# A sentence that negates the claim (the negation word comes before the phrase) is not a finding.
+# Anything else is exempted one exact line at a time through scripts/claim-allowlist.txt, whose
+# entries are `<relative path><TAB><exact line>`: appending a new claim to an allowlisted line
+# changes the line, so the exemption stops applying. Never exempt a file, a directory or a
+# pattern.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-allowlist="scripts/claim-allowlist.txt"
+mode="${1:-check}"
+case "$mode" in
+check | --self-test) ;;
+*)
+    echo "usage: scripts/check-claims.sh [--self-test]" >&2
+    exit 2
+    ;;
+esac
 
-# One alternative per line, each naming the checklist sentence it enforces. A single opaque regex
-# literal is not reviewable, which is why this is a list.
-patterns=(
-    # "no 'Hancom parity' claim is made for a profile with exclusions" (readiness line 26)
-    'hancom parity'
-    '한컴 패리티'
-    '한글 패리티'
-    # "provide Hancom pixel parity" (readiness line 40)
-    'pixel parity'
-    '픽셀 패리티'
-    '픽셀 단위 동일'
-    # "cover every real document form" (readiness line 40)
-    'full coverage'
-    'complete coverage'
-    '전체 커버'
-    '완전 커버'
-    '모든 문서 형태를 커버'
-    # "prove cross-platform-identical raster bytes" (readiness line 41)
-    'cross-platform[- ]identical raster'
-    'identical raster bytes'
-    '플랫폼 간 동일 래스터'
-    '크로스 플랫폼 동일 래스터'
-)
-pattern="$(IFS='|'; printf '%s' "${patterns[*]}")"
+exec python3 - "$mode" <<'PY'
+import re
+import sys
+import tempfile
+from glob import glob
+from pathlib import Path
 
-# Guard the globs: an unmatched glob must not reach grep as a literal pattern.
-shopt -s nullglob
-files=(README.md README.ko.md CHANGELOG.md docs/manual/*.md skills/hwp/SKILL*.md)
-shopt -u nullglob
+mode = sys.argv[1]
+ROOT = Path.cwd()
+ALLOWLIST = "scripts/claim-allowlist.txt"
 
-existing=()
-for f in "${files[@]}"; do
-    [ -f "$f" ] && existing+=("$f")
-done
-if [ "${#existing[@]}" -eq 0 ]; then
-    echo "check-claims: no files to scan" >&2
-    exit 1
-fi
+# One alternative per line, each naming the checklist sentence it enforces, both word orders and
+# the documented equivalents. A single opaque regex literal is not reviewable, which is why this
+# is a list. Never drop a shape to silence a finding: fix the copy.
+CLAIM_SHAPES = [
+    # readiness line 26: "no 'Hancom parity' claim is made for a profile with exclusions"
+    (r"hancom(\s+office)?\s+parity", "Hancom parity"),
+    (r"parity\s+with\s+hancom", "parity with Hancom"),
+    (r"identical\s+to\s+hancom", "identical to Hancom"),
+    (r"한컴(\s*오피스)?\s*(parity|패리티)", "한컴 parity"),
+    (r"한글\s*(parity|패리티)", "한글 parity"),
+    (r"한컴(과|와)\s*(완전히\s*)?(똑같|동일)", "한컴과 동일"),
+    # readiness line 40: "provide Hancom pixel parity"
+    (r"pixel[-\s]*(level[-\s]*)?parity", "pixel parity"),
+    (r"parity\s+at\s+the\s+pixel\s+level", "parity at the pixel level"),
+    (r"픽셀\s*(수준|단위)?\s*패리티", "픽셀 패리티"),
+    (r"픽셀\s*(수준|단위)(으로|로)?\s*(똑같|동일)", "픽셀 수준으로 동일"),
+    # readiness line 40: "cover every real document form"
+    (r"(full|complete|total)\s+coverage", "full coverage"),
+    (r"cover(s|ed|ing)?\s+(every|all)\s+(real[-\s]+)?document\s+(form|type|shape)s?",
+     "covers every real document form"),
+    (r"(완전|전체)\s*(하게\s*)?커버", "완전 커버"),
+    (r"모든\s*(실제\s*)?문서\s*(형식|형태|유형)", "모든 실제 문서 형식"),
+    # readiness line 41: "prove cross-platform-identical raster bytes"
+    (r"cross[-\s]platform[-\s]*identical\s+raster", "cross-platform identical raster"),
+    (r"(byte|pixel)[-\s]*identical\s+raster", "byte-identical raster"),
+    (r"identical\s+raster\s+bytes", "identical raster bytes"),
+    (r"플랫폼\s*(간|간에)\s*(동일한?|같은)\s*(raster|래스터|래스터화)", "플랫폼 간 동일 raster"),
+    (r"(raster|래스터)(가|는|도)?\s*플랫폼\s*간\s*(동일|같)", "래스터가 플랫폼 간 동일"),
+]
+CLAIM_PATTERNS = [(re.compile(p, re.IGNORECASE), name) for p, name in CLAIM_SHAPES]
 
-hits="$(mktemp)"
-allowed="$(mktemp)"
-surviving="$(mktemp)"
-trap 'rm -f "$hits" "$allowed" "$surviving"' EXIT
+# A negation counts only when it comes BEFORE the phrase in the same sentence, which is how the
+# one legitimate occurrence in the repository reads ("No Hancom parity claim ..."). A negation
+# after the phrase is still reported, because "... parity, which we do not claim" is exactly the
+# shape a reader quotes out of context.
+NEGATIONS = re.compile(r"\b(no|not|never)\b|없|않|아니", re.IGNORECASE)
+SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+")
 
-# file:line:text for every hit, so a finding names the exact place to fix.
-grep -rniE -- "$pattern" "${existing[@]}" >"$hits" || true
 
-if [ -f "$allowlist" ]; then
-    grep -v '^[[:space:]]*#' "$allowlist" | grep -v '^[[:space:]]*$' >"$allowed" || true
-fi
+def scan_set(root):
+    root = Path(root)
+    files = [root / "README.md", root / "README.ko.md", root / "CHANGELOG.md"]
+    files += sorted(Path(p) for p in glob(str(root / "docs/manual/*.md")))
+    files += sorted(Path(p) for p in glob(str(root / "skills/hwp/SKILL*.md")))
+    return [f for f in files if f.is_file()]
 
-# Suppress a hit only when its text contains an allowlist entry as a fixed substring. Matching on
-# the text (not on file:line) keeps an allowlisted sentence allowlisted when it moves, and because
-# an entry is a whole sentence, the same words in a different sentence still fail.
-if [ -s "$allowed" ]; then
-    grep -vFf "$allowed" "$hits" >"$surviving" || true
-else
-    cp "$hits" "$surviving"
-fi
 
-if [ -s "$surviving" ]; then
-    echo "check-claims: forbidden release claim(s) found:" >&2
-    while IFS= read -r line; do
-        echo "  $line" >&2
-    done <"$surviving"
-    cat >&2 <<'MSG'
-Release copy must state the excluded gates (fonts, text, raster, roi) and their measured distance
-from docs/design/21-pdf-parity.md sections 4.5 and 4.6 instead of claiming parity or coverage.
-Fix the sentence. Add an entry to scripts/claim-allowlist.txt only for a negated or quoted
-occurrence, and only as the exact sentence.
-MSG
-    exit 1
-fi
+def read_allowlist(path):
+    """{(relative path, exact line)} - an entry exempts one whole line of one file."""
+    entries = set()
+    path = Path(path)
+    if not path.is_file():
+        return entries
+    for n, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        if "\t" not in raw:
+            sys.stderr.write(
+                "check-claims: %s line %d is malformed: an entry is "
+                "`<relative path><TAB><exact line>`\n" % (path, n)
+            )
+            raise SystemExit(1)
+        rel, _, line = raw.partition("\t")
+        entries.add((rel.strip(), line))
+    return entries
 
-echo "check-claims: OK (${#existing[@]} files scanned, no forbidden claim)"
+
+def findings(root, allowlist):
+    """[(relative path, line number, claim name, line text)] for every unexcused claim."""
+    out = []
+    for path in scan_set(root):
+        rel = str(path.relative_to(root))
+        for n, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            for sentence in SENTENCE_SPLIT.split(line):
+                for pattern, name in CLAIM_PATTERNS:
+                    m = pattern.search(sentence)
+                    if not m:
+                        continue
+                    neg = NEGATIONS.search(sentence)
+                    if neg and neg.start() < m.start():
+                        continue
+                    if (rel, line) in allowlist:
+                        continue
+                    out.append((rel, n, name, line.strip()))
+    return out
+
+
+def report(found):
+    print("check-claims: forbidden release claim(s) found:", file=sys.stderr)
+    for rel, n, name, text in found:
+        print("  %s:%d: %s -- %s" % (rel, n, name, text), file=sys.stderr)
+    print(
+        "Release copy must state the excluded gates (fonts, text, raster, roi) and their measured\n"
+        "distance from docs/design/21-pdf-parity.md sections 4.5 and 4.6 instead of claiming parity\n"
+        "or coverage. Fix the sentence. An entry in scripts/claim-allowlist.txt exempts one exact\n"
+        "line of one file and nothing else.",
+        file=sys.stderr,
+    )
+
+
+# --- self-test ----------------------------------------------------------------------------------
+# Adversarial fixtures: every POSITIVE line must be caught and every NEGATIVE line must pass, in a
+# temporary tree with its own allowlist. A shape removed from CLAIM_SHAPES, a negation rule
+# widened to "anywhere in the sentence", or an allowlist match loosened from the exact line makes
+# this fail, so none of the three can be relaxed unnoticed.
+ALLOWED_LINE = "- **No Hancom parity claim** The final verdict is always whether the file opens correctly in Hancom Office."
+
+POSITIVE = [
+    "This release provides parity with Hancom Office.",
+    "Rendering is identical to Hancom for every page.",
+    "한컴과 픽셀 수준으로 동일합니다.",
+    "우리는 한컴 패리티를 제공합니다.",
+    "The renderer reaches pixel parity on this corpus.",
+    "It delivers pixel-level parity with the reference.",
+    "We cover every real document form.",
+    "The suite covers all document forms in the wild.",
+    "The corpus gives full coverage of the format.",
+    "실제 문서 형식을 완전 커버합니다.",
+    "모든 실제 문서 형식을 지원합니다.",
+    "The gate proves cross-platform identical raster output.",
+    "It produces byte-identical raster output on every host.",
+    "플랫폼 간 동일한 래스터를 보장합니다.",
+    # An allowlisted line with a claim appended is a different line, so the exemption lapses.
+    ALLOWED_LINE + " It also provides pixel parity.",
+]
+
+NEGATIVE = [
+    "This does not provide pixel parity.",
+    "No Hancom parity is claimed for a profile with exclusions.",
+    "The public gate never claims full coverage of every real document form.",
+    "We do not prove cross-platform identical raster bytes.",
+    ALLOWED_LINE,
+]
+
+
+def self_test():
+    ok = True
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+        (tmp / "scripts").mkdir()
+        (tmp / "scripts/claim-allowlist.txt").write_text(
+            "# self-test allowlist\nREADME.md\t%s\n" % ALLOWED_LINE, encoding="utf-8"
+        )
+        allowlist = read_allowlist(tmp / "scripts/claim-allowlist.txt")
+        readme = tmp / "README.md"
+
+        for line in POSITIVE:
+            readme.write_text("# Title\n\n%s\n" % line, encoding="utf-8")
+            found = findings(tmp, allowlist)
+            if len(found) < 1 or any(f[1] != 3 for f in found):
+                ok = False
+                print(
+                    "  self-test: positive case not caught at README.md:3: %s" % line,
+                    file=sys.stderr,
+                )
+
+        for line in NEGATIVE:
+            readme.write_text("# Title\n\n%s\n" % line, encoding="utf-8")
+            found = findings(tmp, allowlist)
+            if found:
+                ok = False
+                print("  self-test: negative case reported: %s" % line, file=sys.stderr)
+                report(found)
+    return ok
+
+
+# --- run ------------------------------------------------------------------------------------------
+if mode == "--self-test":
+    if not self_test():
+        print("check-claims --self-test: FAILED", file=sys.stderr)
+        raise SystemExit(1)
+    print(
+        "check-claims --self-test: OK (%d claims caught, %d negated or allowlisted lines passed)"
+        % (len(POSITIVE), len(NEGATIVE))
+    )
+    raise SystemExit(0)
+
+files = scan_set(ROOT)
+if not files:
+    print("check-claims: no files to scan", file=sys.stderr)
+    raise SystemExit(1)
+
+found = findings(ROOT, read_allowlist(ROOT / ALLOWLIST))
+if found:
+    report(found)
+    raise SystemExit(1)
+
+print("check-claims: OK (%d files scanned, no forbidden claim)" % len(files))
+PY

--- a/scripts/check-claims.sh
+++ b/scripts/check-claims.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Forbidden-claim lint over release-facing copy (docs/release-readiness.md lines 26-27, 40-41).
+# The release must not claim Hancom parity, pixel parity, full coverage of every real document
+# form, or cross-platform-identical raster bytes. It states the excluded gates and their measured
+# distance instead (docs/design/21-pdf-parity.md sections 4.5 and 4.6).
+#
+# Legitimate occurrences (a negated or quoted sentence) are exempted one exact sentence at a time
+# through scripts/claim-allowlist.txt. Never exempt a file, a directory or a pattern.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+allowlist="scripts/claim-allowlist.txt"
+
+# One alternative per line, each naming the checklist sentence it enforces. A single opaque regex
+# literal is not reviewable, which is why this is a list.
+patterns=(
+    # "no 'Hancom parity' claim is made for a profile with exclusions" (readiness line 26)
+    'hancom parity'
+    '한컴 패리티'
+    '한글 패리티'
+    # "provide Hancom pixel parity" (readiness line 40)
+    'pixel parity'
+    '픽셀 패리티'
+    '픽셀 단위 동일'
+    # "cover every real document form" (readiness line 40)
+    'full coverage'
+    'complete coverage'
+    '전체 커버'
+    '완전 커버'
+    '모든 문서 형태를 커버'
+    # "prove cross-platform-identical raster bytes" (readiness line 41)
+    'cross-platform[- ]identical raster'
+    'identical raster bytes'
+    '플랫폼 간 동일 래스터'
+    '크로스 플랫폼 동일 래스터'
+)
+pattern="$(IFS='|'; printf '%s' "${patterns[*]}")"
+
+# Guard the globs: an unmatched glob must not reach grep as a literal pattern.
+shopt -s nullglob
+files=(README.md README.ko.md CHANGELOG.md docs/manual/*.md skills/hwp/SKILL*.md)
+shopt -u nullglob
+
+existing=()
+for f in "${files[@]}"; do
+    [ -f "$f" ] && existing+=("$f")
+done
+if [ "${#existing[@]}" -eq 0 ]; then
+    echo "check-claims: no files to scan" >&2
+    exit 1
+fi
+
+hits="$(mktemp)"
+allowed="$(mktemp)"
+surviving="$(mktemp)"
+trap 'rm -f "$hits" "$allowed" "$surviving"' EXIT
+
+# file:line:text for every hit, so a finding names the exact place to fix.
+grep -rniE -- "$pattern" "${existing[@]}" >"$hits" || true
+
+if [ -f "$allowlist" ]; then
+    grep -v '^[[:space:]]*#' "$allowlist" | grep -v '^[[:space:]]*$' >"$allowed" || true
+fi
+
+# Suppress a hit only when its text contains an allowlist entry as a fixed substring. Matching on
+# the text (not on file:line) keeps an allowlisted sentence allowlisted when it moves, and because
+# an entry is a whole sentence, the same words in a different sentence still fail.
+if [ -s "$allowed" ]; then
+    grep -vFf "$allowed" "$hits" >"$surviving" || true
+else
+    cp "$hits" "$surviving"
+fi
+
+if [ -s "$surviving" ]; then
+    echo "check-claims: forbidden release claim(s) found:" >&2
+    while IFS= read -r line; do
+        echo "  $line" >&2
+    done <"$surviving"
+    cat >&2 <<'MSG'
+Release copy must state the excluded gates (fonts, text, raster, roi) and their measured distance
+from docs/design/21-pdf-parity.md sections 4.5 and 4.6 instead of claiming parity or coverage.
+Fix the sentence. Add an entry to scripts/claim-allowlist.txt only for a negated or quoted
+occurrence, and only as the exact sentence.
+MSG
+    exit 1
+fi
+
+echo "check-claims: OK (${#existing[@]} files scanned, no forbidden claim)"

--- a/scripts/check-doc-surface.sh
+++ b/scripts/check-doc-surface.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# Documentation surface gate (docs/release-readiness.md, the tool-count and skill-coverage lines).
+#
+#   scripts/check-doc-surface.sh              run both checks against the working tree
+#   scripts/check-doc-surface.sh --self-test  prove the count pattern still catches every shape
+#
+# Two independent checks, both reported before the script exits, so one run shows every finding:
+#   1. every tool-count claim in README*.md, docs/manual/*.md and skills/hwp/SKILL*.md equals the
+#      length of the live `hwp mcp` tools/list response;
+#   2. skills/hwp/SKILL.md and SKILL.ko.md name every CLI subcommand and every MCP tool.
+#
+# The source of truth is the running server, not a hardcoded list. crates/hwp-cli/tests/
+# cli_surface.rs asserts the same list from the Rust side.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+mode="${1:-check}"
+case "$mode" in
+check | --self-test) ;;
+*)
+    echo "usage: scripts/check-doc-surface.sh [--self-test]" >&2
+    exit 2
+    ;;
+esac
+
+ROOT="$PWD"
+HWP_BIN="${HWP_BIN:-$ROOT/target/debug/hwp}"
+if [ ! -x "$HWP_BIN" ] && [ -x "$ROOT/target/release/hwp" ]; then
+    HWP_BIN="$ROOT/target/release/hwp"
+fi
+if [ ! -x "$HWP_BIN" ]; then
+    echo "[doc-surface] building hwp-cli (no binary at $HWP_BIN)" >&2
+    cargo build -p hwp-cli --quiet
+    HWP_BIN="$ROOT/target/debug/hwp"
+fi
+
+export HWP_BIN
+exec python3 - "$mode" <<'PY'
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from glob import glob
+from pathlib import Path
+
+mode = sys.argv[1]
+hwp_bin = os.environ["HWP_BIN"]
+ROOT = os.getcwd()
+
+# --- the live server ---------------------------------------------------------------------------
+# The same three-message JSON-RPC handshake crates/hwp-cli/tests/cli_surface.rs uses.
+HANDSHAKE = [
+    {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "doc-surface", "version": "0"},
+        },
+    },
+    {"jsonrpc": "2.0", "method": "notifications/initialized"},
+    {"jsonrpc": "2.0", "id": 2, "method": "tools/list"},
+]
+
+
+def live_tools():
+    payload = "\n".join(json.dumps(m) for m in HANDSHAKE) + "\n"
+    proc = subprocess.run(
+        [hwp_bin, "mcp"], input=payload, capture_output=True, text=True, timeout=120
+    )
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("id") == 2 and "result" in msg:
+            return sorted(t["name"] for t in msg["result"]["tools"])
+    sys.stderr.write(
+        "doc-surface: no tools/list response from `%s mcp`\n%s\n" % (hwp_bin, proc.stderr)
+    )
+    raise SystemExit(1)
+
+
+# --- check one: tool-count claims -------------------------------------------------------------
+# One entry per shape the documentation actually uses, each naming a file that uses it. A partial
+# pattern is worse than no gate: it reports a pass while the docs still misstate the count.
+# Never drop a shape to silence a finding - fix the copy, or allowlist the exact line.
+COUNT_SHAPES = [
+    # skills/hwp/SKILL.md: "Quick reports 22 tools and stays enabled"
+    (r"(?P<n>\d+)\s+tools\b", "number before the English noun"),
+    # README.ko.md line 44: "20개 도구를 노출한다", and the 개의 variant
+    (r"(?P<n>\d+)\s*개의?\s*도구", "number with the 개 counter before the Korean noun"),
+    # skills/hwp/SKILL.ko.md line 312: "같은 22종 도구를"
+    (r"(?P<n>\d+)\s*종\s*도구", "number with the 종 counter before the Korean noun"),
+    # README.ko.md line 58: "| MCP 서버 (20 도구) |" - counter-less form
+    (r"(?P<n>\d+)\s+도구", "bare number before the Korean noun"),
+    # README.md line 503: "### Exposed tools (20)"
+    (r"tools\s*\(\s*(?P<n>\d+)", "English noun before a parenthesised number"),
+    # README.ko.md line 469: "### 노출 도구 (22종)"
+    (r"도구\s*\(\s*(?P<n>\d+)", "Korean noun before a parenthesised number"),
+    # skills/hwp/SKILL.md lines 315-316 used to wrap "the same twenty / tools" across a break.
+    # A spelled-out count is a finding whatever its value: write it as a numeral.
+    (
+        r"\b(?P<word>nineteen|twenty|twenty-one|twenty-two|twenty-three|twenty-four|thirty)"
+        r"[\s-]+tools\b",
+        "spelled-out number before the English noun",
+    ),
+]
+COUNT_PATTERNS = [(re.compile(p, re.IGNORECASE), why) for p, why in COUNT_SHAPES]
+
+
+def count_scan_set(root):
+    root = Path(root)
+    files = [root / "README.md", root / "README.ko.md"]
+    files += sorted(Path(p) for p in glob(str(root / "docs/manual/*.md")))
+    files += sorted(Path(p) for p in glob(str(root / "skills/hwp/SKILL*.md")))
+    return [f for f in files if f.is_file()]
+
+
+def read_allowlist(path):
+    if not Path(path).is_file():
+        return []
+    out = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        out.append(stripped)
+    return out
+
+
+def count_findings(root, expected, allowlist):
+    """Return [(relative path, line number, matched text, claimed, why)] over a 2-line window."""
+    findings = []
+    for path in count_scan_set(root):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        rel = str(path.relative_to(root))
+        for i, line in enumerate(lines):
+            # A count can wrap across a line break in reflowed prose, so match over the line and
+            # its successor joined by a single space.
+            window = " ".join(lines[i : i + 2])
+            head = len(line)
+            seen = set()
+            for pattern, why in COUNT_PATTERNS:
+                for m in pattern.finditer(window):
+                    # Report each match once, at the line where it begins. A match starting on the
+                    # next line is picked up by that line's own window.
+                    if m.start() > head:
+                        continue
+                    claimed = m.groupdict().get("n")
+                    if claimed is not None and int(claimed) == expected:
+                        continue
+                    if any(entry in window for entry in allowlist):
+                        continue
+                    key = (m.start(), m.group(0))
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    findings.append((rel, i + 1, m.group(0), claimed, why))
+    return findings
+
+
+def report_counts(findings, expected):
+    for rel, line, text, claimed, why in findings:
+        claim = claimed if claimed is not None else "a spelled-out number"
+        print(
+            "  %s:%d: claims %s, server reports %d (%s) -- %s"
+            % (rel, line, claim, expected, why, text.strip()),
+            file=sys.stderr,
+        )
+
+
+# --- check two: skill coverage -----------------------------------------------------------------
+# Coupling point: the subcommand list is parsed out of the `pub enum Cmd` block of
+# crates/hwp-cli/src/cli.rs. If that enum is restructured (renamed, split, or given clap
+# `#[command(name = ...)]` overrides), this parse must be revisited rather than the gate relaxed.
+def cli_subcommands(root):
+    src = (Path(root) / "crates/hwp-cli/src/cli.rs").read_text(encoding="utf-8").splitlines()
+    try:
+        start = next(i for i, l in enumerate(src) if l.startswith("pub enum Cmd {"))
+    except StopIteration:
+        sys.stderr.write("doc-surface: `pub enum Cmd {` not found in crates/hwp-cli/src/cli.rs\n")
+        raise SystemExit(1)
+    end = next(i for i in range(start + 1, len(src)) if src[i] == "}")
+    names = []
+    for line in src[start + 1 : end]:
+        m = re.match(r"    ([A-Z][A-Za-z0-9]*)\s*[\{\(,]", line)
+        if m:
+            names.append(m.group(1).lower())
+    if not names:
+        sys.stderr.write("doc-surface: parsed no variants out of `pub enum Cmd`\n")
+        raise SystemExit(1)
+    return names
+
+
+def read_exemptions(path):
+    exempt = {}
+    if not Path(path).is_file():
+        return exempt
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        name, _, reason = stripped.partition(" ")
+        exempt[name] = reason.strip()
+    return exempt
+
+
+def coverage_findings(root, tools, exempt):
+    skill_paths = [Path(root) / "skills/hwp/SKILL.md", Path(root) / "skills/hwp/SKILL.ko.md"]
+    texts = {str(p.relative_to(root)): p.read_text(encoding="utf-8") for p in skill_paths}
+    findings = []
+    for name in cli_subcommands(root):
+        if name in exempt:
+            continue
+        for rel, text in texts.items():
+            if "hwp %s" % name not in text:
+                findings.append((rel, "CLI subcommand", "hwp %s" % name))
+    for tool in tools:
+        for rel, text in texts.items():
+            if tool not in text:
+                findings.append((rel, "MCP tool", tool))
+    return findings
+
+
+# --- self-test ---------------------------------------------------------------------------------
+# Seed one stale occurrence of each shape into a temporary copy of the scan set, one shape at a
+# time, and require the count check to report exactly that line. A shape removed from
+# COUNT_SHAPES makes this fail, so the pattern cannot be narrowed silently.
+def seeds(expected):
+    stale = expected + 1
+    return [
+        ("number before the English noun", "README.md", ["The server exposes %d tools." % stale]),
+        ("개 counter", "README.md", ["서버는 %d개 도구를 노출한다." % stale]),
+        ("개의 counter", "README.md", ["서버는 %d개의 도구를 노출한다." % stale]),
+        ("종 counter", "README.md", ["서버는 %d종 도구를 노출한다." % stale]),
+        ("counter-less Korean noun", "README.md", ["| MCP 서버 (%d 도구) |" % stale]),
+        ("parenthesised English", "README.md", ["### Exposed tools (%d)" % stale]),
+        ("parenthesised Korean", "README.md", ["### 노출 도구 (%d종)" % stale]),
+        ("spelled-out English", "README.md", ["The server exposes the same twenty tools."]),
+        (
+            "count wrapped across a line break",
+            "README.md",
+            ["The server exposes %d" % stale, "tools in total."],
+        ),
+    ]
+
+
+def self_test(expected, allowlist):
+    ok = True
+    scan = count_scan_set(ROOT)
+    with tempfile.TemporaryDirectory() as tmp:
+        for path in scan:
+            dest = Path(tmp) / path.relative_to(ROOT)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, dest)
+        clean = count_findings(tmp, expected, allowlist)
+        if clean:
+            ok = False
+            print("  self-test: the unseeded copy already reports findings:", file=sys.stderr)
+            report_counts(clean, expected)
+        base = (Path(tmp) / "README.md").read_text(encoding="utf-8").splitlines()
+        for label, rel, extra in seeds(expected):
+            target = Path(tmp) / rel
+            target.write_text("\n".join(base + extra) + "\n", encoding="utf-8")
+            found = count_findings(tmp, expected, allowlist)
+            want_line = len(base) + 1
+            hit = [f for f in found if f[0] == rel and f[1] == want_line]
+            if len(found) != len(hit) or len(hit) != 1:
+                ok = False
+                print(
+                    "  self-test: shape '%s' expected exactly one finding at %s:%d, got %d"
+                    % (label, rel, want_line, len(found)),
+                    file=sys.stderr,
+                )
+                report_counts(found, expected)
+            target.write_text("\n".join(base) + "\n", encoding="utf-8")
+    return ok
+
+
+# --- run ---------------------------------------------------------------------------------------
+tools = live_tools()
+expected = len(tools)
+allowlist = read_allowlist(Path(ROOT) / "scripts/doc-count-allowlist.txt")
+
+if mode == "--self-test":
+    if not self_test(expected, allowlist):
+        print("doc-surface --self-test: FAILED", file=sys.stderr)
+        raise SystemExit(1)
+    print(
+        "doc-surface --self-test: OK (%d shapes seeded and caught, server reports %d tools)"
+        % (len(seeds(expected)), expected)
+    )
+    raise SystemExit(0)
+
+fail = False
+
+counts = count_findings(ROOT, expected, allowlist)
+if counts:
+    fail = True
+    print("doc-surface: stale tool-count claim(s):", file=sys.stderr)
+    report_counts(counts, expected)
+    print(
+        "Fix the count in the copy. A line whose count shape is not a tool count goes in\n"
+        "scripts/doc-count-allowlist.txt verbatim; never narrow the pattern.",
+        file=sys.stderr,
+    )
+
+exempt = read_exemptions(Path(ROOT) / "scripts/skill-coverage-exempt.txt")
+gaps = coverage_findings(ROOT, tools, exempt)
+if gaps:
+    fail = True
+    print("doc-surface: bundled skill omits:", file=sys.stderr)
+    for rel, kind, name in gaps:
+        print("  %s: %s %s is not named" % (rel, kind, name), file=sys.stderr)
+    print(
+        "Document it in both skills/hwp/SKILL.md and SKILL.ko.md, or add a subcommand to\n"
+        "scripts/skill-coverage-exempt.txt with a reason on the same line.",
+        file=sys.stderr,
+    )
+
+if fail:
+    raise SystemExit(1)
+
+print(
+    "doc-surface: OK (%d tools live; counts agree in %d files; skill covers every command and tool)"
+    % (expected, len(count_scan_set(ROOT)))
+)
+PY

--- a/scripts/check-doc-surface.sh
+++ b/scripts/check-doc-surface.sh
@@ -26,14 +26,14 @@ check | --self-test) ;;
 esac
 
 ROOT="$PWD"
-HWP_BIN="${HWP_BIN:-$ROOT/target/debug/hwp}"
-if [ ! -x "$HWP_BIN" ] && [ -x "$ROOT/target/release/hwp" ]; then
-    HWP_BIN="$ROOT/target/release/hwp"
+if [ -z "${HWP_BIN:-}" ]; then
+    # Cargo checks freshness even when a binary from an older checkout exists.
+    cargo build --locked -p hwp-cli --quiet
+    HWP_BIN="${CARGO_TARGET_DIR:-$ROOT/target}/debug/hwp"
 fi
 if [ ! -x "$HWP_BIN" ]; then
-    echo "[doc-surface] building hwp-cli (no binary at $HWP_BIN)" >&2
-    cargo build -p hwp-cli --quiet
-    HWP_BIN="$ROOT/target/debug/hwp"
+    echo "[doc-surface] executable not found: $HWP_BIN" >&2
+    exit 2
 fi
 
 export HWP_BIN

--- a/scripts/check-doc-surface.sh
+++ b/scripts/check-doc-surface.sh
@@ -3,6 +3,8 @@
 #
 #   scripts/check-doc-surface.sh              run both checks against the working tree
 #   scripts/check-doc-surface.sh --self-test  prove the count pattern still catches every shape
+#                                            (table-driven fixtures: every shape x several stale
+#                                            values, plus the live count, which must NOT report)
 #
 # Two independent checks, both reported before the script exits, so one run shows every finding:
 #   1. every tool-count claim in README*.md, docs/manual/*.md and skills/hwp/SKILL*.md equals the
@@ -93,6 +95,14 @@ def live_tools():
 # One entry per shape the documentation actually uses, each naming a file that uses it. A partial
 # pattern is worse than no gate: it reports a pass while the docs still misstate the count.
 # Never drop a shape to silence a finding - fix the copy, or allowlist the exact line.
+ONES = "one|two|three|four|five|six|seven|eight|nine"
+SPELLED = (
+    r"ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen"
+    r"|twenty[\s-]+(?:%s)|twenty|thirty" % ONES
+)
+# Korean native numerals: 열/스물/서른 with an optional ones word ("스물두 개 도구").
+KO_NATIVE = r"(?:열|스물|서른)\s*(?:하나|한|둘|두|셋|세|넷|네|다섯|여섯|일곱|여덟|아홉)?"
+
 COUNT_SHAPES = [
     # skills/hwp/SKILL.md: "Quick reports 22 tools and stays enabled"
     (r"(?P<n>\d+)\s+tools\b", "number before the English noun"),
@@ -106,15 +116,23 @@ COUNT_SHAPES = [
     (r"tools\s*\(\s*(?P<n>\d+)", "English noun before a parenthesised number"),
     # README.ko.md line 469: "### 노출 도구 (22종)"
     (r"도구\s*\(\s*(?P<n>\d+)", "Korean noun before a parenthesised number"),
+    # Labelled forms, the shape a table cell or a front-matter line uses: "MCP tools: 22".
+    (r"tools\s*:\s*(?P<n>\d+)", "English noun before a colon and a number"),
+    (r"tool\s+counts?\s*[:=]\s*(?P<n>\d+)", "an English count label"),
+    # "도구: 22", "도구 수(22개)", "도구 수: 22"
+    (r"도구\s*:\s*(?P<n>\d+)", "Korean noun before a colon and a number"),
+    (r"도구\s*수\s*[:(]\s*(?P<n>\d+)", "a Korean count label"),
     # skills/hwp/SKILL.md lines 315-316 used to wrap "the same twenty / tools" across a break.
-    # A spelled-out count is a finding whatever its value: write it as a numeral.
-    (
-        r"\b(?P<word>nineteen|twenty|twenty-one|twenty-two|twenty-three|twenty-four|thirty)"
-        r"[\s-]+tools\b",
-        "spelled-out number before the English noun",
-    ),
+    # A spelled-out count is a finding whatever its value: write it as a numeral, which is the
+    # only shape the gate can compare against the server.
+    (r"\b(?P<word>%s)[\s-]+tools\b" % SPELLED, "spelled-out number before the English noun"),
+    # "스물두 개 도구", "스물두 개의 도구" - same rule, Korean side.
+    (r"(?P<word>%s)\s*개의?\s*도구" % KO_NATIVE, "Korean native numeral before the noun"),
 ]
 COUNT_PATTERNS = [(re.compile(p, re.IGNORECASE), why) for p, why in COUNT_SHAPES]
+
+# How many consecutive lines a single count claim may be spread over.
+WINDOW = 3
 
 
 def count_scan_set(root):
@@ -138,15 +156,16 @@ def read_allowlist(path):
 
 
 def count_findings(root, expected, allowlist):
-    """Return [(relative path, line number, matched text, claimed, why)] over a 2-line window."""
+    """[(relative path, line number, matched text, claimed, why)] over a WINDOW-line window."""
     findings = []
     for path in count_scan_set(root):
         lines = path.read_text(encoding="utf-8").splitlines()
         rel = str(path.relative_to(root))
         for i, line in enumerate(lines):
             # A count can wrap across a line break in reflowed prose, so match over the line and
-            # its successor joined by a single space.
-            window = " ".join(lines[i : i + 2])
+            # its two successors joined by single spaces (a numeral, its counter and the noun can
+            # land on three consecutive lines in a narrow table cell or a wrapped bullet).
+            window = " ".join(lines[i : i + WINDOW])
             head = len(line)
             seen = set()
             for pattern, why in COUNT_PATTERNS:
@@ -232,30 +251,56 @@ def coverage_findings(root, tools, exempt):
 
 
 # --- self-test ---------------------------------------------------------------------------------
-# Seed one stale occurrence of each shape into a temporary copy of the scan set, one shape at a
-# time, and require the count check to report exactly that line. A shape removed from
-# COUNT_SHAPES makes this fail, so the pattern cannot be narrowed silently.
-def seeds(expected):
-    stale = expected + 1
-    return [
-        ("number before the English noun", "README.md", ["The server exposes %d tools." % stale]),
-        ("개 counter", "README.md", ["서버는 %d개 도구를 노출한다." % stale]),
-        ("개의 counter", "README.md", ["서버는 %d개의 도구를 노출한다." % stale]),
-        ("종 counter", "README.md", ["서버는 %d종 도구를 노출한다." % stale]),
-        ("counter-less Korean noun", "README.md", ["| MCP 서버 (%d 도구) |" % stale]),
-        ("parenthesised English", "README.md", ["### Exposed tools (%d)" % stale]),
-        ("parenthesised Korean", "README.md", ["### 노출 도구 (%d종)" % stale]),
-        ("spelled-out English", "README.md", ["The server exposes the same twenty tools."]),
-        (
-            "count wrapped across a line break",
-            "README.md",
-            ["The server exposes %d" % stale, "tools in total."],
-        ),
-    ]
+# Table-driven adversarial fixtures. Every numeral shape is seeded with several wrong values and
+# with the correct one; every value-free shape (spelled-out English, Korean native numeral) is
+# seeded once. A shape removed from COUNT_SHAPES, a window narrowed back to one or two lines, or
+# a pattern that reports the correct count as stale all make this fail, so none of them can
+# change unnoticed.
+#
+# Each row is (label, template lines). "{n}" is substituted with the seeded value; a row with no
+# "{n}" is a shape that is a finding whatever it says.
+NUMERAL_SHAPES = [
+    ("number before the English noun", ["The server exposes {n} tools."]),
+    ("개 counter", ["서버는 {n}개 도구를 노출한다."]),
+    ("개의 counter", ["서버는 {n}개의 도구를 노출한다."]),
+    ("종 counter", ["서버는 {n}종 도구를 노출한다."]),
+    ("counter-less Korean noun", ["| MCP 서버 ({n} 도구) |"]),
+    ("parenthesised English", ["### Exposed tools ({n})"]),
+    ("parenthesised Korean", ["### 노출 도구 ({n}종)"]),
+    ("English noun, colon, number", ["| MCP tools: {n} |"]),
+    ("English count label", ["tool count: {n}"]),
+    ("Korean noun, colon, number", ["| 도구: {n} |"]),
+    ("Korean count label", ["도구 수({n}개)"]),
+    ("wrapped across two lines", ["The server exposes {n}", "tools in total."]),
+    # These two need the full three-line window: two lines are not enough to join the number
+    # to its noun.
+    ("wrapped across three lines", ["### Exposed tools", "(", "{n})"]),
+    ("Korean wrapped across three lines", ["서버는 {n}", "개", "도구를 노출한다."]),
+]
+
+VALUE_FREE_SHAPES = [
+    ("spelled-out English", ["The server exposes the same twenty tools."]),
+    ("spelled-out English, compound", ["The server exposes twenty-two tools."]),
+    ("spelled-out English, spaced compound", ["The server exposes twenty two tools."]),
+    ("Korean native numeral", ["서버는 스물두 개 도구를 노출한다."]),
+    ("Korean native numeral, 개의", ["서버는 스물두 개의 도구를 노출한다."]),
+]
+
+
+def wrong_values(expected):
+    """The stale values every numeral shape is probed with: neighbours plus historical drift."""
+    return [v for v in (expected - 1, expected + 1, 20, 16, 9) if v != expected and v > 0]
+
+
+def _seed(tmp, base, rel, lines):
+    target = Path(tmp) / rel
+    target.write_text("\n".join(base + lines) + "\n", encoding="utf-8")
+    return len(base) + 1
 
 
 def self_test(expected, allowlist):
     ok = True
+    rel = "README.md"
     scan = count_scan_set(ROOT)
     with tempfile.TemporaryDirectory() as tmp:
         for path in scan:
@@ -267,23 +312,55 @@ def self_test(expected, allowlist):
             ok = False
             print("  self-test: the unseeded copy already reports findings:", file=sys.stderr)
             report_counts(clean, expected)
-        base = (Path(tmp) / "README.md").read_text(encoding="utf-8").splitlines()
-        for label, rel, extra in seeds(expected):
-            target = Path(tmp) / rel
-            target.write_text("\n".join(base + extra) + "\n", encoding="utf-8")
+        base = (Path(tmp) / rel).read_text(encoding="utf-8").splitlines()
+        cases = 0
+
+        def expect(label, lines, want):
+            """Seed `lines`, then require exactly `want` findings, at the seeded line."""
+            nonlocal ok, cases
+            cases += 1
+            at = _seed(tmp, base, rel, lines)
             found = count_findings(tmp, expected, allowlist)
-            want_line = len(base) + 1
-            hit = [f for f in found if f[0] == rel and f[1] == want_line]
-            if len(found) != len(hit) or len(hit) != 1:
+            # A wrapped shape is reported at the line where the match begins, which is the
+            # first seeded line for every row here; accept anywhere in the seeded range.
+            hit = [f for f in found if f[0] == rel and at <= f[1] < at + len(lines)]
+            if len(found) != len(hit) or len(hit) != want:
                 ok = False
                 print(
-                    "  self-test: shape '%s' expected exactly one finding at %s:%d, got %d"
-                    % (label, rel, want_line, len(found)),
+                    "  self-test: %s expected %d finding(s) at %s:%d, got %d"
+                    % (label, want, rel, at, len(found)),
                     file=sys.stderr,
                 )
                 report_counts(found, expected)
-            target.write_text("\n".join(base) + "\n", encoding="utf-8")
-    return ok
+
+        for label, template in NUMERAL_SHAPES:
+            for value in wrong_values(expected):
+                expect(
+                    "%s claiming %d" % (label, value),
+                    [l.replace("{n}", str(value)) for l in template],
+                    1,
+                )
+            # The same shape with the live count is not a finding, so the gate compares the
+            # number instead of reporting every count-shaped line.
+            expect(
+                "%s claiming the live count" % label,
+                [l.replace("{n}", str(expected)) for l in template],
+                0,
+            )
+        for label, lines in VALUE_FREE_SHAPES:
+            expect(label, lines, 1)
+
+        # The allowlist is consulted, not decorative: the same seeded line passes once its exact
+        # text is allowlisted, and fails again when the entry is removed.
+        seeded = ["The server exposes %d tools." % (expected + 1)]
+        at = _seed(tmp, base, rel, seeded)
+        cases += 1
+        if [f for f in count_findings(tmp, expected, allowlist + seeded) if f[1] == at]:
+            ok = False
+            print("  self-test: an allowlisted line was still reported", file=sys.stderr)
+
+        (Path(tmp) / rel).write_text("\n".join(base) + "\n", encoding="utf-8")
+    return ok, cases
 
 
 # --- run ---------------------------------------------------------------------------------------
@@ -292,12 +369,13 @@ expected = len(tools)
 allowlist = read_allowlist(Path(ROOT) / "scripts/doc-count-allowlist.txt")
 
 if mode == "--self-test":
-    if not self_test(expected, allowlist):
+    ok, cases = self_test(expected, allowlist)
+    if not ok:
         print("doc-surface --self-test: FAILED", file=sys.stderr)
         raise SystemExit(1)
     print(
-        "doc-surface --self-test: OK (%d shapes seeded and caught, server reports %d tools)"
-        % (len(seeds(expected)), expected)
+        "doc-surface --self-test: OK (%d seeded cases over %d shapes, server reports %d tools)"
+        % (cases, len(NUMERAL_SHAPES) + len(VALUE_FREE_SHAPES), expected)
     )
     raise SystemExit(0)
 

--- a/scripts/check-verification-block.sh
+++ b/scripts/check-verification-block.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# scripts/check-verification-block.sh <version> <commit-ish>
+#
+# The release-boundary gate, shared by scripts/release.sh (before it bumps, commits or tags) and
+# by .github/workflows/release.yml (before it publishes the tagged release), so both ends of the
+# release check the same thing in the same way.
+#
+# It fails unless ALL of this holds:
+#   1. the version's CHANGELOG section carries exactly one `<!-- verification:begin -->` /
+#      `<!-- verification:end -->` pair, in that order, around a `**Verification**` block;
+#   2. the block cites exactly one release-readiness run URL, and it is an Actions run URL of
+#      this repository;
+#   3. with `gh` available, the GitHub API says that run finished with conclusion `success`, that
+#      it is a run of the release-readiness workflow, and that its head_sha is the commit being
+#      released.
+#
+# There is no override flag. Missing evidence is a stop, not a warning: the block is the public
+# claim that the release was evaluated, and a claim nobody can check is worse than none.
+#
+# Without `gh` (a developer machine with no GitHub CLI) checks 1 and 2 still run and check 3 is
+# reported as unverified with a non-zero-free warning; the release workflow always has `gh`, so
+# the published release is never gated on the operator's laptop having it.
+#
+# HWP_CHANGELOG overrides the file that is read (tests only).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+REPO="STAIxBWLB/hwp-cli"
+WORKFLOW_FILE="release-readiness.yml"
+BEGIN_MARKER="<!-- verification:begin -->"
+END_MARKER="<!-- verification:end -->"
+
+version="${1:-}"
+commitish="${2:-}"
+changelog="${HWP_CHANGELOG:-CHANGELOG.md}"
+version="${version#v}"
+
+if [ -z "$version" ] || [ -z "$commitish" ]; then
+    echo "usage: scripts/check-verification-block.sh <version> <commit-ish>" >&2
+    exit 2
+fi
+
+die() {
+    echo "verification-block: $*" >&2
+    exit 1
+}
+
+# --- 1. the marker-bounded block ----------------------------------------------------------------
+section="$(awk -v want="[$version]" '
+    /^## / { if (found) exit; if ($2 == want) { found = 1; next } }
+    found  { print }' "$changelog")"
+[ -n "$section" ] || die "$changelog has no [$version] section."
+
+begins="$(grep -cF -- "$BEGIN_MARKER" <<<"$section" || true)"
+ends="$(grep -cF -- "$END_MARKER" <<<"$section" || true)"
+if [ "$begins" != 1 ] || [ "$ends" != 1 ]; then
+    die "the [$version] section must carry exactly one $BEGIN_MARKER and one $END_MARKER
+                    (found $begins and $ends). Regenerate it with
+                    scripts/release_verification_block.sh $version <readiness-run-url>."
+fi
+
+begin_at="$(grep -nF -- "$BEGIN_MARKER" <<<"$section" | cut -d: -f1)"
+end_at="$(grep -nF -- "$END_MARKER" <<<"$section" | cut -d: -f1)"
+[ "$begin_at" -lt "$end_at" ] ||
+    die "the [$version] Verification markers are out of order (begin at line $begin_at of the
+                    section, end at $end_at)."
+
+block="$(sed -n "$((begin_at + 1)),$((end_at - 1))p" <<<"$section")"
+grep -q '^\*\*Verification\*\*' <<<"$block" ||
+    die "the marked region of [$version] carries no **Verification** label."
+
+urls="$(grep -oE "https://github\.com/$REPO/actions/runs/[0-9]+" <<<"$block" | sort -u || true)"
+count="$(printf '%s' "$urls" | grep -c . || true)"
+[ "$count" = 1 ] ||
+    die "the [$version] Verification block must cite exactly one $REPO Actions run URL (found $count)."
+run_url="$urls"
+run_id="${run_url##*/}"
+
+# --- 2. the commit the evidence must belong to --------------------------------------------------
+if printf '%s' "$commitish" | grep -Eq '^[0-9a-f]{40}$'; then
+    sha="$commitish"
+else
+    sha="$(git rev-parse --verify "${commitish}^{commit}" 2>/dev/null || true)"
+    [ -n "$sha" ] || die "cannot resolve '$commitish' to a commit."
+fi
+
+# --- 3. the run itself ---------------------------------------------------------------------------
+if ! command -v gh >/dev/null 2>&1; then
+    echo "verification-block: WARNING - gh is not installed, so run $run_id was NOT verified" >&2
+    echo "verification-block: block OK for $version (run $run_url, API check skipped)"
+    exit 0
+fi
+
+api="$(gh api "repos/$REPO/actions/runs/$run_id" \
+    --jq '[.status, .conclusion // "none", .name // "", .path // "", .head_sha // ""] | @tsv' 2>&1)" ||
+    die "gh api repos/$REPO/actions/runs/$run_id failed:
+                    $api"
+IFS=$'\t' read -r status conclusion name path head_sha <<<"$api"
+
+[ "$status" = completed ] ||
+    die "readiness run $run_id is '$status', not completed."
+[ "$conclusion" = success ] ||
+    die "readiness run $run_id concluded '$conclusion', not success."
+case "$path" in
+*/"$WORKFLOW_FILE" | "$WORKFLOW_FILE") ;;
+*)
+    # `name` is the workflow's display name; accept it when the path is unavailable.
+    printf '%s' "$name" | grep -Eqi '^release[ -]readiness$' ||
+        die "run $run_id is workflow '$name' ($path), not $WORKFLOW_FILE."
+    ;;
+esac
+[ "$head_sha" = "$sha" ] ||
+    die "readiness run $run_id evaluated $head_sha, but the commit being released is $sha.
+                    Dispatch $WORKFLOW_FILE against that commit and cite the new run."
+
+echo "verification-block: OK for $version (run $run_id, $conclusion, head_sha $head_sha)"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -26,6 +26,7 @@ run $CARGO test --workspace
 run python3 -m unittest tools/test_pdf_parity.py
 run bash scripts/check-structured-corpus.sh
 run bash scripts/check-claims.sh
+run bash scripts/check-claims.sh --self-test
 run bash scripts/check-doc-surface.sh
 run bash scripts/check-doc-surface.sh --self-test
 target_dir="${CARGO_TARGET_DIR:-target}"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -26,6 +26,8 @@ run $CARGO test --workspace
 run python3 -m unittest tools/test_pdf_parity.py
 run bash scripts/check-structured-corpus.sh
 run bash scripts/check-claims.sh
+run bash scripts/check-doc-surface.sh
+run bash scripts/check-doc-surface.sh --self-test
 target_dir="${CARGO_TARGET_DIR:-target}"
 run "$target_dir/debug/examples/validate_structured_corpus" \
     schemas/pdf-parity-history-v1.schema.json \
@@ -56,4 +58,4 @@ if [ "$fail" -ne 0 ]; then
     echo "== check: FAILED (위 게이트 중 실패 있음) =="
     exit 1
 fi
-echo "== check: OK (fmt/clippy/test/pdf-runner/structured-corpus/claims/public-parity=$parity_result) =="
+echo "== check: OK (fmt/clippy/test/pdf-runner/structured-corpus/claims/doc-surface/public-parity=$parity_result) =="

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -29,6 +29,7 @@ run bash scripts/check-claims.sh
 run bash scripts/check-claims.sh --self-test
 run bash scripts/check-doc-surface.sh
 run bash scripts/check-doc-surface.sh --self-test
+run bash scripts/release_verification_block.sh --self-test
 target_dir="${CARGO_TARGET_DIR:-target}"
 run "$target_dir/debug/examples/validate_structured_corpus" \
     schemas/pdf-parity-history-v1.schema.json \
@@ -59,4 +60,4 @@ if [ "$fail" -ne 0 ]; then
     echo "== check: FAILED (위 게이트 중 실패 있음) =="
     exit 1
 fi
-echo "== check: OK (fmt/clippy/test/pdf-runner/structured-corpus/claims/doc-surface/public-parity=$parity_result) =="
+echo "== check: OK (fmt/clippy/test/pdf-runner/structured-corpus/claims/doc-surface/release-block/public-parity=$parity_result) =="

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -25,6 +25,7 @@ run $CARGO clippy --workspace --all-targets -- -D warnings
 run $CARGO test --workspace
 run python3 -m unittest tools/test_pdf_parity.py
 run bash scripts/check-structured-corpus.sh
+run bash scripts/check-claims.sh
 target_dir="${CARGO_TARGET_DIR:-target}"
 run "$target_dir/debug/examples/validate_structured_corpus" \
     schemas/pdf-parity-history-v1.schema.json \
@@ -55,4 +56,4 @@ if [ "$fail" -ne 0 ]; then
     echo "== check: FAILED (위 게이트 중 실패 있음) =="
     exit 1
 fi
-echo "== check: OK (fmt/clippy/test/pdf-runner/structured-corpus/public-parity=$parity_result) =="
+echo "== check: OK (fmt/clippy/test/pdf-runner/structured-corpus/claims/public-parity=$parity_result) =="

--- a/scripts/claim-allowlist.txt
+++ b/scripts/claim-allowlist.txt
@@ -1,14 +1,16 @@
 # Allowlist for scripts/check-claims.sh.
 #
-# Each non-comment, non-blank line is ONE exact sentence that is allowed to contain a scanned
-# phrase, because the sentence negates or quotes the claim rather than making it.
+# Each non-comment, non-blank line exempts ONE exact line of ONE file, because that line negates
+# or quotes the claim rather than making it.
+#
+# Format: <relative path><TAB><the exact line, verbatim>
 #
 # Rules:
-#   - An entry is a sentence. It is never a file name, a directory or a pattern.
-#   - An entry is matched as a fixed substring of the offending line, so the same forbidden words
-#     in a different sentence still fail the lint.
-#   - A new genuine claim is fixed in the copy. It is never silenced by widening an entry here.
-#
-# Format: one sentence per line, '#' starts a comment line, blank lines ignored.
+#   - An entry names one file and one whole line. It is never a directory or a pattern.
+#   - The line must match exactly, so appending a claim to an allowlisted line is still caught:
+#     the appended sentence changes the line and the exemption lapses.
+#   - A new genuine claim is fixed in the copy. It is never silenced by an entry here.
+#   - Most negated sentences need no entry at all: the lint already ignores a claim whose sentence
+#     negates it before the phrase. An entry is for the residue that rule cannot see.
 
-**No Hancom parity claim** The final verdict is always whether the file opens correctly in Hancom Office.
+README.md	- **No Hancom parity claim** The final verdict is always whether the file opens correctly in Hancom Office.

--- a/scripts/claim-allowlist.txt
+++ b/scripts/claim-allowlist.txt
@@ -1,0 +1,14 @@
+# Allowlist for scripts/check-claims.sh.
+#
+# Each non-comment, non-blank line is ONE exact sentence that is allowed to contain a scanned
+# phrase, because the sentence negates or quotes the claim rather than making it.
+#
+# Rules:
+#   - An entry is a sentence. It is never a file name, a directory or a pattern.
+#   - An entry is matched as a fixed substring of the offending line, so the same forbidden words
+#     in a different sentence still fail the lint.
+#   - A new genuine claim is fixed in the copy. It is never silenced by widening an entry here.
+#
+# Format: one sentence per line, '#' starts a comment line, blank lines ignored.
+
+**No Hancom parity claim** The final verdict is always whether the file opens correctly in Hancom Office.

--- a/scripts/doc-count-allowlist.txt
+++ b/scripts/doc-count-allowlist.txt
@@ -9,5 +9,7 @@
 #   - The pattern in scripts/check-doc-surface.sh is never narrowed to make a finding go away;
 #     dropping a shape is what this file exists to make unnecessary.
 #
-# There are no entries at introduction: every count-shaped occurrence in the scan set today is a
-# real tool count.
+# docs/manual/amazon-quick-desktop.md: a historical statement about the connector as it stood at
+# the 0.8.3 baseline, not a claim about the current server. The line right under it counts the
+# tools added since, so restating it as today's number would make the section false.
+The connector exposed sixteen tools when this runbook was first written. Four more arrived, and

--- a/scripts/doc-count-allowlist.txt
+++ b/scripts/doc-count-allowlist.txt
@@ -1,0 +1,13 @@
+# Allowlist for the tool-count check of scripts/check-doc-surface.sh.
+#
+# Each non-comment, non-blank line is ONE exact line of prose whose count shape is not a tool
+# count, and which the check must therefore not report.
+#
+# Rules:
+#   - An entry is one exact line. It is never a file name, a directory or a pattern.
+#   - A genuinely stale count is fixed in the copy. It is never silenced by an entry here.
+#   - The pattern in scripts/check-doc-surface.sh is never narrowed to make a finding go away;
+#     dropping a shape is what this file exists to make unnecessary.
+#
+# There are no entries at introduction: every count-shaped occurrence in the scan set today is a
+# real tool count.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -13,8 +13,11 @@
 #
 # 두 번째 인수는 release-readiness 워크플로 실행 URL이다. docs/release-readiness.md는 릴리스
 # 문구가 제외된 parity 게이트와 그 측정 거리를 밝히도록 요구하므로, bump 전에
-# scripts/release_verification_block.sh 가 그 URL로 해당 버전 절에 **Verification** 블록을
-# 쓴다. URL이 없거나 블록이 없으면 이 스크립트는 파일을 건드리기 전에 거부한다.
+# scripts/release_verification_block.sh 가 그 URL로 해당 버전 절에 마커로 둘러싸인
+# **Verification** 블록을 쓰고, scripts/check-verification-block.sh 가 그 실행이 실제로
+# release-readiness.yml 의 성공한 실행이며 릴리스 대상 커밋을 평가했는지 GitHub API 로
+# 확인한다. 어느 하나라도 어긋나면 파일을 건드리기 전에(또는 되돌린 뒤) 거부한다.
+# 우회 플래그는 없다.
 #
 #     scripts/release.sh 0.18.0 https://github.com/STAIxBWLB/hwp-cli/actions/runs/1234567890
 #
@@ -59,16 +62,21 @@ fi
 if [ -z "$readiness_url" ]; then
   cat >&2 <<EOF
 오류: release-readiness 실행 URL이 없습니다. 버전 bump, 커밋, 태그를 모두 중단합니다.
-      .github 의 release-readiness 워크플로를 먼저 dispatch 하고 그 실행 URL을 두 번째
-      인수로 넘기세요:
+      릴리스 준비 워크플로 .github/workflows/release-readiness.yml 은 Phase 4 plan 04-04
+      이 추가한다(PR 대기 중). 그 PR 이 머지되기 전에는 dispatch 할 수 없으므로 릴리스도
+      진행할 수 없다. 머지된 뒤 릴리스 대상 커밋(지금의 HEAD)으로 dispatch 하고, 그 실행
+      URL 을 두 번째 인수로 넘긴다:
         scripts/release.sh $ver https://github.com/STAIxBWLB/hwp-cli/actions/runs/<run-id>
 EOF
   exit 1
 fi
 bash scripts/release_verification_block.sh "$ver" "$readiness_url"
-if ! awk -v want="[$ver]" '/^## / { if (found) exit; if ($2 == want) { found = 1; next } }
-                           found { print }' CHANGELOG.md | grep -q '^\*\*Verification\*\*'; then
-  echo "오류: CHANGELOG.md의 [$ver] 절에 Verification 블록이 없습니다. 태그를 만들지 않습니다." >&2
+# 블록 자체 + 인용된 실행(성공 여부, 워크플로, head_sha)까지 확인한다. release.yml 도 태그
+# 커밋에 대해 같은 스크립트를 돌린다. 실패하면 방금 쓴 블록을 되돌려 트리를 원상복구한다
+# (위에서 트리가 깨끗함을 이미 확인했다).
+if ! bash scripts/check-verification-block.sh "$ver" "$(git rev-parse HEAD)"; then
+  git checkout -- CHANGELOG.md
+  echo "오류: 릴리스 준비 증거가 확인되지 않았습니다. CHANGELOG.md 변경을 되돌렸고, 태그를 만들지 않습니다." >&2
   exit 1
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/release.sh X.Y.Z
+# scripts/release.sh X.Y.Z <readiness-run-url>
 #
 # 워크스페이스 버전(Cargo.toml [workspace.package] version)을 bump 하고 커밋 + 태그를
 # 만든다. main 은 보호 브랜치라 이 커밋을 직접 밀 수 없다 — 브랜치에서 실행하고 PR 로
@@ -10,6 +10,13 @@
 #     gh pr create ... && gh pr merge --squash        # CHANGELOG 절 마감도 같은 PR 에서
 #     git switch main && git pull                     # main CI 가 초록인지 확인 후
 #     git tag -a v0.2.0 -m v0.2.0 && git push origin v0.2.0
+#
+# 두 번째 인수는 release-readiness 워크플로 실행 URL이다. docs/release-readiness.md는 릴리스
+# 문구가 제외된 parity 게이트와 그 측정 거리를 밝히도록 요구하므로, bump 전에
+# scripts/release_verification_block.sh 가 그 URL로 해당 버전 절에 **Verification** 블록을
+# 쓴다. URL이 없거나 블록이 없으면 이 스크립트는 파일을 건드리기 전에 거부한다.
+#
+#     scripts/release.sh 0.18.0 https://github.com/STAIxBWLB/hwp-cli/actions/runs/1234567890
 #
 # 자체 점검:  scripts/release.sh --self-test
 set -euo pipefail
@@ -37,7 +44,8 @@ fi
 
 # --- 릴리스 준비 -------------------------------------------------------------
 ver="${1:-}"
-[ -n "$ver" ] || { echo "usage: scripts/release.sh X.Y.Z" >&2; exit 2; }
+readiness_url="${2:-}"
+[ -n "$ver" ] || { echo "usage: scripts/release.sh X.Y.Z <readiness-run-url>" >&2; exit 2; }
 semver_ok "$ver" || { echo "오류: 시맨틱 버전 형식이 아닙니다: '$ver' (예: 0.2.0, 0.2.0-rc1)" >&2; exit 1; }
 
 cd "$(git rev-parse --show-toplevel)"
@@ -45,6 +53,23 @@ cd "$(git rev-parse --show-toplevel)"
 [ -z "$(git status --porcelain)" ] || { echo "오류: 작업 트리가 깨끗하지 않습니다. 커밋/스태시 후 다시 실행하세요." >&2; exit 1; }
 if git rev-parse -q --verify "refs/tags/v$ver" >/dev/null; then
   echo "오류: 태그 v$ver 가 이미 존재합니다." >&2; exit 1
+fi
+
+# 릴리스 준비 증거 게이트 — 파일을 하나라도 고치기 전에 거부한다.
+if [ -z "$readiness_url" ]; then
+  cat >&2 <<EOF
+오류: release-readiness 실행 URL이 없습니다. 버전 bump, 커밋, 태그를 모두 중단합니다.
+      .github 의 release-readiness 워크플로를 먼저 dispatch 하고 그 실행 URL을 두 번째
+      인수로 넘기세요:
+        scripts/release.sh $ver https://github.com/STAIxBWLB/hwp-cli/actions/runs/<run-id>
+EOF
+  exit 1
+fi
+bash scripts/release_verification_block.sh "$ver" "$readiness_url"
+if ! awk -v want="[$ver]" '/^## / { if (found) exit; if ($2 == want) { found = 1; next } }
+                           found { print }' CHANGELOG.md | grep -q '^\*\*Verification\*\*'; then
+  echo "오류: CHANGELOG.md의 [$ver] 절에 Verification 블록이 없습니다. 태그를 만들지 않습니다." >&2
+  exit 1
 fi
 
 old=$(extract_version Cargo.toml)
@@ -65,7 +90,7 @@ fi
 # 않게 한다(릴리스 커밋에 원치 않는 dependency 변경 혼입 방지).
 cargo update --workspace --offline >/dev/null
 
-git add Cargo.toml Cargo.lock
+git add Cargo.toml Cargo.lock CHANGELOG.md
 git commit -m "chore(release): v$ver"
 git tag -a "v$ver" -m "v$ver"
 

--- a/scripts/release_verification_block.sh
+++ b/scripts/release_verification_block.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# scripts/release_verification_block.sh <version> <readiness-run-url>
+#
+# Write the **Verification** block into that version's `## [X.Y.Z]` section of CHANGELOG.md.
+# docs/release-readiness.md requires the release copy to state the excluded parity gates and their
+# measured distance; scripts/release_notes.sh extracts the version section verbatim as the GitHub
+# Release body, so the block has to exist in CHANGELOG.md before the release is cut. No line of the
+# block may begin with `## `, which is where release_notes.sh stops.
+#
+# The measurements are quoted from docs/design/21-pdf-parity.md sections 4.5 and 4.6. They are
+# never recomputed here, and they come from the private composite run, not the public one-page
+# gate, which declares no exclusions at all (section 4.3).
+#
+# Running it twice for the same version replaces the block rather than appending a second one.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+version="${1:-}"
+run_url="${2:-}"
+usage() {
+    echo "usage: scripts/release_verification_block.sh <version> <readiness-run-url>" >&2
+    echo "  example: scripts/release_verification_block.sh 0.18.0 \\" >&2
+    echo "           https://github.com/STAIxBWLB/hwp-cli/actions/runs/1234567890" >&2
+}
+
+[ -n "$version" ] && [ -n "$run_url" ] || {
+    echo "오류: 버전과 릴리스 준비 실행 URL이 모두 필요합니다." >&2
+    usage
+    exit 2
+}
+version="${version#v}"
+
+if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+    echo "오류: 시맨틱 버전 형식이 아닙니다: '$version'" >&2
+    exit 1
+fi
+if ! printf '%s' "$run_url" |
+    grep -Eq '^https://github\.com/STAIxBWLB/hwp-cli/actions/runs/[0-9]+(/[A-Za-z0-9/_-]+)?$'; then
+    echo "오류: 이 저장소의 actions run URL이 아닙니다: '$run_url'" >&2
+    echo "      예: https://github.com/STAIxBWLB/hwp-cli/actions/runs/1234567890" >&2
+    exit 1
+fi
+if ! grep -q "^## \[$version\]" CHANGELOG.md; then
+    echo "오류: CHANGELOG.md에 [$version] 절이 없습니다. 절을 먼저 연 뒤 다시 실행하세요." >&2
+    exit 1
+fi
+
+# The block as prose, so a reviewer reads what the release will say.
+block="$(
+    cat <<EOF
+**Verification**
+
+- Release-readiness run: $run_url
+- The private PDF-parity profile excludes four gates. The public one-page gate declares none
+  (docs/design/21-pdf-parity.md section 4.3), so these exclusions describe the private profile
+  only.
+- \`fonts\`: the document declares its dominant body face through a \`substFont\`, and the oracle
+  host did not have that face either, so our substitutions resolve to the same faces the oracle
+  embedded. The gate's \`substitution_free\` criterion is unreachable for this case by
+  construction (section 4.5).
+- \`text\`: 1/13 pages byte-equal; the differences are pagination, not characters. Page 4's only
+  diff is one line that crosses a page boundary (section 4.6).
+- \`raster\`: \`bad_pixel_pct\` 0.1418-0.2332, MAE 18.5-27.9, ink ratio 0.854-1.435, max abs dx/dy
+  40px (section 4.6).
+- \`roi\`: 3 of 4 pass; only the page-2 diagram region fails (precision 0.848, recall 0.892)
+  (section 4.6).
+- Provenance: these distances were measured by the private composite run of 2026-08-16, not by
+  the public one-page gate.
+EOF
+)"
+
+export HWP_VERSION="$version" HWP_BLOCK="$block"
+python3 - <<'PY'
+import os
+import sys
+import tempfile
+
+version = os.environ["HWP_VERSION"]
+block = os.environ["HWP_BLOCK"].splitlines()
+path = "CHANGELOG.md"
+
+lines = open(path, encoding="utf-8").read().splitlines()
+heading = "## [%s]" % version
+start = next(i for i, l in enumerate(lines) if l.startswith(heading))
+end = next((i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")), len(lines))
+
+window = lines[start + 1 : end]
+
+# Drop an existing block: the bold label and everything up to the next bold label, a separator,
+# or the end of the section. This is what makes a repeated run replace rather than append.
+if "**Verification**" in window:
+    at = window.index("**Verification**")
+    stop = at + 1
+    while stop < len(window):
+        s = window[stop].strip()
+        if s == "---" or (s.startswith("**") and s.endswith("**")):
+            break
+        stop += 1
+    window = window[:at] + window[stop:]
+
+# Keep the section's trailing separator and blank lines after the block, so the block is the last
+# content of the section and the file's shape is unchanged.
+tail = []
+while window and window[-1].strip() in ("", "---"):
+    tail.insert(0, window.pop())
+
+new_window = window + [""] + block + tail
+lines[start + 1 : end] = new_window
+
+fd, tmp = tempfile.mkstemp(dir=".", prefix=".CHANGELOG.", suffix=".tmp")
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+    os.replace(tmp, path)
+except BaseException:
+    if os.path.exists(tmp):
+        os.unlink(tmp)
+    raise
+
+bullets = sum(1 for l in block if l.startswith("- "))
+print("release_verification_block: %s, %d bullets written" % (version, bullets), file=sys.stdout)
+PY

--- a/scripts/release_verification_block.sh
+++ b/scripts/release_verification_block.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # scripts/release_verification_block.sh <version> <readiness-run-url>
+# scripts/release_verification_block.sh --self-test
 #
 # Write the **Verification** block into that version's `## [X.Y.Z]` section of CHANGELOG.md.
 # docs/release-readiness.md requires the release copy to state the excluded parity gates and their
@@ -7,21 +8,138 @@
 # Release body, so the block has to exist in CHANGELOG.md before the release is cut. No line of the
 # block may begin with `## `, which is where release_notes.sh stops.
 #
+# The block is bounded by the HTML comments `<!-- verification:begin -->` and
+# `<!-- verification:end -->`. A rerun replaces exactly that region and nothing else, so anything
+# an editor added after the block survives; markers that are missing on one side, duplicated, or
+# out of order are refused rather than guessed at, and an unmarked legacy block is refused too.
+# (The markers render as nothing in the release body.)
+#
 # The measurements are quoted from docs/design/21-pdf-parity.md sections 4.5 and 4.6. They are
 # never recomputed here, and they come from the private composite run, not the public one-page
 # gate, which declares no exclusions at all (section 4.3).
 #
-# Running it twice for the same version replaces the block rather than appending a second one.
+# HWP_CHANGELOG overrides the file that is rewritten (the self-test uses it; nothing else should).
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-version="${1:-}"
-run_url="${2:-}"
+BEGIN_MARKER="<!-- verification:begin -->"
+END_MARKER="<!-- verification:end -->"
+
 usage() {
     echo "usage: scripts/release_verification_block.sh <version> <readiness-run-url>" >&2
+    echo "       scripts/release_verification_block.sh --self-test" >&2
     echo "  example: scripts/release_verification_block.sh 0.18.0 \\" >&2
     echo "           https://github.com/STAIxBWLB/hwp-cli/actions/runs/1234567890" >&2
 }
+
+# --- self-test (no repository side effects: everything happens in a temporary file) -------------
+# The regression this pins: a rerun must replace the bounded region and leave every other line of
+# the section alone, including a bullet an editor appended after the block.
+if [ "${1:-}" = "--self-test" ]; then
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    cl="$tmpdir/CHANGELOG.md"
+    url1="https://github.com/STAIxBWLB/hwp-cli/actions/runs/111"
+    url2="https://github.com/STAIxBWLB/hwp-cli/actions/runs/222"
+    cat >"$cl" <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+**Added**
+
+- something on the next version
+
+## [9.9.9]
+
+**Added**
+
+- a released thing
+
+---
+
+## [9.9.8]
+
+**Added**
+
+- an older thing
+EOF
+    HWP_CHANGELOG="$cl" bash "$0" 9.9.9 "$url1" >/dev/null
+    # An editor appends a bullet after the generated block, inside the same section.
+    python3 - "$cl" <<'PY'
+import sys
+p = sys.argv[1]
+lines = open(p, encoding="utf-8").read().splitlines()
+at = lines.index("<!-- verification:end -->")
+lines[at + 1 : at + 1] = ["", "- appended by hand after the block"]
+open(p, "w", encoding="utf-8").write("\n".join(lines) + "\n")
+PY
+    cp "$cl" "$tmpdir/before"
+    HWP_CHANGELOG="$cl" bash "$0" 9.9.9 "$url2" >/dev/null
+    fail=0
+    check() { # <description> <test result already evaluated by caller>
+        if [ "$2" != "0" ]; then
+            echo "self-test FAIL: $1" >&2
+            fail=1
+        fi
+    }
+    grep -qF -- "- appended by hand after the block" "$cl" && rc=0 || rc=1
+    check "the hand-appended bullet survived the rerun" "$rc"
+    grep -qF -- "$url2" "$cl" && rc=0 || rc=1
+    check "the new run URL is present" "$rc"
+    grep -qF -- "$url1" "$cl" && rc=1 || rc=0
+    check "the old run URL is gone" "$rc"
+    [ "$(grep -cF -- "$BEGIN_MARKER" "$cl")" = 1 ] && rc=0 || rc=1
+    check "exactly one begin marker" "$rc"
+    [ "$(grep -cF -- "$END_MARKER" "$cl")" = 1 ] && rc=0 || rc=1
+    check "exactly one end marker" "$rc"
+    # Only lines inside the marked region changed: every differing line must sit between the
+    # markers of one of the two files.
+    if python3 - "$tmpdir/before" "$cl" <<'PY'
+import sys
+
+BEGIN, END = "<!-- verification:begin -->", "<!-- verification:end -->"
+
+
+def outside(path):
+    keep, inside = [], False
+    for line in open(path, encoding="utf-8").read().splitlines():
+        if line.strip() == BEGIN:
+            inside = True
+            continue
+        if line.strip() == END:
+            inside = False
+            continue
+        if not inside:
+            keep.append(line)
+    return keep
+
+
+before, after = outside(sys.argv[1]), outside(sys.argv[2])
+if before != after:
+    print("self-test FAIL: content outside the markers changed", file=sys.stderr)
+    import difflib
+
+    sys.stderr.writelines(difflib.unified_diff(before, after, "before", "after", lineterm="\n"))
+    raise SystemExit(1)
+PY
+    then rc=0; else rc=1; fi
+    check "only the marked region changed" "$rc"
+    # A malformed marker pair is refused rather than guessed at.
+    sed -i.bak "s|$END_MARKER||" "$cl" && rm -f "$cl.bak"
+    if HWP_CHANGELOG="$cl" bash "$0" 9.9.9 "$url1" >/dev/null 2>&1; then
+        check "an unpaired begin marker is refused" 1
+    fi
+    if [ "$fail" -ne 0 ]; then
+        echo "release_verification_block --self-test: FAILED" >&2
+        exit 1
+    fi
+    echo "release_verification_block --self-test: OK (rerun replaced only the marked region)"
+    exit 0
+fi
+
+version="${1:-}"
+run_url="${2:-}"
 
 [ -n "$version" ] && [ -n "$run_url" ] || {
     echo "오류: 버전과 릴리스 준비 실행 URL이 모두 필요합니다." >&2
@@ -29,6 +147,7 @@ usage() {
     exit 2
 }
 version="${version#v}"
+changelog="${HWP_CHANGELOG:-CHANGELOG.md}"
 
 if ! printf '%s' "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
     echo "오류: 시맨틱 버전 형식이 아닙니다: '$version'" >&2
@@ -40,14 +159,15 @@ if ! printf '%s' "$run_url" |
     echo "      예: https://github.com/STAIxBWLB/hwp-cli/actions/runs/1234567890" >&2
     exit 1
 fi
-if ! grep -q "^## \[$version\]" CHANGELOG.md; then
-    echo "오류: CHANGELOG.md에 [$version] 절이 없습니다. 절을 먼저 연 뒤 다시 실행하세요." >&2
+if ! grep -q "^## \[$version\]" "$changelog"; then
+    echo "오류: $changelog에 [$version] 절이 없습니다. 절을 먼저 연 뒤 다시 실행하세요." >&2
     exit 1
 fi
 
 # The block as prose, so a reviewer reads what the release will say.
 block="$(
     cat <<EOF
+$BEGIN_MARKER
 **Verification**
 
 - Release-readiness run: $run_url
@@ -66,18 +186,21 @@ block="$(
   (section 4.6).
 - Provenance: these distances were measured by the private composite run of 2026-08-16, not by
   the public one-page gate.
+$END_MARKER
 EOF
 )"
 
-export HWP_VERSION="$version" HWP_BLOCK="$block"
+export HWP_VERSION="$version" HWP_BLOCK="$block" HWP_CHANGELOG_PATH="$changelog"
 python3 - <<'PY'
 import os
 import sys
 import tempfile
 
+BEGIN, END = "<!-- verification:begin -->", "<!-- verification:end -->"
+
 version = os.environ["HWP_VERSION"]
 block = os.environ["HWP_BLOCK"].splitlines()
-path = "CHANGELOG.md"
+path = os.environ["HWP_CHANGELOG_PATH"]
 
 lines = open(path, encoding="utf-8").read().splitlines()
 heading = "## [%s]" % version
@@ -85,29 +208,43 @@ start = next(i for i, l in enumerate(lines) if l.startswith(heading))
 end = next((i for i in range(start + 1, len(lines)) if lines[i].startswith("## ")), len(lines))
 
 window = lines[start + 1 : end]
+begins = [i for i, l in enumerate(window) if l.strip() == BEGIN]
+ends = [i for i, l in enumerate(window) if l.strip() == END]
 
-# Drop an existing block: the bold label and everything up to the next bold label, a separator,
-# or the end of the section. This is what makes a repeated run replace rather than append.
-if "**Verification**" in window:
-    at = window.index("**Verification**")
-    stop = at + 1
-    while stop < len(window):
-        s = window[stop].strip()
-        if s == "---" or (s.startswith("**") and s.endswith("**")):
-            break
-        stop += 1
-    window = window[:at] + window[stop:]
 
-# Keep the section's trailing separator and blank lines after the block, so the block is the last
-# content of the section and the file's shape is unchanged.
-tail = []
-while window and window[-1].strip() in ("", "---"):
-    tail.insert(0, window.pop())
+def refuse(why):
+    sys.stderr.write(
+        "오류: %s에 [%s] 절의 Verification 마커가 %s. 파일을 수정하지 않았습니다.\n"
+        "      블록은 %s 와 %s 사이에만 존재해야 하며, 손상된 마커는 손으로 고칩니다.\n"
+        % (path, version, why, BEGIN, END)
+    )
+    raise SystemExit(1)
 
-new_window = window + [""] + block + tail
+
+if len(begins) > 1 or len(ends) > 1:
+    refuse("중복되었습니다")
+if len(begins) != len(ends):
+    refuse("한쪽만 있습니다")
+if begins and begins[0] > ends[0]:
+    refuse("순서가 뒤바뀌었습니다")
+if not begins and any(l.strip() == "**Verification**" for l in window):
+    refuse("없는데 마커 없는 Verification 블록이 있습니다")
+
+if begins:
+    # Replace exactly the bounded region; everything before and after it is left untouched, so a
+    # bullet an editor appended after the block survives the rerun.
+    new_window = window[: begins[0]] + block + window[ends[0] + 1 :]
+else:
+    # First run: the block becomes the last content of the section, before its trailing separator.
+    tail = []
+    while window and window[-1].strip() in ("", "---"):
+        tail.insert(0, window.pop())
+    new_window = window + [""] + block + tail
+
 lines[start + 1 : end] = new_window
 
-fd, tmp = tempfile.mkstemp(dir=".", prefix=".CHANGELOG.", suffix=".tmp")
+directory = os.path.dirname(os.path.abspath(path))
+fd, tmp = tempfile.mkstemp(dir=directory, prefix=".CHANGELOG.", suffix=".tmp")
 try:
     with os.fdopen(fd, "w", encoding="utf-8") as fh:
         fh.write("\n".join(lines) + "\n")

--- a/scripts/skill-coverage-exempt.txt
+++ b/scripts/skill-coverage-exempt.txt
@@ -1,0 +1,9 @@
+# CLI subcommands deliberately outside the bundled agent skill's scope, for
+# scripts/check-doc-surface.sh.
+#
+# Each non-comment line is a subcommand name followed by a reason on the same line. A subcommand
+# that operates on a document is never exempted here: it is documented in skills/hwp/SKILL.md and
+# skills/hwp/SKILL.ko.md instead.
+
+corpus the frozen structured-corpus harness is a repository gate, not a document operation an agent performs
+update the self-updater replaces the binary on the host; an agent is given a binary, it does not install one

--- a/skills/hwp/SKILL.ko.md
+++ b/skills/hwp/SKILL.ko.md
@@ -105,6 +105,9 @@ HWPX 형식을 읽고 쓰며, docx, pdf, html, markdown, json, odt, txt, csv로 
   — 필드 (이름/종류/값), 책갈피 (bokm), `{{name}}` 템플릿 슬롯 나열.
 - `hwp validate {file} [--json]` — 구조 검증 (mimetype, 필수 엔트리, XML 파싱);
   유효하면 종료 코드 0.
+- `hwp dump {file} [--stream DocInfo|BodyText/Section0|Contents/header.xml] [--raw] [--json]`:
+  파일 하나의 저수준 레코드·스트림 진단. `hwp info`와 `hwp validate`로 결함이 설명되지
+  않을 때만 사용합니다. 문서 내용이 아니라 포맷 내부 구조를 출력합니다.
 - `hwp lint {file.md|file.hwp|file.hwpx} [--json] [--strict] [--profile gongmun|report]` —
   공문서 표기·구조 규칙 열 가지를 검사합니다 (`-`는 표준 입력을 markdown으로 읽습니다).
   기본은 조언용이라 항상 종료 코드 0이며, `--strict`가 error 등급 지적을 찾았을 때만
@@ -271,7 +274,7 @@ Quick의 로컬 폴터 권한에 추가된 폴터는 내장 읽기/검색 도구
 
 Quick 설정을 도와줄 때는 JSON 임포트를 선호하고, 인수 안에 셸 인용 문자를 넣지 마세요.
 세 계층을 순서대로 검증하세요: 정확한 절대 경로 바이너리가 버전을 반환하는지; Quick이
-20개 도구를 보고하고 새로고침 후에도 활성 상태인지; 마지막으로 `hwp_new`와 이어진
+22개 도구를 보고하고 새로고침 후에도 활성 상태인지; 마지막으로 `hwp_new`와 이어진
 `hwp_validate`가 설정된 LocalLow 루트 아래 절대 경로에서 성공하는지 (예:
 `C:\Users\YOUR_NAME\AppData\LocalLow\hwp-quick-workspace\quick-hwp-smoke.hwpx`).
 디스커버리만으로 파일 접근이 증명된다고 주장하지 마세요.
@@ -280,7 +283,7 @@ Quick 설정을 도와줄 때는 JSON 임포트를 선호하고, 인수 안에 �
 복사-붙여넣기 운영자 및 AI 런북:
 `https://github.com/STAIxBWLB/hwp-cli/blob/main/docs/manual/amazon-quick-desktop.md`.
 
-도구 (20):
+도구 (22):
 
 | 도구 | 필수 인수 | 용도 |
 |---|---|---|

--- a/skills/hwp/SKILL.md
+++ b/skills/hwp/SKILL.md
@@ -108,6 +108,9 @@ syntax (used by `fill`, `slots` and the template tools).
   — list fields (name/kind/value), bookmarks (bokm), `{{name}}` template slots.
 - `hwp validate {file} [--json]` — structural validation (mimetype, required entries, XML
   parsing); exit code 0 when valid.
+- `hwp dump {file} [--stream DocInfo|BodyText/Section0|Contents/header.xml] [--raw] [--json]`:
+  low-level record and stream diagnostics for a single file. Reach for it only when `hwp info`
+  and `hwp validate` do not explain a defect; it prints format internals, not document content.
 - `hwp lint {file.md|file.hwp|file.hwpx} [--json] [--strict] [--profile gongmun|report]` — ten
   official-document notation and structure rules (`-` reads stdin as markdown). Advisory: it
   always exits 0 unless `--strict` finds an error-severity finding. `--json` prints the
@@ -283,7 +286,7 @@ After a connector edit, refresh or start a new chat instead of reusing an old ge
 The copy-paste operator and AI runbook is:
 `https://github.com/STAIxBWLB/hwp-cli/blob/main/docs/manual/amazon-quick-desktop.md`.
 
-Tools (20):
+Tools (22):
 
 | Tool | Required arguments | Purpose |
 |---|---|---|
@@ -312,8 +315,8 @@ Tools (20):
 
 ## HTTP mode for containers
 
-`hwp serve` speaks the same protocol as `hwp mcp`, over HTTP instead of stdio, so the same twenty
-tools are reachable from a container. It is meant to sit behind a trusted edge that has already
+`hwp serve` speaks the same protocol as `hwp mcp`, over HTTP instead of stdio, so the same
+22 tools are reachable from a container. It is meant to sit behind a trusted edge that has already
 terminated TLS, authenticated the caller and capped the request body — not to face the internet
 directly.
 


### PR DESCRIPTION
## Summary

Enforce RLSE-03 release-copy requirements in local checks, GitHub CI, and the release boundary. Forbidden claims and stale CLI/MCP documentation fail before release; release copy must contain one marked Verification block backed by a successful readiness run.

- Check claim families in English and Korean, with exact-line exemptions and positive/negative fixtures.
- Compare documented counts and skill coverage with a freshly built MCP server. Cargo checks freshness on every default invocation; an explicit `HWP_BIN` override remains supported.
- Generate or replace only the marked Verification region, preserving surrounding release notes.
- Validate workflow identity, conclusion, and commit binding in both `release.sh` and `release.yml`. PR #240 supersedes this PR's API `head_sha` comparison with downloaded-record `evaluated_sha` validation and separate workflow-source provenance.
- Run the gates in CI, including path-filter coverage for all scanned inputs, and update stale English/Korean counts and skill coverage.

Refs RLSE-03, Phase 04-02. Applies to the next release, v0.18.0; no tag or release is created here.

## Validation

- `scripts/check.sh`: fmt, clippy, workspace tests, PDF runner, structured corpus, claim checks, documentation checks, and Verification-block fixtures.
- Stale-binary probe reproduced before the fix; after the fix, the default rebuilds an existing executable and an explicit override avoids the build.
- `bash -n`, `shellcheck`, and `git diff --check`.
- Public PDF parity runs on pinned Ubuntu CI; the local macOS gate reports an explicit skip when the pinned Poppler version is absent.
- No writer, renderer, or IR changes; no Hancom acceptance observation is claimed.
