### PR TITLE
ci(release): add the manual release-readiness run and record its gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,12 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: bash scripts/release_verification_block.sh --self-test
+      # Runs the readiness workflow's own steps against fixtures: the trust policy, the gate
+      # entries the record is assembled from, and the release binding that reads it.
+      - name: Release readiness workflow fixtures
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: bash scripts/tests/release-readiness-selfcheck.sh
 
   pdf-parity:
     name: pdf-parity

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ name: CI
 # The same list must be kept identical under push and pull_request (GitHub Actions does not
 # support YAML anchors).
 on:
+  # Readiness binds CI to the exact evaluated SHA, including docs-only main commits.
+  # Run this manually before readiness when the path filters skip automatic CI.
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -18,13 +18,15 @@ name: Release readiness
 #
 # Controller steps and target steps. A step that executes code from the evaluated ref is a target
 # step: it runs the command, captures stdout/stderr into $RUNNER_TEMP/gates/<name>/log, and does
-# nothing else. It is never told where the ledger is - the ledger path is a random file name held
-# in a step OUTPUT of the prepare step, which the runner passes only to the steps that reference
-# it, and it is never written to $GITHUB_ENV (which every later step, target steps included,
-# receives). Every gate ENTRY is written by a controller step, whose shell lives in this file (the
-# dispatch ref) rather than in the evaluated checkout, from the target step's recorded outcome.
-# So a gate script from the evaluated ref decides its own exit status and nothing else: it cannot
-# append an entry, rewrite an earlier one, or change what the record says about it.
+# nothing else. Every gate ENTRY is written by a controller step, whose shell lives in this file
+# (the dispatch ref) rather than in the evaluated checkout, out of `steps.<id>.outcome` - the exit
+# status the runner recorded for the target step, which no process on the runner can rewrite.
+# There is deliberately no ledger file shared across steps: a random name under $RUNNER_TEMP would
+# still be one `find` away for a gate script running as the same user. Each controller step keeps
+# its entries in a file that lives only for the length of that step and hands them to the record
+# assembly as a step OUTPUT instead. So a gate script from the evaluated ref decides its own exit
+# status and nothing else: it cannot append an entry, rewrite an earlier one, or change what the
+# record says about it.
 #
 # Step order is dependency order, not checklist order: the clean-tree gate runs before anything
 # writes to the checkout, and the public parity gate runs last because it writes scorecards into
@@ -68,10 +70,11 @@ jobs:
       # ref, not the code this run evaluated; scripts/check-verification-block.sh compares the
       # record's evaluated_sha instead.
       #
-      # The ledger and the check-run file are created here, with random names, and their paths
-      # leave this step as step outputs only. Nothing puts them in $GITHUB_ENV, so no target step
-      # is handed a way to locate the evidence.
-      - name: Prepare the controller ledger
+      # There is no shared ledger file for a gate script to find: each controller step keeps its
+      # entries in a file of its own for the length of that one step and emits them as a step
+      # output, which the runner holds and which nothing running later can write to. Nothing goes
+      # into $GITHUB_ENV either, since every later step - target steps included - receives that.
+      - name: Prepare the evaluated commit
         id: prepare
         shell: bash
         env:
@@ -79,14 +82,8 @@ jobs:
         run: |
           set -euo pipefail
           sha="$(git rev-parse HEAD)"
-          ledger="$(mktemp "$RUNNER_TEMP/ledger.XXXXXXXXXXXX")"
-          check_runs="$(mktemp "$RUNNER_TEMP/check-runs.XXXXXXXXXXXX")"
           mkdir -p "$RUNNER_TEMP/gates"
-          {
-            echo "evaluated_sha=$sha"
-            echo "ledger=$ledger"
-            echo "check_runs=$check_runs"
-          } >>"$GITHUB_OUTPUT"
+          echo "evaluated_sha=$sha" >>"$GITHUB_OUTPUT"
           echo "ref=$READINESS_REF evaluated_sha=$sha workflow_source_sha=$GITHUB_SHA"
 
       # The gate that has to come before every target step: this run executes the evaluated ref's
@@ -163,12 +160,15 @@ jobs:
       # fetch fonts and write parity scorecards into the working tree. Controller step: `git
       # status` reads the checkout, it does not execute anything from it.
       - name: Gate clean-tree
+        id: gate-clean-tree
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
-        env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           dirty="$(git status --porcelain --untracked-files=all)"
           if [ -z "$dirty" ]; then
             status=pass
@@ -178,6 +178,11 @@ jobs:
             evidence="git status --short --untracked-files=all is not empty: $(echo "$dirty" | tr '\n' ';')"
           fi
           printf '%s\t%s\t%s\n' clean-tree "$status" "$evidence" >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       - if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         uses: dtolnay/rust-toolchain@1.93.0
@@ -248,19 +253,28 @@ jobs:
           exit "${PIPESTATUS[0]}"
 
       - name: Gate fmt
+        id: gate-fmt
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
           OUTCOME: ${{ steps.target-fmt.outcome }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           case "$OUTCOME" in
           success) status=pass ;;
           failure) status=fail ;;
           *) status=pending ;;
           esac
           printf '%s\t%s\t%s\n' fmt "$status" 'cargo fmt --all --check' >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       - name: Target clippy
         id: target-clippy
@@ -274,19 +288,28 @@ jobs:
           exit "${PIPESTATUS[0]}"
 
       - name: Gate clippy
+        id: gate-clippy
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
           OUTCOME: ${{ steps.target-clippy.outcome }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           case "$OUTCOME" in
           success) status=pass ;;
           failure) status=fail ;;
           *) status=pending ;;
           esac
           printf '%s\t%s\t%s\n' clippy "$status" 'cargo clippy --workspace --all-targets -- -D warnings' >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # No font package is installed anywhere in this job, which is what keeps the corpus gate's
       # no-ambient-font line meaningful. The render tests print "skip: no usable font" and drop
@@ -305,19 +328,28 @@ jobs:
           exit "${PIPESTATUS[0]}"
 
       - name: Gate test-workspace
+        id: gate-test-workspace
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
           OUTCOME: ${{ steps.target-test.outcome }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           case "$OUTCOME" in
           success) status=pass ;;
           failure) status=fail ;;
           *) status=pending ;;
           esac
           printf '%s\t%s\t%s\n' test-workspace "$status" 'cargo test --workspace' >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # One script, four checklist lines: it also validates the three frozen corpus schemas and
       # asserts the manifest pins and TRACKED_FILES.txt are in the Git index. The three derived
@@ -337,13 +369,17 @@ jobs:
       # derived entries are not re-executed: when the corpus gate failed, the schema and index
       # checks inside it did not report a pass either.
       - name: Gates structured-corpus, corpus-schemas and corpus-git-index
+        id: gate-corpus
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
           OUTCOME: ${{ steps.target-corpus.outcome }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           case "$OUTCOME" in
           success) status=pass ;;
           failure) status=fail ;;
@@ -356,18 +392,26 @@ jobs:
             printf '%s\t%s\t%s\n' corpus-git-index "$status" \
               'scripts/check-structured-corpus.sh checks every TRACKED_FILES.txt entry and every corpus schema with git ls-files --error-unmatch and git check-ignore'
           } >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # Structural plus a runtime assertion on the environment the corpus gate just ran in: this
       # job installs poppler-utils only and never a font package, and no step sets HWP_FONT_DIR
       # for the corpus gate (only the public parity target step sets it, on its own step). The
       # corpus font bytes come from scripts/fetch-corpus-fonts.sh through the manifest hashes.
       - name: Gate corpus-no-ambient-fonts
+        id: gate-corpus-no-ambient-fonts
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
-        env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           if [ -n "${HWP_FONT_DIR:-}" ]; then
             status=fail
             evidence="the job environment the corpus gate ran in sets HWP_FONT_DIR=${HWP_FONT_DIR}"
@@ -376,6 +420,11 @@ jobs:
             evidence='the corpus gate step declares no font environment variable and the job installs poppler-utils only, never a font package; corpus fonts come from scripts/fetch-corpus-fonts.sh through the manifest hashes'
           fi
           printf '%s\t%s\t%s\n' corpus-no-ambient-fonts "$status" "$evidence" >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       - name: Target corpus-fonts-reproduce
         id: target-corpus-fonts
@@ -392,13 +441,17 @@ jobs:
           exit "${PIPESTATUS[0]}"
 
       - name: Gate corpus-fonts-reproduce
+        id: gate-corpus-fonts-reproduce
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
           OUTCOME: ${{ steps.target-corpus-fonts.outcome }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           case "$OUTCOME" in
           success) status=pass ;;
           failure) status=fail ;;
@@ -406,16 +459,24 @@ jobs:
           esac
           printf '%s\t%s\t%s\n' corpus-fonts-reproduce "$status" \
             'bash scripts/fetch-corpus-fonts.sh against an emptied corpus/structured-v1/fonts; the script verifies every font, license and metadata file against the manifest sha256' >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # The checklist line is conditional ("if the corpus ships"). It does not: release.yml
       # publishes the hwp binary archive only. Assert that shape rather than assume it.
       - name: Gate release-archive-fonts
+        id: gate-release-archive-fonts
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
-        env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           status=pass
           evidence='.github/workflows/release.yml packages bin: hwp through upload-rust-binary-action and names no font file, so the corpus does not ship and no OFL inventory is required'
           if grep -nEi '\.(ttf|otf|ttc|woff2?)' .github/workflows/release.yml; then
@@ -426,6 +487,11 @@ jobs:
             evidence='.github/workflows/release.yml no longer packages bin: hwp; the archive contents must be re-checked by hand'
           fi
           printf '%s\t%s\t%s\n' release-archive-fonts "$status" "$evidence" >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # Not applicable by construction, and never a pass. The independent import oracle is the
       # LibreOffice + H2Orestart certification container of docs/design/16-certification-v1.md,
@@ -437,10 +503,12 @@ jobs:
         id: oracle
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
-        env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -euo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           lock=oracle/primary-artifacts.lock.json
           eval "$(python3 - "$lock" <<'PY'
           import hashlib
@@ -465,19 +533,32 @@ jobs:
           printf '%s\t%s\t%s\n' independent-oracle 'n/a' \
             "no supported public oracle image is shipped by this repository: docs/design/16-certification-v1.md section 'Independent import oracle' states that required oracle mode remains partial until the image gaps are closed, and $lock reports status $lock_status with a null image digest, so the gate cannot run and is not a pass" \
             >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # Not applicable in CI: the Hancom-open evidence is an owner observation made on Hancom
       # Office, and the receipts are private (never committed).
       - name: Gate hancom-receipt
+        id: gate-hancom-receipt
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
-        env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           printf '%s\t%s\t%s\n' hancom-receipt 'n/a' \
             'the hancom-verification-receipt-v1 receipts are recorded by the owner opening each artifact in Hancom Office and are kept privately outside the repository; CI has no Hancom oracle, so this gate cannot run here and is not a pass' \
             >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # Checklist line 26-27, the release-copy claim lint. Guarded: a retroactive dispatch may
       # evaluate a ref from before this script existed, and a missing script is n/a, never a pass.
@@ -498,14 +579,18 @@ jobs:
           exit "${PIPESTATUS[0]}"
 
       - name: Gate release-copy-claims
+        id: gate-release-copy-claims
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
           OUTCOME: ${{ steps.target-claims.outcome }}
           READINESS_REF: ${{ inputs.ref }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           script=scripts/check-claims.sh
           if [ ! -f "$script" ]; then
             status='n/a'
@@ -519,6 +604,11 @@ jobs:
             evidence="bash $script, the same file scripts/check.sh runs locally"
           fi
           printf '%s\t%s\t%s\n' release-copy-claims "$status" "$evidence" >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # Checklist lines 32-35. One script covers both lines: it reports the tool-count check and
       # the skill-coverage check in one invocation, so both entries carry that run's status and
@@ -540,14 +630,18 @@ jobs:
           exit "${PIPESTATUS[0]}"
 
       - name: Gates tool-count and skill-coverage
+        id: gate-doc-surface
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
           OUTCOME: ${{ steps.target-doc-surface.outcome }}
           READINESS_REF: ${{ inputs.ref }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           script=scripts/check-doc-surface.sh
           if [ ! -f "$script" ]; then
             status='n/a'
@@ -564,6 +658,11 @@ jobs:
             "$detail the documented tool counts against the length of the live hwp mcp tools/list response" >>"$GATES_FILE"
           printf '%s\t%s\t%s\n' skill-coverage "$status" \
             "$detail skills/hwp/SKILL.md and SKILL.ko.md naming every CLI subcommand and every MCP tool" >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # Checklist lines 30-31. Only meaningful against a tag: a branch is not a release being cut.
       # Three things this gate has to get right, because each of them used to turn a real release
@@ -577,82 +676,107 @@ jobs:
       #   - a missing file, a grep failure or an empty extraction is a `fail`. There is no reading
       #     of "the pinned versions could not be read" that is evidence the pins are right.
       - name: Gate readme-pinned-tag
+        id: gate-readme-pinned-tag
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
           READINESS_REF: ${{ inputs.ref }}
           EVALUATED_SHA: ${{ steps.prepare.outputs.evaluated_sha }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           tag="${READINESS_REF#refs/tags/}"
           tag_sha="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" 2>/dev/null)"
+          # One exit path, so the entry is always emitted: an early `exit 0` here would leave the
+          # record with no readme-pinned-tag line at all, which the assembly refuses.
           if [ -z "$tag_sha" ]; then
-            printf '%s\t%s\t%s\n' readme-pinned-tag 'n/a' \
-              "the evaluated ref ${READINESS_REF} is not a tag in this checkout, so there is no release being cut to compare the install snippets against" >>"$GATES_FILE"
-            exit 0
-          fi
-          if [ "$tag_sha" != "$EVALUATED_SHA" ]; then
-            printf '%s\t%s\t%s\n' readme-pinned-tag fail \
-              "refs/tags/${tag} points at ${tag_sha}, but this run evaluated ${EVALUATED_SHA}; the checkout and the tag disagree about which commit is being released" >>"$GATES_FILE"
-            exit 0
-          fi
-          # Only the install.sh snippets, which all pipe into `sh -s --`. `hwp update --tag v0.9.0`
-          # is a rollback example and is deliberately not compared. Each README must carry the
-          # complete pin on its own.
-          status=pass
-          evidence="the install.sh --tag snippets in README.md and README.ko.md pin ${tag}"
-          problems=""
-          for file in README.md README.ko.md; do
-            if [ ! -f "$file" ]; then
-              problems="${problems:+$problems; }$file does not exist"
-              continue
-            fi
-            snippets="$(grep -h -- 'sh -s --' "$file")"
-            if [ -z "$snippets" ]; then
-              problems="${problems:+$problems; }$file carries no install.sh 'sh -s --' snippet"
-              continue
-            fi
-            found="$(printf '%s\n' "$snippets" | grep -oE -- '--tag v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^--tag //' | sort -u)"
-            if [ -z "$found" ]; then
-              problems="${problems:+$problems; }$file has an install.sh snippet with no --tag pin"
-            elif [ "$found" != "$tag" ]; then
-              problems="${problems:+$problems; }$file pins $(echo "$found" | tr '\n' ' ')instead of ${tag}"
-            fi
-          done
-          if [ -n "$problems" ]; then
+            status='n/a'
+            evidence="the evaluated ref ${READINESS_REF} is not a tag in this checkout, so there is no release being cut to compare the install snippets against"
+          elif [ "$tag_sha" != "$EVALUATED_SHA" ]; then
             status=fail
-            evidence="the evaluated tag is ${tag}, but: ${problems}"
+            evidence="refs/tags/${tag} points at ${tag_sha}, but this run evaluated ${EVALUATED_SHA}; the checkout and the tag disagree about which commit is being released"
+          else
+            # Only the install.sh snippets, which all pipe into `sh -s --`. `hwp update --tag
+            # v0.9.0` is a rollback example and is deliberately not compared. Each README must
+            # carry the complete pin on its own.
+            status=pass
+            evidence="the install.sh --tag snippets in README.md and README.ko.md pin ${tag}"
+            problems=""
+            for file in README.md README.ko.md; do
+              if [ ! -f "$file" ]; then
+                problems="${problems:+$problems; }$file does not exist"
+                continue
+              fi
+              snippets="$(grep -h -- 'sh -s --' "$file")"
+              if [ -z "$snippets" ]; then
+                problems="${problems:+$problems; }$file carries no install.sh 'sh -s --' snippet"
+                continue
+              fi
+              found="$(printf '%s\n' "$snippets" | grep -oE -- '--tag v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^--tag //' | sort -u)"
+              if [ -z "$found" ]; then
+                problems="${problems:+$problems; }$file has an install.sh snippet with no --tag pin"
+              elif [ "$found" != "$tag" ]; then
+                problems="${problems:+$problems; }$file pins $(echo "$found" | tr '\n' ' ')instead of ${tag}"
+              fi
+            done
+            if [ -n "$problems" ]; then
+              status=fail
+              evidence="the evaluated tag is ${tag}, but: ${problems}"
+            fi
           fi
           printf '%s\t%s\t%s\n' readme-pinned-tag "$status" "$evidence" >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # Checklist line 29. A structural property of this workflow file rather than a runtime
       # command: the run holds a read-only token and declares no mutating step, which is what the
       # plan's own verify gate and review assert. Recorded as such, with no claim that a command
       # proved it.
       - name: Gate no-publish
+        id: gate-no-publish
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
-        env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           printf '%s\t%s\t%s\n' no-publish pass \
             'structural: the top-level permissions block of .github/workflows/release-readiness.yml grants contents: read and checks: read only, and the file declares no step that commits, creates or moves a ref, publishes a release or contacts a registry; the only upload is this run record artifact' \
             >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # Checklist lines 36-38. The comparison target is the retired STAIxBWLB/skills repository,
       # which is not checked out here, so this stays a manual cross-repository review.
       - name: Gate hwpx-skill-parity
+        id: gate-hwpx-skill-parity
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
-        env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           printf '%s\t%s\t%s\n' hwpx-skill-parity 'n/a' \
             'the retired downstream skills/hwpx lives in the separate STAIxBWLB/skills repository, which this run does not check out; the parity matrix in docs/design/23-hwpx-skill-absorption.md is compared by manual cross-repository review, so this gate cannot run here and is not a pass' \
             >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # Checklist line 12, read rather than re-run (D-07): the evaluated commit's own CI check
       # runs are the 3-OS evidence. The expected job names below must stay in sync with ci.yml,
@@ -660,15 +784,19 @@ jobs:
       # `pending` and fails the job; it is never a pass. Controller step: it queries the API, it
       # runs nothing from the evaluated ref.
       - name: Gate ci-matrix
+        id: gate-ci-matrix
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
-          CHECK_RUNS_FILE: ${{ steps.prepare.outputs.check_runs }}
           READINESS_SHA: ${{ steps.prepare.outputs.evaluated_sha }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
+          CHECK_RUNS_FILE="$(mktemp)"
           expected=("lint" "pdf-parity" "test (ubuntu-latest)" "test (macos-latest)" "test (windows-latest)")
           if ! runs="$(gh api "repos/$GITHUB_REPOSITORY/commits/$READINESS_SHA/check-runs?filter=latest&per_page=100")"; then
             runs='{"check_runs":[]}'
@@ -702,6 +830,14 @@ jobs:
             evidence="check-runs API for $READINESS_SHA: $problems"
           fi
           printf '%s\t%s\t%s\n' ci-matrix "$status" "$evidence" >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+            echo "check_runs<<CHECK_RUNS_EOF"
+            cat "$CHECK_RUNS_FILE"
+            echo "CHECK_RUNS_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # Checklist lines 21-25, last because it writes scorecards into the tracked scoreboard
       # directory. Same shape as ci.yml's pdf-parity job, against the committed public oracle,
@@ -724,13 +860,17 @@ jobs:
           exit "${PIPESTATUS[0]}"
 
       - name: Gate pdf-parity-public
+        id: gate-pdf-parity-public
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
           OUTCOME: ${{ steps.target-parity.outcome }}
         run: |
           set -uo pipefail
+          # The ledger is this controller step's own file: it exists only while this step
+          # runs, and the entries leave it as a step output the runner holds, so nothing
+          # that runs later can reach them.
+          GATES_FILE="$(mktemp)"
           case "$OUTCOME" in
           success) status=pass ;;
           failure) status=fail ;;
@@ -738,6 +878,11 @@ jobs:
           esac
           printf '%s\t%s\t%s\n' pdf-parity-public "$status" \
             'bash scripts/pdf-parity.sh run --oracle-dir fixtures/pdf-parity/public/oracle with the pinned Poppler and the exact OFL fonts; the public manifest declares no gate_exclusions, so every gate blocks' >>"$GATES_FILE"
+          {
+            echo "entry<<GATE_ENTRY_EOF"
+            cat "$GATES_FILE"
+            echo "GATE_ENTRY_EOF"
+          } >>"$GITHUB_OUTPUT"
 
       # --- run record ---------------------------------------------------------------------------
       # Runs even when a gate failed, so the record is always complete. It is the step that
@@ -748,8 +893,27 @@ jobs:
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
-          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
-          CHECK_RUNS_FILE: ${{ steps.prepare.outputs.check_runs }}
+          # One variable per controller step, each carrying that step's gate entries. This is the
+          # whole ledger: it is assembled here out of values the runner held, never out of a file
+          # any earlier step could have written to.
+          GATE_CLEAN_TREE: ${{ steps.gate-clean-tree.outputs.entry }}
+          GATE_FMT: ${{ steps.gate-fmt.outputs.entry }}
+          GATE_CLIPPY: ${{ steps.gate-clippy.outputs.entry }}
+          GATE_TEST_WORKSPACE: ${{ steps.gate-test-workspace.outputs.entry }}
+          GATE_CORPUS: ${{ steps.gate-corpus.outputs.entry }}
+          GATE_CORPUS_NO_AMBIENT_FONTS: ${{ steps.gate-corpus-no-ambient-fonts.outputs.entry }}
+          GATE_CORPUS_FONTS_REPRODUCE: ${{ steps.gate-corpus-fonts-reproduce.outputs.entry }}
+          GATE_RELEASE_ARCHIVE_FONTS: ${{ steps.gate-release-archive-fonts.outputs.entry }}
+          GATE_INDEPENDENT_ORACLE: ${{ steps.oracle.outputs.entry }}
+          GATE_HANCOM_RECEIPT: ${{ steps.gate-hancom-receipt.outputs.entry }}
+          GATE_RELEASE_COPY_CLAIMS: ${{ steps.gate-release-copy-claims.outputs.entry }}
+          GATE_DOC_SURFACE: ${{ steps.gate-doc-surface.outputs.entry }}
+          GATE_README_PINNED_TAG: ${{ steps.gate-readme-pinned-tag.outputs.entry }}
+          GATE_NO_PUBLISH: ${{ steps.gate-no-publish.outputs.entry }}
+          GATE_HWPX_SKILL_PARITY: ${{ steps.gate-hwpx-skill-parity.outputs.entry }}
+          GATE_CI_MATRIX: ${{ steps.gate-ci-matrix.outputs.entry }}
+          GATE_PDF_PARITY_PUBLIC: ${{ steps.gate-pdf-parity-public.outputs.entry }}
+          CHECK_RUNS: ${{ steps.gate-ci-matrix.outputs.check_runs }}
           READINESS_REF: ${{ inputs.ref }}
           READINESS_SHA: ${{ steps.prepare.outputs.evaluated_sha }}
           WORKFLOW_SOURCE_SHA: ${{ github.sha }}
@@ -836,21 +1000,25 @@ jobs:
               """Digests are recorded as lowercase hexadecimal, never mixed case."""
               return value.lower() if HEX.match(value.lower()) else value
 
-          def read_tsv(path, fields):
+          def read_tsv(source, text, fields):
               rows = []
-              with open(path, encoding="utf-8") as handle:
-                  for number, line in enumerate(handle, 1):
-                      line = line.rstrip("\n")
-                      if not line:
-                          continue
-                      parts = line.split("\t")
-                      if len(parts) != fields:
-                          sys.exit(f"{path} line {number} has {len(parts)} fields, not {fields}")
-                      rows.append([part.strip() for part in parts])
+              for number, line in enumerate(text.splitlines(), 1):
+                  if not line.strip():
+                      continue
+                  parts = line.split("\t")
+                  if len(parts) != fields:
+                      sys.exit(f"{source} line {number} has {len(parts)} fields, not {fields}")
+                  rows.append([part.strip() for part in parts])
               return rows
 
+          def gate_entries():
+              """Every GATE_* variable holds the entries one controller step emitted."""
+              for key in sorted(os.environ):
+                  if key.startswith("GATE_"):
+                      yield from read_tsv(key, os.environ[key], 3)
+
           recorded = {}
-          for name, status, evidence in read_tsv(os.environ["GATES_FILE"], 3):
+          for name, status, evidence in gate_entries():
               if status not in ALLOWED:
                   sys.exit(f"gate {name!r} has status {status!r}, not one of {ALLOWED}")
               if not name or not evidence:
@@ -867,10 +1035,7 @@ jobs:
               sys.exit(f"checklist lines with no recorded gate: {missing}")
           gates = [recorded[name] for name in CHECKLIST]
 
-          check_runs = {}
-          check_runs_path = os.environ.get("CHECK_RUNS_FILE", "")
-          if check_runs_path and os.path.exists(check_runs_path):
-              check_runs = {name: state for name, state in read_tsv(check_runs_path, 2)}
+          check_runs = dict(read_tsv("CHECK_RUNS", os.environ.get("CHECK_RUNS", ""), 2))
 
           blocking = [g for g in gates if g["status"] in ("fail", "pending")]
 

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -9,6 +9,11 @@ name: Release readiness
 # readiness run". That is why the permissions below are read-only and why no step in this file
 # commits, creates or moves a ref, publishes a release, or builds or pushes an image. The only
 # thing the run uploads is its own record artifact.
+#
+# Step order is dependency order, not checklist order: the clean-tree gate runs before anything
+# writes to the checkout, and the public parity gate runs last because it writes scorecards into
+# the tracked scoreboard directory. The record assembly re-orders every entry into the checklist's
+# order, and fails when an entry is missing, duplicated or unknown.
 on:
   workflow_dispatch:
     inputs:
@@ -39,26 +44,88 @@ jobs:
       # ref's, so resolve the checked-out commit explicitly and use it everywhere below.
       - name: Resolve the evaluated commit
         shell: bash
+        env:
+          READINESS_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
           sha="$(git rev-parse HEAD)"
-          echo "READINESS_SHA=$sha" >>"$GITHUB_ENV"
-          echo "GATES_FILE=$RUNNER_TEMP/gates.tsv" >>"$GITHUB_ENV"
+          {
+            echo "READINESS_SHA=$sha"
+            echo "GATES_FILE=$RUNNER_TEMP/gates.tsv"
+            echo "CHECK_RUNS_FILE=$RUNNER_TEMP/check-runs.tsv"
+          } >>"$GITHUB_ENV"
           : >"$RUNNER_TEMP/gates.tsv"
           echo "ref=$READINESS_REF sha=$sha"
-        env:
-          READINESS_REF: ${{ inputs.ref }}
+
+      # Checklist line 28, run first: the checklist asks for a clean checkout, and later gates
+      # fetch fonts and write parity scorecards into the working tree.
+      - name: Gate clean-tree
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          dirty="$(git status --porcelain --untracked-files=all)"
+          if [ -z "$dirty" ]; then
+            status=pass
+            evidence='git status --short --untracked-files=all is empty on the fresh checkout'
+          else
+            status=fail
+            evidence="git status --short --untracked-files=all is not empty: $(echo "$dirty" | tr '\n' ';')"
+          fi
+          printf '%s\t%s\t%s\n' clean-tree "$status" "$evidence" >>"$GATES_FILE"
+
       - uses: dtolnay/rust-toolchain@1.93.0
         with:
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2
 
-      # --- gates, in docs/release-readiness.md order -------------------------------------------
+      # Copied from ci.yml's pdf-parity job, including the mirror pin and the bounded retry: the
+      # public manifest pins the Poppler version, so the parity gate is only meaningful when the
+      # installed pdfinfo matches it.
+      - name: Install pinned Poppler tools
+        if: ${{ !cancelled() }}
+        shell: bash
+        # Worst case is 3 x (120s update + 120s install) + 2 x 10s sleep, ~12.3 min;
+        # with the mirror pinned and apt-level timeouts the normal case is seconds.
+        timeout-minutes: 15
+        run: |
+          set -euo pipefail
+          # Hosted 24.04 runners select repositories through mirror+file:/etc/apt/apt-mirrors.txt
+          # with the azure mirror first, and that mirror intermittently accepts the connection and
+          # then stalls (#119). Pin the official archive there (the .sources sed is belt-and-braces
+          # for runners without the mirrorlist) and cap apt's own per-request waits.
+          echo "https://archive.ubuntu.com/ubuntu" | sudo tee /etc/apt/apt-mirrors.txt >/dev/null
+          sudo sed -i 's|http://azure\.archive\.ubuntu\.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+            /etc/apt/sources.list /etc/apt/sources.list.d/*.sources 2>/dev/null || true
+          apt_get="sudo apt-get -o Acquire::http::Timeout=10 -o Acquire::https::Timeout=10 -o Acquire::Retries=1"
+          installed=0
+          # $apt_get is a command prefix with options and must word-split, which is why ci.yml
+          # writes it the same way.
+          # shellcheck disable=SC2086
+          for attempt in 1 2 3; do
+            if timeout 120 $apt_get update && timeout 120 $apt_get install --no-install-recommends -y poppler-utils; then
+              installed=1
+              break
+            fi
+            echo "poppler install attempt ${attempt} failed or timed out; retrying" >&2
+            sleep 10
+          done
+          if [ "$installed" != 1 ]; then
+            echo "poppler-utils could not be installed after 3 attempts" >&2
+            exit 1
+          fi
+          expected="$(python3 -c 'import json; print(json.load(open("fixtures/pdf-parity/public/manifest.json", encoding="utf-8"))["pins"]["poppler_version"])')"
+          actual="$(pdfinfo -v 2>&1 | sed -n '1p')"
+          echo "pdfinfo: $actual"
+          echo "PDFINFO_VERSION=$actual" >>"$GITHUB_ENV"
+          test "$actual" = "$expected"
+
+      # --- gates ---------------------------------------------------------------------------------
       # Every gate step records one tab-separated `name<TAB>status<TAB>evidence` line and never
       # fails the job itself: the record-assembly step decides the outcome, so one run reports
       # every gate instead of stopping at the first failure. `if: ${{ !cancelled() }}` keeps the
-      # remaining gates running when an earlier step does fail anyway (same idiom as ci.yml's
-      # lint job).
+      # remaining gates running when a non-gate step does fail (same idiom as ci.yml's lint job).
+
       - name: Gate fmt
         if: ${{ !cancelled() }}
         shell: bash
@@ -66,6 +133,302 @@ jobs:
           set -uo pipefail
           if cargo fmt --all --check; then status=pass; else status=fail; fi
           printf '%s\t%s\t%s\n' fmt "$status" 'cargo fmt --all --check' >>"$GATES_FILE"
+
+      - name: Gate clippy
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          if cargo clippy --workspace --all-targets -- -D warnings; then status=pass; else status=fail; fi
+          printf '%s\t%s\t%s\n' clippy "$status" 'cargo clippy --workspace --all-targets -- -D warnings' >>"$GATES_FILE"
+
+      # No font package is installed anywhere in this job, which is what keeps the corpus gate's
+      # no-ambient-font line meaningful. The render tests print "skip: no usable font" and drop
+      # their text assertions when no system CJK face exists; the 3-OS matrix cited by the
+      # ci-matrix gate is where those assertions actually run (ci.yml's test job installs
+      # fonts-nanum).
+      - name: Gate test-workspace
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          if cargo test --workspace; then status=pass; else status=fail; fi
+          printf '%s\t%s\t%s\n' test-workspace "$status" 'cargo test --workspace' >>"$GATES_FILE"
+
+      # One script, four checklist lines: it also validates the three frozen corpus schemas and
+      # asserts the manifest pins and TRACKED_FILES.txt are in the Git index. The three derived
+      # entries below cite it rather than re-running any of that.
+      - name: Gate structured-corpus
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          if bash scripts/check-structured-corpus.sh; then status=pass; else status=fail; fi
+          printf '%s\t%s\t%s\n' structured-corpus "$status" 'bash scripts/check-structured-corpus.sh' >>"$GATES_FILE"
+
+      # Derived from the run above, not re-executed. The status is that run's status: when the
+      # corpus gate failed, the schema and index checks inside it did not report a pass either.
+      - name: Gates corpus-schemas and corpus-git-index (derived from the corpus run)
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          status="$(awk -F'\t' '$1 == "structured-corpus" { print $2 }' "$GATES_FILE")"
+          [ -n "$status" ] || status=pending
+          printf '%s\t%s\t%s\n' corpus-schemas "$status" \
+            'scripts/check-structured-corpus.sh validates the manifest, the run summary and the artifacts against schemas/structured-corpus{,-run,-artifacts}-v1.schema.json through the validate_structured_corpus example' >>"$GATES_FILE"
+          printf '%s\t%s\t%s\n' corpus-git-index "$status" \
+            'scripts/check-structured-corpus.sh checks every TRACKED_FILES.txt entry and every corpus schema with git ls-files --error-unmatch and git check-ignore' >>"$GATES_FILE"
+
+      # Structural plus a runtime assertion on the environment the corpus gate just ran in: this
+      # job installs poppler-utils only and never a font package, and no step sets HWP_FONT_DIR
+      # for the corpus gate (only the public parity gate sets it, on its own step). The corpus
+      # font bytes come from scripts/fetch-corpus-fonts.sh through the manifest hashes.
+      - name: Gate corpus-no-ambient-fonts
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          if [ -n "${HWP_FONT_DIR:-}" ]; then
+            status=fail
+            evidence="the job environment the corpus gate ran in sets HWP_FONT_DIR=${HWP_FONT_DIR}"
+          else
+            status=pass
+            evidence='the corpus gate step declares no font environment variable and the job installs poppler-utils only, never a font package; corpus fonts come from scripts/fetch-corpus-fonts.sh through the manifest hashes'
+          fi
+          printf '%s\t%s\t%s\n' corpus-no-ambient-fonts "$status" "$evidence" >>"$GATES_FILE"
+
+      - name: Gate corpus-fonts-reproduce
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          # From a clean fonts directory, so the script's own sha256 verification against the
+          # manifest is what passes the gate, not a cached byte.
+          rm -rf corpus/structured-v1/fonts
+          if bash scripts/fetch-corpus-fonts.sh; then status=pass; else status=fail; fi
+          printf '%s\t%s\t%s\n' corpus-fonts-reproduce "$status" \
+            'bash scripts/fetch-corpus-fonts.sh against an emptied corpus/structured-v1/fonts; the script verifies every font, license and metadata file against the manifest sha256' >>"$GATES_FILE"
+
+      # The checklist line is conditional ("if the corpus ships"). It does not: release.yml
+      # publishes the hwp binary archive only. Assert that shape rather than assume it.
+      - name: Gate release-archive-fonts
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          status=pass
+          evidence='.github/workflows/release.yml packages bin: hwp through upload-rust-binary-action and names no font file, so the corpus does not ship and no OFL inventory is required'
+          if grep -nEi '\.(ttf|otf|ttc|woff2?)' .github/workflows/release.yml; then
+            status=fail
+            evidence='.github/workflows/release.yml names a font file in the published assets, so the archive needs an OFL license inventory'
+          elif ! grep -q 'bin: hwp' .github/workflows/release.yml; then
+            status=fail
+            evidence='.github/workflows/release.yml no longer packages bin: hwp; the archive contents must be re-checked by hand'
+          fi
+          printf '%s\t%s\t%s\n' release-archive-fonts "$status" "$evidence" >>"$GATES_FILE"
+
+      # Not applicable by construction, and never a pass. The independent import oracle is the
+      # LibreOffice + H2Orestart certification container of docs/design/16-certification-v1.md,
+      # section "Independent import oracle"; this repository ships no supported public image for
+      # it. The status is read from the lock file so a future lock file moves the record with it,
+      # and nothing here builds, tags or attests an image.
+      - name: Gate independent-oracle
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          lock=oracle/primary-artifacts.lock.json
+          eval "$(python3 - "$lock" <<'PY'
+          import hashlib
+          import json
+          import shlex
+          import sys
+
+          path = sys.argv[1]
+          raw = open(path, "rb").read()
+          lock = json.loads(raw.decode("utf-8"))
+          status = lock["status"]
+          digest = hashlib.sha256(raw).hexdigest()
+          print("lock_status=" + shlex.quote(status))
+          print("oracle=" + shlex.quote("partial" if status.startswith("partial") else status))
+          print("lock_sha256=" + shlex.quote(digest.lower()))
+          PY
+          )"
+          echo "ORACLE_STATUS=$oracle" >>"$GITHUB_ENV"
+          echo "ORACLE_LOCK_SHA256=$lock_sha256" >>"$GITHUB_ENV"
+          printf '%s\t%s\t%s\n' independent-oracle 'n/a' \
+            "no supported public oracle image is shipped by this repository: docs/design/16-certification-v1.md section 'Independent import oracle' states that required oracle mode remains partial until the image gaps are closed, and $lock reports status $lock_status with a null image digest, so the gate cannot run and is not a pass" \
+            >>"$GATES_FILE"
+
+      # Not applicable in CI: the Hancom-open evidence is an owner observation made on Hancom
+      # Office, and the receipts are private (never committed).
+      - name: Gate hancom-receipt
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          printf '%s\t%s\t%s\n' hancom-receipt 'n/a' \
+            'the hancom-verification-receipt-v1 receipts are recorded by the owner opening each artifact in Hancom Office and are kept privately outside the repository; CI has no Hancom oracle, so this gate cannot run here and is not a pass' \
+            >>"$GATES_FILE"
+
+      # Checklist line 26-27, the release-copy claim lint. Guarded: a retroactive dispatch may
+      # evaluate a ref from before this script existed, and a missing script is n/a, never a pass.
+      - name: Gate release-copy-claims
+        if: ${{ !cancelled() }}
+        shell: bash
+        env:
+          READINESS_REF: ${{ inputs.ref }}
+        run: |
+          set -uo pipefail
+          script=scripts/check-claims.sh
+          if [ ! -f "$script" ]; then
+            status='n/a'
+            evidence="$script is absent from the checkout of $READINESS_REF, so the claim lint cannot run against that ref"
+          else
+            if bash "$script"; then status=pass; else status=fail; fi
+            evidence="bash $script, the same file scripts/check.sh runs locally"
+          fi
+          printf '%s\t%s\t%s\n' release-copy-claims "$status" "$evidence" >>"$GATES_FILE"
+
+      # Checklist lines 32-35. One script covers both lines: it reports the tool-count check and
+      # the skill-coverage check in one invocation, so both entries carry that run's status and
+      # say which check they stand for. Guarded the same way as the claim lint.
+      - name: Gates tool-count and skill-coverage
+        if: ${{ !cancelled() }}
+        shell: bash
+        env:
+          READINESS_REF: ${{ inputs.ref }}
+        run: |
+          set -uo pipefail
+          script=scripts/check-doc-surface.sh
+          if [ ! -f "$script" ]; then
+            status='n/a'
+            detail="$script is absent from the checkout of $READINESS_REF, so this check could not run:"
+          else
+            if bash "$script"; then status=pass; else status=fail; fi
+            detail="bash $script, one invocation that reports both checks, so both entries carry its status:"
+          fi
+          printf '%s\t%s\t%s\n' tool-count "$status" \
+            "$detail the documented tool counts against the length of the live hwp mcp tools/list response" >>"$GATES_FILE"
+          printf '%s\t%s\t%s\n' skill-coverage "$status" \
+            "$detail skills/hwp/SKILL.md and SKILL.ko.md naming every CLI subcommand and every MCP tool" >>"$GATES_FILE"
+
+      # Checklist lines 30-31. Only meaningful against a tag: a branch is not a release being cut.
+      - name: Gate readme-pinned-tag
+        if: ${{ !cancelled() }}
+        shell: bash
+        env:
+          READINESS_REF: ${{ inputs.ref }}
+        run: |
+          set -uo pipefail
+          if ! git rev-parse -q --verify "refs/tags/${READINESS_REF}^{commit}" >/dev/null; then
+            printf '%s\t%s\t%s\n' readme-pinned-tag 'n/a' \
+              "the evaluated ref ${READINESS_REF} is not a tag in this checkout, so there is no release being cut to compare the install snippets against" >>"$GATES_FILE"
+            exit 0
+          fi
+          # Only the install.sh snippets, which all pipe into `sh -s --`. `hwp update --tag v0.9.0`
+          # is a rollback example and is deliberately not compared.
+          found="$(grep -h -- 'sh -s --' README.md README.ko.md | grep -oE -- '--tag v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^--tag //' | sort -u)"
+          if [ -z "$found" ]; then
+            status=fail
+            evidence='no install.sh --tag snippet was found in README.md or README.ko.md; the version-pinned examples cannot be checked'
+          elif [ "$found" = "$READINESS_REF" ]; then
+            status=pass
+            evidence="the install.sh --tag snippets in README.md and README.ko.md pin ${READINESS_REF}"
+          else
+            status=fail
+            evidence="the install.sh --tag snippets in README.md and README.ko.md pin $(echo "$found" | tr '\n' ' ')but the evaluated tag is ${READINESS_REF}"
+          fi
+          printf '%s\t%s\t%s\n' readme-pinned-tag "$status" "$evidence" >>"$GATES_FILE"
+
+      # Checklist line 29. A structural property of this workflow file rather than a runtime
+      # command: the run holds a read-only token and declares no mutating step, which is what the
+      # plan's own verify gate and review assert. Recorded as such, with no claim that a command
+      # proved it.
+      - name: Gate no-publish
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          printf '%s\t%s\t%s\n' no-publish pass \
+            'structural: the top-level permissions block of .github/workflows/release-readiness.yml grants contents: read and checks: read only, and the file declares no step that commits, creates or moves a ref, publishes a release or contacts a registry; the only upload is this run record artifact' \
+            >>"$GATES_FILE"
+
+      # Checklist lines 36-38. The comparison target is the retired STAIxBWLB/skills repository,
+      # which is not checked out here, so this stays a manual cross-repository review.
+      - name: Gate hwpx-skill-parity
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          printf '%s\t%s\t%s\n' hwpx-skill-parity 'n/a' \
+            'the retired downstream skills/hwpx lives in the separate STAIxBWLB/skills repository, which this run does not check out; the parity matrix in docs/design/23-hwpx-skill-absorption.md is compared by manual cross-repository review, so this gate cannot run here and is not a pass' \
+            >>"$GATES_FILE"
+
+      # Checklist line 12, read rather than re-run (D-07): the evaluated commit's own CI check
+      # runs are the 3-OS evidence. The expected job names below must stay in sync with ci.yml,
+      # exactly as release.yml's verify-ci job already requires. An absent or incomplete run is
+      # `pending` and fails the job; it is never a pass.
+      - name: Gate ci-matrix
+        if: ${{ !cancelled() }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -uo pipefail
+          expected=("lint" "pdf-parity" "test (ubuntu-latest)" "test (macos-latest)" "test (windows-latest)")
+          if ! runs="$(gh api "repos/$GITHUB_REPOSITORY/commits/$READINESS_SHA/check-runs?filter=latest&per_page=100")"; then
+            runs='{"check_runs":[]}'
+            echo "the check-runs API call failed; treating the evaluated commit as having no completed runs" >&2
+          fi
+          : >"$CHECK_RUNS_FILE"
+          status=pass
+          problems=""
+          for name in "${expected[@]}"; do
+            state="$(jq -r --arg n "$name" \
+              '[.check_runs[] | select(.name == $n)] | sort_by(.completed_at) | .[-1] | if . == null then "absent" else "\(.status)/\(.conclusion // "pending")" end' \
+              <<<"$runs")"
+            echo "$name: $state"
+            printf '%s\t%s\n' "$name" "$state" >>"$CHECK_RUNS_FILE"
+            case "$state" in
+            completed/success) ;;
+            completed/*)
+              status=fail
+              problems="${problems:+$problems, }$name=$state"
+              ;;
+            *)
+              # absent, queued or in_progress: no conclusion exists to cite.
+              [ "$status" = fail ] || status=pending
+              problems="${problems:+$problems, }$name=$state"
+              ;;
+            esac
+          done
+          if [ "$status" = pass ]; then
+            evidence="check-runs API for $READINESS_SHA: all five ci.yml jobs are completed/success"
+          else
+            evidence="check-runs API for $READINESS_SHA: $problems"
+          fi
+          printf '%s\t%s\t%s\n' ci-matrix "$status" "$evidence" >>"$GATES_FILE"
+
+      # Checklist lines 21-25, last because it writes scorecards into the tracked scoreboard
+      # directory. Same shape as ci.yml's pdf-parity job, against the committed public oracle,
+      # whose manifest declares no gate exclusions.
+      - name: Gate pdf-parity-public
+        if: ${{ !cancelled() }}
+        shell: bash
+        env:
+          HWP_FONT_DIR: fixtures/pdf-parity/fonts
+        run: |
+          set -uo pipefail
+          status=fail
+          if bash scripts/fetch-pdf-parity-fonts.sh &&
+            cargo build --locked -p hwp-cli &&
+            bash scripts/pdf-parity.sh run --oracle-dir fixtures/pdf-parity/public/oracle; then
+            status=pass
+          fi
+          printf '%s\t%s\t%s\n' pdf-parity-public "$status" \
+            'bash scripts/pdf-parity.sh run --oracle-dir fixtures/pdf-parity/public/oracle with the pinned Poppler and the exact OFL fonts; the public manifest declares no gate_exclusions, so every gate blocks' >>"$GATES_FILE"
 
       # --- run record ---------------------------------------------------------------------------
       # Runs even when a gate failed, so the record is always complete. It is the step that
@@ -89,6 +452,56 @@ jobs:
           ALLOWED = ("pass", "fail", "n/a", "pending")
           HEX = re.compile(r"^[0-9a-f]+$")
 
+          # docs/release-readiness.md, in the order its lines appear. The record follows this
+          # order, and a run that records a name outside it, twice, or not at all, fails here.
+          CHECKLIST = [
+              "fmt",
+              "clippy",
+              "test-workspace",
+              "structured-corpus",
+              "ci-matrix",
+              "corpus-schemas",
+              "corpus-git-index",
+              "corpus-no-ambient-fonts",
+              "corpus-fonts-reproduce",
+              "release-archive-fonts",
+              "independent-oracle",
+              "hancom-receipt",
+              "pdf-parity-public",
+              "release-copy-claims",
+              "clean-tree",
+              "no-publish",
+              "readme-pinned-tag",
+              "tool-count",
+              "skill-coverage",
+              "hwpx-skill-parity",
+          ]
+
+          # docs/design/21-pdf-parity.md sections 4.5 and 4.6. These describe the private
+          # composite profile; the public gate this run executes declares no exclusions.
+          GATE_EXCLUSIONS = [
+              {
+                  "gate": "fonts",
+                  "measured_distance": "the document declares its dominant body face through a substFont and the oracle host did not have that face either, so the substitutions resolve to the same faces the oracle embedded; the substitution_free criterion is unreachable for this case by construction (section 4.5)",
+              },
+              {
+                  "gate": "text",
+                  "measured_distance": "1/13 pages byte-equal; the differences are pagination, not characters, and page 4's only diff is one line that crosses a page boundary (section 4.6)",
+              },
+              {
+                  "gate": "raster",
+                  "measured_distance": "bad_pixel_pct 0.1418-0.2332, MAE 18.5-27.9, ink ratio 0.854-1.435, max abs dx/dy 40px (section 4.6)",
+              },
+              {
+                  "gate": "roi",
+                  "measured_distance": "3 of 4 pass; only the page-2 diagram region fails, precision 0.848, recall 0.892 (section 4.6)",
+              },
+          ]
+          PROVENANCE = (
+              "measured by the private composite run of 2026-08-16 recorded in "
+              "docs/design/21-pdf-parity.md, not by the public one-page gate this run executed"
+          )
+
           def cargo_version():
               """[workspace.package] version of the evaluated ref, without building anything."""
               section = False
@@ -105,23 +518,41 @@ jobs:
               """Digests are recorded as lowercase hexadecimal, never mixed case."""
               return value.lower() if HEX.match(value.lower()) else value
 
-          gates = []
-          with open(os.environ["GATES_FILE"], encoding="utf-8") as handle:
-              for number, line in enumerate(handle, 1):
-                  line = line.rstrip("\n")
-                  if not line:
-                      continue
-                  fields = line.split("\t")
-                  if len(fields) != 3:
-                      sys.exit(f"gate line {number} is not name/status/evidence: {line!r}")
-                  name, status, evidence = (field.strip() for field in fields)
-                  if status not in ALLOWED:
-                      sys.exit(f"gate {name!r} has status {status!r}, not one of {ALLOWED}")
-                  if not name or not evidence:
-                      sys.exit(f"gate line {number} is missing a name or its evidence")
-                  gates.append({"name": name, "status": status, "evidence": evidence})
-          if not gates:
-              sys.exit("no gate was recorded; the run evaluated nothing")
+          def read_tsv(path, fields):
+              rows = []
+              with open(path, encoding="utf-8") as handle:
+                  for number, line in enumerate(handle, 1):
+                      line = line.rstrip("\n")
+                      if not line:
+                          continue
+                      parts = line.split("\t")
+                      if len(parts) != fields:
+                          sys.exit(f"{path} line {number} has {len(parts)} fields, not {fields}")
+                      rows.append([part.strip() for part in parts])
+              return rows
+
+          recorded = {}
+          for name, status, evidence in read_tsv(os.environ["GATES_FILE"], 3):
+              if status not in ALLOWED:
+                  sys.exit(f"gate {name!r} has status {status!r}, not one of {ALLOWED}")
+              if not name or not evidence:
+                  sys.exit(f"gate {name!r} is missing a name or its evidence")
+              if name in recorded:
+                  sys.exit(f"gate {name!r} was recorded twice")
+              recorded[name] = {"name": name, "status": status, "evidence": evidence}
+
+          unknown = sorted(set(recorded) - set(CHECKLIST))
+          if unknown:
+              sys.exit(f"recorded gates that are not checklist lines: {unknown}")
+          missing = [name for name in CHECKLIST if name not in recorded]
+          if missing:
+              sys.exit(f"checklist lines with no recorded gate: {missing}")
+          gates = [recorded[name] for name in CHECKLIST]
+
+          check_runs = {}
+          check_runs_path = os.environ.get("CHECK_RUNS_FILE", "")
+          if check_runs_path and os.path.exists(check_runs_path):
+              check_runs = {name: state for name, state in read_tsv(check_runs_path, 2)}
 
           record = {
               "schema": "hwp-release-readiness-record-v1",
@@ -133,8 +564,14 @@ jobs:
               "sha": lower_hex(os.environ["READINESS_SHA"]),
               "run_url": os.environ["RUN_URL"],
               "hwp_version": cargo_version(),
+              "pdfinfo_version": os.environ.get("PDFINFO_VERSION") or None,
+              "oracle": os.environ.get("ORACLE_STATUS") or None,
+              "oracle_lock_sha256": lower_hex(os.environ.get("ORACLE_LOCK_SHA256", "")) or None,
+              "check_runs": check_runs,
               "gates": gates,
+              "gate_exclusions": [dict(entry, provenance=PROVENANCE) for entry in GATE_EXCLUSIONS],
           }
+
           text = json.dumps(record, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
           with open(os.environ["RECORD_PATH"], "w", encoding="utf-8") as handle:
               handle.write(text)

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -566,6 +566,16 @@ jobs:
             "$detail skills/hwp/SKILL.md and SKILL.ko.md naming every CLI subcommand and every MCP tool" >>"$GATES_FILE"
 
       # Checklist lines 30-31. Only meaningful against a tag: a branch is not a release being cut.
+      # Three things this gate has to get right, because each of them used to turn a real release
+      # into a green line:
+      #   - `refs/tags/v1` and `v1` name the same tag. Concatenating the prefix again produced
+      #     refs/tags/refs/tags/v1, which resolves to nothing, so a fully qualified tag dispatch
+      #     recorded `n/a` and the READMEs were never compared at all.
+      #   - the two READMEs are checked one at a time. Grepping both at once let README.md's
+      #     correct pin stand in for a README.ko.md that carries no snippet, or no file at all
+      #     (the grep error went to stderr and the gate still recorded a pass).
+      #   - a missing file, a grep failure or an empty extraction is a `fail`. There is no reading
+      #     of "the pinned versions could not be read" that is evidence the pins are right.
       - name: Gate readme-pinned-tag
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
@@ -575,23 +585,44 @@ jobs:
           EVALUATED_SHA: ${{ steps.prepare.outputs.evaluated_sha }}
         run: |
           set -uo pipefail
-          if ! git rev-parse -q --verify "refs/tags/${READINESS_REF}^{commit}" >/dev/null; then
+          tag="${READINESS_REF#refs/tags/}"
+          tag_sha="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" 2>/dev/null)"
+          if [ -z "$tag_sha" ]; then
             printf '%s\t%s\t%s\n' readme-pinned-tag 'n/a' \
               "the evaluated ref ${READINESS_REF} is not a tag in this checkout, so there is no release being cut to compare the install snippets against" >>"$GATES_FILE"
             exit 0
           fi
+          if [ "$tag_sha" != "$EVALUATED_SHA" ]; then
+            printf '%s\t%s\t%s\n' readme-pinned-tag fail \
+              "refs/tags/${tag} points at ${tag_sha}, but this run evaluated ${EVALUATED_SHA}; the checkout and the tag disagree about which commit is being released" >>"$GATES_FILE"
+            exit 0
+          fi
           # Only the install.sh snippets, which all pipe into `sh -s --`. `hwp update --tag v0.9.0`
-          # is a rollback example and is deliberately not compared.
-          found="$(grep -h -- 'sh -s --' README.md README.ko.md | grep -oE -- '--tag v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^--tag //' | sort -u)"
-          if [ -z "$found" ]; then
+          # is a rollback example and is deliberately not compared. Each README must carry the
+          # complete pin on its own.
+          status=pass
+          evidence="the install.sh --tag snippets in README.md and README.ko.md pin ${tag}"
+          problems=""
+          for file in README.md README.ko.md; do
+            if [ ! -f "$file" ]; then
+              problems="${problems:+$problems; }$file does not exist"
+              continue
+            fi
+            snippets="$(grep -h -- 'sh -s --' "$file")"
+            if [ -z "$snippets" ]; then
+              problems="${problems:+$problems; }$file carries no install.sh 'sh -s --' snippet"
+              continue
+            fi
+            found="$(printf '%s\n' "$snippets" | grep -oE -- '--tag v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^--tag //' | sort -u)"
+            if [ -z "$found" ]; then
+              problems="${problems:+$problems; }$file has an install.sh snippet with no --tag pin"
+            elif [ "$found" != "$tag" ]; then
+              problems="${problems:+$problems; }$file pins $(echo "$found" | tr '\n' ' ')instead of ${tag}"
+            fi
+          done
+          if [ -n "$problems" ]; then
             status=fail
-            evidence='no install.sh --tag snippet was found in README.md or README.ko.md; the version-pinned examples cannot be checked'
-          elif [ "$found" = "$READINESS_REF" ]; then
-            status=pass
-            evidence="the install.sh --tag snippets in README.md and README.ko.md pin ${READINESS_REF}"
-          else
-            status=fail
-            evidence="the install.sh --tag snippets in README.md and README.ko.md pin $(echo "$found" | tr '\n' ' ')but the evaluated tag is ${READINESS_REF}"
+            evidence="the evaluated tag is ${tag}, but: ${problems}"
           fi
           printf '%s\t%s\t%s\n' readme-pinned-tag "$status" "$evidence" >>"$GATES_FILE"
 

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -10,6 +10,22 @@ name: Release readiness
 # commits, creates or moves a ref, publishes a release, or builds or pushes an image. The only
 # thing the run uploads is its own record artifact.
 #
+# Trust policy. Half of what this run executes is code from the EVALUATED ref (cargo build
+# scripts, scripts/*.sh), and the record it produces is the evidence a release cites. So before
+# any of that code runs, the trust step requires the evaluated commit to be either a tag of this
+# repository or an ancestor of origin/main. Anything else is refused with a single `refused`
+# outcome, and no gate step runs at all.
+#
+# Controller steps and target steps. A step that executes code from the evaluated ref is a target
+# step: it runs the command, captures stdout/stderr into $RUNNER_TEMP/gates/<name>/log, and does
+# nothing else. It is never told where the ledger is - the ledger path is a random file name held
+# in a step OUTPUT of the prepare step, which the runner passes only to the steps that reference
+# it, and it is never written to $GITHUB_ENV (which every later step, target steps included,
+# receives). Every gate ENTRY is written by a controller step, whose shell lives in this file (the
+# dispatch ref) rather than in the evaluated checkout, from the target step's recorded outcome.
+# So a gate script from the evaluated ref decides its own exit status and nothing else: it cannot
+# append an entry, rewrite an earlier one, or change what the record says about it.
+#
 # Step order is dependency order, not checklist order: the clean-tree gate runs before anything
 # writes to the checkout, and the public parity gate runs last because it writes scorecards into
 # the tracked scoreboard directory. The record assembly re-orders every entry into the checklist's
@@ -40,32 +56,117 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
+          # The trust policy resolves this repository's tags and asks whether the evaluated
+          # commit is an ancestor of origin/main; neither question is answerable in a shallow
+          # clone.
+          fetch-depth: 0
+
       # A workflow_dispatch run's own GITHUB_SHA is the dispatch ref's commit (the run's
       # head_sha), not the evaluated ref's, so the two are recorded as separate fields and the
       # evaluated one is resolved explicitly here and used everywhere below. A verifier that
       # compares the run's head_sha to the commit being released would be checking the dispatch
       # ref, not the code this run evaluated; scripts/check-verification-block.sh compares the
       # record's evaluated_sha instead.
-      - name: Resolve the evaluated commit
+      #
+      # The ledger and the check-run file are created here, with random names, and their paths
+      # leave this step as step outputs only. Nothing puts them in $GITHUB_ENV, so no target step
+      # is handed a way to locate the evidence.
+      - name: Prepare the controller ledger
+        id: prepare
         shell: bash
         env:
           READINESS_REF: ${{ inputs.ref }}
         run: |
           set -euo pipefail
           sha="$(git rev-parse HEAD)"
+          ledger="$(mktemp "$RUNNER_TEMP/ledger.XXXXXXXXXXXX")"
+          check_runs="$(mktemp "$RUNNER_TEMP/check-runs.XXXXXXXXXXXX")"
+          mkdir -p "$RUNNER_TEMP/gates"
           {
-            echo "READINESS_SHA=$sha"
-            echo "GATES_FILE=$RUNNER_TEMP/gates.tsv"
-            echo "CHECK_RUNS_FILE=$RUNNER_TEMP/check-runs.tsv"
-          } >>"$GITHUB_ENV"
-          : >"$RUNNER_TEMP/gates.tsv"
+            echo "evaluated_sha=$sha"
+            echo "ledger=$ledger"
+            echo "check_runs=$check_runs"
+          } >>"$GITHUB_OUTPUT"
           echo "ref=$READINESS_REF evaluated_sha=$sha workflow_source_sha=$GITHUB_SHA"
 
-      # Checklist line 28, run first: the checklist asks for a clean checkout, and later gates
-      # fetch fonts and write parity scorecards into the working tree.
-      - name: Gate clean-tree
-        if: ${{ !cancelled() }}
+      # The gate that has to come before every target step: this run executes the evaluated ref's
+      # build scripts and shell scripts, so the evaluated commit must be code this repository has
+      # already accepted. A tag of this repository, or a commit reachable from origin/main, is
+      # accepted; a fork branch, a pull-request head or a rewritten commit is refused, recorded as
+      # one `refused` outcome, and stops the job before any target-ref code runs.
+      - name: Trust policy for the evaluated ref
+        id: trust
         shell: bash
+        env:
+          READINESS_REF: ${{ inputs.ref }}
+          EVALUATED_SHA: ${{ steps.prepare.outputs.evaluated_sha }}
+          WORKFLOW_SOURCE_SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RECORD_PATH: ${{ runner.temp }}/release-readiness-record.json
+        run: |
+          set -euo pipefail
+          # `refs/tags/v1` and `v1` name the same tag; normalize before resolving so the policy
+          # never builds refs/tags/refs/tags/... and never misses a genuine tag.
+          tag="${READINESS_REF#refs/tags/}"
+          git fetch --quiet --force origin "+refs/heads/main:refs/remotes/origin/main"
+          git fetch --quiet --force origin "+refs/tags/*:refs/tags/*"
+          trusted=no
+          why=""
+          if tag_sha="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" 2>/dev/null)" &&
+            [ "$tag_sha" = "$EVALUATED_SHA" ]; then
+            trusted=yes
+            why="the evaluated commit is refs/tags/${tag} of this repository"
+          elif git merge-base --is-ancestor "$EVALUATED_SHA" refs/remotes/origin/main; then
+            trusted=yes
+            why="the evaluated commit is reachable from origin/main"
+          else
+            why="the evaluated commit is neither a tag of this repository nor reachable from origin/main"
+          fi
+          echo "trusted=$trusted" >>"$GITHUB_OUTPUT"
+          echo "trust: $trusted ($why)"
+          if [ "$trusted" = yes ]; then
+            exit 0
+          fi
+          # Refused: write the record here, because no gate ran and none will.
+          export WHY="$why"
+          python3 - <<'PY'
+          import datetime
+          import json
+          import os
+
+          record = {
+              "schema": "hwp-release-readiness-record-v1",
+              "generated_at": datetime.datetime.now(datetime.timezone.utc)
+              .replace(microsecond=0)
+              .isoformat()
+              .replace("+00:00", "Z"),
+              "ref": os.environ["READINESS_REF"],
+              "evaluated_sha": os.environ["EVALUATED_SHA"].lower(),
+              "workflow_source_sha": os.environ["WORKFLOW_SOURCE_SHA"].lower(),
+              "result": "refused",
+              "run_url": os.environ["RUN_URL"],
+              "gates": [
+                  {
+                      "name": "trust-policy",
+                      "status": "refused",
+                      "evidence": os.environ["WHY"],
+                  }
+              ],
+          }
+          with open(os.environ["RECORD_PATH"], "w", encoding="utf-8") as handle:
+              handle.write(json.dumps(record, ensure_ascii=False, indent=2, sort_keys=True) + "\n")
+          PY
+          echo "::error::refused: $why. No gate ran and no code from ${READINESS_REF} was executed."
+          exit 1
+
+      # Checklist line 28, run first: the checklist asks for a clean checkout, and later gates
+      # fetch fonts and write parity scorecards into the working tree. Controller step: `git
+      # status` reads the checkout, it does not execute anything from it.
+      - name: Gate clean-tree
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        shell: bash
+        env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -uo pipefail
           dirty="$(git status --porcelain --untracked-files=all)"
@@ -78,16 +179,19 @@ jobs:
           fi
           printf '%s\t%s\t%s\n' clean-tree "$status" "$evidence" >>"$GATES_FILE"
 
-      - uses: dtolnay/rust-toolchain@1.93.0
+      - if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        uses: dtolnay/rust-toolchain@1.93.0
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        uses: Swatinem/rust-cache@v2
 
       # Copied from ci.yml's pdf-parity job, including the mirror pin and the bounded retry: the
       # public manifest pins the Poppler version, so the parity gate is only meaningful when the
       # installed pdfinfo matches it.
       - name: Install pinned Poppler tools
-        if: ${{ !cancelled() }}
+        id: poppler
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         # Worst case is 3 x (120s update + 120s install) + 2 x 10s sleep, ~12.3 min;
         # with the mirror pinned and apt-level timeouts the normal case is seconds.
@@ -121,29 +225,67 @@ jobs:
           expected="$(python3 -c 'import json; print(json.load(open("fixtures/pdf-parity/public/manifest.json", encoding="utf-8"))["pins"]["poppler_version"])')"
           actual="$(pdfinfo -v 2>&1 | sed -n '1p')"
           echo "pdfinfo: $actual"
-          echo "PDFINFO_VERSION=$actual" >>"$GITHUB_ENV"
+          echo "pdfinfo_version=$actual" >>"$GITHUB_OUTPUT"
           test "$actual" = "$expected"
 
       # --- gates ---------------------------------------------------------------------------------
-      # Every gate step records one tab-separated `name<TAB>status<TAB>evidence` line and never
-      # fails the job itself: the record-assembly step decides the outcome, so one run reports
-      # every gate instead of stopping at the first failure. `if: ${{ !cancelled() }}` keeps the
+      # Target steps carry `continue-on-error: true` and run one command from the evaluated ref;
+      # the controller step that follows turns `steps.<id>.outcome`, which the runner holds and no
+      # target process can touch, into one `name<TAB>status<TAB>evidence` line. No gate step fails
+      # the job: the record-assembly step decides the outcome, so one run reports every gate
+      # instead of stopping at the first failure. `if: ${{ !cancelled() && ... }}` keeps the
       # remaining gates running when a non-gate step does fail (same idiom as ci.yml's lint job).
 
-      - name: Gate fmt
-        if: ${{ !cancelled() }}
+      - name: Target fmt
+        id: target-fmt
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        continue-on-error: true
         shell: bash
         run: |
           set -uo pipefail
-          if cargo fmt --all --check; then status=pass; else status=fail; fi
+          mkdir -p "$RUNNER_TEMP/gates/fmt"
+          cargo fmt --all --check 2>&1 | tee "$RUNNER_TEMP/gates/fmt/log"
+          exit "${PIPESTATUS[0]}"
+
+      - name: Gate fmt
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        shell: bash
+        env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
+          OUTCOME: ${{ steps.target-fmt.outcome }}
+        run: |
+          set -uo pipefail
+          case "$OUTCOME" in
+          success) status=pass ;;
+          failure) status=fail ;;
+          *) status=pending ;;
+          esac
           printf '%s\t%s\t%s\n' fmt "$status" 'cargo fmt --all --check' >>"$GATES_FILE"
 
-      - name: Gate clippy
-        if: ${{ !cancelled() }}
+      - name: Target clippy
+        id: target-clippy
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        continue-on-error: true
         shell: bash
         run: |
           set -uo pipefail
-          if cargo clippy --workspace --all-targets -- -D warnings; then status=pass; else status=fail; fi
+          mkdir -p "$RUNNER_TEMP/gates/clippy"
+          cargo clippy --workspace --all-targets -- -D warnings 2>&1 | tee "$RUNNER_TEMP/gates/clippy/log"
+          exit "${PIPESTATUS[0]}"
+
+      - name: Gate clippy
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        shell: bash
+        env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
+          OUTCOME: ${{ steps.target-clippy.outcome }}
+        run: |
+          set -uo pipefail
+          case "$OUTCOME" in
+          success) status=pass ;;
+          failure) status=fail ;;
+          *) status=pending ;;
+          esac
           printf '%s\t%s\t%s\n' clippy "$status" 'cargo clippy --workspace --all-targets -- -D warnings' >>"$GATES_FILE"
 
       # No font package is installed anywhere in this job, which is what keeps the corpus gate's
@@ -151,46 +293,79 @@ jobs:
       # their text assertions when no system CJK face exists; the 3-OS matrix cited by the
       # ci-matrix gate is where those assertions actually run (ci.yml's test job installs
       # fonts-nanum).
-      - name: Gate test-workspace
-        if: ${{ !cancelled() }}
+      - name: Target test-workspace
+        id: target-test
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        continue-on-error: true
         shell: bash
         run: |
           set -uo pipefail
-          if cargo test --workspace; then status=pass; else status=fail; fi
+          mkdir -p "$RUNNER_TEMP/gates/test-workspace"
+          cargo test --workspace 2>&1 | tee "$RUNNER_TEMP/gates/test-workspace/log"
+          exit "${PIPESTATUS[0]}"
+
+      - name: Gate test-workspace
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        shell: bash
+        env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
+          OUTCOME: ${{ steps.target-test.outcome }}
+        run: |
+          set -uo pipefail
+          case "$OUTCOME" in
+          success) status=pass ;;
+          failure) status=fail ;;
+          *) status=pending ;;
+          esac
           printf '%s\t%s\t%s\n' test-workspace "$status" 'cargo test --workspace' >>"$GATES_FILE"
 
       # One script, four checklist lines: it also validates the three frozen corpus schemas and
       # asserts the manifest pins and TRACKED_FILES.txt are in the Git index. The three derived
       # entries below cite it rather than re-running any of that.
-      - name: Gate structured-corpus
-        if: ${{ !cancelled() }}
+      - name: Target structured-corpus
+        id: target-corpus
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        continue-on-error: true
         shell: bash
         run: |
           set -uo pipefail
-          if bash scripts/check-structured-corpus.sh; then status=pass; else status=fail; fi
-          printf '%s\t%s\t%s\n' structured-corpus "$status" 'bash scripts/check-structured-corpus.sh' >>"$GATES_FILE"
+          mkdir -p "$RUNNER_TEMP/gates/structured-corpus"
+          bash scripts/check-structured-corpus.sh 2>&1 | tee "$RUNNER_TEMP/gates/structured-corpus/log"
+          exit "${PIPESTATUS[0]}"
 
-      # Derived from the run above, not re-executed. The status is that run's status: when the
-      # corpus gate failed, the schema and index checks inside it did not report a pass either.
-      - name: Gates corpus-schemas and corpus-git-index (derived from the corpus run)
-        if: ${{ !cancelled() }}
+      # Controller for the corpus run and for the three checklist lines derived from it. The
+      # derived entries are not re-executed: when the corpus gate failed, the schema and index
+      # checks inside it did not report a pass either.
+      - name: Gates structured-corpus, corpus-schemas and corpus-git-index
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
+        env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
+          OUTCOME: ${{ steps.target-corpus.outcome }}
         run: |
           set -uo pipefail
-          status="$(awk -F'\t' '$1 == "structured-corpus" { print $2 }' "$GATES_FILE")"
-          [ -n "$status" ] || status=pending
-          printf '%s\t%s\t%s\n' corpus-schemas "$status" \
-            'scripts/check-structured-corpus.sh validates the manifest, the run summary and the artifacts against schemas/structured-corpus{,-run,-artifacts}-v1.schema.json through the validate_structured_corpus example' >>"$GATES_FILE"
-          printf '%s\t%s\t%s\n' corpus-git-index "$status" \
-            'scripts/check-structured-corpus.sh checks every TRACKED_FILES.txt entry and every corpus schema with git ls-files --error-unmatch and git check-ignore' >>"$GATES_FILE"
+          case "$OUTCOME" in
+          success) status=pass ;;
+          failure) status=fail ;;
+          *) status=pending ;;
+          esac
+          {
+            printf '%s\t%s\t%s\n' structured-corpus "$status" 'bash scripts/check-structured-corpus.sh'
+            printf '%s\t%s\t%s\n' corpus-schemas "$status" \
+              'scripts/check-structured-corpus.sh validates the manifest, the run summary and the artifacts against schemas/structured-corpus{,-run,-artifacts}-v1.schema.json through the validate_structured_corpus example'
+            printf '%s\t%s\t%s\n' corpus-git-index "$status" \
+              'scripts/check-structured-corpus.sh checks every TRACKED_FILES.txt entry and every corpus schema with git ls-files --error-unmatch and git check-ignore'
+          } >>"$GATES_FILE"
 
       # Structural plus a runtime assertion on the environment the corpus gate just ran in: this
       # job installs poppler-utils only and never a font package, and no step sets HWP_FONT_DIR
-      # for the corpus gate (only the public parity gate sets it, on its own step). The corpus
-      # font bytes come from scripts/fetch-corpus-fonts.sh through the manifest hashes.
+      # for the corpus gate (only the public parity target step sets it, on its own step). The
+      # corpus font bytes come from scripts/fetch-corpus-fonts.sh through the manifest hashes.
       - name: Gate corpus-no-ambient-fonts
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
+        env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -uo pipefail
           if [ -n "${HWP_FONT_DIR:-}" ]; then
@@ -202,23 +377,43 @@ jobs:
           fi
           printf '%s\t%s\t%s\n' corpus-no-ambient-fonts "$status" "$evidence" >>"$GATES_FILE"
 
-      - name: Gate corpus-fonts-reproduce
-        if: ${{ !cancelled() }}
+      - name: Target corpus-fonts-reproduce
+        id: target-corpus-fonts
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        continue-on-error: true
         shell: bash
         run: |
           set -uo pipefail
+          mkdir -p "$RUNNER_TEMP/gates/corpus-fonts-reproduce"
           # From a clean fonts directory, so the script's own sha256 verification against the
           # manifest is what passes the gate, not a cached byte.
           rm -rf corpus/structured-v1/fonts
-          if bash scripts/fetch-corpus-fonts.sh; then status=pass; else status=fail; fi
+          bash scripts/fetch-corpus-fonts.sh 2>&1 | tee "$RUNNER_TEMP/gates/corpus-fonts-reproduce/log"
+          exit "${PIPESTATUS[0]}"
+
+      - name: Gate corpus-fonts-reproduce
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        shell: bash
+        env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
+          OUTCOME: ${{ steps.target-corpus-fonts.outcome }}
+        run: |
+          set -uo pipefail
+          case "$OUTCOME" in
+          success) status=pass ;;
+          failure) status=fail ;;
+          *) status=pending ;;
+          esac
           printf '%s\t%s\t%s\n' corpus-fonts-reproduce "$status" \
             'bash scripts/fetch-corpus-fonts.sh against an emptied corpus/structured-v1/fonts; the script verifies every font, license and metadata file against the manifest sha256' >>"$GATES_FILE"
 
       # The checklist line is conditional ("if the corpus ships"). It does not: release.yml
       # publishes the hwp binary archive only. Assert that shape rather than assume it.
       - name: Gate release-archive-fonts
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
+        env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -uo pipefail
           status=pass
@@ -236,10 +431,14 @@ jobs:
       # LibreOffice + H2Orestart certification container of docs/design/16-certification-v1.md,
       # section "Independent import oracle"; this repository ships no supported public image for
       # it. The status is read from the lock file so a future lock file moves the record with it,
-      # and nothing here builds, tags or attests an image.
+      # and nothing here builds, tags or attests an image. Controller step: it parses the lock
+      # file as data, it does not execute anything from the evaluated ref.
       - name: Gate independent-oracle
-        if: ${{ !cancelled() }}
+        id: oracle
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
+        env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -euo pipefail
           lock=oracle/primary-artifacts.lock.json
@@ -259,8 +458,10 @@ jobs:
           print("lock_sha256=" + shlex.quote(digest.lower()))
           PY
           )"
-          echo "ORACLE_STATUS=$oracle" >>"$GITHUB_ENV"
-          echo "ORACLE_LOCK_SHA256=$lock_sha256" >>"$GITHUB_ENV"
+          {
+            echo "oracle_status=$oracle"
+            echo "oracle_lock_sha256=$lock_sha256"
+          } >>"$GITHUB_OUTPUT"
           printf '%s\t%s\t%s\n' independent-oracle 'n/a' \
             "no supported public oracle image is shipped by this repository: docs/design/16-certification-v1.md section 'Independent import oracle' states that required oracle mode remains partial until the image gaps are closed, and $lock reports status $lock_status with a null image digest, so the gate cannot run and is not a pass" \
             >>"$GATES_FILE"
@@ -268,8 +469,10 @@ jobs:
       # Not applicable in CI: the Hancom-open evidence is an owner observation made on Hancom
       # Office, and the receipts are private (never committed).
       - name: Gate hancom-receipt
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
+        env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -uo pipefail
           printf '%s\t%s\t%s\n' hancom-receipt 'n/a' \
@@ -278,10 +481,28 @@ jobs:
 
       # Checklist line 26-27, the release-copy claim lint. Guarded: a retroactive dispatch may
       # evaluate a ref from before this script existed, and a missing script is n/a, never a pass.
+      - name: Target release-copy-claims
+        id: target-claims
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -uo pipefail
+          mkdir -p "$RUNNER_TEMP/gates/release-copy-claims"
+          script=scripts/check-claims.sh
+          if [ ! -f "$script" ]; then
+            echo "$script is absent from this checkout" | tee "$RUNNER_TEMP/gates/release-copy-claims/log"
+            exit 0
+          fi
+          bash "$script" 2>&1 | tee "$RUNNER_TEMP/gates/release-copy-claims/log"
+          exit "${PIPESTATUS[0]}"
+
       - name: Gate release-copy-claims
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
+          OUTCOME: ${{ steps.target-claims.outcome }}
           READINESS_REF: ${{ inputs.ref }}
         run: |
           set -uo pipefail
@@ -290,7 +511,11 @@ jobs:
             status='n/a'
             evidence="$script is absent from the checkout of $READINESS_REF, so the claim lint cannot run against that ref"
           else
-            if bash "$script"; then status=pass; else status=fail; fi
+            case "$OUTCOME" in
+            success) status=pass ;;
+            failure) status=fail ;;
+            *) status=pending ;;
+            esac
             evidence="bash $script, the same file scripts/check.sh runs locally"
           fi
           printf '%s\t%s\t%s\n' release-copy-claims "$status" "$evidence" >>"$GATES_FILE"
@@ -298,10 +523,28 @@ jobs:
       # Checklist lines 32-35. One script covers both lines: it reports the tool-count check and
       # the skill-coverage check in one invocation, so both entries carry that run's status and
       # say which check they stand for. Guarded the same way as the claim lint.
+      - name: Target doc-surface
+        id: target-doc-surface
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -uo pipefail
+          mkdir -p "$RUNNER_TEMP/gates/doc-surface"
+          script=scripts/check-doc-surface.sh
+          if [ ! -f "$script" ]; then
+            echo "$script is absent from this checkout" | tee "$RUNNER_TEMP/gates/doc-surface/log"
+            exit 0
+          fi
+          bash "$script" 2>&1 | tee "$RUNNER_TEMP/gates/doc-surface/log"
+          exit "${PIPESTATUS[0]}"
+
       - name: Gates tool-count and skill-coverage
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
+          OUTCOME: ${{ steps.target-doc-surface.outcome }}
           READINESS_REF: ${{ inputs.ref }}
         run: |
           set -uo pipefail
@@ -310,7 +553,11 @@ jobs:
             status='n/a'
             detail="$script is absent from the checkout of $READINESS_REF, so this check could not run:"
           else
-            if bash "$script"; then status=pass; else status=fail; fi
+            case "$OUTCOME" in
+            success) status=pass ;;
+            failure) status=fail ;;
+            *) status=pending ;;
+            esac
             detail="bash $script, one invocation that reports both checks, so both entries carry its status:"
           fi
           printf '%s\t%s\t%s\n' tool-count "$status" \
@@ -320,10 +567,12 @@ jobs:
 
       # Checklist lines 30-31. Only meaningful against a tag: a branch is not a release being cut.
       - name: Gate readme-pinned-tag
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
           READINESS_REF: ${{ inputs.ref }}
+          EVALUATED_SHA: ${{ steps.prepare.outputs.evaluated_sha }}
         run: |
           set -uo pipefail
           if ! git rev-parse -q --verify "refs/tags/${READINESS_REF}^{commit}" >/dev/null; then
@@ -351,8 +600,10 @@ jobs:
       # plan's own verify gate and review assert. Recorded as such, with no claim that a command
       # proved it.
       - name: Gate no-publish
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
+        env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -uo pipefail
           printf '%s\t%s\t%s\n' no-publish pass \
@@ -362,8 +613,10 @@ jobs:
       # Checklist lines 36-38. The comparison target is the retired STAIxBWLB/skills repository,
       # which is not checked out here, so this stays a manual cross-repository review.
       - name: Gate hwpx-skill-parity
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
+        env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
         run: |
           set -uo pipefail
           printf '%s\t%s\t%s\n' hwpx-skill-parity 'n/a' \
@@ -373,12 +626,16 @@ jobs:
       # Checklist line 12, read rather than re-run (D-07): the evaluated commit's own CI check
       # runs are the 3-OS evidence. The expected job names below must stay in sync with ci.yml,
       # exactly as release.yml's verify-ci job already requires. An absent or incomplete run is
-      # `pending` and fails the job; it is never a pass.
+      # `pending` and fails the job; it is never a pass. Controller step: it queries the API, it
+      # runs nothing from the evaluated ref.
       - name: Gate ci-matrix
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
+          CHECK_RUNS_FILE: ${{ steps.prepare.outputs.check_runs }}
+          READINESS_SHA: ${{ steps.prepare.outputs.evaluated_sha }}
         run: |
           set -uo pipefail
           expected=("lint" "pdf-parity" "test (ubuntu-latest)" "test (macos-latest)" "test (windows-latest)")
@@ -418,33 +675,58 @@ jobs:
       # Checklist lines 21-25, last because it writes scorecards into the tracked scoreboard
       # directory. Same shape as ci.yml's pdf-parity job, against the committed public oracle,
       # whose manifest declares no gate exclusions.
-      - name: Gate pdf-parity-public
-        if: ${{ !cancelled() }}
+      - name: Target pdf-parity-public
+        id: target-parity
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        continue-on-error: true
         shell: bash
         env:
           HWP_FONT_DIR: fixtures/pdf-parity/fonts
         run: |
           set -uo pipefail
-          status=fail
-          if bash scripts/fetch-pdf-parity-fonts.sh &&
-            cargo build --locked -p hwp-cli &&
-            bash scripts/pdf-parity.sh run --oracle-dir fixtures/pdf-parity/public/oracle; then
-            status=pass
-          fi
+          mkdir -p "$RUNNER_TEMP/gates/pdf-parity-public"
+          {
+            bash scripts/fetch-pdf-parity-fonts.sh &&
+              cargo build --locked -p hwp-cli &&
+              bash scripts/pdf-parity.sh run --oracle-dir fixtures/pdf-parity/public/oracle
+          } 2>&1 | tee "$RUNNER_TEMP/gates/pdf-parity-public/log"
+          exit "${PIPESTATUS[0]}"
+
+      - name: Gate pdf-parity-public
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
+        shell: bash
+        env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
+          OUTCOME: ${{ steps.target-parity.outcome }}
+        run: |
+          set -uo pipefail
+          case "$OUTCOME" in
+          success) status=pass ;;
+          failure) status=fail ;;
+          *) status=pending ;;
+          esac
           printf '%s\t%s\t%s\n' pdf-parity-public "$status" \
             'bash scripts/pdf-parity.sh run --oracle-dir fixtures/pdf-parity/public/oracle with the pinned Poppler and the exact OFL fonts; the public manifest declares no gate_exclusions, so every gate blocks' >>"$GATES_FILE"
 
       # --- run record ---------------------------------------------------------------------------
       # Runs even when a gate failed, so the record is always complete. It is the step that
       # decides the job outcome: any `fail` or `pending` entry exits non-zero. `n/a` does not.
+      # Controller step: it reads the ledger the controller steps wrote and nothing from the
+      # evaluated ref except Cargo.toml's version string.
       - name: Assemble the run record
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
         env:
+          GATES_FILE: ${{ steps.prepare.outputs.ledger }}
+          CHECK_RUNS_FILE: ${{ steps.prepare.outputs.check_runs }}
           READINESS_REF: ${{ inputs.ref }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          RECORD_PATH: release-readiness-record.json
+          READINESS_SHA: ${{ steps.prepare.outputs.evaluated_sha }}
           WORKFLOW_SOURCE_SHA: ${{ github.sha }}
+          PDFINFO_VERSION: ${{ steps.poppler.outputs.pdfinfo_version }}
+          ORACLE_STATUS: ${{ steps.oracle.outputs.oracle_status }}
+          ORACLE_LOCK_SHA256: ${{ steps.oracle.outputs.oracle_lock_sha256 }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RECORD_PATH: ${{ runner.temp }}/release-readiness-record.json
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -595,14 +877,16 @@ jobs:
               print(f"::error::release readiness gates not green: {names}", file=sys.stderr)
               sys.exit(1)
           PY
+
       # The artifact name is the record's own contract string, because
       # scripts/check-verification-block.sh downloads it by that name from the run the release
-      # copy cites and reads evaluated_sha out of it.
+      # copy cites and reads evaluated_sha out of it. The record is written outside the checkout,
+      # so no gate from the evaluated ref shares a directory with it.
       - name: Upload the run record
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: hwp-release-readiness-record-v1
-          path: release-readiness-record.json
+          path: ${{ runner.temp }}/release-readiness-record.json
           if-no-files-found: error
           retention-days: 90

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,156 @@
+name: Release readiness
+
+# Manual, read-only run of the automatable gates in docs/release-readiness.md against a chosen
+# ref, from a clean checkout. It records gate outcomes and uploads one run-record JSON artifact.
+#
+# The checklist's own words (docs/release-readiness.md lines 5-6 and line 29): "Run from a clean
+# checkout. This checklist records gates; it does not authorize commit, push, tag, package upload
+# or release publication" and "no commit, push, tag, package upload or release performed by the
+# readiness run". That is why the permissions below are read-only and why no step in this file
+# commits, creates or moves a ref, publishes a release, or builds or pushes an image. The only
+# thing the run uploads is its own record artifact.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or branch to evaluate (for example v0.17.0 or main)"
+        required: true
+        default: main
+
+permissions:
+  contents: read
+  checks: read # the CI-matrix gate reads the evaluated commit's check runs
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  readiness:
+    name: readiness
+    # The public parity manifest pins the Poppler binary, so do not use ubuntu-latest here
+    # (same reason as ci.yml's pdf-parity job).
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+      # A workflow_dispatch run's own GITHUB_SHA is the default branch's, not the evaluated
+      # ref's, so resolve the checked-out commit explicitly and use it everywhere below.
+      - name: Resolve the evaluated commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          echo "READINESS_SHA=$sha" >>"$GITHUB_ENV"
+          echo "GATES_FILE=$RUNNER_TEMP/gates.tsv" >>"$GITHUB_ENV"
+          : >"$RUNNER_TEMP/gates.tsv"
+          echo "ref=$READINESS_REF sha=$sha"
+        env:
+          READINESS_REF: ${{ inputs.ref }}
+      - uses: dtolnay/rust-toolchain@1.93.0
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+
+      # --- gates, in docs/release-readiness.md order -------------------------------------------
+      # Every gate step records one tab-separated `name<TAB>status<TAB>evidence` line and never
+      # fails the job itself: the record-assembly step decides the outcome, so one run reports
+      # every gate instead of stopping at the first failure. `if: ${{ !cancelled() }}` keeps the
+      # remaining gates running when an earlier step does fail anyway (same idiom as ci.yml's
+      # lint job).
+      - name: Gate fmt
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          set -uo pipefail
+          if cargo fmt --all --check; then status=pass; else status=fail; fi
+          printf '%s\t%s\t%s\n' fmt "$status" 'cargo fmt --all --check' >>"$GATES_FILE"
+
+      # --- run record ---------------------------------------------------------------------------
+      # Runs even when a gate failed, so the record is always complete. It is the step that
+      # decides the job outcome: any `fail` or `pending` entry exits non-zero. `n/a` does not.
+      - name: Assemble the run record
+        if: ${{ !cancelled() }}
+        shell: bash
+        env:
+          READINESS_REF: ${{ inputs.ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          RECORD_PATH: release-readiness-record.json
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import datetime
+          import json
+          import os
+          import re
+          import sys
+
+          ALLOWED = ("pass", "fail", "n/a", "pending")
+          HEX = re.compile(r"^[0-9a-f]+$")
+
+          def cargo_version():
+              """[workspace.package] version of the evaluated ref, without building anything."""
+              section = False
+              with open("Cargo.toml", encoding="utf-8") as handle:
+                  for line in handle:
+                      line = line.strip()
+                      if line.startswith("["):
+                          section = line == "[workspace.package]"
+                      elif section and line.startswith("version"):
+                          return line.split("=", 1)[1].strip().strip('"')
+              sys.exit("Cargo.toml has no [workspace.package] version")
+
+          def lower_hex(value):
+              """Digests are recorded as lowercase hexadecimal, never mixed case."""
+              return value.lower() if HEX.match(value.lower()) else value
+
+          gates = []
+          with open(os.environ["GATES_FILE"], encoding="utf-8") as handle:
+              for number, line in enumerate(handle, 1):
+                  line = line.rstrip("\n")
+                  if not line:
+                      continue
+                  fields = line.split("\t")
+                  if len(fields) != 3:
+                      sys.exit(f"gate line {number} is not name/status/evidence: {line!r}")
+                  name, status, evidence = (field.strip() for field in fields)
+                  if status not in ALLOWED:
+                      sys.exit(f"gate {name!r} has status {status!r}, not one of {ALLOWED}")
+                  if not name or not evidence:
+                      sys.exit(f"gate line {number} is missing a name or its evidence")
+                  gates.append({"name": name, "status": status, "evidence": evidence})
+          if not gates:
+              sys.exit("no gate was recorded; the run evaluated nothing")
+
+          record = {
+              "schema": "hwp-release-readiness-record-v1",
+              "generated_at": datetime.datetime.now(datetime.timezone.utc)
+              .replace(microsecond=0)
+              .isoformat()
+              .replace("+00:00", "Z"),
+              "ref": os.environ["READINESS_REF"],
+              "sha": lower_hex(os.environ["READINESS_SHA"]),
+              "run_url": os.environ["RUN_URL"],
+              "hwp_version": cargo_version(),
+              "gates": gates,
+          }
+          text = json.dumps(record, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+          with open(os.environ["RECORD_PATH"], "w", encoding="utf-8") as handle:
+              handle.write(text)
+          print(text)
+
+          blocking = [g for g in gates if g["status"] in ("fail", "pending")]
+          if blocking:
+              names = ", ".join(f'{g["name"]}={g["status"]}' for g in blocking)
+              print(f"::error::release readiness gates not green: {names}", file=sys.stderr)
+              sys.exit(1)
+          PY
+      - name: Upload the run record
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-readiness-record
+          path: release-readiness-record.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -40,8 +40,12 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref }}
-      # A workflow_dispatch run's own GITHUB_SHA is the default branch's, not the evaluated
-      # ref's, so resolve the checked-out commit explicitly and use it everywhere below.
+      # A workflow_dispatch run's own GITHUB_SHA is the dispatch ref's commit (the run's
+      # head_sha), not the evaluated ref's, so the two are recorded as separate fields and the
+      # evaluated one is resolved explicitly here and used everywhere below. A verifier that
+      # compares the run's head_sha to the commit being released would be checking the dispatch
+      # ref, not the code this run evaluated; scripts/check-verification-block.sh compares the
+      # record's evaluated_sha instead.
       - name: Resolve the evaluated commit
         shell: bash
         env:
@@ -55,7 +59,7 @@ jobs:
             echo "CHECK_RUNS_FILE=$RUNNER_TEMP/check-runs.tsv"
           } >>"$GITHUB_ENV"
           : >"$RUNNER_TEMP/gates.tsv"
-          echo "ref=$READINESS_REF sha=$sha"
+          echo "ref=$READINESS_REF evaluated_sha=$sha workflow_source_sha=$GITHUB_SHA"
 
       # Checklist line 28, run first: the checklist asks for a clean checkout, and later gates
       # fetch fonts and write parity scorecards into the working tree.
@@ -440,6 +444,7 @@ jobs:
           READINESS_REF: ${{ inputs.ref }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           RECORD_PATH: release-readiness-record.json
+          WORKFLOW_SOURCE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -554,6 +559,8 @@ jobs:
           if check_runs_path and os.path.exists(check_runs_path):
               check_runs = {name: state for name, state in read_tsv(check_runs_path, 2)}
 
+          blocking = [g for g in gates if g["status"] in ("fail", "pending")]
+
           record = {
               "schema": "hwp-release-readiness-record-v1",
               "generated_at": datetime.datetime.now(datetime.timezone.utc)
@@ -561,7 +568,13 @@ jobs:
               .isoformat()
               .replace("+00:00", "Z"),
               "ref": os.environ["READINESS_REF"],
-              "sha": lower_hex(os.environ["READINESS_SHA"]),
+              # The commit this run actually evaluated (the resolved `ref` input). This is the
+              # field a release verifier must compare against the commit being released.
+              "evaluated_sha": lower_hex(os.environ["READINESS_SHA"]),
+              # The commit the workflow file itself came from (the dispatch ref, = this run's
+              # head_sha). Recorded for provenance only; it says nothing about what was evaluated.
+              "workflow_source_sha": lower_hex(os.environ["WORKFLOW_SOURCE_SHA"]),
+              "result": "fail" if blocking else "pass",
               "run_url": os.environ["RUN_URL"],
               "hwp_version": cargo_version(),
               "pdfinfo_version": os.environ.get("PDFINFO_VERSION") or None,
@@ -577,17 +590,19 @@ jobs:
               handle.write(text)
           print(text)
 
-          blocking = [g for g in gates if g["status"] in ("fail", "pending")]
           if blocking:
               names = ", ".join(f'{g["name"]}={g["status"]}' for g in blocking)
               print(f"::error::release readiness gates not green: {names}", file=sys.stderr)
               sys.exit(1)
           PY
+      # The artifact name is the record's own contract string, because
+      # scripts/check-verification-block.sh downloads it by that name from the run the release
+      # copy cites and reads evaluated_sha out of it.
       - name: Upload the run record
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
-          name: release-readiness-record
+          name: hwp-release-readiness-record-v1
           path: release-readiness-record.json
           if-no-files-found: error
           retention-days: 90

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,15 +43,24 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
   refused rather than guessed at.
 - `scripts/check-verification-block.sh` is the release boundary both ends share: it requires the
   version's section to carry one marked block citing one Actions run URL of this repository, and
-  the GitHub API to report that run as a successful `release-readiness.yml` run whose head_sha is
-  the commit being released. `scripts/release.sh` runs it before the version bump and
-  `.github/workflows/release.yml` runs it against the tagged commit. There is no override flag.
+  the GitHub API to report that run as a successful `release-readiness.yml` run. What binds the
+  evidence to the code is that run's own `hwp-release-readiness-record-v1` artifact, which the
+  script downloads and reads: its `evaluated_sha` must be the commit being released, its result a
+  pass with a clean tree, and its `workflow_source_sha` the run's head_sha. A dispatch run's
+  head_sha is the ref the run was started from, not the ref it evaluated, so head_sha is recorded
+  as provenance and is no longer what the release is checked against. A record that is missing,
+  expired, unparsable or not a pass is a stop. `scripts/release.sh` runs it before the version
+  bump and `.github/workflows/release.yml` runs it against the tagged commit. There is no
+  override flag.
 - The CI `lint` job now runs the claim lint, the doc-surface gate and both fixture suites, and
   the workflow's path filters no longer exclude the documents those gates read.
 - `.github/workflows/release-readiness.yml` runs every automatable gate of
   `docs/release-readiness.md` against a dispatched tag or branch, from a clean checkout on the
   runner whose Poppler the public parity manifest pins, and uploads one
   `hwp-release-readiness-record-v1` JSON artifact naming each gate, its status and its evidence.
+  The record separates `evaluated_sha`, the commit the run checked out and measured, from
+  `workflow_source_sha`, the commit the workflow file itself came from, and carries one `result`
+  field, so a reader and the release gate can both tell which code the evidence belongs to.
   The run holds a read-only token and performs no commit, tag, package upload, release or
   registry push; the 3-OS evidence is the evaluated commit's own CI check runs, and an absent or
   incomplete one is recorded as pending rather than as a pass. A line the run cannot evaluate is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,17 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
   `.github/workflows/release.yml` runs it against the tagged commit. There is no override flag.
 - The CI `lint` job now runs the claim lint, the doc-surface gate and both fixture suites, and
   the workflow's path filters no longer exclude the documents those gates read.
+- `.github/workflows/release-readiness.yml` runs every automatable gate of
+  `docs/release-readiness.md` against a dispatched tag or branch, from a clean checkout on the
+  runner whose Poppler the public parity manifest pins, and uploads one
+  `hwp-release-readiness-record-v1` JSON artifact naming each gate, its status and its evidence.
+  The run holds a read-only token and performs no commit, tag, package upload, release or
+  registry push; the 3-OS evidence is the evaluated commit's own CI check runs, and an absent or
+  incomplete one is recorded as pending rather than as a pass. A line the run cannot evaluate is
+  recorded as not applicable with a reason, among them the independent certification oracle,
+  which remains partial: no supported public oracle image is shipped, as
+  `docs/design/16-certification-v1.md` and the `partial_not_buildable` status of
+  `oracle/primary-artifacts.lock.json` both state.
 
 ## [0.17.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,21 @@ The workspace `Cargo.toml` `[workspace.package] version` is the single source fo
   which remains partial: no supported public oracle image is shipped, as
   `docs/design/16-certification-v1.md` and the `partial_not_buildable` status of
   `oracle/primary-artifacts.lock.json` both state.
+  The run executes code from the ref it evaluates, so it first requires that commit to be a tag
+  of this repository or an ancestor of `origin/main`; anything else records one `refused`
+  outcome and stops the job before a single gate runs. A step that runs evaluated-ref code does
+  nothing but run it: the gate entry is written by a step defined in the workflow itself, out of
+  the exit status the runner recorded, and the entries travel as step outputs rather than
+  through a file on disk, so a gate script cannot add, edit or delete the evidence it is
+  measured by. The tag gate that compares the README install snippets accepts `v0.17.0` and
+  `refs/tags/v0.17.0` alike, requires the tag to point at the evaluated commit, and requires
+  `README.md` and `README.ko.md` each to carry the matching pin; a missing file or an
+  unreadable pin is a failure, not a pass.
+- `scripts/tests/release-readiness-selfcheck.sh` runs the readiness workflow's own steps against
+  fixtures - the trust policy, the ledger a gate script must not be able to reach, the record
+  fields and the release gate that reads them, and the README tag comparison - by extracting each
+  step out of the workflow file, so the harness cannot drift from what ships. `scripts/check.sh`
+  and the CI `lint` job run it.
 
 ## [0.17.0]
 

--- a/scripts/check-verification-block.sh
+++ b/scripts/check-verification-block.sh
@@ -10,23 +10,37 @@
 #      `<!-- verification:end -->` pair, in that order, around a `**Verification**` block;
 #   2. the block cites exactly one release-readiness run URL, and it is an Actions run URL of
 #      this repository;
-#   3. with `gh` available, the GitHub API says that run finished with conclusion `success`, that
-#      it is a run of the release-readiness workflow, and that its head_sha is the commit being
-#      released.
+#   3. with `gh` available, the GitHub API says that run finished with conclusion `success` and
+#      that it is a run of the release-readiness workflow;
+#   4. that run's own record artifact says it evaluated the commit being released, and passed.
+#
+# Why 4 and not a head_sha comparison: release-readiness.yml checks out `inputs.ref`, which is
+# independent of the ref the run was dispatched from. A dispatch run's head_sha is the DISPATCH
+# ref's commit, so comparing it to the release commit checks the wrong thing in both directions -
+# it rejects a correct run dispatched from main against a tag, and it accepts a run dispatched
+# from the release commit that evaluated something else entirely. The binding therefore reads the
+# run record's `evaluated_sha`. head_sha is still queried, and is required to match the record's
+# `workflow_source_sha`, which ties the downloaded record to the cited run's dispatch.
+# (This supersedes the head_sha check this script shipped with.)
 #
 # There is no override flag. Missing evidence is a stop, not a warning: the block is the public
-# claim that the release was evaluated, and a claim nobody can check is worse than none.
+# claim that the release was evaluated, and a claim nobody can check is worse than none. A record
+# that is absent, expired, unparsable or short of a required field is a stop for the same reason.
 #
-# Without `gh` (a developer machine with no GitHub CLI) checks 1 and 2 still run and check 3 is
+# Without `gh` (a developer machine with no GitHub CLI) checks 1 and 2 still run and checks 3-4 are
 # reported as unverified with a non-zero-free warning; the release workflow always has `gh`, so
 # the published release is never gated on the operator's laptop having it.
 #
-# HWP_CHANGELOG overrides the file that is read (tests only).
+# HWP_CHANGELOG overrides the file that is read, and HWP_READINESS_RECORD substitutes a local
+# record file for the artifact download and the run API lookup (both tests only).
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
 REPO="STAIxBWLB/hwp-cli"
 WORKFLOW_FILE="release-readiness.yml"
+CONTRACT="hwp-release-readiness-record-v1"
+ARTIFACT_NAME="$CONTRACT"
+RECORD_FILE="release-readiness-record.json"
 BEGIN_MARKER="<!-- verification:begin -->"
 END_MARKER="<!-- verification:end -->"
 
@@ -85,32 +99,119 @@ else
 fi
 
 # --- 3. the run itself ---------------------------------------------------------------------------
-if ! command -v gh >/dev/null 2>&1; then
+head_sha=""
+record=""
+if [ -n "${HWP_READINESS_RECORD:-}" ]; then
+    # tests only: stand in for the artifact download and the run API lookup.
+    record="$HWP_READINESS_RECORD"
+    [ -f "$record" ] || die "HWP_READINESS_RECORD=$record does not exist."
+    echo "verification-block: WARNING - HWP_READINESS_RECORD is set, so run $run_id was NOT queried" >&2
+elif ! command -v gh >/dev/null 2>&1; then
     echo "verification-block: WARNING - gh is not installed, so run $run_id was NOT verified" >&2
-    echo "verification-block: block OK for $version (run $run_url, API check skipped)"
+    echo "verification-block: block OK for $version (run $run_url, API and record checks skipped)"
     exit 0
+else
+    api="$(gh api "repos/$REPO/actions/runs/$run_id" \
+        --jq '[.status, .conclusion // "none", .name // "", .path // "", .head_sha // ""] | @tsv' 2>&1)" ||
+        die "gh api repos/$REPO/actions/runs/$run_id failed:
+                    $api"
+    IFS=$'\t' read -r status conclusion name path head_sha <<<"$api"
+
+    [ "$status" = completed ] ||
+        die "readiness run $run_id is '$status', not completed."
+    [ "$conclusion" = success ] ||
+        die "readiness run $run_id concluded '$conclusion', not success."
+    case "$path" in
+    */"$WORKFLOW_FILE" | "$WORKFLOW_FILE") ;;
+    *)
+        # `name` is the workflow's display name; accept it when the path is unavailable.
+        printf '%s' "$name" | grep -Eqi '^release[ -]readiness$' ||
+            die "run $run_id is workflow '$name' ($path), not $WORKFLOW_FILE."
+        ;;
+    esac
+
+    # --- 4. the record that run produced --------------------------------------------------------
+    tmpdir="$(mktemp -d)"
+    trap 'rm -rf "$tmpdir"' EXIT
+    download="$(gh run download "$run_id" --repo "$REPO" --name "$ARTIFACT_NAME" --dir "$tmpdir" 2>&1)" ||
+        die "cannot download the $ARTIFACT_NAME artifact of run $run_id (expired, deleted or never
+                    uploaded), so what that run evaluated cannot be established:
+                    $download"
+    record="$tmpdir/$RECORD_FILE"
+    [ -f "$record" ] ||
+        die "the $ARTIFACT_NAME artifact of run $run_id carries no $RECORD_FILE."
 fi
 
-api="$(gh api "repos/$REPO/actions/runs/$run_id" \
-    --jq '[.status, .conclusion // "none", .name // "", .path // "", .head_sha // ""] | @tsv' 2>&1)" ||
-    die "gh api repos/$REPO/actions/runs/$run_id failed:
-                    $api"
-IFS=$'\t' read -r status conclusion name path head_sha <<<"$api"
+command -v python3 >/dev/null 2>&1 ||
+    die "python3 is required to read the run record."
+python3 - "$record" "$sha" "$CONTRACT" "$run_id" "$head_sha" <<'PY' || exit 1
+import json
+import sys
 
-[ "$status" = completed ] ||
-    die "readiness run $run_id is '$status', not completed."
-[ "$conclusion" = success ] ||
-    die "readiness run $run_id concluded '$conclusion', not success."
-case "$path" in
-*/"$WORKFLOW_FILE" | "$WORKFLOW_FILE") ;;
-*)
-    # `name` is the workflow's display name; accept it when the path is unavailable.
-    printf '%s' "$name" | grep -Eqi '^release[ -]readiness$' ||
-        die "run $run_id is workflow '$name' ($path), not $WORKFLOW_FILE."
-    ;;
-esac
-[ "$head_sha" = "$sha" ] ||
-    die "readiness run $run_id evaluated $head_sha, but the commit being released is $sha.
-                    Dispatch $WORKFLOW_FILE against that commit and cite the new run."
+path, want_sha, contract, run_id, head_sha = sys.argv[1:6]
 
-echo "verification-block: OK for $version (run $run_id, $conclusion, head_sha $head_sha)"
+
+def die(message):
+    print(f"verification-block: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+try:
+    with open(path, encoding="utf-8") as handle:
+        record = json.load(handle)
+except (OSError, ValueError) as error:
+    die(f"the run record {path} could not be read as JSON: {error}")
+if not isinstance(record, dict):
+    die(f"the run record {path} is not a JSON object.")
+
+
+def field(name):
+    value = record.get(name)
+    if not isinstance(value, str) or not value.strip():
+        die(f"the run record of run {run_id} has no {name} field.")
+    return value.strip()
+
+
+if field("schema") != contract:
+    die(f"the run record of run {run_id} declares schema {record['schema']!r}, not {contract!r}.")
+evaluated = field("evaluated_sha").lower()
+if evaluated != want_sha.lower():
+    die(
+        f"readiness run {run_id} evaluated {evaluated}, but the commit being released is"
+        f" {want_sha}.\n                    Dispatch release-readiness.yml against that commit"
+        " and cite the new run."
+    )
+source = field("workflow_source_sha").lower()
+if head_sha and source != head_sha.lower():
+    die(
+        f"the record of run {run_id} says its workflow came from {source}, but the run's head_sha"
+        f" is {head_sha}."
+    )
+if not field("run_url").rstrip("/").endswith(f"/{run_id}"):
+    die(f"the record of run {run_id} cites run_url {record['run_url']!r}, which is another run.")
+if field("result") != "pass":
+    die(f"readiness run {run_id} recorded result {record['result']!r}, not 'pass'.")
+
+gates = record.get("gates")
+if not isinstance(gates, list) or not gates:
+    die(f"the record of run {run_id} carries no gates.")
+statuses = {}
+for gate in gates:
+    if not isinstance(gate, dict):
+        die(f"the record of run {run_id} carries a gate that is not an object.")
+    name, status = gate.get("name"), gate.get("status")
+    if not isinstance(name, str) or not isinstance(status, str):
+        die(f"the record of run {run_id} carries a gate with no name or no status.")
+    statuses[name] = status
+blocking = sorted(f"{n}={s}" for n, s in statuses.items() if s in ("fail", "pending"))
+if blocking:
+    die(f"readiness run {run_id} records non-passing gates: {', '.join(blocking)}.")
+if statuses.get("clean-tree") != "pass":
+    die(
+        f"readiness run {run_id} records clean-tree={statuses.get('clean-tree')!r}, not 'pass', so"
+        " it did not evaluate a clean checkout."
+    )
+print(f"verification-block: record OK (evaluated_sha {evaluated}, {len(gates)} gates, result pass)")
+PY
+
+echo "verification-block: OK for $version (run $run_id, evaluated_sha $sha, head_sha ${head_sha:-not queried})"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -30,6 +30,7 @@ run bash scripts/check-claims.sh --self-test
 run bash scripts/check-doc-surface.sh
 run bash scripts/check-doc-surface.sh --self-test
 run bash scripts/release_verification_block.sh --self-test
+run bash scripts/tests/release-readiness-selfcheck.sh
 target_dir="${CARGO_TARGET_DIR:-target}"
 run "$target_dir/debug/examples/validate_structured_corpus" \
     schemas/pdf-parity-history-v1.schema.json \
@@ -60,4 +61,4 @@ if [ "$fail" -ne 0 ]; then
     echo "== check: FAILED (위 게이트 중 실패 있음) =="
     exit 1
 fi
-echo "== check: OK (fmt/clippy/test/pdf-runner/structured-corpus/claims/doc-surface/release-block/public-parity=$parity_result) =="
+echo "== check: OK (fmt/clippy/test/pdf-runner/structured-corpus/claims/doc-surface/release-block/readiness-selfcheck/public-parity=$parity_result) =="

--- a/scripts/tests/release-readiness-selfcheck.sh
+++ b/scripts/tests/release-readiness-selfcheck.sh
@@ -1,0 +1,409 @@
+#!/usr/bin/env bash
+# scripts/tests/release-readiness-selfcheck.sh
+#
+# Regression harness for .github/workflows/release-readiness.yml. Every case extracts the step's
+# shell out of the workflow file and runs it against a fixture, so what is tested is the workflow
+# that ships rather than a second copy of its logic. Nothing here dispatches a run, and nothing
+# touches the repository: all fixtures live in a temporary directory.
+#
+# The regressions it pins, one per finding of the 2026-09-05 review:
+#
+#   1. The dispatch commit and the evaluated commit are recorded as separate fields, and
+#      scripts/check-verification-block.sh refuses a record whose evaluated_sha is not the commit
+#      being released.
+#   2. A gate script from the evaluated ref cannot touch the evidence: no target step is handed
+#      the ledger path, the ledger name is unpredictable, and the assembled record carries only
+#      what the controller steps wrote.
+#   3. A ref that is neither a tag of this repository nor an ancestor of origin/main is refused,
+#      and every step that runs evaluated-ref code is guarded by that refusal.
+#   4. readme-pinned-tag: fully qualified tag refs are compared instead of skipped, a tag that is
+#      not the evaluated commit fails, and README.ko.md has to carry the pin on its own.
+#
+# PyYAML reads the workflow. Without it the harness reports SKIP and exits 0: it is a developer
+# gate, not a release gate, and the release gate it protects is scripts/check-verification-block.sh.
+set -uo pipefail
+cd "$(dirname "$0")/../.." || exit 1
+
+WORKFLOW=.github/workflows/release-readiness.yml
+ROOT="$PWD"
+
+if ! python3 -c "import yaml" 2>/dev/null; then
+    echo "== release-readiness self-check: SKIP (PyYAML is not installed)"
+    exit 0
+fi
+
+fail=0
+check() { # <description> <rc already evaluated by the caller>
+    if [ "$2" = "0" ]; then
+        printf '  ok   %s\n' "$1"
+    else
+        printf '  FAIL %s\n' "$1" >&2
+        fail=1
+    fi
+}
+same() { # <description> <actual> <expected>
+    if [ "$2" = "$3" ]; then
+        printf '  ok   %s\n' "$1"
+    else
+        printf '  FAIL %s\n         actual:   %s\n         expected: %s\n' "$1" "$2" "$3" >&2
+        fail=1
+    fi
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+steps="$tmp/steps"
+mkdir -p "$steps"
+
+# --- extract every named `run:` step, and the checklist the assembly enforces ------------------
+python3 - "$WORKFLOW" "$steps" <<'PY'
+import os
+import re
+import sys
+
+import yaml
+
+workflow, out = sys.argv[1], sys.argv[2]
+job = yaml.safe_load(open(workflow, encoding="utf-8"))["jobs"]["readiness"]
+for step in job["steps"]:
+    name, run = step.get("name"), step.get("run")
+    if name and run:
+        slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+        with open(os.path.join(out, slug + ".sh"), "w", encoding="utf-8") as handle:
+            handle.write(run)
+PY
+[ -s "$steps/trust-policy-for-the-evaluated-ref.sh" ] ||
+    { echo "self-check: the workflow has no trust step to extract" >&2; exit 1; }
+
+echo "== release-readiness self-check"
+
+# --- 1. structure: what the target steps are and are not given ---------------------------------
+echo "-- isolation, structural"
+structure="$(python3 - "$WORKFLOW" <<'PY'
+import re
+import sys
+
+import yaml
+
+problems = []
+workflow = yaml.safe_load(open(sys.argv[1], encoding="utf-8"))
+job = workflow["jobs"]["readiness"]
+steps = job["steps"]
+guard = "steps.trust.outputs.trusted == 'yes'"
+if not [s for s in steps if s.get("continue-on-error")]:
+    problems.append("no step is marked continue-on-error, so no step is a target step")
+emitting = set()
+for step in steps:
+    name = step.get("name") or step.get("uses")
+    env = step.get("env") or {}
+    run = step.get("run") or ""
+    is_target = bool(step.get("continue-on-error"))
+    if is_target:
+        leaked = sorted(
+            k
+            for k, v in env.items()
+            if k in ("GATES_FILE", "CHECK_RUNS_FILE", "RECORD_PATH")
+            or ".outputs.entry" in str(v)
+            or "ledger" in str(v)
+        )
+        if leaked:
+            problems.append(f"target step {name!r} is handed the evidence through {leaked}")
+        if guard not in (step.get("if") or ""):
+            problems.append(f"target step {name!r} is not guarded by the trust policy")
+        if "GITHUB_OUTPUT" in run:
+            problems.append(f"target step {name!r} writes a step output")
+    if "GITHUB_ENV" in run:
+        problems.append(f"step {name!r} writes to $GITHUB_ENV, which every later step receives")
+    if "ledger" in str(env):
+        problems.append(f"step {name!r} is handed a shared ledger path")
+    if "GATES_FILE" in run:
+        if 'GATES_FILE="$(mktemp)"' not in run:
+            problems.append(f"controller step {name!r} does not create its own ledger file")
+        if "entry<<GATE_ENTRY_EOF" not in run:
+            problems.append(f"controller step {name!r} does not emit its entries as a step output")
+        elif re.search(r"^\s*exit ", run[: run.index("entry<<GATE_ENTRY_EOF")], re.M):
+            problems.append(f"controller step {name!r} can exit before it emits its entries")
+        elif step.get("id"):
+            emitting.add(step["id"])
+        else:
+            problems.append(f"controller step {name!r} emits an output without an id")
+trust_at = next((n for n, s in enumerate(steps) if s.get("id") == "trust"), None)
+if trust_at is None:
+    problems.append("no step has id: trust")
+else:
+    first_target = min(n for n, s in enumerate(steps) if s.get("continue-on-error"))
+    if trust_at > first_target:
+        problems.append("the trust policy runs after a step that executes evaluated-ref code")
+assembly = next(s for s in steps if s.get("name") == "Assemble the run record")
+wired = {
+    v.split("steps.", 1)[1].split(".outputs", 1)[0]
+    for k, v in (assembly.get("env") or {}).items()
+    if k.startswith("GATE_")
+}
+unread = sorted(emitting - wired)
+if unread:
+    problems.append(f"controller steps whose entries the record never reads: {unread}")
+if workflow["permissions"] != {"contents": "read", "checks": "read"}:
+    problems.append("the workflow permissions are no longer contents: read + checks: read")
+if job.get("permissions"):
+    problems.append("the job overrides the read-only permissions")
+print("\n".join(problems))
+PY
+)"
+[ -z "$structure" ] || printf '%s\n' "$structure" >&2
+check "no target step is handed the ledger, and every one is behind the trust policy" \
+    "$([ -z "$structure" ] && echo 0 || echo 1)"
+
+# --- 2. the trust policy, executed --------------------------------------------------------------
+echo "-- trust policy"
+origin="$tmp/origin.git"
+work="$tmp/work"
+git init -q --bare "$origin"
+git init -q -b main "$work"
+(
+    cd "$work"
+    git config user.email selfcheck@example.invalid
+    git config user.name selfcheck
+    echo one >a
+    git add -A
+    git commit -qm one
+    git checkout -q -b side
+    echo side >b
+    git add -A
+    git commit -qm side
+    git checkout -q main
+    echo two >a
+    git commit -qam two
+    git tag v9.9.9 side
+    git remote add origin "$origin"
+    git push -q origin main
+    git push -q origin v9.9.9
+) || { echo "self-check: fixture repository setup failed" >&2; exit 1; }
+main_sha="$(git -C "$work" rev-parse main)"
+side_sha="$(git -C "$work" rev-parse side)"
+
+trust() { # <ref> <sha> -> prints "<rc> <trusted>"
+    local out="$tmp/gh_out" rc
+    : >"$out"
+    rm -f "$tmp/record.json"
+    (
+        cd "$work" &&
+            RUNNER_TEMP="$tmp" \
+                READINESS_REF="$1" EVALUATED_SHA="$2" WORKFLOW_SOURCE_SHA="$(printf 'b%.0s' {1..40})" \
+                RUN_URL="https://github.com/STAIxBWLB/hwp-cli/actions/runs/424242" \
+                RECORD_PATH="$tmp/record.json" GITHUB_OUTPUT="$out" \
+                bash "$steps/trust-policy-for-the-evaluated-ref.sh"
+    ) >"$tmp/trust.log" 2>&1
+    rc=$?
+    printf '%s %s' "$rc" "$(sed -n 's/^trusted=//p' "$out")"
+}
+same "a commit reachable from origin/main is trusted" "$(trust main "$main_sha")" "0 yes"
+same "a tag of this repository is trusted" "$(trust v9.9.9 "$side_sha")" "0 yes"
+same "a fully qualified tag ref is trusted" "$(trust refs/tags/v9.9.9 "$side_sha")" "0 yes"
+git -C "$work" tag -d v9.9.9 >/dev/null
+git -C "$work" push -q origin :refs/tags/v9.9.9
+same "a ref that is neither a tag nor an ancestor of main is refused" \
+    "$(trust side "$side_sha")" "1 no"
+python3 - "$tmp/record.json" "$side_sha" <<'PY'
+import json
+import sys
+
+record = json.load(open(sys.argv[1], encoding="utf-8"))
+assert record["result"] == "refused", record["result"]
+assert record["schema"] == "hwp-release-readiness-record-v1", record["schema"]
+assert record["evaluated_sha"] == sys.argv[2], record["evaluated_sha"]
+assert [g["name"] for g in record["gates"]] == ["trust-policy"], record["gates"]
+PY
+check "the refusal writes one trust-policy outcome and nothing else" "$?"
+
+# --- 3. evidence a target step cannot reach -----------------------------------------------------
+echo "-- ledger isolation, executed"
+export RUNNER_TEMP="$tmp/runner"
+mkdir -p "$RUNNER_TEMP/gates"
+
+# out_value <github-output file> <key>: read one step output, plain or heredoc-delimited.
+out_value() {
+    python3 - "$1" "$2" <<'PYEOF'
+import sys
+
+path, key = sys.argv[1], sys.argv[2]
+lines = open(path, encoding="utf-8").read().splitlines()
+index = 0
+while index < len(lines):
+    line = lines[index]
+    if line.startswith(key + "<<"):
+        delimiter = line.split("<<", 1)[1]
+        body = []
+        index += 1
+        while index < len(lines) and lines[index] != delimiter:
+            body.append(lines[index])
+            index += 1
+        print("\n".join(body))
+        raise SystemExit(0)
+    if line.startswith(key + "="):
+        print(line.split("=", 1)[1])
+        raise SystemExit(0)
+    index += 1
+raise SystemExit(1)
+PYEOF
+}
+
+# A stand-in for a gate script of the evaluated ref, run with the environment a target step gets:
+# it hunts for the evidence and forges entries wherever it can write.
+cat >"$tmp/hostile.sh" <<'EOF'
+env | grep -iE 'ledger|gates_file|check_runs|record_path|github_output' >"$HOSTILE_OUT/env-hits" || true
+for guess in "$RUNNER_TEMP/gates.tsv" "$RUNNER_TEMP/ledger" "$RUNNER_TEMP/gates/ledger" \
+    "$PWD/gates.tsv" "$RUNNER_TEMP/release-readiness-record.json"; do
+    printf 'fmt\tpass\tforged by the evaluated ref\n' >>"$guess" 2>/dev/null || true
+done
+# and anything that looks like a ledger, wherever it is
+find "$RUNNER_TEMP" /tmp -maxdepth 2 -type f \( -name 'ledger*' -o -name '*gates*' \) -newer "$0" \
+    -exec sh -c 'printf "clean-tree\tpass\tforged by the evaluated ref\n" >>"$1" 2>/dev/null' _ {} \; 2>/dev/null
+exit 1
+EOF
+mkdir -p "$tmp/hostile"
+(cd "$work" && env -i PATH="$PATH" HOME="$HOME" RUNNER_TEMP="$RUNNER_TEMP" \
+    HOSTILE_OUT="$tmp/hostile" bash "$tmp/hostile.sh") >/dev/null 2>&1
+check "nothing in a target step's environment names the evidence" \
+    "$([ ! -s "$tmp/hostile/env-hits" ] && echo 0 || echo 1)"
+check "the simulated gate script did write its forgery somewhere" \
+    "$(grep -rqF 'forged by the evaluated ref' "$RUNNER_TEMP" && echo 0 || echo 1)"
+
+# The controller records the gate from the outcome the runner holds, after the hostile step ran:
+# a failing target step becomes exactly one `fail` line, emitted as this step's own output.
+fmt_out="$tmp/gate-fmt-output"
+: >"$fmt_out"
+(cd "$work" && RUNNER_TEMP="$RUNNER_TEMP" GITHUB_OUTPUT="$fmt_out" OUTCOME=failure \
+    bash "$steps/gate-fmt.sh") >/dev/null 2>&1
+fmt_entry="$(out_value "$fmt_out" entry)"
+same "the controller records the failing target step once, as fail" \
+    "$fmt_entry" "$(printf 'fmt\tfail\tcargo fmt --all --check')"
+check "the controller entry carries nothing the simulated gate script wrote" \
+    "$(printf '%s' "$fmt_entry" | grep -qF 'forged' && echo 1 || echo 0)"
+
+# --- 4. the record, and the release gate that reads it ------------------------------------------
+echo "-- record fields and the release binding"
+assembly="$steps/assemble-the-run-record.sh"
+record_dir="$tmp/record"
+mkdir -p "$record_dir"
+cat >"$record_dir/Cargo.toml" <<'EOF'
+[workspace.package]
+version = "9.9.9"
+EOF
+# Every checklist entry except fmt, which comes from the controller step run above.
+rest="$(python3 - "$assembly" <<'PYEOF'
+import ast
+import re
+import sys
+
+source = open(sys.argv[1], encoding="utf-8").read()
+names = ast.literal_eval(re.search(r"CHECKLIST = (\[.*?\])", source, re.S).group(1))
+print("\n".join(f"{name}\tpass\trecorded by a controller step" for name in names if name != "fmt"))
+PYEOF
+)"
+evaluated="$(printf 'a%.0s' {1..40})"
+dispatched="$(printf 'b%.0s' {1..40})"
+released_elsewhere="$(printf 'c%.0s' {1..40})"
+run_url="https://github.com/STAIxBWLB/hwp-cli/actions/runs/424242"
+(cd "$record_dir" && GATE_FMT="$fmt_entry" GATE_REST="$rest" CHECK_RUNS="" READINESS_REF=v9.9.9 \
+    READINESS_SHA="$evaluated" WORKFLOW_SOURCE_SHA="$dispatched" PDFINFO_VERSION="" \
+    ORACLE_STATUS="" ORACLE_LOCK_SHA256="" RUN_URL="$run_url" \
+    RECORD_PATH="$record_dir/record.json" bash "$assembly") >/dev/null 2>&1
+check "the assembly writes a record from the controller entries" \
+    "$([ -f "$record_dir/record.json" ] && echo 0 || echo 1)"
+python3 - "$record_dir/record.json" "$evaluated" "$dispatched" <<'PYEOF'
+import json
+import sys
+
+record = json.load(open(sys.argv[1], encoding="utf-8"))
+assert record["evaluated_sha"] == sys.argv[2], record["evaluated_sha"]
+assert record["workflow_source_sha"] == sys.argv[3], record["workflow_source_sha"]
+assert record["evaluated_sha"] != record["workflow_source_sha"]
+assert record["result"] == "fail", record["result"]
+gates = {gate["name"]: gate for gate in record["gates"]}
+assert gates["fmt"]["status"] == "fail", gates["fmt"]
+assert not any("forged" in gate["evidence"] for gate in record["gates"])
+PYEOF
+check "the record keeps the two commits apart and carries no forged gate" "$?"
+
+# The same assembly with every gate passing, which is what the release gate is shown next.
+(cd "$record_dir" && GATE_ALL="$(printf '%s\n%s\n' "$(printf 'fmt\tpass\tcargo fmt --all --check')" "$rest")" \
+    CHECK_RUNS="" READINESS_REF=v9.9.9 READINESS_SHA="$evaluated" WORKFLOW_SOURCE_SHA="$dispatched" \
+    PDFINFO_VERSION="" ORACLE_STATUS="" ORACLE_LOCK_SHA256="" RUN_URL="$run_url" \
+    RECORD_PATH="$record_dir/green.json" bash "$assembly") >/dev/null 2>&1
+check "a run with every gate passing records result pass" \
+    "$(python3 -c "import json,sys; sys.exit(0 if json.load(open(sys.argv[1]))['result'] == 'pass' else 1)" \
+        "$record_dir/green.json" && echo 0 || echo 1)"
+
+# The release boundary: same record, two candidate release commits.
+changelog="$tmp/CHANGELOG.md"
+cat >"$changelog" <<'EOF'
+# Changelog
+
+## [9.9.9]
+
+**Added**
+
+- a released thing
+EOF
+HWP_CHANGELOG="$changelog" bash scripts/release_verification_block.sh 9.9.9 "$run_url" >/dev/null 2>&1
+check "the verification block fixture was written" "$?"
+HWP_CHANGELOG="$changelog" HWP_READINESS_RECORD="$record_dir/green.json" \
+    bash "$ROOT/scripts/check-verification-block.sh" 9.9.9 "$evaluated" >/dev/null 2>&1
+check "the release gate accepts the record of the commit being released" "$?"
+if HWP_CHANGELOG="$changelog" HWP_READINESS_RECORD="$record_dir/green.json" \
+    bash "$ROOT/scripts/check-verification-block.sh" 9.9.9 "$released_elsewhere" >/dev/null 2>&1; then
+    rejected=1
+else
+    rejected=0
+fi
+check "the release gate rejects a record that evaluated another commit" "$rejected"
+if HWP_CHANGELOG="$changelog" HWP_READINESS_RECORD="$record_dir/record.json" \
+    bash "$ROOT/scripts/check-verification-block.sh" 9.9.9 "$evaluated" >/dev/null 2>&1; then
+    rejected=1
+else
+    rejected=0
+fi
+check "the release gate rejects a record whose gates did not all pass" "$rejected"
+
+# --- 5. readme-pinned-tag ------------------------------------------------------------------------
+echo "-- readme-pinned-tag"
+readme="$tmp/readme"
+mkdir -p "$readme"
+(
+    cd "$readme"
+    git init -q -b main .
+    git config user.email selfcheck@example.invalid
+    git config user.name selfcheck
+    printf 'curl -sSfL https://example.invalid/install.sh | sh -s -- --tag v9.9.9\n' >README.md
+    cp README.md README.ko.md
+    git add -A
+    git commit -qm readme
+    git tag v9.9.9
+) || { echo "self-check: readme fixture setup failed" >&2; exit 1; }
+readme_sha="$(git -C "$readme" rev-parse HEAD)"
+readme_gate() { # <ref> <sha> -> prints the recorded status
+    local out="$tmp/readme-output"
+    : >"$out"
+    (cd "$readme" && GITHUB_OUTPUT="$out" READINESS_REF="$1" EVALUATED_SHA="$2" \
+        bash "$steps/gate-readme-pinned-tag.sh") >/dev/null 2>&1
+    out_value "$out" entry | cut -f2
+}
+same "a bare tag with both READMEs pinned passes" "$(readme_gate v9.9.9 "$readme_sha")" "pass"
+same "a fully qualified tag ref is compared, not skipped" \
+    "$(readme_gate refs/tags/v9.9.9 "$readme_sha")" "pass"
+same "a branch ref is not applicable" "$(readme_gate main "$readme_sha")" "n/a"
+same "a tag that is not the evaluated commit fails" \
+    "$(readme_gate v9.9.9 "$(printf 'd%.0s' {1..40})")" "fail"
+: >"$readme/README.ko.md"
+same "a README.ko.md with no install snippet fails" "$(readme_gate v9.9.9 "$readme_sha")" "fail"
+rm -f "$readme/README.ko.md"
+same "a missing README.ko.md fails" "$(readme_gate v9.9.9 "$readme_sha")" "fail"
+printf 'curl | sh -s -- --tag v0.0.1\n' >"$readme/README.ko.md"
+same "a README.ko.md pinning another version fails" "$(readme_gate v9.9.9 "$readme_sha")" "fail"
+
+if [ "$fail" -ne 0 ]; then
+    echo "== release-readiness self-check: FAILED" >&2
+    exit 1
+fi
+echo "== release-readiness self-check: OK"


### PR DESCRIPTION
## Summary

`.github/workflows/release-readiness.yml` is a manual `workflow_dispatch` run that evaluates every
automatable line of `docs/release-readiness.md` against a chosen tag or branch, from a clean
checkout on `ubuntu-24.04` (the runner whose Poppler the public parity manifest pins), and uploads
one `hwp-release-readiness-record-v1` JSON artifact. No documentation file changes: the run reports
each line's status instead of the checklist restating it.

Refs RLSE-02
Phase 04 milestone release gate

**Stacked on #235** (`feat/release-copy-gates`), because this workflow calls
`scripts/check-claims.sh` and `scripts/check-doc-surface.sh`, which that PR adds. The base is
`feat/release-copy-gates`; GitHub retargets this PR to `main` when #235 is squash merged. Follow-up
after that merge: rebase onto main.

## The run is read-only by construction

- Top-level `permissions:` grants `contents: read` and `checks: read`. Nothing else, and no job
  overrides it.
- No step commits, creates or moves a ref, publishes a release, or contacts a registry. Nothing is
  built, tagged or attested as an image. The only upload is the run record artifact
  (`docs/release-readiness.md` line 29).
- Every `uses:` reference already appears at the same version in `ci.yml` or `release.yml`:
  `actions/checkout@v7`, `dtolnay/rust-toolchain@1.93.0`, `Swatinem/rust-cache@v2`,
  `actions/upload-artifact@v7`. No new action is introduced.

## Trust policy, and what a gate script can and cannot touch

The run executes code from the ref it evaluates (cargo build scripts, `scripts/*.sh`), and the
record it produces is what a release cites. Two rules keep that from being self-certifying:

- **Trust policy.** Before any evaluated-ref code runs, the commit must be a tag of this
  repository or an ancestor of `origin/main`. Anything else records one `refused` outcome and
  fails the job without running a single gate. The checkout is full-depth so both questions are
  answerable, and `v0.17.0` and `refs/tags/v0.17.0` normalize to the same tag.
- **Controller steps and target steps.** A step that runs evaluated-ref code does nothing but run
  it and tee its output to `$RUNNER_TEMP/gates/<name>/log`. Every gate entry is written by a
  controller step whose shell lives in this file, out of `steps.<id>.outcome` - the exit status
  the runner recorded, which no process on the runner can rewrite. There is deliberately no
  ledger file shared between steps: a random name under `$RUNNER_TEMP` is still one `find` away
  for a gate script running as the same user (the self-check demonstrated exactly that). Each
  controller step keeps its entries for the length of its own step and hands them to the record
  assembly as a step output.

## The twenty gate entries

Each entry carries a `name`, a `status` in `pass`/`fail`/`n/a`/`pending`, and an `evidence` string.
The assembly step reorders them into checklist order and refuses a run whose entries are missing,
duplicated or unknown, so the steps themselves are sequenced by dependency: `clean-tree` runs
first, before anything writes to the checkout, and the public parity gate runs last, because it
writes scorecards into the tracked scoreboard directory.

**Gates that run a command** (`fail` when the command fails): `fmt`, `clippy`, `test-workspace`,
`structured-corpus`, `corpus-fonts-reproduce` (from an emptied `corpus/structured-v1/fonts`, so the
script's own sha256 verification is the gate), `pdf-parity-public` (pinned Poppler plus the exact
OFL fonts, against the committed public oracle, whose manifest declares no exclusions),
`release-copy-claims` and `tool-count`/`skill-coverage`. The last three invoke
`scripts/check-claims.sh` and `scripts/check-doc-surface.sh`, the same files `scripts/check.sh`
runs locally, rather than reimplementing their logic.

**Derived from the structured-corpus run, not re-executed**: `corpus-schemas` and
`corpus-git-index` cite the specific check inside `scripts/check-structured-corpus.sh` and carry
that run's status, because that one script also validates the three frozen schemas and asserts
Git-index membership. `corpus-no-ambient-fonts` asserts that the environment the corpus gate ran in
carries no font variable, and the job installs no font package at all.

**Structural, with a real assertion**: `release-archive-fonts` checks `release.yml` still packages
`bin: hwp` and names no font file, so the corpus does not ship and no OFL inventory is required.
`no-publish` records the read-only permissions block and the absence of any mutating step, and says
in its evidence that it is a structural property rather than a command that ran.

**Read rather than re-run**: `ci-matrix` queries the check-runs API for the resolved commit with the
same five expected job names and the same `jq` extraction as `release.yml`'s `verify-ci` job (those
names must stay in sync with `ci.yml`). All five completed and successful is a `pass`; a completed
non-success is a `fail`; absent, queued or in progress is `pending`. An absent check run is never a
pass, and both `fail` and `pending` fail the job.

**Recorded as not applicable, with a reason, never as a pass**:

- `independent-oracle` - no supported public oracle image is shipped by this repository. The reason
  cites the "Independent import oracle" section of `docs/design/16-certification-v1.md` and quotes
  the `partial_not_buildable` status of `oracle/primary-artifacts.lock.json`, whose sha256 the
  record carries. The record's `oracle` key is read from that lock file rather than hardcoded, so a
  future lock file moves the record with it. `docs/release-readiness.md` line 18 is untouched.
  The decision that would have built and attested an image (D-06) was withdrawn on 2026-09-05; the
  oracle stays partial and this PR builds no image.
- `hancom-receipt` - the receipts are an owner observation made in Hancom Office and are kept
  privately outside the repository; CI has no Hancom oracle.
- `hwpx-skill-parity` - the comparison target is the separate `STAIxBWLB/skills` repository, which
  this run does not check out; the parity matrix in `docs/design/23-hwpx-skill-absorption.md` is
  reviewed by hand.
- `readme-pinned-tag` - `n/a` when the evaluated ref is a branch, because there is no release being
  cut to compare the `install.sh --tag` snippets against. Against a tag it is a real comparison:
  the ref is normalized first (so a `refs/tags/vX` dispatch is compared instead of skipped), the
  resolved tag has to point at the commit this run evaluated, and `README.md` and `README.ko.md`
  each have to carry the complete matching pin on their own. A missing file, an absent snippet or
  an empty extraction is a `fail` naming the file - never a pass and never `n/a`.

A gate whose script does not exist in the evaluated ref's checkout is recorded as `n/a` naming the
missing script and the ref, so a retroactive dispatch against an older tag is honest rather than
empty. A gate whose script exists but fails is still a `fail`.

## The run record

UTF-8 JSON, `schema: hwp-release-readiness-record-v1`, uploaded as the
`hwp-release-readiness-record-v1` artifact and never written into the repository. It carries
`ref`, `evaluated_sha` (the commit the run checked out and measured), `workflow_source_sha` (the
dispatch ref's commit, = the run's head_sha, provenance only), one `result` field, the run URL,
`hwp_version`, the observed `pdfinfo_version`, the five check-run conclusions, `oracle` and
`oracle_lock_sha256`, the ordered `gates` array, and the four `gate_exclusions` (`fonts`, `text`,
`raster`, `roi`) with the distances measured in `docs/design/21-pdf-parity.md` sections 4.5 and 4.6
and a provenance field stating they come from the private composite run of 2026-08-16, not from the
public gate this run executes.

## This supersedes the head_sha check introduced in #235

`scripts/check-verification-block.sh` is edited on this branch (it lands with the stack). It used
to require the cited readiness run's `head_sha` to be the commit being released. That checks the
wrong thing in both directions, because this workflow checks out `inputs.ref` independently of the
ref the run was dispatched from: it rejects a correct run dispatched from `main` against a tag, and
it accepts a run dispatched from the release commit that evaluated something else.

The gate now downloads the cited run's `hwp-release-readiness-record-v1` artifact and requires the
record's `evaluated_sha` to be the release commit, the schema to be the contract string, `result`
to be `pass` with `clean-tree` passing, and `workflow_source_sha` to equal the run's head_sha
(which is what ties the downloaded record to that dispatch). A record that is missing, expired,
unparsable or short of a required field is a stop, not a warning. `HWP_READINESS_RECORD` stands in
for the download in tests only, the same way `HWP_CHANGELOG` already does for the file it reads.

## Verification

Not dispatched: the dispatches (including the retroactive one against `v0.17.0`) belong to the next
plan, after this merges.

- `actionlint` clean on the new workflow (installed to a temporary GOBIN), and the file parses as
  YAML with `workflow_dispatch` as its only trigger and every permission value `read`.
- Local dry runs of each step's script, extracted from the parsed workflow and executed with a
  hand-made gate file: the record assembly rejects a status outside the four allowed values, a
  missing entry, a duplicate entry and an unknown name, lowercases digests, and exits non-zero on
  `fail` or `pending` while `n/a` passes.
- `ci-matrix` driven against a stubbed check-runs API: an empty response yields `pending`, five
  completed successes yield `pass`, and one completed failure yields `fail`.
- The missing-script guard driven from a directory without `scripts/`: both guarded gates record
  `n/a` naming the script and the ref.
- `readme-pinned-tag` driven against the real `v0.17.0` tag (`pass`) and against a scratch tag the
  READMEs do not pin (`fail`, naming both versions).
- `scripts/tests/release-readiness-selfcheck.sh` (new, run by `scripts/check.sh` and the CI `lint`
  job): 24 assertions over the extracted steps - the trust policy accepting a main commit, a bare
  tag and a fully qualified tag ref and refusing a side branch; a simulated hostile gate script
  that hunts for the evidence and forges entries changing nothing in the assembled record; the
  record keeping the evaluated and dispatch commits apart; the release gate accepting the matching
  record and rejecting one that evaluated another commit or whose gates did not all pass; and the
  seven readme-pinned-tag cases. Mutation-checked: removing the trust guard from a target step and
  reverting the tag normalization each make it fail.
- `corpus-fonts-reproduce`, `release-copy-claims` and the doc-surface gate run for real on this
  host.
- `bash scripts/check.sh`: OK. The public PDF-parity gate SKIPPED because this macOS host does not
  have the pinned `pdfinfo version 24.02.0`; that is the script's designed behaviour off Ubuntu,
  and CI runs the gate on `ubuntu-24.04`.

## Checklist

- [x] `scripts/check.sh` passes (fmt -> clippy --all-targets -D warnings -> test; the same gates as CI)
- [x] Does this change need verification in Hancom Office? (writer or compatibility-rule impact)
  - If it does not: [x] one line of justification: CI workflow and CHANGELOG copy only, no writer,
    renderer or document output is touched, and the run produces no document.
- [x] Data policy respected (no fixtures committed beyond the fixtures/samples exception, no Hancom specification or derivatives bundled - CLAUDE.md "Data policy")
- [x] Design documents updated where applicable: no design document changes. The readiness checklist
  keeps its current wording, including the independent oracle line, so nothing here reads as an
  attestation.
- [x] New features come with tests: the gates are exercised by the local dry runs listed above; the
  workflow's own end-to-end proof is its first dispatch, which the next plan performs after merge.
- [x] User-facing documentation updated on both sides: no user-facing document changes, so the
  bilingual pair rule does not apply. `CHANGELOG.md` is English only by policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fZ11gwTiyWETK6tmMJ6n8



## Manual CI before readiness

CI now also accepts `workflow_dispatch`. A docs-only merge can skip automatic CI through path filters; readiness still requires all five checks on its exact evaluated SHA. After the final merge, run `gh workflow run ci.yml --ref main`, wait for all five jobs, then dispatch readiness. This does not relax the commit binding or accept ancestor CI results.

Verified with the readiness self-check (PyYAML available), YAML parsing, unchanged job names, and the existing push/pull_request filters.
