### PR TITLE
fix(ci): scope Korean fonts to readiness workspace tests

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -193,8 +193,9 @@ jobs:
 
       # Copied from ci.yml's pdf-parity job, including the mirror pin and the bounded retry: the
       # public manifest pins the Poppler version, so the parity gate is only meaningful when the
-      # installed pdfinfo matches it.
-      - name: Install pinned Poppler tools
+      # installed pdfinfo matches it. The workspace render smoke tests also need the same
+      # glyf-outline Korean fonts as ci.yml's Ubuntu test job.
+      - name: Install Korean test fonts and pinned Poppler tools
         id: poppler
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
@@ -216,15 +217,15 @@ jobs:
           # writes it the same way.
           # shellcheck disable=SC2086
           for attempt in 1 2 3; do
-            if timeout 120 $apt_get update && timeout 120 $apt_get install --no-install-recommends -y poppler-utils; then
+            if timeout 120 $apt_get update && timeout 120 $apt_get install --no-install-recommends -y poppler-utils fonts-nanum; then
               installed=1
               break
             fi
-            echo "poppler install attempt ${attempt} failed or timed out; retrying" >&2
+            echo "Poppler/font install attempt ${attempt} failed or timed out; retrying" >&2
             sleep 10
           done
           if [ "$installed" != 1 ]; then
-            echo "poppler-utils could not be installed after 3 attempts" >&2
+            echo "poppler-utils and fonts-nanum could not be installed after 3 attempts" >&2
             exit 1
           fi
           expected="$(python3 -c 'import json; print(json.load(open("fixtures/pdf-parity/public/manifest.json", encoding="utf-8"))["pins"]["poppler_version"])')"

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -193,9 +193,8 @@ jobs:
 
       # Copied from ci.yml's pdf-parity job, including the mirror pin and the bounded retry: the
       # public manifest pins the Poppler version, so the parity gate is only meaningful when the
-      # installed pdfinfo matches it. The workspace render smoke tests also need the same
-      # glyf-outline Korean fonts as ci.yml's Ubuntu test job.
-      - name: Install Korean test fonts and pinned Poppler tools
+      # installed pdfinfo matches it.
+      - name: Install pinned Poppler tools
         id: poppler
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
         shell: bash
@@ -217,15 +216,15 @@ jobs:
           # writes it the same way.
           # shellcheck disable=SC2086
           for attempt in 1 2 3; do
-            if timeout 120 $apt_get update && timeout 120 $apt_get install --no-install-recommends -y poppler-utils fonts-nanum; then
+            if timeout 120 $apt_get update && timeout 120 $apt_get install --no-install-recommends -y poppler-utils; then
               installed=1
               break
             fi
-            echo "Poppler/font install attempt ${attempt} failed or timed out; retrying" >&2
+            echo "poppler install attempt ${attempt} failed or timed out; retrying" >&2
             sleep 10
           done
           if [ "$installed" != 1 ]; then
-            echo "poppler-utils and fonts-nanum could not be installed after 3 attempts" >&2
+            echo "poppler-utils could not be installed after 3 attempts" >&2
             exit 1
           fi
           expected="$(python3 -c 'import json; print(json.load(open("fixtures/pdf-parity/public/manifest.json", encoding="utf-8"))["pins"]["poppler_version"])')"
@@ -312,11 +311,9 @@ jobs:
             echo "GATE_ENTRY_EOF"
           } >>"$GITHUB_OUTPUT"
 
-      # No font package is installed anywhere in this job, which is what keeps the corpus gate's
-      # no-ambient-font line meaningful. The render tests print "skip: no usable font" and drop
-      # their text assertions when no system CJK face exists; the 3-OS matrix cited by the
-      # ci-matrix gate is where those assertions actually run (ci.yml's test job installs
-      # fonts-nanum).
+      # The CLI render smoke tests require Korean glyphs. Extract the same package used by
+      # ci.yml into a private directory, without installing it into the system. Only this
+      # command receives HWP_FONT_DIR; the directory is removed before the corpus gate.
       - name: Target test-workspace
         id: target-test
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
@@ -325,7 +322,13 @@ jobs:
         run: |
           set -uo pipefail
           mkdir -p "$RUNNER_TEMP/gates/test-workspace"
-          cargo test --workspace 2>&1 | tee "$RUNNER_TEMP/gates/test-workspace/log"
+          font_root="$(mktemp -d)" || exit 1
+          trap 'rm -rf "$font_root"' EXIT
+          (cd "$font_root" && timeout 120 apt-get -o Acquire::Retries=2 download fonts-nanum) || exit 1
+          dpkg-deb --extract "$font_root"/fonts-nanum_*.deb "$font_root/extracted" || exit 1
+          test_fonts="$font_root/extracted/usr/share/fonts/truetype/nanum"
+          test -d "$test_fonts" || exit 1
+          HWP_FONT_DIR="$test_fonts" cargo test --workspace 2>&1 | tee "$RUNNER_TEMP/gates/test-workspace/log"
           exit "${PIPESTATUS[0]}"
 
       - name: Gate test-workspace
@@ -401,7 +404,7 @@ jobs:
 
       # Structural plus a runtime assertion on the environment the corpus gate just ran in: this
       # job installs poppler-utils only and never a font package, and no step sets HWP_FONT_DIR
-      # for the corpus gate (only the public parity target step sets it, on its own step). The
+      # for the corpus gate (workspace tests and public parity scope it to their own commands). The
       # corpus font bytes come from scripts/fetch-corpus-fonts.sh through the manifest hashes.
       - name: Gate corpus-no-ambient-fonts
         id: gate-corpus-no-ambient-fonts

--- a/scripts/tests/release-readiness-selfcheck.sh
+++ b/scripts/tests/release-readiness-selfcheck.sh
@@ -402,6 +402,50 @@ same "a missing README.ko.md fails" "$(readme_gate v9.9.9 "$readme_sha")" "fail"
 printf 'curl | sh -s -- --tag v0.0.1\n' >"$readme/README.ko.md"
 same "a README.ko.md pinning another version fails" "$(readme_gate v9.9.9 "$readme_sha")" "fail"
 
+# --- 5. workspace test fonts stay private and are cleaned on success and failure ---------------
+echo "-- workspace font isolation"
+font_bin="$tmp/font-bin"
+mkdir -p "$font_bin"
+cat >"$font_bin/timeout" <<'SH'
+#!/usr/bin/env bash
+shift
+exec "$@"
+SH
+cat >"$font_bin/apt-get" <<'SH'
+#!/usr/bin/env bash
+[[ "$*" == *"download fonts-nanum" ]] || exit 90
+[[ "$*" != *"install"* ]] || exit 91
+touch fonts-nanum_fixture.deb
+SH
+cat >"$font_bin/dpkg-deb" <<'SH'
+#!/usr/bin/env bash
+[[ "$1" == --extract ]] || exit 92
+mkdir -p "$3/usr/share/fonts/truetype/nanum"
+SH
+cat >"$font_bin/cargo" <<'SH'
+#!/usr/bin/env bash
+[[ "$*" == 'test --workspace' && -d "${HWP_FONT_DIR:-}" ]] || exit 93
+printf '%s' "$HWP_FONT_DIR" >"$FONT_PROBE"
+exit "$FONT_TEST_EXIT"
+SH
+chmod +x "$font_bin/"*
+for test_exit in 0 101; do
+    font_probe="$tmp/font-probe-$test_exit"
+    rc=0
+    env -u HWP_FONT_DIR PATH="$font_bin:$PATH" RUNNER_TEMP="$tmp" \
+        FONT_PROBE="$font_probe" FONT_TEST_EXIT="$test_exit" \
+        bash "$steps/target-test-workspace.sh" >"$tmp/font-test-$test_exit.log" 2>&1 || rc=$?
+    same "workspace test exit $test_exit is preserved" "$rc" "$test_exit"
+    probe_status=1
+    test -s "$font_probe" && probe_status=0
+    check "workspace test receives an isolated font directory (exit $test_exit)" "$probe_status"
+    cleanup_status=1
+    if [ -s "$font_probe" ] && [ ! -e "$(cat "$font_probe")" ]; then
+        cleanup_status=0
+    fi
+    check "test font directory is removed before corpus (exit $test_exit)" "$cleanup_status"
+done
+
 if [ "$fail" -ne 0 ]; then
     echo "== release-readiness self-check: FAILED" >&2
     exit 1


### PR DESCRIPTION
## Problem and change

The first v0.17.0 readiness run failed two render smoke tests: 11 Korean fonts were missing, its page PNG was 6039 bytes, and its PDF was below the content-size threshold. Existing CI supplies Korean glyphs, while readiness incorrectly assumed these tests would skip without them.

Download the same `fonts-nanum` package into a private temporary directory and extract it without installing a system font package. Pass that directory through `HWP_FONT_DIR` only to `cargo test --workspace`, then remove it on both success and failure. The corpus step still receives no font environment override and no ambient font package is installed. Poppler pinning, trust guards, gate criteria and artifact provenance remain intact.

Failure evidence: https://github.com/STAIxBWLB/hwp-cli/actions/runs/33942923837
The original failed record is preserved. The same tag will be evaluated again from the corrected default-branch workflow after merge.

## Validation

- Readiness self-check passes, including six new assertions executing the workflow's actual test step with package/Cargo stubs: scoped fonts, preserved success/failure exit status, and cleanup before corpus in both paths.
- `bash -n`, `shellcheck`, YAML parsing and `git diff --check` pass.
- Full local `scripts/check.sh` passed on the unchanged runtime source; final CI covers all five required jobs.
- No writer/runtime change, skipped assertion, new exclusion or Hancom acceptance claim.
