### PR TITLE
fix(ci): preserve readiness records and isolated test fonts

### DIFF
--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -109,7 +109,7 @@ jobs:
           git fetch --quiet --force origin "+refs/tags/*:refs/tags/*"
           trusted=no
           why=""
-          if tag_sha="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" 2>/dev/null)" || tag_sha="" &&
+          if tag_sha="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" 2>/dev/null)" &&
             [ "$tag_sha" = "$EVALUATED_SHA" ]; then
             trusted=yes
             why="the evaluated commit is refs/tags/${tag} of this repository"

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -109,7 +109,7 @@ jobs:
           git fetch --quiet --force origin "+refs/tags/*:refs/tags/*"
           trusted=no
           why=""
-          if tag_sha="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" 2>/dev/null)" &&
+          if tag_sha="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" 2>/dev/null)" || tag_sha="" &&
             [ "$tag_sha" = "$EVALUATED_SHA" ]; then
             trusted=yes
             why="the evaluated commit is refs/tags/${tag} of this repository"
@@ -696,7 +696,7 @@ jobs:
           # that runs later can reach them.
           GATES_FILE="$(mktemp)"
           tag="${READINESS_REF#refs/tags/}"
-          tag_sha="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" 2>/dev/null)"
+          tag_sha="$(git rev-parse -q --verify "refs/tags/${tag}^{commit}" 2>/dev/null)" || tag_sha=""
           # One exit path, so the entry is always emitted: an early `exit 0` here would leave the
           # record with no readme-pinned-tag line at all, which the assembly refuses.
           if [ -z "$tag_sha" ]; then
@@ -717,12 +717,12 @@ jobs:
                 problems="${problems:+$problems; }$file does not exist"
                 continue
               fi
-              snippets="$(grep -h -- 'sh -s --' "$file")"
+              snippets="$(grep -h -- 'sh -s --' "$file")" || snippets=""
               if [ -z "$snippets" ]; then
                 problems="${problems:+$problems; }$file carries no install.sh 'sh -s --' snippet"
                 continue
               fi
-              found="$(printf '%s\n' "$snippets" | grep -oE -- '--tag v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^--tag //' | sort -u)"
+              found="$(printf '%s\n' "$snippets" | grep -oE -- '--tag v[0-9]+\.[0-9]+\.[0-9]+' | sed 's/^--tag //' | sort -u)" || found=""
               if [ -z "$found" ]; then
                 problems="${problems:+$problems; }$file has an install.sh snippet with no --tag pin"
               elif [ "$found" != "$tag" ]; then

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -313,7 +313,8 @@ jobs:
 
       # The CLI render smoke tests require Korean glyphs. Extract the same package used by
       # ci.yml into a private directory, without installing it into the system. Only this
-      # command receives HWP_FONT_DIR; the directory is removed before the corpus gate.
+      # command receives HWP_FONT_DIR and FONTCONFIG_FILE; the latter also supplies fonts to
+      # renderer unit tests using fontdb's system discovery. Both are gone before corpus.
       - name: Target test-workspace
         id: target-test
         if: ${{ !cancelled() && steps.trust.outputs.trusted == 'yes' }}
@@ -328,7 +329,9 @@ jobs:
           dpkg-deb --extract "$font_root"/fonts-nanum_*.deb "$font_root/extracted" || exit 1
           test_fonts="$font_root/extracted/usr/share/fonts/truetype/nanum"
           test -d "$test_fonts" || exit 1
-          HWP_FONT_DIR="$test_fonts" cargo test --workspace 2>&1 | tee "$RUNNER_TEMP/gates/test-workspace/log"
+          printf '<fontconfig><include ignore_missing="yes">/etc/fonts/fonts.conf</include><dir>%s</dir></fontconfig>\n' "$test_fonts" >"$font_root/fonts.conf"
+          HWP_FONT_DIR="$test_fonts" FONTCONFIG_FILE="$font_root/fonts.conf" \
+            cargo test --workspace 2>&1 | tee "$RUNNER_TEMP/gates/test-workspace/log"
           exit "${PIPESTATUS[0]}"
 
       - name: Gate test-workspace

--- a/scripts/tests/release-readiness-selfcheck.sh
+++ b/scripts/tests/release-readiness-selfcheck.sh
@@ -192,7 +192,7 @@ trust() { # <ref> <sha> -> prints "<rc> <trusted>"
                 READINESS_REF="$1" EVALUATED_SHA="$2" WORKFLOW_SOURCE_SHA="$(printf 'b%.0s' {1..40})" \
                 RUN_URL="https://github.com/STAIxBWLB/hwp-cli/actions/runs/424242" \
                 RECORD_PATH="$tmp/record.json" GITHUB_OUTPUT="$out" \
-                bash "$steps/trust-policy-for-the-evaluated-ref.sh"
+                bash --noprofile --norc -e -o pipefail "$steps/trust-policy-for-the-evaluated-ref.sh"
     ) >"$tmp/trust.log" 2>&1
     rc=$?
     printf '%s %s' "$rc" "$(sed -n 's/^trusted=//p' "$out")"
@@ -274,7 +274,7 @@ check "the simulated gate script did write its forgery somewhere" \
 fmt_out="$tmp/gate-fmt-output"
 : >"$fmt_out"
 (cd "$work" && RUNNER_TEMP="$RUNNER_TEMP" GITHUB_OUTPUT="$fmt_out" OUTCOME=failure \
-    bash "$steps/gate-fmt.sh") >/dev/null 2>&1
+    bash --noprofile --norc -e -o pipefail "$steps/gate-fmt.sh") >/dev/null 2>&1
 fmt_entry="$(out_value "$fmt_out" entry)"
 same "the controller records the failing target step once, as fail" \
     "$fmt_entry" "$(printf 'fmt\tfail\tcargo fmt --all --check')"
@@ -308,7 +308,7 @@ run_url="https://github.com/STAIxBWLB/hwp-cli/actions/runs/424242"
 (cd "$record_dir" && GATE_FMT="$fmt_entry" GATE_REST="$rest" CHECK_RUNS="" READINESS_REF=v9.9.9 \
     READINESS_SHA="$evaluated" WORKFLOW_SOURCE_SHA="$dispatched" PDFINFO_VERSION="" \
     ORACLE_STATUS="" ORACLE_LOCK_SHA256="" RUN_URL="$run_url" \
-    RECORD_PATH="$record_dir/record.json" bash "$assembly") >/dev/null 2>&1
+    RECORD_PATH="$record_dir/record.json" bash --noprofile --norc -e -o pipefail "$assembly") >/dev/null 2>&1
 check "the assembly writes a record from the controller entries" \
     "$([ -f "$record_dir/record.json" ] && echo 0 || echo 1)"
 python3 - "$record_dir/record.json" "$evaluated" "$dispatched" <<'PYEOF'
@@ -330,7 +330,7 @@ check "the record keeps the two commits apart and carries no forged gate" "$?"
 (cd "$record_dir" && GATE_ALL="$(printf '%s\n%s\n' "$(printf 'fmt\tpass\tcargo fmt --all --check')" "$rest")" \
     CHECK_RUNS="" READINESS_REF=v9.9.9 READINESS_SHA="$evaluated" WORKFLOW_SOURCE_SHA="$dispatched" \
     PDFINFO_VERSION="" ORACLE_STATUS="" ORACLE_LOCK_SHA256="" RUN_URL="$run_url" \
-    RECORD_PATH="$record_dir/green.json" bash "$assembly") >/dev/null 2>&1
+    RECORD_PATH="$record_dir/green.json" bash --noprofile --norc -e -o pipefail "$assembly") >/dev/null 2>&1
 check "a run with every gate passing records result pass" \
     "$(python3 -c "import json,sys; sys.exit(0 if json.load(open(sys.argv[1]))['result'] == 'pass' else 1)" \
         "$record_dir/green.json" && echo 0 || echo 1)"
@@ -386,7 +386,7 @@ readme_gate() { # <ref> <sha> -> prints the recorded status
     local out="$tmp/readme-output"
     : >"$out"
     (cd "$readme" && GITHUB_OUTPUT="$out" READINESS_REF="$1" EVALUATED_SHA="$2" \
-        bash "$steps/gate-readme-pinned-tag.sh") >/dev/null 2>&1
+        bash --noprofile --norc -e -o pipefail "$steps/gate-readme-pinned-tag.sh") >/dev/null 2>&1
     out_value "$out" entry | cut -f2
 }
 same "a bare tag with both READMEs pinned passes" "$(readme_gate v9.9.9 "$readme_sha")" "pass"
@@ -401,6 +401,8 @@ rm -f "$readme/README.ko.md"
 same "a missing README.ko.md fails" "$(readme_gate v9.9.9 "$readme_sha")" "fail"
 printf 'curl | sh -s -- --tag v0.0.1\n' >"$readme/README.ko.md"
 same "a README.ko.md pinning another version fails" "$(readme_gate v9.9.9 "$readme_sha")" "fail"
+printf 'curl | sh -s -- --dir ./bin\n' >"$readme/README.ko.md"
+same "an install snippet without a tag pin records fail" "$(readme_gate v9.9.9 "$readme_sha")" "fail"
 
 # --- 5. workspace test fonts stay private and are cleaned on success and failure ---------------
 echo "-- workspace font isolation"
@@ -436,7 +438,7 @@ for test_exit in 0 101; do
     rc=0
     env -u HWP_FONT_DIR -u FONTCONFIG_FILE PATH="$font_bin:$PATH" RUNNER_TEMP="$tmp" \
         FONT_PROBE="$font_probe" FONT_TEST_EXIT="$test_exit" \
-        bash "$steps/target-test-workspace.sh" >"$tmp/font-test-$test_exit.log" 2>&1 || rc=$?
+        bash --noprofile --norc -e -o pipefail "$steps/target-test-workspace.sh" >"$tmp/font-test-$test_exit.log" 2>&1 || rc=$?
     same "workspace test exit $test_exit is preserved" "$rc" "$test_exit"
     probe_status=1
     test -s "$font_probe" && probe_status=0

--- a/scripts/tests/release-readiness-selfcheck.sh
+++ b/scripts/tests/release-readiness-selfcheck.sh
@@ -200,6 +200,10 @@ trust() { # <ref> <sha> -> prints "<rc> <trusted>"
 same "a commit reachable from origin/main is trusted" "$(trust main "$main_sha")" "0 yes"
 same "a tag of this repository is trusted" "$(trust v9.9.9 "$side_sha")" "0 yes"
 same "a fully qualified tag ref is trusted" "$(trust refs/tags/v9.9.9 "$side_sha")" "0 yes"
+git -C "$work" tag -f v9.9.9 "$main_sha" >/dev/null
+git -C "$work" push -q --force origin v9.9.9
+same "an existing tag pointing elsewhere does not trust a side commit" \
+    "$(trust v9.9.9 "$side_sha")" "1 no"
 git -C "$work" tag -d v9.9.9 >/dev/null
 git -C "$work" push -q origin :refs/tags/v9.9.9
 same "a ref that is neither a tag nor an ancestor of main is refused" \

--- a/scripts/tests/release-readiness-selfcheck.sh
+++ b/scripts/tests/release-readiness-selfcheck.sh
@@ -425,6 +425,8 @@ SH
 cat >"$font_bin/cargo" <<'SH'
 #!/usr/bin/env bash
 [[ "$*" == 'test --workspace' && -d "${HWP_FONT_DIR:-}" ]] || exit 93
+[[ -f "${FONTCONFIG_FILE:-}" ]] || exit 94
+grep -Fq "<dir>$HWP_FONT_DIR</dir>" "$FONTCONFIG_FILE" || exit 95
 printf '%s' "$HWP_FONT_DIR" >"$FONT_PROBE"
 exit "$FONT_TEST_EXIT"
 SH
@@ -432,7 +434,7 @@ chmod +x "$font_bin/"*
 for test_exit in 0 101; do
     font_probe="$tmp/font-probe-$test_exit"
     rc=0
-    env -u HWP_FONT_DIR PATH="$font_bin:$PATH" RUNNER_TEMP="$tmp" \
+    env -u HWP_FONT_DIR -u FONTCONFIG_FILE PATH="$font_bin:$PATH" RUNNER_TEMP="$tmp" \
         FONT_PROBE="$font_probe" FONT_TEST_EXIT="$test_exit" \
         bash "$steps/target-test-workspace.sh" >"$tmp/font-test-$test_exit.log" 2>&1 || rc=$?
     same "workspace test exit $test_exit is preserved" "$rc" "$test_exit"


### PR DESCRIPTION
## Problem and change

Readiness has two gaps exposed by its first live runs. Renderer unit tests use fontdb system discovery rather than the CLI's `HWP_FONT_DIR`, so private test fonts must be available through both paths. Separately, evaluating `main` makes the tag lookup return nonzero; GitHub's `bash -e` then exits before emitting `readme-pinned-tag`, preventing record assembly and artifact upload.

- Provide a temporary `FONTCONFIG_FILE` that includes `/etc/fonts/fonts.conf` and the already-extracted private Nanum directory. Scope it and `HWP_FONT_DIR` to workspace tests; the existing trap removes both before corpus. No ambient font installation or runtime-code change.
- Handle expected empty tag/snippet/pin lookups explicitly so branch evaluation records `n/a` and missing README pins record `fail`, rather than aborting before evidence is emitted.
- Execute extracted workflow steps in the self-check with GitHub's actual `bash --noprofile --norc -e -o pipefail` options.

Failure evidence: [tag WMF test](https://github.com/STAIxBWLB/hwp-cli/actions/runs/33943685057), [main record assembly](https://github.com/STAIxBWLB/hwp-cli/actions/runs/33943932510). Available failure records and the main run metadata are preserved; no missing run artifact is reconstructed or edited.

## Validation

- Before the shell fix, the actual GitHub shell options reproduce missing branch and absent-snippet records. After it, all 32 readiness assertions pass, including an install snippet without a tag pin and a tag pointing at another commit.
- Installed fontdb 0.23 source confirms its default Linux fontconfig path reads `FONTCONFIG_FILE`; a real Linux readiness probe is also running against the font change.
- Shell syntax, shellcheck, YAML/XML parsing and `git diff --check` pass.
- Full CI remains required; final evidence is collected from the default-branch workflow after merge.
